### PR TITLE
Replicate greenlight PR state from S3 to ClickHouse

### DIFF
--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -727,6 +727,29 @@ def runner_fleet_count_adapter(table, bucket, key):
     general_adapter(table, bucket, key, schema, ["gzip", "none"], "JSONEachRow")
 
 
+def greenlight_pr_state_adapter(table, bucket, key):
+    # Column order must match the misc.greenlight_pr_state table's ordinary
+    # columns (minus `_meta`, which general_adapter appends via `SELECT *,
+    # (bucket, key)`). JSONEachRow maps by field name. LowCardinality(String)
+    # table columns are read as plain String here; ClickHouse widens on insert.
+    # NB: no timezone literal here -- general_adapter wraps this schema in single
+    # quotes, so an inner 'UTC' would break the s3() SQL. `version` is a UTC
+    # wall-clock string with millisecond precision.
+    schema = """
+    `repo` String,
+    `pr_number` Int64,
+    `head_sha` String,
+    `status` String,
+    `reason` String,
+    `eval_hash` String,
+    `message` String,
+    `eval_job` String,
+    `agent_job` String,
+    `version` DateTime64(3)
+    """
+    general_adapter(table, bucket, key, schema, ["gzip", "none"], "JSONEachRow")
+
+
 SUPPORTED_PATHS = {
     "merges": "default.merges",
     "queue_times_historical": "default.queue_times_historical",
@@ -753,6 +776,7 @@ SUPPORTED_PATHS = {
     "ghci-related": "infra_metrics.cloudwatch_metrics",
     "test_jsons_while_running": "tests.all_test_runs",
     "runner_fleet_count": "misc.runner_fleet_count",
+    "greenlight_pr_state": "misc.greenlight_pr_state",
 }
 
 OBJECT_CONVERTER = {
@@ -780,6 +804,7 @@ OBJECT_CONVERTER = {
     "misc.autorevert_advisor_verdicts": autorevert_advisor_verdicts_adapter,
     "infra_metrics.cloudwatch_metrics": cloudwatch_metrics_adapter,
     "misc.runner_fleet_count": runner_fleet_count_adapter,
+    "misc.greenlight_pr_state": greenlight_pr_state_adapter,
 }
 
 


### PR DESCRIPTION
**Impact:** CI data pipeline only
**Risk:** low

## What
Adds a `greenlight_pr_state` adapter and registers it so objects landing under that S3 path are replicated into the `misc.greenlight_pr_state` ClickHouse table.

## Why
The greenlight/PR-eval workflow writes per-PR verdicts (status, reason, eval/agent job refs, version) to S3, and those records need to be queryable in ClickHouse. This wires up the replicator so the data flows automatically, following the same JSONEachRow pattern used by the other adapters (e.g. `runner_fleet_count`).

# Notes
- Purely additive: a new adapter function plus two dictionary entries (`SUPPORTED_PATHS`, `OBJECT_CONVERTER`). No existing paths are touched.
- The schema here must stay in sync with the `misc.greenlight_pr_state` table definition; column order matches the table's ordinary columns and `JSONEachRow` maps by field name.