### PR TITLE
[CRCR] Fix the way of searching PR

### DIFF
--- a/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
@@ -216,7 +216,7 @@ def _create_upstream_check_run(
     Best-effort: a GitHub failure must not fail the callback.
     """
     output = gh_helper.build_check_run_output(
-        status, conclusion, details_url, verified_repo, pr_number
+        status, conclusion, details_url, verified_repo
     )
     try:
         upstream_token = gh_helper.get_repo_access_token(
@@ -234,7 +234,7 @@ def _create_upstream_check_run(
             details_url=details_url,
             # Store the downstream run_id so a check-run rerequest can re-run
             # the failed jobs of that workflow run.
-            external_id=str(run_id),
+            external_id=f"{run_id}:{pr_number}" if pr_number else str(run_id),
             output=output,
         )
         logger.info(
@@ -370,7 +370,7 @@ def handle(config: RelayConfig, body: dict, verified_repo: str) -> dict:
     if repo_level.value >= AllowlistLevel.L3.value:
         pr_field = (body.get("payload") or {}).get("pull_request") or {}
         head_sha = (pr_field.get("head") or {}).get("sha", "")
-        pr_number = str(pr_field.get("number", ""))
+        pr_number = str(pr_field.get("number") or "")
         if head_sha:
             conclusion = (body.get("workflow") or {}).get("conclusion")
             details_url = f"https://github.com/{verified_repo}/actions/runs/{run_id}"

--- a/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
@@ -203,6 +203,7 @@ def _create_upstream_check_run(
     workflow_name: str,
     job_name: str | None,
     details_url: str,
+    pr_number: str = "",
 ) -> None:
     """Create a new upstream check run mirroring the downstream job's status.
 
@@ -215,7 +216,7 @@ def _create_upstream_check_run(
     Best-effort: a GitHub failure must not fail the callback.
     """
     output = gh_helper.build_check_run_output(
-        status, conclusion, details_url, verified_repo
+        status, conclusion, details_url, verified_repo, pr_number
     )
     try:
         upstream_token = gh_helper.get_repo_access_token(
@@ -369,6 +370,7 @@ def handle(config: RelayConfig, body: dict, verified_repo: str) -> dict:
     if repo_level.value >= AllowlistLevel.L3.value:
         pr_field = (body.get("payload") or {}).get("pull_request") or {}
         head_sha = (pr_field.get("head") or {}).get("sha", "")
+        pr_number = str(pr_field.get("number", ""))
         if head_sha:
             conclusion = (body.get("workflow") or {}).get("conclusion")
             details_url = f"https://github.com/{verified_repo}/actions/runs/{run_id}"
@@ -408,6 +410,7 @@ def handle(config: RelayConfig, body: dict, verified_repo: str) -> dict:
                     workflow_name=workflow_name,
                     job_name=job_name,
                     details_url=details_url,
+                    pr_number=pr_number,
                 )
 
     if status == "in_progress":

--- a/aws/lambda/cross_repo_ci_relay/callback/cleanup_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/cleanup_handler.py
@@ -83,7 +83,7 @@ def _finalize_timed_out_check_run(
 
     pr_field = (body.get("payload") or {}).get("pull_request") or {}
     head_sha = (pr_field.get("head") or {}).get("sha", "")
-    pr_number = str(pr_field.get("number", ""))
+    pr_number = str(pr_field.get("number") or "")
     if not head_sha:
         return
 
@@ -101,7 +101,7 @@ def _finalize_timed_out_check_run(
     run_id = str(workflow.get("run_id"))
     details_url = f"https://github.com/{verified_repo}/actions/runs/{run_id}"
     output = gh_helper.build_check_run_output(
-        "completed", "timed_out", details_url, verified_repo, pr_number
+        "completed", "timed_out", details_url, verified_repo
     )
 
     try:
@@ -118,7 +118,7 @@ def _finalize_timed_out_check_run(
             status="completed",
             conclusion="timed_out",
             details_url=details_url,
-            external_id=run_id,
+            external_id=f"{run_id}:{pr_number}" if pr_number else run_id,
             output=output,
         )
         logger.info(

--- a/aws/lambda/cross_repo_ci_relay/callback/cleanup_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/cleanup_handler.py
@@ -83,6 +83,7 @@ def _finalize_timed_out_check_run(
 
     pr_field = (body.get("payload") or {}).get("pull_request") or {}
     head_sha = (pr_field.get("head") or {}).get("sha", "")
+    pr_number = str(pr_field.get("number", ""))
     if not head_sha:
         return
 
@@ -100,7 +101,7 @@ def _finalize_timed_out_check_run(
     run_id = str(workflow.get("run_id"))
     details_url = f"https://github.com/{verified_repo}/actions/runs/{run_id}"
     output = gh_helper.build_check_run_output(
-        "completed", "timed_out", details_url, verified_repo
+        "completed", "timed_out", details_url, verified_repo, pr_number
     )
 
     try:

--- a/aws/lambda/cross_repo_ci_relay/tests/test_callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_callback_handler.py
@@ -365,7 +365,7 @@ class TestCallbackCheckRunUpdate(unittest.TestCase):
         )
 
         kw = self.mock_gh.create_check_run.call_args[1]
-        self.assertEqual(kw["external_id"], "99999")  # run_id from _body
+        self.assertEqual(kw["external_id"], "99999:42")  # run_id:pr_number
 
     def test_in_progress_callback_creates_check_run(self):
         self.mock_gh.create_check_run.return_value = 999

--- a/aws/lambda/cross_repo_ci_relay/tests/test_event_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_event_handler.py
@@ -191,7 +191,7 @@ class TestPrLabeledHandler(unittest.TestCase):
         self.assertEqual(kw["head_sha"], "abc123")
         self.assertEqual(kw["status"], "in_progress")
         self.assertIsNone(kw["conclusion"])
-        self.assertEqual(kw["external_id"], "99999")  # run_id
+        self.assertEqual(kw["external_id"], "99999:42")  # run_id:pr_number
 
     def test_scenario2_backfills_every_job_not_just_one(self):
         """Multi-job workflow: a mid-run label backfills a check run for EVERY
@@ -215,7 +215,7 @@ class TestPrLabeledHandler(unittest.TestCase):
             c.kwargs["external_id"]
             for c in self.mock_gh.create_check_run.call_args_list
         }
-        self.assertEqual(external_ids, {"99999"})  # run_id
+        self.assertEqual(external_ids, {"99999:42"})  # run_id:pr_number
 
     def test_scenario3_completed_job_creates_completed_check_run(self):
         """Scenario 3: label arrives after workflow completed → create completed CR directly."""

--- a/aws/lambda/cross_repo_ci_relay/utils/gh_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/gh_helper.py
@@ -143,6 +143,7 @@ def build_check_run_output(
     conclusion: str,
     details_url: str,
     downstream_repo: str,
+    pr_number: str
 ) -> dict:
     """Return a GitHub Check Run output dict shown in the detail panel."""
     if status != "completed":
@@ -153,7 +154,7 @@ def build_check_run_output(
         title = "Completed"
     return {
         "title": title,
-        "summary": f"{downstream_repo} workflow: {details_url}",
+        "summary": f"{downstream_repo} workflow for PR {pr_number}: {details_url}",
     }
 
 

--- a/aws/lambda/cross_repo_ci_relay/utils/gh_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/gh_helper.py
@@ -143,7 +143,6 @@ def build_check_run_output(
     conclusion: str,
     details_url: str,
     downstream_repo: str,
-    pr_number: str = "",
 ) -> dict:
     """Return a GitHub Check Run output dict shown in the detail panel."""
     if status != "completed":
@@ -152,10 +151,9 @@ def build_check_run_output(
         title = conclusion.capitalize()
     else:
         title = "Completed"
-    pr_part = f" for PR {pr_number}" if pr_number else ""
     return {
         "title": title,
-        "summary": f"{downstream_repo} workflow{pr_part}: {details_url}",
+        "summary": f"{downstream_repo} workflow: {details_url}",
     }
 
 

--- a/aws/lambda/cross_repo_ci_relay/utils/gh_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/gh_helper.py
@@ -143,7 +143,7 @@ def build_check_run_output(
     conclusion: str,
     details_url: str,
     downstream_repo: str,
-    pr_number: str
+    pr_number: str = "",
 ) -> dict:
     """Return a GitHub Check Run output dict shown in the detail panel."""
     if status != "completed":
@@ -152,9 +152,10 @@ def build_check_run_output(
         title = conclusion.capitalize()
     else:
         title = "Completed"
+    pr_part = f" for PR {pr_number}" if pr_number else ""
     return {
         "title": title,
-        "summary": f"{downstream_repo} workflow for PR {pr_number}: {details_url}",
+        "summary": f"{downstream_repo} workflow{pr_part}: {details_url}",
     }
 
 

--- a/aws/lambda/cross_repo_ci_relay/webhook/event_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/webhook/event_handler.py
@@ -207,7 +207,11 @@ def _handle_pr_labeled(config: RelayConfig, payload: dict) -> dict:
                     details_url=details_url,
                     external_id=str(run_id),
                     output=gh_helper.build_check_run_output(
-                        job_status, job_conclusion, details_url, downstream_repo
+                        job_status,
+                        job_conclusion,
+                        details_url,
+                        downstream_repo,
+                        pr_number,
                     ),
                 )
                 created.append(f"{downstream_repo}/{job_name}")

--- a/aws/lambda/cross_repo_ci_relay/webhook/event_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/webhook/event_handler.py
@@ -152,7 +152,7 @@ def _handle_pr_labeled(config: RelayConfig, payload: dict) -> dict:
         return {"ok": True, "created_check_runs": []}
 
     pr = payload.get("pull_request") or {}
-    pr_number = str(pr.get("number", ""))
+    pr_number = str(pr.get("number") or "")
     head_sha = (pr.get("head") or {}).get("sha", "")
     if not pr_number or not head_sha:
         return {"ignored": True, "reason": "missing pr context"}
@@ -205,13 +205,12 @@ def _handle_pr_labeled(config: RelayConfig, payload: dict) -> dict:
                     status=job_status,
                     conclusion=(job_conclusion if job_status == "completed" else None),
                     details_url=details_url,
-                    external_id=str(run_id),
+                    external_id=f"{run_id}:{pr_number}" if pr_number else str(run_id),
                     output=gh_helper.build_check_run_output(
                         job_status,
                         job_conclusion,
                         details_url,
                         downstream_repo,
-                        pr_number,
                     ),
                 )
                 created.append(f"{downstream_repo}/{job_name}")
@@ -267,7 +266,7 @@ def _handle_check_run_rerequested(config: RelayConfig, payload: dict) -> dict:
     """
     check_run = payload.get("check_run") or {}
     name = check_run.get("name", "")
-    run_id = check_run.get("external_id") or ""
+    run_id = (check_run.get("external_id") or "").split(":")[0]
     downstream_repo = _downstream_repo_from_check_run(name)
     if not downstream_repo or not run_id:
         return {"ignored": True, "reason": "not a crcr check run"}
@@ -350,7 +349,7 @@ def _handle_check_suite_rerequested(config: RelayConfig, payload: dict) -> dict:
     rerun: list[str] = []
     for check_run in check_runs:
         downstream_repo = _downstream_repo_from_check_run(check_run.get("name", ""))
-        run_id = check_run.get("external_id") or ""
+        run_id = (check_run.get("external_id") or "").split(":")[0]
         if not downstream_repo or not run_id:
             continue
         if (downstream_repo, run_id) in seen:

--- a/torchci/lib/bot/crcrOncallBot.ts
+++ b/torchci/lib/bot/crcrOncallBot.ts
@@ -83,10 +83,10 @@ export default function crcrOncallBot(app: Probot): void {
     let prNumbers: number[] = [];
     if (checkRun.pull_requests && checkRun.pull_requests.length > 0) {
       prNumbers = checkRun.pull_requests.map((pr) => pr.number);
-    } else if (checkRun.output?.summary) {
-      const match = checkRun.output.summary.match(/for PR (\d+)/);
-      if (match) {
-        prNumbers = [parseInt(match[1], 10)];
+    } else if (checkRun.external_id) {
+      const parts = checkRun.external_id.split(":");
+      if (parts.length === 2 && parts[1]) {
+        prNumbers = [parseInt(parts[1], 10)];
       }
     }
 

--- a/torchci/lib/bot/crcrOncallBot.ts
+++ b/torchci/lib/bot/crcrOncallBot.ts
@@ -81,14 +81,18 @@ export default function crcrOncallBot(app: Probot): void {
 
     // Get the PRs this check run belongs to.
     let prNumbers: number[] = [];
-    if (checkRun.pull_requests && checkRun.pull_requests.length > 0) {
-      prNumbers = checkRun.pull_requests.map((pr) => pr.number);
-    } else if (checkRun.output?.summary) {
+    if (checkRun.output?.summary) {
       const match = checkRun.output.summary.match(/for PR (\d+)/);
       if (match) {
         prNumbers = [parseInt(match[1], 10)];
       }
-    } else if (checkRun.head_sha) {
+    } else if (checkRun.pull_requests && checkRun.pull_requests.length > 0) {
+      prNumbers = checkRun.pull_requests.map((pr) => pr.number);
+    }
+
+    // Fall back to Search API if still no PR found (e.g., pr_number was empty
+    // on the Lambda side).
+    if (prNumbers.length === 0 && checkRun.head_sha) {
       try {
         const result = await ctx.octokit.rest.search.issuesAndPullRequests({
           q: `${checkRun.head_sha} type:pr repo:${owner}/${repo}`,

--- a/torchci/lib/bot/crcrOncallBot.ts
+++ b/torchci/lib/bot/crcrOncallBot.ts
@@ -81,29 +81,12 @@ export default function crcrOncallBot(app: Probot): void {
 
     // Get the PRs this check run belongs to.
     let prNumbers: number[] = [];
-    if (checkRun.output?.summary) {
+    if (checkRun.pull_requests && checkRun.pull_requests.length > 0) {
+      prNumbers = checkRun.pull_requests.map((pr) => pr.number);
+    } else if (checkRun.output?.summary) {
       const match = checkRun.output.summary.match(/for PR (\d+)/);
       if (match) {
         prNumbers = [parseInt(match[1], 10)];
-      }
-    } else if (checkRun.pull_requests && checkRun.pull_requests.length > 0) {
-      prNumbers = checkRun.pull_requests.map((pr) => pr.number);
-    }
-
-    // Fall back to Search API if still no PR found (e.g., pr_number was empty
-    // on the Lambda side).
-    if (prNumbers.length === 0 && checkRun.head_sha) {
-      try {
-        const result = await ctx.octokit.rest.search.issuesAndPullRequests({
-          q: `${checkRun.head_sha} type:pr repo:${owner}/${repo}`,
-        });
-        prNumbers = result.data.items.map((item: any) => item.number);
-      } catch (err) {
-        ctx.log(
-          { err },
-          `crcrOncall: failed to resolve PRs for commit ${checkRun.head_sha}, skipping`
-        );
-        return;
       }
     }
 

--- a/torchci/lib/bot/crcrOncallBot.ts
+++ b/torchci/lib/bot/crcrOncallBot.ts
@@ -81,20 +81,19 @@ export default function crcrOncallBot(app: Probot): void {
 
     // Get the PRs this check run belongs to.
     // checkRun.pull_requests is empty for cross-fork PRs (most pytorch
-    // contributions), so fall back to the commits API to resolve PRs
-    // from the head SHA — the same strategy used by the merge-blocking path.
+    // contributions), so fall back to the Search API to resolve PRs from
+    // the head SHA.  The commits-pulls API (listPullRequestsAssociatedWithCommit)
+    // also returns empty for cross-fork PRs on large repos like pytorch/pytorch,
+    // but the Search API indexes commits across forks and reliably finds them.
     let prNumbers: number[] = [];
     if (checkRun.pull_requests && checkRun.pull_requests.length > 0) {
       prNumbers = checkRun.pull_requests.map((pr) => pr.number);
     } else if (checkRun.head_sha) {
       try {
-        const result =
-          await ctx.octokit.rest.repos.listPullRequestsAssociatedWithCommit({
-            owner,
-            repo,
-            commit_sha: checkRun.head_sha,
-          });
-        prNumbers = result.data.map((pr: any) => pr.number);
+        const result = await ctx.octokit.rest.search.issuesAndPullRequests({
+          q: `${checkRun.head_sha} type:pr repo:${owner}/${repo}`,
+        });
+        prNumbers = result.data.items.map((item: any) => item.number);
       } catch (err) {
         ctx.log(
           { err },

--- a/torchci/lib/bot/crcrOncallBot.ts
+++ b/torchci/lib/bot/crcrOncallBot.ts
@@ -80,14 +80,14 @@ export default function crcrOncallBot(app: Probot): void {
     }
 
     // Get the PRs this check run belongs to.
-    // checkRun.pull_requests is empty for cross-fork PRs (most pytorch
-    // contributions), so fall back to the Search API to resolve PRs from
-    // the head SHA.  The commits-pulls API (listPullRequestsAssociatedWithCommit)
-    // also returns empty for cross-fork PRs on large repos like pytorch/pytorch,
-    // but the Search API indexes commits across forks and reliably finds them.
     let prNumbers: number[] = [];
     if (checkRun.pull_requests && checkRun.pull_requests.length > 0) {
       prNumbers = checkRun.pull_requests.map((pr) => pr.number);
+    } else if (checkRun.output?.summary) {
+      const match = checkRun.output.summary.match(/for PR (\d+)/);
+      if (match) {
+        prNumbers = [parseInt(match[1], 10)];
+      }
     } else if (checkRun.head_sha) {
       try {
         const result = await ctx.octokit.rest.search.issuesAndPullRequests({

--- a/torchci/test/crcrOncallBot.test.ts
+++ b/torchci/test/crcrOncallBot.test.ts
@@ -177,13 +177,8 @@ L3:
   });
 
   test("does not comment when output has no PR number", async () => {
-    // output.summary exists but regex doesn't match (empty pr_number);
-    // falls through to Search API which also returns nothing
-    const scope = nock("https://api.github.com")
-      .get("/search/issues")
-      .query(true)
-      .reply(200, { total_count: 0, items: [] });
-
+    // output.summary exists but regex doesn't match (no PR number
+    // after "for PR"), so the bot returns early without any API call.
     await probot.receive({
       name: "check_run" as any,
       payload: checkRunPayload({
@@ -195,7 +190,6 @@ L3:
       }) as any,
       id: "8",
     });
-    handleScope(scope);
   });
 
   test("posts comment when output contains PR number for cross-fork PR", async () => {

--- a/torchci/test/crcrOncallBot.test.ts
+++ b/torchci/test/crcrOncallBot.test.ts
@@ -176,7 +176,12 @@ L3:
     });
   });
 
-  test("does not comment when no PR is associated", async () => {
+  test("does not comment when Search API returns no PRs", async () => {
+    const scope = nock("https://api.github.com")
+      .get("/search/issues")
+      .query(true)
+      .reply(200, { total_count: 0, items: [] });
+
     await probot.receive({
       name: "check_run" as any,
       payload: checkRunPayload({
@@ -184,6 +189,39 @@ L3:
       }) as any,
       id: "8",
     });
+    handleScope(scope);
+  });
+
+  test("posts comment when fallback Search API finds cross-fork PR", async () => {
+    const scope = nock("https://api.github.com")
+      .get("/search/issues")
+      .query(true)
+      .reply(200, {
+        total_count: 1,
+        items: [{ number: PR_NUMBER }],
+      })
+      .get(`/repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments`)
+      .reply(200, [])
+      .post(
+        `/repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments`,
+        (body: any) => {
+          expect(body.body).toContain(
+            "<!-- crcr-oncall:intel/torch-xpu-ops -->"
+          );
+          expect(body.body).toContain("@oncall_xpu");
+          return true;
+        }
+      )
+      .reply(200);
+
+    await probot.receive({
+      name: "check_run" as any,
+      payload: checkRunPayload({
+        pull_requests: [], // empty — simulates cross-fork PR
+      }) as any,
+      id: "10",
+    });
+    handleScope(scope);
   });
 
   test("does nothing for unsupported org", async () => {

--- a/torchci/test/crcrOncallBot.test.ts
+++ b/torchci/test/crcrOncallBot.test.ts
@@ -176,23 +176,20 @@ L3:
     });
   });
 
-  test("does not comment when output has no PR number", async () => {
-    // output.summary exists but regex doesn't match (no PR number
-    // after "for PR"), so the bot returns early without any API call.
+  test("does not comment when external_id has no PR number", async () => {
+    // external_id carries bare run_id (no ":" separator) when pr_number
+    // is unavailable — the bot returns early without any API call.
     await probot.receive({
       name: "check_run" as any,
       payload: checkRunPayload({
         pull_requests: [],
-        output: {
-          title: "In progress",
-          summary: "intel/torch-xpu-ops workflow for PR : https://example.com",
-        },
+        external_id: "12345",
       }) as any,
       id: "8",
     });
   });
 
-  test("posts comment when output contains PR number for cross-fork PR", async () => {
+  test("posts comment when external_id contains PR number for cross-fork PR", async () => {
     const scope = nock("https://api.github.com")
       .get(`/repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments`)
       .reply(200, [])
@@ -212,10 +209,7 @@ L3:
       name: "check_run" as any,
       payload: checkRunPayload({
         pull_requests: [], // empty — simulates cross-fork PR
-        output: {
-          title: "Failure",
-          summary: `intel/torch-xpu-ops workflow for PR ${PR_NUMBER}: https://example.com`,
-        },
+        external_id: `12345:${PR_NUMBER}`,
       }) as any,
       id: "10",
     });

--- a/torchci/test/crcrOncallBot.test.ts
+++ b/torchci/test/crcrOncallBot.test.ts
@@ -177,6 +177,13 @@ L3:
   });
 
   test("does not comment when output has no PR number", async () => {
+    // output.summary exists but regex doesn't match (empty pr_number);
+    // falls through to Search API which also returns nothing
+    const scope = nock("https://api.github.com")
+      .get("/search/issues")
+      .query(true)
+      .reply(200, { total_count: 0, items: [] });
+
     await probot.receive({
       name: "check_run" as any,
       payload: checkRunPayload({
@@ -188,6 +195,7 @@ L3:
       }) as any,
       id: "8",
     });
+    handleScope(scope);
   });
 
   test("posts comment when output contains PR number for cross-fork PR", async () => {

--- a/torchci/test/crcrOncallBot.test.ts
+++ b/torchci/test/crcrOncallBot.test.ts
@@ -176,30 +176,22 @@ L3:
     });
   });
 
-  test("does not comment when Search API returns no PRs", async () => {
-    const scope = nock("https://api.github.com")
-      .get("/search/issues")
-      .query(true)
-      .reply(200, { total_count: 0, items: [] });
-
+  test("does not comment when output has no PR number", async () => {
     await probot.receive({
       name: "check_run" as any,
       payload: checkRunPayload({
         pull_requests: [],
+        output: {
+          title: "In progress",
+          summary: "intel/torch-xpu-ops workflow for PR : https://example.com",
+        },
       }) as any,
       id: "8",
     });
-    handleScope(scope);
   });
 
-  test("posts comment when fallback Search API finds cross-fork PR", async () => {
+  test("posts comment when output contains PR number for cross-fork PR", async () => {
     const scope = nock("https://api.github.com")
-      .get("/search/issues")
-      .query(true)
-      .reply(200, {
-        total_count: 1,
-        items: [{ number: PR_NUMBER }],
-      })
       .get(`/repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments`)
       .reply(200, [])
       .post(
@@ -218,6 +210,10 @@ L3:
       name: "check_run" as any,
       payload: checkRunPayload({
         pull_requests: [], // empty — simulates cross-fork PR
+        output: {
+          title: "Failure",
+          summary: `intel/torch-xpu-ops workflow for PR ${PR_NUMBER}: https://example.com`,
+        },
       }) as any,
       id: "10",
     });


### PR DESCRIPTION
## Summary

Fix `crcrOncallBot`'s "commit SHA → PR number" resolution for cross-fork pull requests on `pytorch/pytorch`, where the bot was silently failing to comment on downstream CI failures for the majority of contributions.

## Problem

`crcrOncallBot` reacts to `check_run.completed` webhook events and posts oncall-ping comments on the associated PR when downstream CI fails. To find which PR a check run belongs to, it uses a two-step strategy:

1. **`checkRun.pull_requests`** — the `check_run` payload's `pull_requests` array
2. **Fallback: `listPullRequestsAssociatedWithCommit`** (GitHub Commits API) — when `pull_requests` is empty, which happens for **cross-fork PRs** (the code comment itself admits this)

The problem: **both paths are dead ends for cross-fork PRs on large repos like `pytorch/pytorch`.**

| API | Behavior for fork PR |
|-----|---------------------|
| `checkRun.pull_requests` | Empty `[]` — GitHub does not populate this for cross-fork check runs |
| `GET /repos/{owner}/{repo}/commits/{sha}/pulls` | Returns `[]` — the commits-pulls endpoint does not return PRs from forked repositories on repos of `pytorch/pytorch`'s scale |

The commits-pulls API returns HTTP 200 with `[]` (not an error), so the `try/catch` on the fallback doesn't fire — execution falls through to an empty-array check that silently returns without posting a comment. The bot was effectively **completely broken for cross-fork PRs**, which is the dominant contribution pattern for `pytorch/pytorch`.

### Evidence

Tested with two real open fork PRs on `pytorch/pytorch`:

```bash
# PR #191304 (head: RohitRathore1/pytorch)
$ gh api repos/pytorch/pytorch/commits/29249453f.../pulls --jq 'length'
0          # ← commits API returns nothing

$ gh api 'search/issues?q=29249453f...+type:pr+repo:pytorch/pytorch' \
    --jq '[.items[].number]'
[191304]   # ← Search API returns the correct PR

# PR #191301 (head: vishals-3/pytorch)
$ gh api repos/pytorch/pytorch/commits/159d04cd9.../pulls --jq 'length'
0
$ gh api 'search/issues?q=159d04cd9...+type:pr+repo:pytorch/pytorch' \
    --jq '[.items[].number]'
[191301]
```

Fork-branch PR (not functional): https://github.com/pytorch/pytorch/pull/189246
Intra-branch PR (functional): https://github.com/pytorch/pytorch/pull/191313

## Fix

### Core approach: embed PR number at the source

Instead of a server-side API lookup, the PR number is now embedded in the check run's `external_id` field at creation time — alongside the downstream `run_id` that was already stored there. The bot reads it back directly with no external API call.

**Producer side** (Python — `callback_handler.py`, `cleanup_handler.py`, `event_handler.py`):
```python
# Before: external_id stored only the run_id
external_id=str(run_id)

# After: external_id encodes both run_id and pr_number
external_id=f"{run_id}:{pr_number}" if pr_number else str(run_id)
```

**Consumer side** (`crcrOncallBot.ts`):
```ts
// Before: fallback tried the Commits API (broken for forks)
// After: parse external_id to extract the PR number
} else if (checkRun.external_id) {
  const parts = checkRun.external_id.split(":");
  if (parts.length === 2 && parts[1]) {
    prNumbers = [parseInt(parts[1], 10)];
  }
}
```

**Read sites** (`event_handler.py` — check run rerequest handlers) parse out the run_id portion:
```python
# Before: run_id = check_run.get("external_id") or ""
# After: split on ":" to extract just the run_id
run_id = (check_run.get("external_id") or "").split(":")[0]
```

### Why `external_id` instead of `output.summary`

`output.summary` is user-facing display text rendered in the check run detail panel. Binding a machine contract to it means any future copy change silently breaks the bot, with no shared constant or cross-repo test between the Python (AWS Lambda) and TypeScript (Probot) deploy units. `external_id` is purpose-built for machine-readable data and was already used to store `run_id` for rerequest handling.

### Also fixed: `str(None)` bug

`str(pr_field.get("number", ""))` produces the literal string `"None"` when the `number` key exists but is `null` — Python's `dict.get()` only returns the default when the key is missing, not when it's `None`. Changed to `str(pr_field.get("number") or "")` in all three call sites.
