### PR TITLE
Drop CI-wrapper boilerplate lines so the classifier surfaces the real failure

### DIFF
--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -314,10 +314,6 @@ name = 'ghstack merge check error'
 pattern = '^Mergeability Error: .*'
 
 [[rule]]
-name = 'OSDC step script failure'
-pattern = '\[OSDC\] Step script exited.*'
-
-[[rule]]
 name = 'GHA error'
 pattern = '^##\[error\](.*)'
 

--- a/aws/lambda/log-classifier/src/bedrock.rs
+++ b/aws/lambda/log-classifier/src/bedrock.rs
@@ -175,12 +175,12 @@ mod test {
         let log_content = fs::read_to_string("fixtures/error_log1.txt");
         let log = Log::new(log_content.unwrap());
         // Define the error line and number of lines for the snippet
-        let error_line = "<error_line>##[error]Process completed with exit code 1.</error_line>";
+        let error_line = "<error_line>OSError: We couldn't connect to 'https://huggingface.co' to load this file, couldn't find it in the cached files and it looks like t5-small is not the path to a directory containing a file named config.json.</error_line>";
         let (_, validation_result) = validate_output_in_log(error_line, &log);
         // Assert is error_line
         assert_eq!(
             validation_result,
-            Some("##[error]Process completed with exit code 1.".to_string())
+            Some("OSError: We couldn't connect to 'https://huggingface.co' to load this file, couldn't find it in the cached files and it looks like t5-small is not the path to a directory containing a file named config.json.".to_string())
         );
     }
 

--- a/aws/lambda/log-classifier/src/engine.rs
+++ b/aws/lambda/log-classifier/src/engine.rs
@@ -91,7 +91,7 @@ pub fn evaluate_ruleset_all_lines(ruleset: &RuleSet, log: &Log) -> Vec<usize> {
 ///
 /// This function will panic if:
 /// * `min_context_padding` is greater than or equal to `max_chunk_size`.
-/// * Any line number is less than 1 or greater than the number of lines in the log.
+/// * Any line number is less than 1 or greater than the highest line number present in the log.
 fn get_line_number_chunks(
     log: &Log,
     line_numbers: Vec<usize>,
@@ -112,8 +112,10 @@ fn get_line_number_chunks(
     let mut line_numbers = line_numbers;
     line_numbers.sort();
 
-    // assert length of log is at least last line number and no negative line numbers
-    if *line_numbers.first().unwrap() < 1 || *line_numbers.last().unwrap() > log.lines.len() {
+    // Keys are original 1-indexed line positions; dropped lines leave gaps, so the
+    // highest key can exceed log.lines.len(). Bound against the max key, not the count.
+    let max_line_number = *log.lines.keys().next_back().unwrap_or(&0);
+    if *line_numbers.first().unwrap() < 1 || *line_numbers.last().unwrap() > max_line_number {
         panic!("line numbers must be within the range of the log");
     }
 
@@ -131,7 +133,7 @@ fn get_line_number_chunks(
             chunk_end = line_number;
         } else {
             chunk_start = chunk_start.saturating_sub(min_context_padding).max(1);
-            chunk_end = min(chunk_end + min_context_padding, log.lines.len());
+            chunk_end = min(chunk_end + min_context_padding, max_line_number);
 
             merged_line_numbers.push((chunk_start, chunk_end));
             chunk_start = line_number;
@@ -141,7 +143,7 @@ fn get_line_number_chunks(
     // add remaining chunk
     merged_line_numbers.push((
         chunk_start.saturating_sub(min_context_padding).max(1),
-        min(chunk_end + min_context_padding, log.lines.len()),
+        min(chunk_end + min_context_padding, max_line_number),
     ));
 
     // if there are chunks with the same start point keep the largest chunk and remove the rest
@@ -391,7 +393,7 @@ mod test {
         let log_content = fs::read_to_string("fixtures/error_log1.txt");
         let log = Log::new(log_content.unwrap());
         // Define the error line and number of lines for the snippet
-        let error_line = Vec::from([4047]);
+        let error_line = Vec::from([4037]);
         let num_lines = 10;
 
         // Call the function
@@ -421,5 +423,23 @@ mod test {
         let result_string = result.join("\n");
         // Assert against the snapshot
         assert_snapshot!(result_string);
+    }
+
+    #[test]
+    fn test_get_snippets_sparse_map_key_exceeds_retained_len() {
+        use std::collections::BTreeMap;
+        // A retained line at original position 2 with position 1 dropped during
+        // preprocessing: keys = [2] but len = 1, so the match key exceeds the
+        // retained count. Bounding against len() instead of the max key panics here.
+        let mut lines = BTreeMap::new();
+        lines.insert(2, "the real error line".to_string());
+        let log = Log { lines };
+
+        // Mirrors the Bedrock make_query call shape: get_snippets(log, [key], num/2, num+1).
+        let chunks = get_line_number_chunks(&log, vec![2], 50, 101);
+        assert_eq!(chunks, vec![(1, 2)]);
+
+        let snippets = get_snippets(&log, vec![2], 50, 101);
+        assert_eq!(snippets, vec!["the real error line\n".to_string()]);
     }
 }

--- a/aws/lambda/log-classifier/src/log.rs
+++ b/aws/lambda/log-classifier/src/log.rs
@@ -22,6 +22,19 @@ static ESCAPE_CODE_REGEX: Lazy<Regex> = Lazy::new(|| {
 static TIMESTAMP_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z ").unwrap());
 
+/// Lines that are pure CI-wrapper boilerplate: they are always emitted when a
+/// step fails but never describe the underlying failure. We drop them during
+/// preprocessing so that matching falls through to the real error line.
+static IGNORE_LINE_REGEXES: Lazy<Vec<Regex>> = Lazy::new(|| {
+    vec![
+        Regex::new(r"^##\[error\]Process completed with exit code \d+\.?$").unwrap(),
+        Regex::new(r"\[OSDC\] Step script exited").unwrap(),
+        Regex::new(r"^##\[error\]Executing the custom container implementation failed").unwrap(),
+        Regex::new(r"^##\[error\]TypeError: Cannot read properties of null \(reading 'jobPod'\)")
+            .unwrap(),
+    ]
+});
+
 impl Log {
     /// Create a log from a string, applying some preprocessing to make it
     /// easier to match against.
@@ -36,6 +49,11 @@ impl Log {
 
             // Strip ANSI escape codes that interfere with matching.
             let line = ESCAPE_CODE_REGEX.replace_all(&line, "");
+
+            // Drop lines that match a known-boilerplate pattern before matching.
+            if IGNORE_LINE_REGEXES.iter().any(|re| re.is_match(&line)) {
+                continue;
+            }
 
             // If this line should be ignored, don't add it to the Log.
             if ignore_state.should_ignore(&line) {
@@ -89,5 +107,78 @@ impl IgnoreStateMachine {
                 false
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const FAKE_TIMESTAMP: &str = "2024-07-08T16:59:08.1747875Z ";
+
+    fn retained_lines(raw: &str) -> Vec<String> {
+        Log::new(raw.to_string())
+            .lines
+            .into_values()
+            .collect::<Vec<_>>()
+    }
+
+    #[test]
+    fn ignore_regexes_match_their_targets() {
+        // Exit code, with and without the trailing period.
+        assert!(IGNORE_LINE_REGEXES[0].is_match("##[error]Process completed with exit code 1."));
+        assert!(IGNORE_LINE_REGEXES[0].is_match("##[error]Process completed with exit code 128"));
+        // OSDC wrapper (intentionally unanchored).
+        assert!(IGNORE_LINE_REGEXES[1].is_match("[OSDC] Step script exited with code 1"));
+        // Custom container implementation failure.
+        assert!(IGNORE_LINE_REGEXES[2].is_match(
+            "##[error]Executing the custom container implementation failed with exit code 1."
+        ));
+        // jobPod null-read TypeError.
+        assert!(IGNORE_LINE_REGEXES[3]
+            .is_match("##[error]TypeError: Cannot read properties of null (reading 'jobPod')"));
+    }
+
+    #[test]
+    fn log_new_drops_ignored_boilerplate_lines() {
+        let raw = format!(
+            "{ts}##[error]Process completed with exit code 1.\n\
+             {ts}[OSDC] Step script exited with code 1\n\
+             {ts}##[error]Executing the custom container implementation failed with exit code 1.\n\
+             {ts}##[error]TypeError: Cannot read properties of null (reading 'jobPod')\n\
+             {ts}##[error]RuntimeError: real failure\n\
+             {ts}OSError: boom\n",
+            ts = FAKE_TIMESTAMP
+        );
+        assert_eq!(
+            retained_lines(&raw),
+            vec![
+                "##[error]RuntimeError: real failure".to_string(),
+                "OSError: boom".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn log_new_keeps_lines_that_only_resemble_boilerplate() {
+        let raw = format!(
+            "{ts}##[error]TypeError: something real\n\
+             {ts}some [OSDC] unrelated info line\n",
+            ts = FAKE_TIMESTAMP
+        );
+        assert_eq!(
+            retained_lines(&raw),
+            vec![
+                "##[error]TypeError: something real".to_string(),
+                "some [OSDC] unrelated info line".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn ignore_line_regexes_compile() {
+        // Forcing the Lazy to evaluate runs every Regex::new().unwrap(), which
+        // would panic here if any pattern were malformed.
+        assert_eq!(IGNORE_LINE_REGEXES.len(), 4);
     }
 }

--- a/aws/lambda/log-classifier/src/main.rs
+++ b/aws/lambda/log-classifier/src/main.rs
@@ -288,6 +288,38 @@ mod test {
         );
     }
 
+    #[test]
+    fn evaluate_ruleset_matches_real_error_after_dropping_boilerplate() {
+        let ruleset = RuleSet::new_from_config();
+        let log = Log::new(
+            "\
+            >>> Lint for test/foo.py:\n\
+            ##[error]Process completed with exit code 1.\n\
+            "
+            .into(),
+        );
+        let match_ = evaluate_ruleset(&ruleset, &log).expect("should match the real error line");
+        assert_eq!(match_.line_number, 1);
+        assert_eq!(match_.rule.name, "Lintrunner failure");
+        assert_eq!(log.lines.get(&1).unwrap(), ">>> Lint for test/foo.py:");
+    }
+
+    #[test]
+    fn evaluate_ruleset_returns_none_for_only_boilerplate() {
+        let ruleset = RuleSet::new_from_config();
+        let log = Log::new(
+            "\
+            ##[error]Process completed with exit code 1.\n\
+            [OSDC] Step script exited with code 1\n\
+            "
+            .into(),
+        );
+        // Every line is boilerplate and dropped, so the log is empty; the classify
+        // path yields "No match found" (None) rather than panicking.
+        assert!(log.lines.is_empty());
+        assert!(evaluate_ruleset(&ruleset, &log).is_none());
+    }
+
     // Actually download some id.
     // #[tokio::test]
     // async fn test_real() {

--- a/aws/lambda/log-classifier/src/snapshots/log_classifier__engine__test__get_snippets_on_log.snap
+++ b/aws/lambda/log-classifier/src/snapshots/log_classifier__engine__test__get_snippets_on_log.snap
@@ -2,12 +2,12 @@
 source: src/engine.rs
 expression: result_string
 ---
-    sudo: setrlimit(RLIMIT_STACK): Operation not permitted
-+ echo 'For more details refer to https://github.com/sudo-project/sudo/issues/42'
-For more details refer to https://github.com/sudo-project/sudo/issues/42
-+ sudo chown -R 1000 /var/lib/jenkins/workspace
-##[error]Process completed with exit code 1.
-Prepare all required actions
-Getting action download info
-##[group]Run ./.github/actions/pytest-cache-upload
-with:
+  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/transformers/configuration_utils.py", line 689, in _get_config_dict
+    resolved_config_file = cached_file(
+  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/transformers/utils/hub.py", line 442, in cached_file
+    raise EnvironmentError(
+OSError: We couldn't connect to 'https://huggingface.co' to load this file, couldn't find it in the cached files and it looks like t5-small is not the path to a directory containing a file named config.json.
+Checkout your internet connection or see how to run the library in offline mode at 'https://huggingface.co/docs/transformers/installation#offline-mode'.
++ cleanup_workspace
++ echo 'sudo may print the following warning message that can be ignored. The chown command will still run.'
+sudo may print the following warning message that can be ignored. The chown command will still run.

--- a/aws/lambda/log-classifier/src/snapshots/log_classifier__engine__test__get_snippets_on_log_with_multiple_matches.snap
+++ b/aws/lambda/log-classifier/src/snapshots/log_classifier__engine__test__get_snippets_on_log_with_multiple_matches.snap
@@ -22,7 +22,6 @@ sudo may print the following warning message that can be ignored. The chown comm
 + echo 'For more details refer to https://github.com/sudo-project/sudo/issues/42'
 For more details refer to https://github.com/sudo-project/sudo/issues/42
 + sudo chown -R 1000 /var/lib/jenkins/workspace
-##[error]Process completed with exit code 1.
 Prepare all required actions
 Getting action download info
 ##[group]Run ./.github/actions/pytest-cache-upload


### PR DESCRIPTION
**Impact:** HUD / Dr.CI
**Risk:** low

## What
Boilerplate CI-wrapper lines (`##[error]Process completed with exit code N`, `[OSDC] Step script exited...`, custom-container failures, and the `jobPod` null-read TypeError) are now dropped during log preprocessing instead of being matched as rules, so the classifier falls through to the actual error line.

## Why
These lines are always emitted when a step fails but say nothing about *why* it failed. The old `OSDC step script failure` / generic-error rules would match them and end up displaying a useless "exit code 1" as the failure summary on the HUD, hiding the real error (e.g. an `OSError`/`RuntimeError` a few lines up). Dropping them at preprocessing time lets matching reach the meaningful line.

# Notes
- Dropping lines leaves gaps in the 1-indexed line map, so a retained line's key can exceed `log.lines.len()`. `get_line_number_chunks` now bounds against the highest key rather than the line count to avoid a spurious panic; a regression test covers the sparse-map case.
- The `OSDC step script failure` rule is removed from `ruleset.toml` (now handled by the ignore list). Snapshot/unit tests were updated to reflect the new surfaced error line.