### PR TITLE
[BE] Upgrade XPU support package to 2026.1 in Windows CICD

### DIFF
--- a/.github/scripts/install_xpu.bat
+++ b/.github/scripts/install_xpu.bat
@@ -5,9 +5,9 @@ REM BKM reference: https://www.intel.com/content/www/us/en/developer/articles/to
 :xpu_bundle_install_start
 
 set XPU_BUNDLE_PARENT_DIR=C:\Program Files (x86)\Intel\oneAPI
-set XPU_BUNDLE_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/e5a5ada1-6bce-45ed-ac6e-e3b79d7a847e/intel-deep-learning-essentials-2025.3.2.35_offline.exe
+set XPU_BUNDLE_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/d2148e15-b3c4-4313-afa9-a2373318b0b5/intel-deep-learning-essentials-2026.0.0.613_offline.exe
 set XPU_BUNDLE_PRODUCT_NAME=intel.oneapi.win.deep-learning-essentials.product
-set XPU_BUNDLE_VERSION=2025.3.2+34
+set XPU_BUNDLE_VERSION=2026.0.0+611
 set XPU_BUNDLE_INSTALLED=0
 set XPU_BUNDLE_UNINSTALL=0
 set XPU_EXTRA_URL=NULL
@@ -16,9 +16,9 @@ set XPU_EXTRA_VERSION=2025.0.1+1226
 set XPU_EXTRA_INSTALLED=0
 set XPU_EXTRA_UNINSTALL=0
 
-if not [%XPU_VERSION%]==[] if [%XPU_VERSION%]==[2026.0] (
-    set XPU_BUNDLE_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/d2148e15-b3c4-4313-afa9-a2373318b0b5/intel-deep-learning-essentials-2026.0.0.613_offline.exe
-    set XPU_BUNDLE_VERSION=2026.0.0+611
+if not [%XPU_VERSION%]==[] if [%XPU_VERSION%]==[2026.1] (
+    set XPU_BUNDLE_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/5d44690a-84fb-4d3b-bc5d-caed4bab56fc/intel-deep-learning-essentials-2026.1.2.22_offline.exe
+    set XPU_BUNDLE_VERSION=2026.1.2+17
 )
 
 :: Check if XPU bundle is target version or already installed

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -166,7 +166,7 @@ jobs:
       - name: Install XPU support package
         if: ${{ matrix.gpu_arch_type == 'xpu' }}
         env:
-          XPU_VERSION: '2026.0'
+          XPU_VERSION: '2026.1'
         run: |
           cmd //c .\\test-infra\\.github\\scripts\\install_xpu.bat
       - name: Update NVIDIA driver


### PR DESCRIPTION
## Summary

Upgrade oneAPI Deep Learning Essentials from 2026.0 to 2026.1 for Windows CI/CD.

- Update default installer URL and version to 2026.0 (baseline)
- Add conditional block for 2026.1 with new DLE offline installer
- Bump XPU_VERSION in build_wheels_windows.yml to 2026.1

Works for https://github.com/pytorch/pytorch/issues/189648, follows https://github.com/pytorch/pytorch/pull/189593
