### PR TITLE
[CRCR] Include job_name in Dr.CI comment display for CRCR non-blocking failures

### DIFF
--- a/torchci/lib/fetchRecentWorkflows.ts
+++ b/torchci/lib/fetchRecentWorkflows.ts
@@ -40,7 +40,7 @@ export async function fetchCrcrWorkflows(
   );
 
   return rows.map((row: any) => ({
-    name: `crcr/${row.downstream_repo}/${row.name}`,
+    name: `crcr/${row.downstream_repo}/${row.name}/${row.jobName || row.name}`,
     jobName: row.jobName || row.name,
     workflowId: 0,
     workflowUniqueId: 0,


### PR DESCRIPTION
CRCR downstream jobs from the same workflow run all showed the identical display name (crcr/<repo>/<workflow_name>) in Dr.CI comments ([example](https://github.com/pytorch/pytorch/pull/185881#issuecomment-4598425368)) because `job_name` was queried from ClickHouse but never appended to the name field. This made it impossible to tell which specific job failed without opening the HUD link.

**Fix:** append `/<job_name>` to the display name so each job is disambiguated — matching the `crcr/<repo>/<workflow>/<job>` convention already used by check_run_name() in the relay.