### PR TITLE
Run numpy preview upload in pytorchbot-env environment

### DIFF
--- a/.github/workflows/build-numpy-preview.yml
+++ b/.github/workflows/build-numpy-preview.yml
@@ -71,6 +71,10 @@ jobs:
             image: pytorch/manylinux2_28_aarch64-builder:cpu-aarch64
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
+    # The S3/R2 upload roles and R2 secrets are only assumable from the
+    # pytorchbot-env environment. Only enter it for a real upload run; dry runs
+    # and pull_request builds stay outside it so they are not gated on approval.
+    environment: ${{ (github.event_name == 'workflow_dispatch' && !inputs.dry_run) && 'pytorchbot-env' || '' }}
     container:
       image: ${{ matrix.image }}
     steps:


### PR DESCRIPTION
## Summary

The `Build numpy for preview Python` workflow (#8362) failed on a real (non-dry) `workflow_dispatch` upload run at the **Configure AWS credentials** step:

```
Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentity
```

The `gha_workflow_nightly_build_wheels` / `gha_workflow_test_build_wheels` OIDC roles (and the `R2_*` upload secrets) are only assumable from the **`pytorchbot-env`** environment — the same environment `_binary_upload.yml` and `update-s3-html.yml` use. The workflow didn't declare it, so the OIDC claim was rejected.

## Fix

Enter `pytorchbot-env` for real upload runs only:

```yaml
environment: ${{ (github.event_name == 'workflow_dispatch' && !inputs.dry_run) && 'pytorchbot-env' || '' }}
```

Dry runs and `pull_request` builds stay outside the environment so they aren't gated on environment approval (they don't touch AWS/R2 anyway).