### PR TITLE
[CI] Prototype sanitized live Claude progress

### DIFF
--- a/.github/workflows/_claude-code.yml
+++ b/.github/workflows/_claude-code.yml
@@ -28,6 +28,10 @@ on:
         description: 'Claude settings JSON'
         type: string
         default: '{"alwaysThinkingEnabled": true}'
+      enable_safe_progress:
+        description: 'Log sanitized model, retry, and tool progress without message contents'
+        type: boolean
+        default: false
       setup_script:
         description: 'Shell commands to run before Claude (e.g. install lintrunner)'
         type: string
@@ -179,13 +183,14 @@ jobs:
             console.log(`Set commit author to: ${name} <${email}>`);
 
       - name: Run Claude Code
-        uses: anthropics/claude-code-action@593d7a5c4e0073569f74772c2b7b64c30ec14707 # v1.0.141
+        uses: drisspg/claude-code-action-progress@92db82fd676eff339a6f35fa3680c8dbbf5488b4
         with:
           allowed_bots: "*"
           use_bedrock: "true"
           claude_args: "--model ${{ inputs.model }} ${{ inputs.additional_claude_args }} ${{ steps.ghstack-check.outputs.extra_claude_args }}"
           settings: ${{ inputs.settings }}
         env:
+          CLAUDE_CODE_ACTION_PROGRESS: ${{ inputs.enable_safe_progress && '1' || '0' }}
           APPEND_SYSTEM_PROMPT: |
               ${{ steps.ghstack-check.outputs.ghstack_notice }}
               ${{ inputs.append_system_prompt }}

--- a/.github/workflows/_claude-code.yml
+++ b/.github/workflows/_claude-code.yml
@@ -183,7 +183,7 @@ jobs:
             console.log(`Set commit author to: ${name} <${email}>`);
 
       - name: Run Claude Code
-        uses: drisspg/claude-code-action-progress@92db82fd676eff339a6f35fa3680c8dbbf5488b4
+        uses: drisspg/claude-code-action-progress@8c6c7fee3659895ff32ff3f81096480ec7355c18
         with:
           allowed_bots: "*"
           use_bedrock: "true"


### PR DESCRIPTION
## Summary

Prototype an opt-in safe-progress mode for Claude Code jobs so long-running reviews no longer appear completely silent.

The reusable workflow exposes `enable_safe_progress`. When enabled, the action logs only operational metadata:

- model-response completion and token counts
- tool names and completion/error counts
- API retry attempt, status/error class, and backoff
- a 60-second heartbeat with the last sanitized event

It does **not** log prompts, assistant text, file paths, file contents, or tool arguments.

This draft intentionally pins a prototype action fork while we validate the behavior before proposing the action change upstream.

## Validation

- Normal tool flow: https://github.com/pytorch/ciforge/actions/runs/30314939379
- Deliberate 70-second tool call demonstrating heartbeat: https://github.com/pytorch/ciforge/actions/runs/30315039858

Heartbeat excerpt:

```text
[claude-progress +6s] model response received; ...; tools=Bash
[claude-progress +60s] no SDK event for 54s; last=...tools=Bash
[claude-progress +77s] tool execution completed; results=1; errors=0
```

## Test plan

- `bun run typecheck`
- `bun test base-action/test/run-claude-sdk.test.ts`
- `prettier --check base-action/src/run-claude-sdk.ts base-action/test/run-claude-sdk.test.ts`
- End-to-end CIForge runs linked above
