### PR TITLE
Add stub greenlight workflows to enable workflow_dispatch testing

### DIFF
--- a/.github/workflows/greenlight-pr-review.yml
+++ b/.github/workflows/greenlight-pr-review.yml
@@ -1,0 +1,23 @@
+name: Green Light PR Review
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "pytorch/pytorch PR number to review"
+        required: true
+        type: string
+      head_sha:
+        description: "Head commit SHA the verdict is pinned to (land-guard)"
+        required: true
+        type: string
+      eval_hash:
+        description: "Land-guard fingerprint of the evaluated inputs"
+        required: true
+        type: string
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "stub"

--- a/.github/workflows/greenlight-review.yml
+++ b/.github/workflows/greenlight-review.yml
@@ -1,0 +1,10 @@
+name: Green Light Review
+
+on:
+  workflow_dispatch:
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "stub"


### PR DESCRIPTION
**Impact:** CI only (feature branch)
**Risk:** low

## What
Adds two no-op GitHub Actions workflows, `greenlight-pr-review.yml` and `greenlight-review.yml`, both triggered via `workflow_dispatch`. `greenlight-pr-review.yml` preserves the real input signature (`pr_number`, `head_sha`, `eval_hash`); `greenlight-review.yml` takes no inputs. Each job just echoes "stub".

## Why
`workflow_dispatch` workflows must exist on a branch before they can be manually triggered. These stubs register the workflow names and input schemas so the actual greenlight review workflows can be developed and invoked/tested from a feature branch without running any privileged logic.

# Notes
Placeholder scaffolding — the real job logic will replace the `noop` steps as the workflows are built out.