### PR TITLE
[CRCR] Treat expected non-success outcomes (xfail/xcancel/xtimeout) as successes in pass rate

### DIFF
--- a/torchci/clickhouse_queries/crcr_backend_summary/query.sql
+++ b/torchci/clickhouse_queries/crcr_backend_summary/query.sql
@@ -1,7 +1,31 @@
 SELECT
-    countIf(conclusion = 'success') AS successes,
-    countIf(conclusion = 'failure') AS failures,
-    countIf(conclusion = 'timed_out') AS timed_out,
+    countIf(
+        conclusion = 'success'
+        OR (
+            {repo: String} = 'pytorch/crcr-test'
+            AND (
+                (job_name LIKE '%xfail%' AND conclusion = 'failure')
+                OR (job_name LIKE '%xcancel%' AND conclusion = 'cancelled')
+                OR (job_name LIKE '%xtimeout%' AND conclusion = 'timed_out')
+            )
+        )
+    ) AS successes,
+    countIf(
+        conclusion = 'failure'
+        AND NOT (
+            {repo: String} = 'pytorch/crcr-test'
+            AND job_name LIKE '%xfail%'
+            AND conclusion = 'failure'
+        )
+    ) AS failures,
+    countIf(
+        conclusion = 'timed_out'
+        AND NOT (
+            {repo: String} = 'pytorch/crcr-test'
+            AND job_name LIKE '%xtimeout%'
+            AND conclusion = 'timed_out'
+        )
+    ) AS timed_out,
     count() AS total_jobs,
     if(total_jobs > 0, successes / total_jobs, 0) AS pass_rate,
     uniqExact(pr_number) AS total_prs,

--- a/torchci/clickhouse_queries/crcr_success_rate/query.sql
+++ b/torchci/clickhouse_queries/crcr_success_rate/query.sql
@@ -1,9 +1,33 @@
 SELECT
     toDate(started_at) AS day,
     downstream_repo AS repo,
-    countIf(conclusion = 'success') AS successes,
-    countIf(conclusion = 'failure') AS failures,
-    countIf(conclusion = 'timed_out') AS timed_out,
+    countIf(
+        conclusion = 'success'
+        OR (
+            downstream_repo = 'pytorch/crcr-test'
+            AND (
+                (job_name LIKE '%xfail%' AND conclusion = 'failure')
+                OR (job_name LIKE '%xcancel%' AND conclusion = 'cancelled')
+                OR (job_name LIKE '%xtimeout%' AND conclusion = 'timed_out')
+            )
+        )
+    ) AS successes,
+    countIf(
+        conclusion = 'failure'
+        AND NOT (
+            downstream_repo = 'pytorch/crcr-test'
+            AND job_name LIKE '%xfail%'
+            AND conclusion = 'failure'
+        )
+    ) AS failures,
+    countIf(
+        conclusion = 'timed_out'
+        AND NOT (
+            downstream_repo = 'pytorch/crcr-test'
+            AND job_name LIKE '%xtimeout%'
+            AND conclusion = 'timed_out'
+        )
+    ) AS timed_out,
     count() AS total,
     if(total > 0, successes / total, 0) AS pass_rate
 FROM

--- a/torchci/clickhouse_queries/crcr_summary/query.sql
+++ b/torchci/clickhouse_queries/crcr_summary/query.sql
@@ -1,9 +1,33 @@
 SELECT
     downstream_repo AS repo,
     anyLast(downstream_repo_level) AS downstream_repo_level,
-    countIf(conclusion = 'success') AS successes,
-    countIf(conclusion = 'failure') AS failures,
-    countIf(conclusion = 'timed_out') AS timed_out,
+    countIf(
+        conclusion = 'success'
+        OR (
+            downstream_repo = 'pytorch/crcr-test'
+            AND (
+                (job_name LIKE '%xfail%' AND conclusion = 'failure')
+                OR (job_name LIKE '%xcancel%' AND conclusion = 'cancelled')
+                OR (job_name LIKE '%xtimeout%' AND conclusion = 'timed_out')
+            )
+        )
+    ) AS successes,
+    countIf(
+        conclusion = 'failure'
+        AND NOT (
+            downstream_repo = 'pytorch/crcr-test'
+            AND job_name LIKE '%xfail%'
+            AND conclusion = 'failure'
+        )
+    ) AS failures,
+    countIf(
+        conclusion = 'timed_out'
+        AND NOT (
+            downstream_repo = 'pytorch/crcr-test'
+            AND job_name LIKE '%xtimeout%'
+            AND conclusion = 'timed_out'
+        )
+    ) AS timed_out,
     count() AS total,
     if(total > 0, successes / total, 0) AS pass_rate,
     avg(duration_seconds) AS avg_duration_s,


### PR DESCRIPTION
## Summary

Fixes the CRCR pass rate calculation to correctly handle **expected non-success outcomes** in health-probe repos like `pytorch/crcr-test`.

The `crcr-test` repo uses jobs with `x`-prefixed names (`xfail`, `xcancel`, `xtimeout`) that intentionally end in failure, cancellation, or timeout to test the relay's handling of these outcomes (see [pytorch/crcr-test#19](https://github.com/pytorch/crcr-test/pull/19)). These expected results were being counted as failures in the ClickHouse pass rate queries, causing `pytorch/crcr-test` to show a degraded health status even though the relay is functioning correctly.

### Changes

Three ClickHouse queries updated with the same logic:

1. **`crcr_summary`** — CRCR summary page (`/crcr`)
2. **`crcr_success_rate`** — CRCR metrics page (`/crcr/metrics`)
3. **`crcr_backend_summary`** — per-repo dashboard (`/crcr/[org]/[repo]`)

For each query:
- **Successes**: now includes jobs where `job_name LIKE '%xfail%'`, `'%xcancel%'`, or `'%xtimeout%'`
- **Failures**: excludes `xfail` jobs
- **Timed out**: excludes `xtimeout` jobs

This uses the `job_name` convention established in [pytorch/crcr-test#19](https://github.com/pytorch/crcr-test/pull/19) — jobs prefixed with `x` are intentional/expected outcomes, not bugs.

Fixes pytorch/test-infra#8306

## Test plan

- [ ] Verify CRCR summary page shows improved pass rate for `pytorch/crcr-test`
- [ ] Verify metrics page charts reflect corrected rates
- [ ] Verify per-repo dashboard for `pytorch/crcr-test` shows accurate stats