### PR TITLE
Restrict @pytorchbot lint to users with write permissions

### DIFF
--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -536,8 +536,16 @@ The explanation needs to be clear on why this is needed. Here are some good exam
     await updateDrciComments(ctx.octokit, owner, repo, [prNum]);
   }
 
-  async handleLint() {
+  async handleLint(login: string) {
     await this.logger.log("lint");
+    if (!(await this.hasWritePermissions(login))) {
+      await this.addComment(
+        "You don't have permissions to trigger lint fixes on this PR since it " +
+          "requires write access to the repository. If you think this is a " +
+          "mistake, please contact PyTorch Dev Infra."
+      );
+      return;
+    }
     await this.dispatchEvent("apply-lint", {});
     await this.ackComment();
   }
@@ -616,7 +624,7 @@ The explanation needs to be clear on why this is needed. Here are some good exam
         case "lint":
         case "fix-lint":
         case "apply-lint": {
-          return await this.handleLint();
+          return await this.handleLint(this.ctx.payload?.comment?.user?.login);
         }
       }
     }


### PR DESCRIPTION
The `@pytorchbot lint` / `fix-lint` / `apply-lint` bot command dispatches the `apply-lint` event, which pushes lint fixes to the PR branch, but previously ran for **any** commenter with no permission check.

This gates it behind write permissions, mirroring how `rebase` gates itself — check permission first, and post an explanatory comment if the user lacks access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)