### PR TITLE
Fix scaleUpChron org filter for fleets with a separate scale-config org

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up-chron.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up-chron.test.ts
@@ -73,6 +73,24 @@ const hudQueryInvalidOrgResponse = [
     max_queue_time_minutes: 32,
   },
 ];
+const hudQueryDivergentOrgResponse = [
+  {
+    runner_label: 'test_runner_type1',
+    org: 'meta_org',
+    repo: 'meta_repo',
+    num_queued_jobs: 1,
+    min_queue_time_minutes: 31,
+    max_queue_time_minutes: 31,
+  },
+  {
+    runner_label: 'test_runner_type1',
+    org: 'scale_org',
+    repo: 'scale_repo',
+    num_queued_jobs: 1,
+    min_queue_time_minutes: 31,
+    max_queue_time_minutes: 31,
+  },
+];
 
 const runnerTypeValid = 'test_runner_type1';
 const runnerTypeInvalid = 'runner_type_invalid';
@@ -158,6 +176,69 @@ describe('scaleUpChron', () => {
     await scaleUpChron(metrics);
     expect(scaleUpChronInstanceNoOpSpy).toBeCalledTimes(0);
     expect(mockedScaleUp).toBeCalledTimes(1);
+  });
+
+  it("backfills the fleet's own org (authGHOrg) even when scaleConfigOrg differs", async () => {
+    const mockedScaleUp = mocked(scaleUp).mockResolvedValue(undefined);
+
+    jest.clearAllMocks();
+    jest.spyOn(Config, 'Instance', 'get').mockImplementation(
+      () =>
+        ({
+          ...baseCfg,
+          authGHOrg: 'meta_org',
+          scaleConfigOrg: 'scale_org',
+        } as unknown as Config),
+    );
+
+    mocked(shuffleArrayInPlace).mockImplementation((a) => a);
+    mocked(getRepo).mockReturnValue({ owner: 'meta_org', repo: 'meta_repo' });
+    mocked(getRunnerTypes).mockResolvedValue(
+      new Map([[runnerTypeValid, { runnerTypeName: 'test_runner_type1' } as RunnerType]]),
+    );
+    mocked(expBackOff).mockResolvedValue({ data: hudQueryDivergentOrgResponse });
+
+    await scaleUpChron(metrics);
+
+    expect(mockedScaleUp).toBeCalledTimes(1);
+    expect(mockedScaleUp).toHaveBeenCalledWith(
+      'aws:sqs',
+      expect.objectContaining({
+        repositoryOwner: 'meta_org',
+        repositoryName: 'meta_repo',
+        runnerLabels: ['test_runner_type1'],
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('falls back to scaleConfigOrg when authGHOrg is empty string (shared-catalog fleet)', async () => {
+    const mockedScaleUp = mocked(scaleUp).mockResolvedValue(undefined);
+
+    jest.clearAllMocks();
+    jest.spyOn(Config, 'Instance', 'get').mockImplementation(
+      () =>
+        ({
+          ...baseCfg,
+          authGHOrg: '',
+        } as unknown as Config),
+    );
+
+    mocked(shuffleArrayInPlace).mockImplementation((a) => a);
+    mocked(getRepo).mockReturnValue({ owner: 'test_org1', repo: 'test_repo1' });
+    mocked(getRunnerTypes).mockResolvedValue(
+      new Map([[runnerTypeValid, { runnerTypeName: 'test_runner_type1' } as RunnerType]]),
+    );
+    mocked(expBackOff).mockResolvedValue({ data: hudQueryValidResponse });
+
+    await scaleUpChron(metrics);
+
+    expect(mockedScaleUp).toBeCalledTimes(1);
+    expect(mockedScaleUp).toHaveBeenCalledWith(
+      'aws:sqs',
+      expect.objectContaining({ repositoryOwner: 'test_org1' }),
+      expect.anything(),
+    );
   });
 
   it('scaled up throws error', async () => {

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up-chron.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-up-chron.ts
@@ -44,7 +44,7 @@ export async function scaleUpChron(metrics: ScaleUpChronMetrics): Promise<void> 
         );
         return (
           runner.max_queue_time_minutes >= Config.Instance.scaleUpMaxQueueTimeMinutes &&
-          runner.org === Config.Instance.scaleConfigOrg
+          runner.org === (Config.Instance.authGHOrg || Config.Instance.scaleConfigOrg)
         );
       })
       .filter((requested_runner) => {


### PR DESCRIPTION
**Impact:** scaleUpChron 
**Risk:** low

## What
The chron scale-up now matches queued jobs against the fleet's own org (`authGHOrg`, falling back to `scaleConfigOrg`) instead of always comparing against `scaleConfigOrg`.

## Why
meta-pytorch runs its runners under `authGHOrg` but pulls the runner catalog from a shared scale-config in a different `scaleConfigOrg`. The org filter only ever matched `scaleConfigOrg`, so every queued job for the fleet's real org was filtered out and `scaleUpChron` never scaled anything — leaving jobs stuck in the queue. The new precedence mirrors what `authRepo` already does a few lines above (`authGHOrg || scaleConfigOrg`), keeping single-org fleets (empty `authGHOrg`) behaving exactly as before.