### PR TITLE
log-classifier: add 4 curated fixtures + 2 rules from a fresh log sweep

### DIFF
--- a/aws/lambda/log-classifier/fixtures/classify/lintrunner_general_failure.txt
+++ b/aws/lambda/log-classifier/fixtures/classify/lintrunner_general_failure.txt
@@ -1,0 +1,62 @@
+#=SOURCE=# https://ossci-raw-job-status.s3.amazonaws.com/log/90388671272
+2026-07-28T19:45:38.7020954Z + [[ -d /tmp/.lintbin ]]
+2026-07-28T19:45:38.7021188Z + cp -r /tmp/.lintbin .
+2026-07-28T19:45:38.7021408Z Running pyrefly
+2026-07-28T19:45:39.1120877Z + [[ '' == \1 ]]
+2026-07-28T19:45:39.1121161Z + spin regenerate-version
+2026-07-28T19:45:39.1121422Z + spin regenerate-type-stubs
+2026-07-28T19:45:39.1121855Z $ /var/lib/jenkins/ci_env/bin/python -m tools.generate_torch_version --is-debug=false
+2026-07-28T19:45:39.1122502Z Changes detected in type stub files for Pytorch type stubs. Regenerating...
+2026-07-28T19:45:39.1123638Z $ /var/lib/jenkins/ci_env/bin/python -m tools.pyi.gen_pyi --native-functions-path aten/src/ATen/native/native_functions.yaml --tags-path aten/src/ATen/native/tags.yaml --deprecated-functions-path tools/autograd/deprecated.yaml
+2026-07-28T19:45:42.7619505Z Type stubs and hashes updated.
+2026-07-28T19:45:42.7620010Z No hash file for Datapipes type stubs. Regenerating...
+2026-07-28T19:45:42.7620496Z $ /var/lib/jenkins/ci_env/bin/python torch/utils/data/datapipes/gen_pyi.py
+2026-07-28T19:45:42.9637645Z + find torch -name '*.pyi' -exec git add --force -- '{}' +
+2026-07-28T19:45:42.9638019Z + RC=0
+2026-07-28T19:45:42.9638256Z + spin lint -- --force-color --tee-json=lint.json
+2026-07-28T19:45:42.9638570Z Type stubs regenerated.
+2026-07-28T19:45:43.1663309Z Changes detected in lint configuration files. Setting up linting tools...
+2026-07-28T19:45:43.9756490Z Linting tools set up and hashes updated.
+2026-07-28T19:45:43.9756836Z Regenerating version...
+2026-07-28T19:45:43.9757245Z $ /var/lib/jenkins/ci_env/bin/python -m tools.generate_torch_version --is-debug=false
+2026-07-28T19:45:44.1782822Z Regenerating type stubs...
+2026-07-28T19:45:44.1783573Z No changes detected in type stub files for Pytorch type stubs.
+2026-07-28T19:45:44.1783996Z No hash file for Datapipes type stubs. Regenerating...
+2026-07-28T19:45:44.1784440Z $ /var/lib/jenkins/ci_env/bin/python torch/utils/data/datapipes/gen_pyi.py
+2026-07-28T19:45:44.1784860Z Type stubs regenerated.
+2026-07-28T19:45:44.1785070Z Done.
+2026-07-28T19:45:44.1785453Z $ uvx --python 3.10 lintrunner@0.12.7 list
+2026-07-28T19:45:44.3810647Z $ uvx --python 3.10 lintrunner@0.12.7 --tee-json /tmp/spinlint_af73oy2t.json --take ROOT_LOGGING,PYBIND11_INCLUDE,ATEN_CPU_GPU_AGNOSTIC,RAWCUDA,NO_WORKFLOWS_ON_FORK,TESTOWNERS,META_NO_CREATE_UNBACKED,RAWCUDADEVICE,C10_NODISCARD,CMAKE_MINIMUM_REQUIRED,GHA,EXEC,DEPLOY_DETECTION,SHELLCHECK,CMAKE,RUFF,WORKFLOWSYNC,HEADER_ONLY_LINTER,NEWLINE,PYPIDEP,CUBINCLUDE,LINTRUNNER_VERSION,MERGE_CONFLICTLESS_CSV,PYREFLY,CALL_ONCE,IMPORT_LINTER,SPACES,C10_UNUSED,NOQA,DOCSTRING_LINTER,RAWTHROW,TYPEIGNORE,TABS,COPYRIGHT,TYPENOSKIP,CONTEXT_DECORATOR,SET_LINTER,SYMPY_MINMAX,INCLUDE,ERROR_PRONE_ISINSTANCE,PYPROJECT,PYBIND11_SPECIALIZATION,CLANGTIDY_EXECUTORCH_COMPATIBILITY,NATIVEFUNCTIONS,ONCE_FLAG --all-files --force-color
+2026-07-28T19:45:58.8164351Z 
+2026-07-28T19:45:58.8164364Z 
+2026-07-28T19:45:58.8164948Z >>> General linter failure:
+2026-07-28T19:45:58.8165175Z 
+#=MATCH=# 2026-07-28T19:45:58.8166295Z   [41m[1mError[0m (‹CLANGTIDY_EXECUTORCH_COMPATIBILITY›) [4mLinter failed[0m
+2026-07-28T19:45:58.8166945Z     Linter failed. This a bug, please file an issue against the linter
+2026-07-28T19:45:58.8167325Z     maintainer.
+2026-07-28T19:45:58.8167507Z     
+2026-07-28T19:45:58.8167670Z     CONTEXT:
+2026-07-28T19:45:58.8167896Z     Linter command failed with non-zero exit code.
+2026-07-28T19:45:58.8168190Z     STDERR:
+2026-07-28T19:45:58.8168501Z     <Thread_0:DEBUG> $ /__w/pytorch/pytorch/.lintbin/clang-tidy -p=/__w/
+2026-07-28T19:45:58.8168995Z     pytorch/pytorch/build --extra-arg -I/usr/lib/llvm-11/include/openmp
+2026-07-28T19:45:58.8169515Z     --extra-arg -I/usr/include/python3.10 --extra-arg -I/__w/pytorch/pytorch/
+2026-07-28T19:45:58.8170082Z     third_party/pybind11/include --extra-arg -I/__w/pytorch/pytorch/aten/
+2026-07-28T19:45:58.8170589Z     src --extra-arg -I/__w/pytorch/pytorch --extra-arg -I/usr/bin/../lib/gcc/
+2026-07-28T19:45:58.8171092Z     x86_64-linux-gnu/11/../../../../include/c++/11 --extra-arg -I/usr/bin/../
+2026-07-28T19:45:58.8171575Z     lib/gcc/x86_64-linux-gnu/11/../../../../include/x86_64-linux-gnu/c++/11
+2026-07-28T19:45:58.8172069Z     --extra-arg -I/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/
+2026-07-28T19:45:58.8172554Z     c++/11/backward --extra-arg -I/usr/lib/llvm-18/lib/clang/18/include
+2026-07-28T19:45:58.8173049Z     --extra-arg -I/usr/local/include --extra-arg -I/usr/include/x86_64-linux-
+2026-07-28T19:45:58.8173563Z     gnu --extra-arg -I/usr/include --extra-arg -I/__w/pytorch/pytorch/build
+2026-07-28T19:45:58.8174069Z     --extra-arg -I/__w/pytorch/pytorch/build/aten/src /__w/pytorch/pytorch/
+2026-07-28T19:45:58.8174480Z     c10/macros/Export.h -- -std=c++17
+2026-07-28T19:45:58.8174852Z     <Thread_1:DEBUG> $ /__w/pytorch/pytorch/.lintbin/clang-tidy -p=/__w/
+2026-07-28T19:45:58.8175335Z     pytorch/pytorch/build --extra-arg -I/usr/lib/llvm-11/include/openmp
+2026-07-28T19:45:58.8175853Z     --extra-arg -I/usr/include/python3.10 --extra-arg -I/__w/pytorch/pytorch/
+2026-07-28T19:45:58.8176382Z     third_party/pybind11/include --extra-arg -I/__w/pytorch/pytorch/aten/
+2026-07-28T19:45:58.8176889Z     src --extra-arg -I/__w/pytorch/pytorch --extra-arg -I/usr/bin/../lib/gcc/
+2026-07-28T19:45:58.8177384Z     x86_64-linux-gnu/11/../../../../include/c++/11 --extra-arg -I/usr/bin/../
+2026-07-28T19:45:58.8177867Z     lib/gcc/x86_64-linux-gnu/11/../../../../include/x86_64-linux-gnu/c++/11
+2026-07-28T19:45:58.8178353Z     --extra-arg -I/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/
+2026-07-28T19:45:58.8178833Z     c++/11/backward --extra-arg -I/usr/lib/llvm-18/lib/clang/18/include

--- a/aws/lambda/log-classifier/fixtures/classify/python_importerror_missing_so.txt
+++ b/aws/lambda/log-classifier/fixtures/classify/python_importerror_missing_so.txt
@@ -1,0 +1,62 @@
+#=SOURCE=# https://ossci-raw-job-status.s3.amazonaws.com/log/90532014328
+2026-07-29T09:31:11.1583316Z 	libdw.so.1 => /usr/local/bin/../lib/python3.11/site-packages/torch/lib/libdw.so.1 (0x00007f3e94600000)
+2026-07-29T09:31:11.1583602Z 	librocfft.so => /usr/local/bin/../lib/python3.11/site-packages/torch/lib/librocfft.so (0x00007f3e92c51000)
+2026-07-29T09:31:11.1583902Z 	librocrand.so => /usr/local/bin/../lib/python3.11/site-packages/torch/lib/librocrand.so (0x00007f3e6308a000)
+2026-07-29T09:31:11.1584214Z 	librocsparse.so => /usr/local/bin/../lib/python3.11/site-packages/torch/lib/librocsparse.so (0x00007f3e4389c000)
+2026-07-29T09:31:11.1584472Z 	liblzma.so.5 => /lib/x86_64-linux-gnu/liblzma.so.5 (0x00007f3e949d3000)
+2026-07-29T09:31:11.1584638Z 	librocm_smi64.so.1 => not found
+2026-07-29T09:31:11.1584850Z 	librocroller.so => /usr/local/bin/../lib/python3.11/site-packages/torch/lib/librocroller.so (0x00007f3e417f3000)
+2026-07-29T09:31:11.1585099Z 	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f3e949b3000)
+2026-07-29T09:31:11.1585332Z 	libelf.so.1 => /usr/local/bin/../lib/python3.11/site-packages/torch/lib/libelf.so.1 (0x00007f3e41400000)
+2026-07-29T09:31:11.1585593Z 	libbz2.so.1 => /lib/x86_64-linux-gnu/libbz2.so.1 (0x00007f3e949a0000) with runpath 
+2026-07-29T09:31:11.1585873Z 	librocrand.so => /usr/local/bin/../lib/python3.11/site-packages/torch/lib/librocrand.so (0x00007f3e6308a000)
+2026-07-29T09:31:11.1586183Z 	librocsparse.so => /usr/local/bin/../lib/python3.11/site-packages/torch/lib/librocsparse.so (0x00007f3e4389c000)
+2026-07-29T09:31:11.1586441Z 	liblzma.so.5 => /lib/x86_64-linux-gnu/liblzma.so.5 (0x00007f3e949d3000)
+2026-07-29T09:31:11.1586604Z 	librocm_smi64.so.1 => not found
+2026-07-29T09:31:11.1586814Z 	librocroller.so => /usr/local/bin/../lib/python3.11/site-packages/torch/lib/librocroller.so (0x00007f3e417f3000)
+2026-07-29T09:31:11.1587061Z 	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f3e949b3000)
+2026-07-29T09:31:11.1587290Z 	libelf.so.1 => /usr/local/bin/../lib/python3.11/site-packages/torch/lib/libelf.so.1 (0x00007f3e41400000)
+2026-07-29T09:31:11.1587550Z 	libbz2.so.1 => /lib/x86_64-linux-gnu/libbz2.so.1 (0x00007f3e949a0000) with runpath '
+2026-07-29T09:31:11.1587747Z +++ realpath /pytorch/.ci/pytorch/check_binary.sh
+2026-07-29T09:31:11.1587916Z ++ dirname /__w/pytorch/pytorch/.ci/pytorch/check_binary.sh
+2026-07-29T09:31:11.1588147Z + TEST_CODE_DIR=/__w/pytorch/pytorch/.ci/pytorch/test_example_code
+2026-07-29T09:31:11.1588310Z + [[ manywheel == \l\i\b\t\o\r\c\h ]]
+2026-07-29T09:31:11.1588430Z + pushd /tmp
+2026-07-29T09:31:11.1588530Z + python -c 'import torch'
+2026-07-29T09:31:11.1588643Z /tmp /__w/pytorch/pytorch
+2026-07-29T09:31:11.1840479Z Traceback (most recent call last):
+2026-07-29T09:31:11.1840624Z   File "<string>", line 1, in <module>
+2026-07-29T09:31:11.1841381Z   File "/usr/local/lib/python3.11/site-packages/torch/__init__.py", line 585, in <module>
+2026-07-29T09:31:11.1841644Z     from torch._C import *  # noqa: F403
+2026-07-29T09:31:11.1841776Z     ^^^^^^^^^^^^^^^^^^^^^^
+#=MATCH=# 2026-07-29T09:31:11.1841963Z ‹ImportError: librocm_smi64.so.1: cannot open shared object file: No such file or directory›
+2026-07-29T09:31:11.1935632Z ##[error]Process completed with exit code 1.
+2026-07-29T09:31:11.1998608Z Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+2026-07-29T09:31:11.1999172Z Post job cleanup.
+2026-07-29T09:31:11.2002857Z ##[command]/usr/bin/docker exec  8bda2e23036fe80d9b13e7d5d77ff945d4efcd0d8e8b24827a685b03a2f9dd5c sh -c "cat /etc/*release | grep ^ID"
+2026-07-29T09:31:11.3020094Z [command]/usr/bin/git version
+2026-07-29T09:31:11.3037699Z git version 2.47.3
+2026-07-29T09:31:11.3050880Z Copying '/github/home/.gitconfig' to '/__w/_temp/878e9770-5b02-48f8-8705-a545bab3dd7b/.gitconfig'
+2026-07-29T09:31:11.3055952Z Temporarily overriding HOME='/__w/_temp/878e9770-5b02-48f8-8705-a545bab3dd7b' before making global git config changes
+2026-07-29T09:31:11.3056310Z Adding repository directory to the temporary git global config as a safe directory
+2026-07-29T09:31:11.3058034Z [command]/usr/bin/git config --global --add safe.directory /__w/pytorch/pytorch
+2026-07-29T09:31:11.3075783Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-07-29T09:31:11.3090460Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-07-29T09:31:11.3281824Z Entering 'android/libs/fbjni'
+2026-07-29T09:31:11.3305899Z Entering 'third_party/FP16'
+2026-07-29T09:31:11.3329111Z Entering 'third_party/FXdiv'
+2026-07-29T09:31:11.3352899Z Entering 'third_party/NNPACK'
+2026-07-29T09:31:11.3374956Z Entering 'third_party/NVTX'
+2026-07-29T09:31:11.3397693Z Entering 'third_party/VulkanMemoryAllocator'
+2026-07-29T09:31:11.3420975Z Entering 'third_party/XNNPACK'
+2026-07-29T09:31:11.3447851Z Entering 'third_party/aiter'
+2026-07-29T09:31:11.3471670Z Entering 'third_party/aiter/3rdparty/composable_kernel'
+2026-07-29T09:31:11.3499848Z Entering 'third_party/benchmark'
+2026-07-29T09:31:11.3523316Z Entering 'third_party/composable_kernel'
+2026-07-29T09:31:11.3548870Z Entering 'third_party/cpp-httplib'
+2026-07-29T09:31:11.3571803Z Entering 'third_party/cpuinfo'
+2026-07-29T09:31:11.3594269Z Entering 'third_party/cudnn_frontend'
+2026-07-29T09:31:11.3614815Z Entering 'third_party/cutlass'
+2026-07-29T09:31:11.3638154Z Entering 'third_party/fbgemm'
+2026-07-29T09:31:11.3665763Z Entering 'third_party/fbgemm/external/asmjit'
+2026-07-29T09:31:11.3683458Z Entering 'third_party/fbgemm/external/composable_kernel'

--- a/aws/lambda/log-classifier/fixtures/classify/python_importerror_name.txt
+++ b/aws/lambda/log-classifier/fixtures/classify/python_importerror_name.txt
@@ -1,0 +1,62 @@
+#=SOURCE=# https://ossci-raw-job-status.s3.amazonaws.com/log/90390561472
+2026-07-28T19:53:48.0466804Z + python tools/dynamo/verify_dynamo.py
+2026-07-28T19:53:48.9552189Z Traceback (most recent call last):
+2026-07-28T19:53:48.9558314Z   File "/__w/pytorch/pytorch/tools/dynamo/verify_dynamo.py", line 153, in check_dynamo
+2026-07-28T19:53:48.9558868Z     import torch._dynamo as dynamo
+2026-07-28T19:53:48.9559450Z   File "/opt/python-3.14-venv/lib/python3.14t/site-packages/torch/_dynamo/__init__.py", line 13, in <module>
+2026-07-28T19:53:48.9560001Z     from . import (
+2026-07-28T19:53:48.9560209Z     ...<7 lines>...
+2026-07-28T19:53:48.9560405Z     )
+2026-07-28T19:53:48.9561385Z   File "/opt/python-3.14-venv/lib/python3.14t/site-packages/torch/_dynamo/aot_compile.py", line 17, in <module>
+2026-07-28T19:53:48.9562150Z     from torch._dynamo.convert_frame import GraphRuntimeEnv
+2026-07-28T19:53:48.9562809Z   File "/opt/python-3.14-venv/lib/python3.14t/site-packages/torch/_dynamo/convert_frame.py", line 62, in <module>
+2026-07-28T19:53:48.9563461Z     from torch._dynamo.symbolic_convert import TensorifyState
+2026-07-28T19:53:48.9564145Z   File "/opt/python-3.14-venv/lib/python3.14t/site-packages/torch/_dynamo/symbolic_convert.py", line 65, in <module>
+2026-07-28T19:53:48.9564710Z     from . import (
+2026-07-28T19:53:48.9564920Z     ...<6 lines>...
+2026-07-28T19:53:48.9565117Z     )
+2026-07-28T19:53:48.9565592Z   File "/opt/python-3.14-venv/lib/python3.14t/site-packages/torch/_dynamo/trace_rules.py", line 60, in <module>
+2026-07-28T19:53:48.9566159Z     from .variables import (
+2026-07-28T19:53:48.9566405Z     ...<22 lines>...
+2026-07-28T19:53:48.9566607Z     )
+2026-07-28T19:53:48.9567115Z   File "/opt/python-3.14-venv/lib/python3.14t/site-packages/torch/_dynamo/variables/__init__.py", line 19, in <module>
+2026-07-28T19:53:48.9567710Z     from .base import VariableTracker
+2026-07-28T19:53:48.9568301Z   File "/opt/python-3.14-venv/lib/python3.14t/site-packages/torch/_dynamo/variables/base.py", line 2550, in <module>
+2026-07-28T19:53:48.9568880Z     from . import builder
+2026-07-28T19:53:48.9569432Z   File "/opt/python-3.14-venv/lib/python3.14t/site-packages/torch/_dynamo/variables/builder.py", line 212, in <module>
+2026-07-28T19:53:48.9570032Z     from .builtin import BuiltinVariable
+2026-07-28T19:53:48.9570636Z   File "/opt/python-3.14-venv/lib/python3.14t/site-packages/torch/_dynamo/variables/builtin.py", line 96, in <module>
+2026-07-28T19:53:48.9571223Z     from .object_protocol import (
+2026-07-28T19:53:48.9571491Z     ...<38 lines>...
+2026-07-28T19:53:48.9571697Z     )
+#=MATCH=# 2026-07-28T19:53:48.9572564Z ‹ImportError: cannot import name 'python_constant_richcompare_impl' from 'torch._dynamo.variables.object_protocol' (/opt/python-3.14-venv/lib/python3.14t/site-packages/torch/_dynamo/variables/object_protocol.py)›
+2026-07-28T19:53:48.9573438Z 
+2026-07-28T19:53:48.9573541Z CPU eager sanity check failed
+2026-07-28T19:53:48.9573714Z 
+2026-07-28T19:53:48.9573815Z Python version: 3.14.6
+2026-07-28T19:53:48.9574055Z `torch` version: 2.14.0a0+giteb77cd9
+2026-07-28T19:53:48.9574328Z CUDA version: None
+2026-07-28T19:53:48.9574543Z ROCM version: None
+2026-07-28T19:53:48.9574679Z 
+2026-07-28T19:53:49.3624494Z + sccache_epilogue
+2026-07-28T19:53:49.3624816Z + echo '::group::Sccache Compilation Log'
+2026-07-28T19:53:49.3625204Z + echo '=================== sccache compilation log ==================='
+2026-07-28T19:53:49.3625807Z + python /__w/pytorch/pytorch/.ci/pytorch/print_sccache_log.py /var/lib/jenkins/sccache_error.log
+2026-07-28T19:53:49.3626545Z + echo '=========== If your build fails, please take a look at the log above for possible reasons ==========='
+2026-07-28T19:53:49.3627061Z + sccache --show-stats
+2026-07-28T19:53:49.3627319Z + sccache --stop-server
+2026-07-28T19:53:49.3627803Z ##[group]Sccache Compilation Log
+2026-07-28T19:53:49.3628129Z =================== sccache compilation log ===================
+2026-07-28T19:53:49.3628951Z storage write check failed: PermissionDenied (permanent) at write => S3Error { code: "AccessDenied", message: "Access Denied", resource: "", request_id: "SJF9RM80BGD8C5RK" }
+2026-07-28T19:53:49.3629645Z 
+2026-07-28T19:53:49.3630068Z 
+2026-07-28T19:53:49.3630073Z 
+2026-07-28T19:53:49.3630159Z Context:
+2026-07-28T19:53:49.3630266Z 
+2026-07-28T19:53:49.3630574Z    uri: https://s3.us-east-1.amazonaws.com/ossci-compiler-cache-circleci-v2/.sccache_check
+2026-07-28T19:53:49.3630981Z 
+2026-07-28T19:53:49.3632439Z    response: Parts { status: 403, version: HTTP/1.1, headers: {"x-amz-request-id": "SJF9RM80BGD8C5RK", "x-amz-id-2": "mCryCpR9VwAv0TL0oaHVBZcS+AVOfH66izPS92bdJKl1xYMF5OdxSO1NPPhW8KHOPGWhz7+GAbo=", "content-type": "application/xml", "transfer-encoding": "chunked", "date": "Tue, 28 Jul 2026 19:53:22 GMT", "connection": "close", "server": "AmazonS3"} }
+2026-07-28T19:53:49.3633838Z 
+2026-07-28T19:53:49.3633921Z    service: s3
+2026-07-28T19:53:49.3634049Z 
+2026-07-28T19:53:49.3634138Z    path: .sccache_check

--- a/aws/lambda/log-classifier/fixtures/classify/uv_python_download_failed.txt
+++ b/aws/lambda/log-classifier/fixtures/classify/uv_python_download_failed.txt
@@ -1,0 +1,62 @@
+#=SOURCE=# https://ossci-raw-job-status.s3.amazonaws.com/log/90611728755
+2026-07-29T17:45:10.6195370Z INFO:delocate.delocating:Modifying install name in torch/_C.cpython-315-darwin.so from @rpath/libtorch_python.dylib to @loader_path/lib/libtorch_python.dylib
+2026-07-29T17:45:10.6668400Z INFO:delocate.delocating:Modifying install name in torch/lib/libtorch_cpu.dylib from @rpath/libomp.dylib to @loader_path/libomp.dylib
+2026-07-29T17:45:21.0990840Z Fixing: /var/folders/8j/sfr9qqcj73j4p6nhwcfpr0th0000gn/T/tmp.B5JxQEFrJ0/torch-2.14.0.dev20260729-cp315-cp315-macosx_14_0_arm64.whl
+2026-07-29T17:45:21.1126230Z Delocated 1 wheel(s) into /Users/runner/work/_temp/artifacts/wheel-py3_15-cpu
+2026-07-29T17:45:21.1165820Z + rm -f /var/folders/8j/sfr9qqcj73j4p6nhwcfpr0th0000gn/T/tmp.FmfbskW61P
+2026-07-29T17:45:21.1218920Z ++ date +%s
+2026-07-29T17:45:21.1248580Z + iter_elapsed=1172
+2026-07-29T17:45:21.1248990Z ##[endgroup]
+2026-07-29T17:45:21.1249200Z + iter=7
+2026-07-29T17:45:21.1249420Z + echo ::endgroup::
+2026-07-29T17:45:21.1249710Z + [[ -n /Users/runner/work/_temp/_runner_file_commands/step_summary_f131439b-56ef-4a21-95bc-a187349a78a3 ]]
+2026-07-29T17:45:21.1250330Z + [[ ! -s /Users/runner/work/_temp/_runner_file_commands/step_summary_f131439b-56ef-4a21-95bc-a187349a78a3 ]]
+2026-07-29T17:45:21.1250750Z + printf '| %s | %dm %ds |\n' 3.15 19 32
+2026-07-29T17:45:21.1257640Z + for desired in '${DESIRED_PYTHONS}'
+2026-07-29T17:45:21.1258040Z + echo '::group::Build wheel for Python 3.15t'
+2026-07-29T17:45:21.1258440Z ##[group]Build wheel for Python 3.15t
+2026-07-29T17:45:21.1261380Z ++ date +%s
+2026-07-29T17:45:21.1279740Z + iter_start=1785347121
+2026-07-29T17:45:21.1279950Z + uv_req=3.15t
+2026-07-29T17:45:21.1280120Z + case "${desired}" in
+2026-07-29T17:45:21.1281500Z + uv_req=3.15.0b3+freethreaded
+2026-07-29T17:45:21.1281730Z + [[ 3.15t == 3.15* ]]
+2026-07-29T17:45:21.1282220Z + export UV_PYTHON_DOWNLOADS_JSON_URL=https://raw.githubusercontent.com/astral-sh/uv/0.11.29/crates/uv-python/download-metadata.json
+2026-07-29T17:45:21.1282930Z + UV_PYTHON_DOWNLOADS_JSON_URL=https://raw.githubusercontent.com/astral-sh/uv/0.11.29/crates/uv-python/download-metadata.json
+2026-07-29T17:45:21.1283370Z + uv python install 3.15.0b3+freethreaded
+2026-07-29T17:45:21.6250830Z Downloading cpython-3.15.0b3+freethreaded-macos-aarch64-none (download) (25.7MiB)
+2026-07-29T17:45:22.2734140Z  Downloaded cpython-3.15.0b3+freethreaded-macos-aarch64-none (download)
+2026-07-29T17:45:22.3596910Z Installed Python 3.15.0b3 in 1.17s
+2026-07-29T17:45:22.3712790Z  + cpython-3.15.0b3+freethreaded-macos-aarch64-none (python3.15t)
+2026-07-29T17:45:22.4083860Z ++ uv python find 3.15.0b3+freethreaded
+#=MATCH=# 2026-07-29T17:45:22.4385450Z error: ‹Error while fetching remote python downloads json› from 'https://raw.githubusercontent.com/astral-sh/uv/0.11.29/crates/uv-python/download-metadata.json'
+2026-07-29T17:45:22.4489290Z   Caused by: Failed to download https://raw.githubusercontent.com/astral-sh/uv/0.11.29/crates/uv-python/download-metadata.json
+2026-07-29T17:45:22.4590500Z   Caused by: error sending request for url (https://raw.githubusercontent.com/astral-sh/uv/0.11.29/crates/uv-python/download-metadata.json)
+2026-07-29T17:45:22.4691600Z   Caused by: client error (Connect)
+2026-07-29T17:45:22.4792510Z   Caused by: dns error
+2026-07-29T17:45:22.4892930Z   Caused by: failed to lookup address information: nodename nor servname provided, or not known
+2026-07-29T17:45:22.4993560Z + py_bin=
+2026-07-29T17:45:22.5105160Z ##[error]Process completed with exit code 2.
+2026-07-29T17:45:22.5245620Z Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+2026-07-29T17:45:22.5246620Z ##[group]Run actions/upload-artifact@v4.4.0
+2026-07-29T17:45:22.5246840Z with:
+2026-07-29T17:45:22.5247000Z   name: wheel-py3_10-cpu
+2026-07-29T17:45:22.5247180Z   retention-days: 14
+2026-07-29T17:45:22.5247320Z   if-no-files-found: error
+2026-07-29T17:45:22.5247520Z   path: /Users/runner/work/_temp/artifacts/wheel-py3_10-cpu
+2026-07-29T17:45:22.5247740Z   compression-level: 6
+2026-07-29T17:45:22.5248010Z   overwrite: false
+2026-07-29T17:45:22.5248180Z   include-hidden-files: false
+2026-07-29T17:45:22.5248360Z env:
+2026-07-29T17:45:22.5248540Z   ALPINE_IMAGE: 308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine
+2026-07-29T17:45:22.5249040Z   AWS_DEFAULT_REGION: us-east-1
+2026-07-29T17:45:22.5249230Z   BUILD_ENVIRONMENT: macos-arm64-binary-wheel
+2026-07-29T17:45:22.5251570Z   GITHUB_TOKEN: ***
+2026-07-29T17:45:22.5251700Z   PR_NUMBER: 
+2026-07-29T17:45:22.5257680Z   SKIP_ALL_TESTS: 1
+2026-07-29T17:45:22.5257840Z   PYTORCH_ROOT: /Users/runner/work/pytorch/pytorch
+2026-07-29T17:45:22.5258350Z   PACKAGE_TYPE: wheel
+2026-07-29T17:45:22.5258510Z   DESIRED_CUDA: cpu
+2026-07-29T17:45:22.5258640Z   GPU_ARCH_TYPE: cpu
+2026-07-29T17:45:22.5258820Z   DESIRED_PYTHONS: 3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t
+2026-07-29T17:45:22.5260410Z   PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.0.3; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' and python_version < '3.15' | nvidia-cudnn-cu13==9.24.0.43; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.30.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'

--- a/aws/lambda/log-classifier/ruleset.toml
+++ b/aws/lambda/log-classifier/ruleset.toml
@@ -38,6 +38,14 @@ pattern = '^Found the unimplemented_v2 or unimplemented_v2_with_warning calls be
 name = 'Lintrunner failure'
 pattern = '^>>> Lint for.*'
 
+# lintrunner's linter tool itself crashed ("General linter failure"), distinct
+# from a per-file lint violation above. Capture the linter code so CLANGTIDY vs
+# RUFF etc. group separately; otherwise only the far-away "##[error]Linter
+# failed" GHA-error catch-all fires and loses which linter died.
+[[rule]]
+name = 'Lintrunner general linter failure'
+pattern = '^\s*Error \((\w+)\) Linter failed$'
+
 [[rule]]
 name = 'GHA timeout'
 pattern = '^##\[error\]The action (.*)has timed out(?: after .* minutes|)?.'
@@ -342,6 +350,15 @@ pattern = 'An unexpected error has occurred. Conda has prepared the above report
 [[rule]]
 name = 'Docker error'
 pattern = '^docker: Error.*'
+
+# `uv python install/find` couldn't fetch download-metadata.json (runner DNS /
+# network failure); the URL carries the uv version, so capture only the stable
+# phrase. Without this the real cause is unclassified and a benign CMake
+# feature-probe "ninja: build stopped" (Build error) wins instead -- so this must
+# sit above the ninja rules below.
+[[rule]]
+name = 'uv python download metadata fetch failed'
+pattern = '''^error: (Error while fetching remote python downloads json) from '.*'$'''
 
 # ninja's per-edge failure marker, printed immediately before the failing command
 # and its error output -- so surfacing it lands the real cause in the context


### PR DESCRIPTION
Sampled recent pytorch/pytorch PR failures and triaged the candidates with discretion — add a fixture only if the landed classifier is *clearly wrong* on it, or it exercises something not already represented. Most candidates were correctly skipped (deploy-lag on the stale prod classifier, dead/rate-limited log blobs, or redundant with existing fixtures).

## New rules (the real cause was mis- or un-classified)

- **`uv python download metadata fetch failed`** — a runner DNS/network failure during `uv python install` was being masked by a benign CMake feature-probe `ninja: build stopped`, so the surfaced line was a meaningless "Build error". The new rule sits *above* the ninja rules and captures only the stable phrase (the URL carries the uv version, so it's excluded from the capture to keep grouping stable).
- **`Lintrunner general linter failure`** — a linter *tool crash* (`General linter failure` / `Error (CODE) Linter failed`) is distinct from a per-file lint violation. Previously only the far-away `##[error]Linter failed` GHA catch-all fired, losing which linter died. Captures the linter code so CLANGTIDY vs RUFF group separately.

## Novel coverage (existing rule, no fixture yet)

- `python_importerror_name` and `python_importerror_missing_so` — two ImportError flavors (bad symbol import; missing `.so` during `import torch`).

## Deliberately NOT added

A `received SIGINT` rule. That line is emitted for **both** a timeout (a build hitting `timeout-minutes` is SIGINT'd and reported "cancelled") **and** a real cancellation (fail-fast / manual / concurrency). The candidate that surfaced it was in fact a 280-minute cu130 build timeout, but the cause isn't determinable from the log text alone, so the neutral GHA-error catch-all is the honest ceiling here.

## Testing

`cargo test` green; 32 fixtures total. Fixtures are the marker-based regression format from #8394 — each carries a `#=SOURCE=#` job link and a `#=MATCH=#` marker on the line the classifier picks.