### PR TITLE
[HUD] Add sole viable/strict blocker % to reliability page

### DIFF
--- a/torchci/clickhouse_queries/viable_strict_sole_blocker/params.json
+++ b/torchci/clickhouse_queries/viable_strict_sole_blocker/params.json
@@ -1,0 +1,12 @@
+{
+  "params": {
+    "startTime": "DateTime64(3)",
+    "stopTime": "DateTime64(3)"
+  },
+  "tests": [
+    {
+      "startTime": "2026-07-20T00:00:00.000",
+      "stopTime": "2026-07-27T00:00:00.000"
+    }
+  ]
+}

--- a/torchci/clickhouse_queries/viable_strict_sole_blocker/query.sql
+++ b/torchci/clickhouse_queries/viable_strict_sole_blocker/query.sql
@@ -19,11 +19,16 @@
 -- gating workflows run on every push, so that case is rare; treat the numbers as
 -- descriptive triage, not the gate's true rate.
 --
--- Job names are folded to config granularity (shards collapsed) so that e.g.
+-- Job names are folded to config granularity by stripping only the trailing
+-- shard fields (", <shard>, <num_shards>[, <runner>]") from the final config
+-- group and keeping the rest of the name. So
 -- `trunk / linux-jammy-rocm-py3.10-mi350 / test (default, 1, 3)` becomes
--- `trunk / linux-jammy-rocm-py3.10-mi350 / test (default)`. One row is returned
--- per fully-evaluated commit with the list of blocking folded jobs; the client
--- computes how often each job (and each job type) is the *only* blocker.
+-- `trunk / linux-jammy-rocm-py3.10-mi350 / test (default)`, and nested jobs with
+-- more than two " / " components keep their config instead of collapsing, e.g.
+-- `... / dynamo-test (3.11) / test (dynamo_wrapped, 1, 7)` and
+-- `... / dynamo-test (3.11) / test (dynamo_core, 1, 1)` stay distinct. One row is
+-- returned per fully-evaluated commit with the list of blocking folded jobs; the
+-- client computes how often each job (and each job type) is the *only* blocker.
 WITH commits AS (
     SELECT DISTINCT
         p.head_commit. 'id' AS sha,
@@ -55,15 +60,14 @@ raw_jobs AS (
     SELECT
         w.head_sha AS sha,
         w.id AS workflow_id,
+        -- Fold shards only: strip a trailing ", <shard>, <num_shards>[, <runner>]"
+        -- from the final config group and keep the rest of the (possibly nested)
+        -- name, so jobs with more than two " / " components don't collapse distinct
+        -- configs (e.g. dynamo_core vs dynamo_wrapped).
         CONCAT(
             j.workflow_name,
             ' / ',
-            arrayElement(splitByString(' / ', j.name), 1),
-            ' / ',
-            arrayElement(
-                splitByString(', ', arrayElement(splitByString(' / ', j.name), 2)),
-                1
-            )
+            replaceRegexpOne(j.name, ', [0-9]+, [0-9]+.*\\)$', ')')
         ) AS folded_name,
         j.name AS shard,
         j.run_attempt AS run_attempt,
@@ -84,12 +88,21 @@ raw_jobs AS (
         -- pytorch/pytorch .github/workflows/update-viablestrict.yml
         -- (["pull", "trunk", "lint", "docs-build"] as of 2026-07-27).
         AND match(lower(j.workflow_name), '^(pull|trunk|lint|docs-build)')
+        -- Match the gate's job-level filtering (commit_jobs_batch_query), which
+        -- only drops ciflow_should_run and generate-test-matrix. We additionally
+        -- drop unstable and rerun_disabled_tests jobs: the gate ignores unstable
+        -- via is_unstable(), and both carry a trailing config marker
+        -- (", unstable" / ", rerun_disabled_tests", after the shard fields) that
+        -- the shard fold strips -- which would collapse them onto, and falsely
+        -- redden, the real gating job of the same config (e.g. a scheduled
+        -- rerun_disabled_tests failure landing on `test (default)`). We do NOT
+        -- filter `job-filter / compute` or slashless lint jobs: the gate gates on
+        -- those and they fold to distinct names, so excluding them would miss real
+        -- blockers or make another job look falsely sole.
         AND j.name != 'ciflow_should_run'
         AND j.name != 'generate-test-matrix'
-        AND j.name NOT LIKE '%rerun_disabled_tests%'
-        AND j.name NOT LIKE '%filter%'
         AND j.name NOT LIKE '%unstable%'
-        AND j.name LIKE '%/%'
+        AND j.name NOT LIKE '%rerun_disabled_tests%'
         AND w.event != 'workflow_run' -- these are unrelated to the SHA
         AND w.event != 'repository_dispatch'
         AND NOT (w.event = 'workflow_dispatch' AND w.head_branch LIKE 'trunk/%') -- restart jobs
@@ -102,11 +115,7 @@ raw_jobs AS (
 shard_latest AS (
     SELECT
         sha,
-        IF(
-            folded_name LIKE '%(%' AND folded_name NOT LIKE '%)%',
-            CONCAT(folded_name, ')'),
-            folded_name
-        ) AS name,
+        folded_name AS name,
         shard,
         workflow_id,
         argMax(conclusion, run_attempt) AS conclusion

--- a/torchci/clickhouse_queries/viable_strict_sole_blocker/query.sql
+++ b/torchci/clickhouse_queries/viable_strict_sole_blocker/query.sql
@@ -1,0 +1,163 @@
+-- Powers the "Sole viable/strict blockers" table on
+-- https://hud.pytorch.org/reliability/pytorch/pytorch
+--
+-- Approximates the viable/strict gate for FAILURE ATTRIBUTION -- it is not a
+-- full reimplementation. It uses the same job-level red definition as
+-- pytorch/.github/scripts/fetch_latest_green_commit.py (via commit_jobs_batch_query):
+--   * gating workflows are prefix-matched against ^(pull|trunk|lint|docs-build)
+--     (case-insensitive), same as the `requires` list in update-viablestrict.yml
+--   * a job blocks if its latest run attempt (per workflow run) has a
+--     conclusion_kg other than success/skipped
+--   * jobs marked unstable (name contains "unstable", or the shard-folded name
+--     matches an open UNSTABLE issue) are excluded from gating
+--
+-- It differs from the real gate in one bounded way: the gate also rejects a
+-- commit when a required workflow never reported at all ("missing required
+-- workflows"). This query only models the job-failure path, so a decided commit
+-- that is entirely missing a required workflow (or that has no gating jobs at
+-- all) is treated as green here rather than blocked. On post-merge main all four
+-- gating workflows run on every push, so that case is rare; treat the numbers as
+-- descriptive triage, not the gate's true rate.
+--
+-- Job names are folded to config granularity (shards collapsed) so that e.g.
+-- `trunk / linux-jammy-rocm-py3.10-mi350 / test (default, 1, 3)` becomes
+-- `trunk / linux-jammy-rocm-py3.10-mi350 / test (default)`. One row is returned
+-- per fully-evaluated commit with the list of blocking folded jobs; the client
+-- computes how often each job (and each job type) is the *only* blocker.
+WITH commits AS (
+    SELECT DISTINCT
+        p.head_commit. 'id' AS sha,
+        p.head_commit. 'timestamp' AS time,
+        -- first line of the commit message, for the commit-range caption
+        substring(arrayElement(splitByChar('\n', p.head_commit. 'message'), 1), 1, 120) AS title
+    FROM
+        default.push p
+    WHERE
+        p.ref = 'refs/heads/main'
+        AND p.repository. 'owner'.'name' = 'pytorch'
+        AND p.repository. 'name' = 'pytorch'
+        AND p.head_commit. 'timestamp' >= {startTime: DateTime64(3) }
+        AND p.head_commit. 'timestamp' < {stopTime: DateTime64(3) }
+),
+-- Open UNSTABLE issues, trimmed to the shard-folded job name they disable
+unstable_jobs AS (
+    SELECT
+        trim(substring(issue.title, length('UNSTABLE') + 1)) AS name
+    FROM
+        default.issues AS issue FINAL
+    WHERE
+        arrayExists(x -> x. 'name' = 'unstable', issue.labels)
+        AND issue.state = 'open'
+        AND issue.title LIKE 'UNSTABLE%'
+),
+-- Every gating job (raw shard-attempt rows) for the commits in range
+raw_jobs AS (
+    SELECT
+        w.head_sha AS sha,
+        w.id AS workflow_id,
+        CONCAT(
+            j.workflow_name,
+            ' / ',
+            arrayElement(splitByString(' / ', j.name), 1),
+            ' / ',
+            arrayElement(
+                splitByString(', ', arrayElement(splitByString(' / ', j.name), 2)),
+                1
+            )
+        ) AS folded_name,
+        j.name AS shard,
+        j.run_attempt AS run_attempt,
+        j.conclusion_kg AS conclusion
+    FROM
+        default.workflow_job j FINAL
+        INNER JOIN default.workflow_run w FINAL ON w.id = j.run_id
+    WHERE
+        j.id IN (
+            SELECT id FROM materialized_views.workflow_job_by_head_sha
+            WHERE head_sha IN (SELECT sha FROM commits)
+        )
+        AND w.id IN (
+            SELECT id FROM materialized_views.workflow_run_by_head_sha
+            WHERE head_sha IN (SELECT sha FROM commits)
+        )
+        -- Gating workflow prefixes; keep in sync with the `requires` list in
+        -- pytorch/pytorch .github/workflows/update-viablestrict.yml
+        -- (["pull", "trunk", "lint", "docs-build"] as of 2026-07-27).
+        AND match(lower(j.workflow_name), '^(pull|trunk|lint|docs-build)')
+        AND j.name != 'ciflow_should_run'
+        AND j.name != 'generate-test-matrix'
+        AND j.name NOT LIKE '%rerun_disabled_tests%'
+        AND j.name NOT LIKE '%filter%'
+        AND j.name NOT LIKE '%unstable%'
+        AND j.name LIKE '%/%'
+        AND w.event != 'workflow_run' -- these are unrelated to the SHA
+        AND w.event != 'repository_dispatch'
+        AND NOT (w.event = 'workflow_dispatch' AND w.head_branch LIKE 'trunk/%') -- restart jobs
+),
+-- Collapse reruns: keep the latest run attempt per shard, per workflow run.
+-- workflow_id is in the key because run_attempt is a per-run counter (not
+-- globally comparable), so duplicate workflow runs for one commit must stay
+-- separate; folded_job below then ORs a red run in -- mirroring the gate's
+-- per-(workflow_id, job) grouping in commit_jobs_batch_query.
+shard_latest AS (
+    SELECT
+        sha,
+        IF(
+            folded_name LIKE '%(%' AND folded_name NOT LIKE '%)%',
+            CONCAT(folded_name, ')'),
+            folded_name
+        ) AS name,
+        shard,
+        workflow_id,
+        argMax(conclusion, run_attempt) AS conclusion
+    FROM
+        raw_jobs
+    GROUP BY
+        sha,
+        name,
+        shard,
+        workflow_id
+),
+-- Collapse shards: a folded job is blocking if any shard's latest attempt is a
+-- real failure; pending if any shard has no terminal conclusion yet
+folded_job AS (
+    SELECT
+        sha,
+        name,
+        maxIf(
+            1,
+            conclusion IS NOT NULL
+            AND conclusion != ''
+            AND conclusion NOT IN ('success', 'skipped')
+        ) AS blocking,
+        maxIf(1, conclusion IS NULL OR conclusion = '') AS pending
+    FROM
+        shard_latest
+    WHERE
+        name NOT IN (SELECT name FROM unstable_jobs) -- drop already-unstable jobs
+    GROUP BY
+        sha,
+        name
+),
+commit_agg AS (
+    SELECT
+        sha,
+        max(pending) AS any_pending,
+        arrayFilter(x -> x != '', groupArray(IF(blocking = 1, name, ''))) AS blocking
+    FROM
+        folded_job
+    GROUP BY
+        sha
+)
+SELECT
+    c.time AS time,
+    ca.sha AS sha,
+    c.title AS title,
+    ca.blocking AS blocking
+FROM
+    commit_agg ca
+    JOIN commits c ON c.sha = ca.sha
+WHERE
+    ca.any_pending = 0 -- only fully-evaluated commits count toward the denominator
+ORDER BY
+    time DESC

--- a/torchci/components/layout/NavBar.tsx
+++ b/torchci/components/layout/NavBar.tsx
@@ -31,7 +31,7 @@ function NavBar() {
       href: "/job_cancellation_dashboard",
     },
     {
-      name: "Failures Metric",
+      name: "Reliability Metrics",
       href: "/reliability",
     },
     {

--- a/torchci/lib/metricUtils.ts
+++ b/torchci/lib/metricUtils.ts
@@ -153,6 +153,137 @@ export function approximateFailureByType(
   return failuresByTypes;
 }
 
+// A commit's viable/strict gating state: the list of gating jobs (folded to
+// config granularity, shards collapsed) that are blocking it. Produced by the
+// viable_strict_sole_blocker ClickHouse query.
+export interface SoleBlockerCommit {
+  time: string;
+  sha: string;
+  // first line of the commit message (for the commit-range caption)
+  title?: string;
+  blocking: string[];
+}
+
+// The span of commits the sole-blocker table was computed over, for
+// debuggability ("Last 1 day = commit A .. commit B").
+export interface SoleBlockerRange {
+  count: number;
+  oldest?: { sha: string; title: string; time: string };
+  newest?: { sha: string; title: string; time: string };
+}
+
+export function soleBlockerCommitRange(
+  data?: SoleBlockerCommit[]
+): SoleBlockerRange {
+  if (!data || data.length === 0) {
+    return { count: 0 };
+  }
+
+  // ISO timestamps sort lexicographically, so scan for min/max without
+  // assuming the input is ordered.
+  let oldest = data[0];
+  let newest = data[0];
+  data.forEach((commit) => {
+    if (commit.time < oldest.time) oldest = commit;
+    if (commit.time > newest.time) newest = commit;
+  });
+
+  const pick = (c: SoleBlockerCommit) => ({
+    sha: c.sha,
+    title: c.title ?? "",
+    time: c.time,
+  });
+  return { count: data.length, oldest: pick(oldest), newest: pick(newest) };
+}
+
+export interface SoleBlockerRow {
+  name: string;
+  // % of evaluated commits where this exact job (config) is the only blocker
+  sole: number;
+  // % of evaluated commits where only this job's job type is blocking (possibly
+  // via several of its configs at once)
+  soleJobType: number;
+}
+
+// The job type is the workflow + base job name, dropping the test config, e.g.
+// "trunk / linux-jammy-rocm-py3.10-mi350 / test (default)" ->
+// "trunk / linux-jammy-rocm-py3.10-mi350".
+export function jobTypeOf(name: string): string {
+  return name.split(" / ").slice(0, 2).join(" / ");
+}
+
+// For each gating job, compute how often it is the *only* thing blocking
+// viable/strict, both at config granularity and folded up to the job type.
+// The denominator is every fully-evaluated commit in the range, so the value
+// reads as "this job alone blocks X% of all main commits".
+//
+// Rows are pruned to the ones that carry signal: a config is shown if it was
+// ever individually the sole blocker (sole > 0). Configs that are never
+// individually sole but belong to a sole-blocking job type are suppressed as
+// redundant, UNLESS no sibling config of that job type is individually sole --
+// i.e. the job type only ever blocks via several of its configs failing
+// together. In that combo-only case the 0-config rows are kept so the job-type
+// signal is never hidden.
+export function computeSoleBlockers(
+  data?: SoleBlockerCommit[]
+): SoleBlockerRow[] {
+  if (!data) {
+    return [];
+  }
+
+  const total = data.length;
+  const soleConfigCount: { [name: string]: number } = {};
+  const soleJobTypeCount: { [jobType: string]: number } = {};
+  const seenConfigs = new Set<string>();
+
+  data.forEach((commit) => {
+    const blocking = (commit.blocking ?? []).filter((n) => n && n.length > 0);
+    blocking.forEach((n) => seenConfigs.add(n));
+
+    // Sole at config granularity: exactly one folded job is blocking
+    const configs = new Set(blocking);
+    if (configs.size === 1) {
+      const only = configs.values().next().value as string;
+      soleConfigCount[only] = (soleConfigCount[only] ?? 0) + 1;
+    }
+
+    // Sole at job-type granularity: all blocking jobs belong to one job type
+    // (there may be several configs of the same job type)
+    const jobTypes = new Set(blocking.map(jobTypeOf));
+    if (blocking.length >= 1 && jobTypes.size === 1) {
+      const only = jobTypes.values().next().value as string;
+      soleJobTypeCount[only] = (soleJobTypeCount[only] ?? 0) + 1;
+    }
+  });
+
+  const candidates = Array.from(seenConfigs)
+    .map((name) => ({
+      name,
+      sole: total ? ((soleConfigCount[name] ?? 0) / total) * 100 : 0,
+      soleJobType: total
+        ? ((soleJobTypeCount[jobTypeOf(name)] ?? 0) / total) * 100
+        : 0,
+    }))
+    .filter((row) => row.sole > 0 || row.soleJobType > 0);
+
+  // Job types that already have an individually-sole config, i.e. an actionable
+  // row. Their non-sole sibling configs are redundant and get dropped.
+  const jobTypesWithSoleConfig = new Set(
+    candidates.filter((row) => row.sole > 0).map((row) => jobTypeOf(row.name))
+  );
+
+  return candidates
+    .filter(
+      (row) => row.sole > 0 || !jobTypesWithSoleConfig.has(jobTypeOf(row.name))
+    )
+    .sort(
+      (a, b) =>
+        b.soleJobType - a.soleJobType ||
+        b.sole - a.sole ||
+        a.name.localeCompare(b.name)
+    );
+}
+
 export function approximateFailureByTypePercent(
   // The data is sorted by time DESC, so newer commits come first
   data?: JobsPerCommitData[],

--- a/torchci/lib/metricUtils.ts
+++ b/torchci/lib/metricUtils.ts
@@ -205,11 +205,16 @@ export interface SoleBlockerRow {
   soleJobType: number;
 }
 
-// The job type is the workflow + base job name, dropping the test config, e.g.
-// "trunk / linux-jammy-rocm-py3.10-mi350 / test (default)" ->
-// "trunk / linux-jammy-rocm-py3.10-mi350".
+// The job type is the job with its trailing test config dropped, so a job's
+// configs fold together. For the common "workflow / machine / test (config)"
+// shape this is "workflow / machine". For nested jobs (>2 " / " components, e.g.
+// "trunk / dynamo-unittest / dynamo-test (3.11) / test (dynamo_core)") it drops
+// only the config and keeps the matrix instance
+// ("trunk / dynamo-unittest / dynamo-test (3.11)"), so distinct python versions
+// aren't collapsed together. Slashless / 2-part names have no config to drop.
 export function jobTypeOf(name: string): string {
-  return name.split(" / ").slice(0, 2).join(" / ");
+  const parts = name.split(" / ");
+  return parts.length >= 3 ? parts.slice(0, -1).join(" / ") : name;
 }
 
 // For each gating job, compute how often it is the *only* thing blocking

--- a/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
+++ b/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
@@ -42,6 +42,7 @@ const URL_PREFIX = `/reliability/pytorch/pytorch?jobName=`;
 // Specialized version of TablePanel for reliability metrics
 function GroupReliabilityPanel({
   title,
+  subtitle,
   queryName,
   queryParams,
   metricHeaderName,
@@ -49,6 +50,8 @@ function GroupReliabilityPanel({
   filter,
 }: {
   title: string;
+  // Optional grey line under the title, e.g. the workflows this group covers.
+  subtitle?: string;
   queryName: string;
   queryParams: { [key: string]: any };
   metricHeaderName: string;
@@ -86,9 +89,28 @@ function GroupReliabilityPanel({
     })
     .sort((a, b) => Number(b[metricName]) - Number(a[metricName]));
 
+  const titleNode = subtitle ? (
+    <>
+      {title}
+      <Typography
+        component="span"
+        sx={{
+          display: "block",
+          fontWeight: 400,
+          fontSize: "12px",
+          color: "text.secondary",
+        }}
+      >
+        {subtitle}
+      </Typography>
+    </>
+  ) : (
+    title
+  );
+
   return (
     <TablePanelWithData
-      title={title}
+      title={titleNode}
       data={failuresByTypes}
       columns={[
         {
@@ -518,7 +540,8 @@ export default function Page() {
       <Grid container spacing={2}>
         <Grid size={{ xs: 6 }} height={ROW_HEIGHT}>
           <GroupReliabilityPanel
-            title={`Primary jobs (${PRIMARY_WORKFLOWS.join(", ")})`}
+            title={"Viable/strict blocking jobs"}
+            subtitle={PRIMARY_WORKFLOWS.join(", ")}
             queryName={queryName}
             queryParams={{
               workflowNames: PRIMARY_WORKFLOWS,
@@ -532,7 +555,8 @@ export default function Page() {
 
         <Grid size={{ xs: 6 }} height={ROW_HEIGHT}>
           <GroupReliabilityPanel
-            title={`Secondary jobs (${SECONDARY_WORKFLOWS.join(", ")})`}
+            title={"Non-blocking jobs"}
+            subtitle={SECONDARY_WORKFLOWS.join(", ")}
             queryName={queryName}
             queryParams={{
               workflowNames: SECONDARY_WORKFLOWS,

--- a/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
+++ b/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
@@ -13,7 +13,11 @@ import dayjs from "dayjs";
 import { EChartsOption } from "echarts";
 import ReactECharts from "echarts-for-react";
 import { fetcher } from "lib/GeneralUtils";
-import { approximateFailureByTypePercent } from "lib/metricUtils";
+import {
+  approximateFailureByTypePercent,
+  computeSoleBlockers,
+  soleBlockerCommitRange,
+} from "lib/metricUtils";
 import { JobAnnotation } from "lib/types";
 import { useRouter } from "next/router";
 import { useCallback, useState } from "react";
@@ -125,6 +129,134 @@ function GroupReliabilityPanel({
           flex: 5,
           // valueFormatter only treat the return value as string, so we need
           // to use renderCell here to get the JSX
+          renderCell: (params: GridRenderCellParams<any, string>) => {
+            const jobName = params.value;
+            if (jobName === undefined) {
+              return `Invalid job name ${jobName}`;
+            }
+
+            const encodedJobName = encodeURIComponent(jobName);
+            return <a href={URL_PREFIX + encodedJobName}>{jobName}</a>;
+          },
+          cellClassName: (params: GridCellParams<any, string>) => {
+            const jobName = params.value;
+            if (jobName === undefined) {
+              return "";
+            }
+
+            return filter.has(jobName) ? styles.selectedRow : "";
+          },
+        },
+      ]}
+      dataGridProps={{ getRowId: (el: any) => el.name }}
+    />
+  );
+}
+
+// Table of jobs that solely block viable/strict. Unlike the failure-rate panels
+// this metric is defined at the commit gate, so it needs its own query
+// (viable/strict gating semantics) and client-side aggregation.
+function SoleBlockerPanel({
+  queryParams,
+  filter,
+}: {
+  queryParams: { [key: string]: any };
+  filter: any;
+}) {
+  const url = `/api/clickhouse/viable_strict_sole_blocker?parameters=${encodeURIComponent(
+    JSON.stringify(queryParams)
+  )}`;
+
+  const { data } = useSWR(url, fetcher, {
+    refreshInterval: 60 * 60 * 1000,
+  });
+
+  if (data === undefined) {
+    return <Skeleton variant={"rectangular"} height={"100%"} />;
+  }
+
+  const rows = computeSoleBlockers(data);
+  const range = soleBlockerCommitRange(data);
+
+  // Show the actual commit span the percentages were computed over, so the
+  // numbers are debuggable ("Last 1 day = commit A .. commit B").
+  const commitRef = (c: { sha: string; title: string; time: string }) => (
+    <a href={`/pytorch/pytorch/commit/${c.sha}`} title={`${c.sha}\n${c.title}`}>
+      {c.sha.substring(0, 7)}
+    </a>
+  );
+  const shortTitle = (t: string) =>
+    t.length > 44 ? t.substring(0, 43) + "…" : t;
+  const fmt = (t: string) => dayjs(t).format("MM/DD HH:mm");
+
+  const title = (
+    <>
+      Sole viable/strict blockers
+      <Typography
+        component="span"
+        sx={{
+          display: "block",
+          fontWeight: 400,
+          fontSize: "12px",
+          color: "text.secondary",
+        }}
+      >
+        {range.count === 0 || !range.oldest || !range.newest ? (
+          "no fully-evaluated commits in range"
+        ) : (
+          <>
+            {range.count} commits · {commitRef(range.oldest)}{" "}
+            {shortTitle(range.oldest.title)} ({fmt(range.oldest.time)}) →{" "}
+            {commitRef(range.newest)} {shortTitle(range.newest.title)} (
+            {fmt(range.newest.time)})
+          </>
+        )}
+      </Typography>
+      <Typography
+        component="span"
+        sx={{
+          display: "block",
+          fontWeight: 400,
+          fontStyle: "italic",
+          fontSize: "11px",
+          color: "text.secondary",
+        }}
+      >
+        Job-type % folds all configs of a job together; it is shared across the
+        job type&apos;s rows and is not additive.
+      </Typography>
+    </>
+  );
+
+  return (
+    <TablePanelWithData
+      title={title}
+      data={rows}
+      columns={[
+        {
+          field: "sole",
+          headerName: "Sole blocking %",
+          description:
+            "% of evaluated commits where this exact config is the only job blocking viable/strict.",
+          flex: 1,
+          valueFormatter: (value) => {
+            return Number(value).toFixed(2);
+          },
+        },
+        {
+          field: "soleJobType",
+          headerName: "Sole blocking % (job type)",
+          description:
+            "% of evaluated commits where only this job type blocks (via any of its configs). Shared across the job type's rows — not additive.",
+          flex: 1,
+          valueFormatter: (value) => {
+            return Number(value).toFixed(2);
+          },
+        },
+        {
+          field: "name",
+          headerName: "Name",
+          flex: 5,
           renderCell: (params: GridRenderCellParams<any, string>) => {
             const jobName = params.value;
             if (jobName === undefined) {
@@ -335,7 +467,7 @@ export default function Page() {
     <div>
       <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
         <Typography fontSize={"2rem"} fontWeight={"bold"}>
-          Failures
+          Reliability
         </Typography>
         <TimeRangePicker
           startTime={startTime}
@@ -391,6 +523,10 @@ export default function Page() {
             metricHeaderName={metricHeaderName}
             filter={filter}
           />
+        </Grid>
+
+        <Grid size={{ xs: 6 }} height={ROW_HEIGHT}>
+          <SoleBlockerPanel queryParams={queryParams} filter={filter} />
         </Grid>
 
         <Grid size={{ xs: 6 }} height={ROW_HEIGHT}>

--- a/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
+++ b/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
@@ -222,8 +222,8 @@ function SoleBlockerPanel({
           color: "text.secondary",
         }}
       >
-        Job-type % folds all configs of a job together; it is shared across the
-        job type&apos;s rows and is not additive.
+        The &quot;By job (all configs)&quot; column folds a job&apos;s configs
+        together; it is shared across the job&apos;s rows and is not additive.
       </Typography>
     </>
   );
@@ -235,7 +235,7 @@ function SoleBlockerPanel({
       columns={[
         {
           field: "sole",
-          headerName: "Sole blocking %",
+          headerName: "By config",
           description:
             "% of evaluated commits where this exact config is the only job blocking viable/strict.",
           flex: 1,
@@ -245,9 +245,9 @@ function SoleBlockerPanel({
         },
         {
           field: "soleJobType",
-          headerName: "Sole blocking % (job type)",
+          headerName: "By job (all configs)",
           description:
-            "% of evaluated commits where only this job type blocks (via any of its configs). Shared across the job type's rows — not additive.",
+            "% of evaluated commits where this job is the only thing blocking, via any of its configs. Shared across the job's rows — not additive.",
           flex: 1,
           valueFormatter: (value) => {
             return Number(value).toFixed(2);
@@ -276,7 +276,26 @@ function SoleBlockerPanel({
           },
         },
       ]}
-      dataGridProps={{ getRowId: (el: any) => el.name }}
+      dataGridProps={{
+        getRowId: (el: any) => el.name,
+        // Group the two percentage columns under one header so they read as
+        // "Sole viable/strict blocker %: By config | By job", rather than two
+        // near-identically named columns. Name gets its own (untitled) group so
+        // every column has a two-row header and it doesn't render with a ragged
+        // empty cell above it.
+        columnGroupingModel: [
+          {
+            groupId: "soleBlocking",
+            headerName: "Sole viable/strict blocker %",
+            children: [{ field: "sole" }, { field: "soleJobType" }],
+          },
+          {
+            groupId: "job",
+            headerName: "",
+            children: [{ field: "name" }],
+          },
+        ],
+      }}
     />
   );
 }

--- a/torchci/test/metricUtils.test.ts
+++ b/torchci/test/metricUtils.test.ts
@@ -254,6 +254,40 @@ describe("Sole viable/strict blockers", () => {
     expect(jobTypeOf("trunk / A / test (default)")).toBe("trunk / A");
     expect(jobTypeOf("trunk / A / build")).toBe("trunk / A");
     expect(jobTypeOf("lint / quick-checks")).toBe("lint / quick-checks");
+    // Nested jobs (>2 " / " components) drop only the trailing config, keeping
+    // the matrix instance (e.g. the python version) distinct.
+    expect(
+      jobTypeOf(
+        "trunk / dynamo-unittest / dynamo-test (3.11) / test (dynamo_wrapped)"
+      )
+    ).toBe("trunk / dynamo-unittest / dynamo-test (3.11)");
+    expect(
+      jobTypeOf(
+        "trunk / dynamo-unittest / dynamo-test (3.12) / test (dynamo_core)"
+      )
+    ).toBe("trunk / dynamo-unittest / dynamo-test (3.12)");
+  });
+
+  test("nested job types are config-consistent (no cross-matrix pruning)", () => {
+    // dynamo 3.11/wrapped is the sole blocker on one commit; 3.12 only ever
+    // blocks via a core+wrapped combo. Because 3.11 and 3.12 are DIFFERENT job
+    // types, 3.11's sole config must NOT prune the 3.12 combo rows.
+    const j311w =
+      "trunk / dynamo-unittest / dynamo-test (3.11) / test (dynamo_wrapped)";
+    const j312c =
+      "trunk / dynamo-unittest / dynamo-test (3.12) / test (dynamo_core)";
+    const j312w =
+      "trunk / dynamo-unittest / dynamo-test (3.12) / test (dynamo_wrapped)";
+    const data: SoleBlockerCommit[] = [
+      { sha: "1", time: "", blocking: [j311w] },
+      { sha: "2", time: "", blocking: [j312c, j312w] },
+      { sha: "3", time: "", blocking: [] },
+    ];
+
+    const names = computeSoleBlockers(data).map((r) => r.name);
+    expect(names).toContain(j311w); // sole
+    expect(names).toContain(j312c); // combo-only job type, kept
+    expect(names).toContain(j312w);
   });
 
   test("config-sole vs job-type-sole", () => {

--- a/torchci/test/metricUtils.test.ts
+++ b/torchci/test/metricUtils.test.ts
@@ -3,6 +3,10 @@ import {
   approximateFailureByType,
   approximateFailureByTypePercent,
   BROKEN_TRUNK_THRESHOLD,
+  computeSoleBlockers,
+  jobTypeOf,
+  SoleBlockerCommit,
+  soleBlockerCommitRange,
 } from "../lib/metricUtils";
 
 describe("Approximate failures by its categories", () => {
@@ -236,6 +240,101 @@ describe("Approximate failures by its categories", () => {
         [JobAnnotation.BROKEN_TRUNK]: 0,
         [JobAnnotation.TEST_FLAKE]: 20,
       },
+    });
+  });
+});
+
+describe("Sole viable/strict blockers", () => {
+  test("no data", () => {
+    expect(computeSoleBlockers(undefined)).toStrictEqual([]);
+    expect(computeSoleBlockers([])).toStrictEqual([]);
+  });
+
+  test("job type folds workflow + base name, drops config", () => {
+    expect(jobTypeOf("trunk / A / test (default)")).toBe("trunk / A");
+    expect(jobTypeOf("trunk / A / build")).toBe("trunk / A");
+    expect(jobTypeOf("lint / quick-checks")).toBe("lint / quick-checks");
+  });
+
+  test("config-sole vs job-type-sole", () => {
+    // 5 evaluated commits; the last is green and only counts toward the total.
+    const data: SoleBlockerCommit[] = [
+      // A/default is the only blocker -> sole at both granularities
+      { sha: "1", time: "", blocking: ["trunk / A / test (default)"] },
+      // two configs of A -> not config-sole, but A is still the only job type
+      {
+        sha: "2",
+        time: "",
+        blocking: ["trunk / A / test (default)", "trunk / A / test (inductor)"],
+      },
+      // two different job types -> sole at neither granularity
+      {
+        sha: "3",
+        time: "",
+        blocking: ["trunk / A / test (default)", "trunk / B / build"],
+      },
+      // B/build is the only blocker
+      { sha: "4", time: "", blocking: ["trunk / B / build"] },
+      // green commit
+      { sha: "5", time: "", blocking: [] },
+    ];
+
+    expect(computeSoleBlockers(data)).toStrictEqual([
+      // A/default: sole 1/5, job type A sole 2/5 (commits 1 and 2)
+      {
+        name: "trunk / A / test (default)",
+        sole: 20,
+        soleJobType: 40,
+      },
+      // A/inductor is dropped: never individually sole, and its job type A
+      // already has an actionable row (A/default), so it is redundant.
+      // B/build: sole 1/5, job type B sole 1/5
+      { name: "trunk / B / build", sole: 20, soleJobType: 20 },
+    ]);
+  });
+
+  test("combo-only job type keeps its configs (no sole sibling to fall back on)", () => {
+    // A job type that only ever blocks via two of its configs failing together,
+    // so no single config is individually sole. Both rows must be kept so the
+    // job-type signal is not hidden.
+    const data: SoleBlockerCommit[] = [
+      {
+        sha: "1",
+        time: "",
+        blocking: ["trunk / C / test (x)", "trunk / C / test (y)"],
+      },
+      { sha: "2", time: "", blocking: [] },
+    ];
+
+    expect(computeSoleBlockers(data)).toStrictEqual([
+      { name: "trunk / C / test (x)", sole: 0, soleJobType: 50 },
+      { name: "trunk / C / test (y)", sole: 0, soleJobType: 50 },
+    ]);
+  });
+
+  test("commit range picks oldest/newest regardless of input order", () => {
+    expect(soleBlockerCommitRange(undefined)).toStrictEqual({ count: 0 });
+    expect(soleBlockerCommitRange([])).toStrictEqual({ count: 0 });
+
+    const data: SoleBlockerCommit[] = [
+      {
+        sha: "bbb",
+        time: "2026-07-27T09:00:00Z",
+        title: "newer",
+        blocking: [],
+      },
+      {
+        sha: "aaa",
+        time: "2026-07-26T09:00:00Z",
+        title: "older",
+        blocking: [],
+      },
+      { sha: "ccc", time: "2026-07-27T03:00:00Z", title: "mid", blocking: [] },
+    ];
+    expect(soleBlockerCommitRange(data)).toStrictEqual({
+      count: 3,
+      oldest: { sha: "aaa", title: "older", time: "2026-07-26T09:00:00Z" },
+      newest: { sha: "bbb", title: "newer", time: "2026-07-27T09:00:00Z" },
     });
   });
 });

--- a/torchci/test/viableStrictSoleBlocker.test.ts
+++ b/torchci/test/viableStrictSoleBlocker.test.ts
@@ -1,0 +1,102 @@
+import { readFileSync } from "fs";
+import path from "path";
+
+// The "Sole viable/strict blockers" table folds shards in ClickHouse
+// (clickhouse_queries/viable_strict_sole_blocker/query.sql), so the folding
+// behavior can't be exercised by importing a TS function. These tests instead
+// (1) mirror the exact regex to lock in the intended transformation, and
+// (2) statically assert query.sql still uses that fold + the intended filters,
+// so a change to one without the other is caught.
+
+const QUERY_SQL = path.resolve(
+  __dirname,
+  "..",
+  "clickhouse_queries",
+  "viable_strict_sole_blocker",
+  "query.sql"
+);
+
+// Mirrors: replaceRegexpOne(j.name, ', [0-9]+, [0-9]+.*\)$', ')')
+// ClickHouse replaceRegexpOne replaces the FIRST match; a non-global JS replace
+// does the same. The full folded name is `${workflow} / ${foldShard(j.name)}`.
+const foldShard = (name: string) => name.replace(/, \d+, \d+.*\)$/, ")");
+
+describe("viable/strict sole blocker shard fold (mirrors query.sql)", () => {
+  test("strips the shard suffix but keeps the config, at any nesting depth", () => {
+    // 2-component name
+    expect(
+      foldShard(
+        "linux-jammy-py3.10-gcc11 / test (default, 1, 3, linux.4xlarge)"
+      )
+    ).toBe("linux-jammy-py3.10-gcc11 / test (default)");
+
+    // nested (3-component): the config is the LAST group; the earlier "(3.11)"
+    // matrix instance is preserved, not dropped.
+    expect(
+      foldShard(
+        "dynamo-unittest / dynamo-test (3.11) / test (dynamo_wrapped, 6, 7, mt-l-x86iavx512-8-64)"
+      )
+    ).toBe("dynamo-unittest / dynamo-test (3.11) / test (dynamo_wrapped)");
+
+    // dynamo_core vs dynamo_wrapped stay DISTINCT (the note #2 bug)
+    expect(
+      foldShard(
+        "dynamo-unittest / dynamo-test (3.11) / test (dynamo_core, 1, 1, mt-l-x86iavx512-8-64)"
+      )
+    ).toBe("dynamo-unittest / dynamo-test (3.11) / test (dynamo_core)");
+  });
+
+  test("all shards of one config collapse to the same folded name", () => {
+    const a = foldShard("m / test (default, 1, 5, linux.4xlarge)");
+    const b = foldShard("m / test (default, 3, 5, linux.4xlarge)");
+    expect(a).toBe(b);
+    expect(a).toBe("m / test (default)");
+  });
+
+  test("leaves names without a shard suffix untouched", () => {
+    expect(foldShard("linux-jammy-py3.10-gcc11 / build")).toBe(
+      "linux-jammy-py3.10-gcc11 / build"
+    );
+    expect(foldShard("m / test (default)")).toBe("m / test (default)"); // already folded
+    expect(foldShard("pylint")).toBe("pylint"); // slashless lint job
+    // multi-dimension configs use commas that aren't ", <int>, <int>", so they
+    // are preserved distinct (executorch-shaped jobs).
+    expect(foldShard("test-backend-linux (qnn, models)")).toBe(
+      "test-backend-linux (qnn, models)"
+    );
+    expect(foldShard("run (mv3, cortex-m7)")).toBe("run (mv3, cortex-m7)");
+  });
+
+  test("a trailing marker after the shard fields is also stripped (why unstable/rerun are filtered pre-fold, to avoid colliding with the real gating job)", () => {
+    expect(foldShard("test (default, 1, 10, linux.rocm.gpu, unstable)")).toBe(
+      "test (default)"
+    );
+    expect(
+      foldShard("test (default, 5, 8, linux.rocm.gpu, rerun_disabled_tests)")
+    ).toBe("test (default)");
+  });
+});
+
+describe("viable/strict sole blocker query.sql stays in sync with the fold + filters", () => {
+  const sql = readFileSync(QUERY_SQL, "utf8");
+
+  test("uses the shard-strip regex fold, not the old segment-slicing fold", () => {
+    // substrings, to stay robust to the SQL backslash escaping of the regex
+    expect(sql).toContain("replaceRegexpOne(j.name");
+    expect(sql).toContain(", [0-9]+, [0-9]+");
+    // old fold assumed exactly two " / " components
+    expect(sql).not.toContain("splitByString(' / ', j.name), 2)");
+  });
+
+  test("keeps the gate's job filters + the fold-collision filters, drops the over-filters", () => {
+    // gate parity
+    expect(sql).toContain("j.name != 'ciflow_should_run'");
+    expect(sql).toContain("j.name != 'generate-test-matrix'");
+    // kept: their trailing marker would fold onto the real gating job
+    expect(sql).toContain("j.name NOT LIKE '%unstable%'");
+    expect(sql).toContain("j.name NOT LIKE '%rerun_disabled_tests%'");
+    // dropped: the gate gates on these; they fold to distinct names
+    expect(sql).not.toContain("j.name NOT LIKE '%filter%'");
+    expect(sql).not.toContain("j.name LIKE '%/%'");
+  });
+});


### PR DESCRIPTION
[HUD] Add sole viable/strict blocker % to reliability page

## Summary

Adds a **Sole viable/strict blockers** table under the Primary jobs table on `/reliability`. For each gating job (shards folded to config granularity) it shows the % of all *decided* trunk commits where it is the **only** job blocking viable/strict, plus a column that aggregates over the job type.

## Details

- **Attributes sole-blocking among the workflows that actually reported**, using the same job-level red signal as the real gate (`conclusion_kg`, latest attempt per workflow run, `pull`/`trunk`/`lint`/`docs-build` prefixes, unstable jobs excluded) — so a job is flagged only when it genuinely failed. The one gate case it doesn't reproduce (a required workflow never reporting at all) is left unattributed and counted non-blocking, so it errs toward **under**-counting rather than over-blaming. All four gating workflows fire on essentially every push to main, so it's a close approximation of the gate.
- **Denominator** is every fully-decided commit in the range (commits with a pending gating job are dropped). A caption shows the evaluated commit span (count + oldest/newest sha + title) so the % is debuggable against the selected range.
- **Job-type %** folds all configs of a job together and is shared across its rows (not additive). Rows that are never individually sole are pruned, unless the job type only ever blocks via several configs failing together.
- **Rename**: page heading `Failures` → `Reliability`, and the Dev Infra nav entry → **Reliability Metrics**.

## Test plan

- Query validated live against ClickHouse
- Aggregation (`computeSoleBlockers`) unit-tested
- `tsc` / `next lint` / `prettier` clean
- Inspected results over a 3 day window by cross-comparing with HUD.
