### PR TITLE
[tools] Update llvm version from 19.1.4 to 21.1.0

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,7 +1,7 @@
 self-hosted-runner:
   labels:
     - ubuntu-24.04  # GitHub hosted runner that actionlint doesn't recognize because actionlint version (1.6.21) is too old
-    - macos-13
+    - macos-15-intel
     - macos-m1-stable
     - linux.arm64.m8g.4xlarge
     - linux.12xlarge

--- a/.github/workflows/clang-tidy-linux.yml
+++ b/.github/workflows/clang-tidy-linux.yml
@@ -52,7 +52,7 @@ jobs:
         uses: ./.github/actions/clang-tidy-upload
         with:
           platform: ${{ matrix.platform }}
-          version: 19.1.4
+          version: 21.1.0
           upload-to-s3: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}
 
 concurrency:

--- a/.github/workflows/clang-tidy-macos.yml
+++ b/.github/workflows/clang-tidy-macos.yml
@@ -50,7 +50,7 @@ jobs:
         uses: ./.github/actions/clang-tidy-upload
         with:
           platform: macos-i386
-          version: 19.1.4
+          version: 21.1.0
           upload-to-s3: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
   build-M1:
@@ -83,7 +83,7 @@ jobs:
         uses: ./.github/actions/clang-tidy-upload
         with:
           platform: macos-arm64
-          version: 19.1.4
+          version: 21.1.0
           upload-to-s3: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
 concurrency:

--- a/.github/workflows/clang-tidy-macos.yml
+++ b/.github/workflows/clang-tidy-macos.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   build-Intel:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/tools/clang-tidy-checks/Dockerfile.cilint-clang-tidy
+++ b/tools/clang-tidy-checks/Dockerfile.cilint-clang-tidy
@@ -1,5 +1,5 @@
-# ubuntu20.04-cuda11.8-py3.8-tidy11
-FROM nvidia/cuda:11.8.0-devel-ubuntu20.04
+# ubuntu22.04-cuda12.4-py3.10-tidy21
+FROM nvidia/cuda:12.4.1-devel-ubuntu22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -10,14 +10,14 @@ COPY . clang-tidy-checks
 RUN apt-get update && apt-get upgrade -y && apt-get install -y software-properties-common wget
 RUN apt-add-repository ppa:git-core/ppa
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-17 main"
+RUN apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main"
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     git python3-dev python3-pip python3-setuptools python3-wheel build-essential time \
     clang-17 lld ninja-build libomp-17-dev
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-17 1000
 RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-17 1000
-run pip3 install cmake==3.22.6
+RUN pip3 install cmake==3.22.6
 
 # Run setup script (See ./clang-tidy-checks/README.md for more details)
 # Build clang-tidy, copy out the binary, and remove the llvm checkout

--- a/tools/clang-tidy-checks/setup.sh
+++ b/tools/clang-tidy-checks/setup.sh
@@ -48,14 +48,14 @@ function clone_llvm() {
   if [[ -d llvm-project ]]; then
     rm -rf llvm-project
   fi
-  git clone -b llvmorg-19.1.4 https://github.com/llvm/llvm-project.git --depth=1
+  git clone -b llvmorg-21.1.0 https://github.com/llvm/llvm-project.git --depth=1
   success
 }
 
 function apply_patches() {
   info "applying patches"
   pushd llvm-project
-  for check in ../19.x-patches/*.diff; do
+  for check in ../21.x-patches/*.diff; do
     patch -p1 -N -d . < "$check"
   done
   popd
@@ -109,7 +109,7 @@ function build() {
 
 function setup() {
   clone_llvm
-  # No need to patch llvm-19
+  # No need to patch llvm-21
   # apply_patches
   build
 }


### PR DESCRIPTION
Bumps the custom clang-tidy / clang-format build from LLVM 19.1.4 to 21.1.0, and modernizes the Linux build image so it can still install pytorch's build requirements.

### LLVM version bump (mirrors #5991, the 17.0.6 -> 19.1.4 change)
- `tools/clang-tidy-checks/setup.sh`: clone `llvmorg-21.1.0`, point `apply_patches` at `21.x-patches`
- `.github/workflows/clang-tidy-linux.yml`: upload `version: 21.1.0`
- `.github/workflows/clang-tidy-macos.yml`: upload `version: 21.1.0` (Intel + M1)

As with 19, `apply_patches` stays commented out and no `21.x-patches` directory is added.

### Base image modernization
The first rebuild failed on the final Docker layer: Ubuntu 20.04 ships Python 3.8, which can no longer satisfy pytorch's `requirements-build.txt` (`setuptools>=77` dropped 3.8 support, so pip caps at 75.3.4). This is drift in pytorch's requirements, not the LLVM bump — the old image would fail the same way on a rebuild.

Rather than bootstrap a newer Python onto EOL Ubuntu 20.04, move to a modern base (matching pytorch's move to CUDA 12):
- `Dockerfile.cilint-clang-tidy`: base `nvidia/cuda:11.8.0-devel-ubuntu20.04` -> `nvidia/cuda:12.4.1-devel-ubuntu22.04`, which provides Python 3.10 natively
- LLVM apt repo pointed at `jammy` instead of `focal`

Ubuntu 22.04 (glibc 2.35) is forward-compatible with manylinux_2_24/_2_28/_2_34 wheels, so all `requirements-build.txt` deps resolve to prebuilt wheels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)