### PR TITLE
Drop additional fetch refs that collide with the checked-out ref

### DIFF
--- a/.github/actions/checkout/__test__/ref-helper.test.ts
+++ b/.github/actions/checkout/__test__/ref-helper.test.ts
@@ -221,4 +221,43 @@ describe('ref-helper tests', () => {
     expect(refSpec[0]).toBe('+refs/heads/main:refs/remotes/origin/main')
     expect(refSpec[1]).toBe('+refs/tags/my-tag:refs/tags/my-tag')
   })
+
+  it('getRefSpec sha + refs/heads/ drops the colliding additional fetch ref', async () => {
+    const refSpec = refHelper.getRefSpec('refs/heads/main', commit, [
+      'refs/heads/main'
+    ])
+    expect(refSpec.length).toBe(1)
+    expect(refSpec[0]).toBe(`+${commit}:refs/remotes/origin/main`)
+  })
+
+  it('getRefSpec keeps additional fetch refs that do not collide', async () => {
+    const refSpec = refHelper.getRefSpec('refs/heads/main', commit, [
+      'refs/heads/main',
+      'refs/heads/viable/strict'
+    ])
+    expect(refSpec.length).toBe(2)
+    expect(refSpec[0]).toBe(`+${commit}:refs/remotes/origin/main`)
+    expect(refSpec[1]).toBe(
+      '+refs/heads/viable/strict:refs/remotes/origin/viable/strict'
+    )
+  })
+
+  it('getRefSpec de-dupes repeated additional fetch refs', async () => {
+    const refSpec = refHelper.getRefSpec('refs/heads/my/branch', '', [
+      'refs/heads/main',
+      'refs/heads/main'
+    ])
+    expect(refSpec.length).toBe(2)
+    expect(refSpec[0]).toBe(
+      '+refs/heads/my/branch:refs/remotes/origin/my/branch'
+    )
+    expect(refSpec[1]).toBe('+refs/heads/main:refs/remotes/origin/main')
+  })
+
+  it('getRefSpec sha only keeps additional fetch refs', async () => {
+    const refSpec = refHelper.getRefSpec('', commit, ['refs/heads/main'])
+    expect(refSpec.length).toBe(2)
+    expect(refSpec[0]).toBe(commit)
+    expect(refSpec[1]).toBe('+refs/heads/main:refs/remotes/origin/main')
+  })
 })

--- a/.github/actions/checkout/__test__/verify-colliding-fetch-refs.sh
+++ b/.github/actions/checkout/__test__/verify-colliding-fetch-refs.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Verify .git folder
+if [ ! -d "./colliding-fetch-refs/.git" ]; then
+  echo "Expected ./colliding-fetch-refs/.git folder to exist"
+  exit 1
+fi
+
+# Verify the checked out commit is the one that triggered the workflow, i.e. the
+# colliding additional fetch ref was dropped rather than fetched over it
+
+ACTUAL_SHA=$(git -C colliding-fetch-refs rev-parse HEAD)
+
+if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+  echo "Expected ./colliding-fetch-refs to be checked out at $EXPECTED_SHA, got $ACTUAL_SHA"
+  exit 1
+fi

--- a/.github/actions/checkout/dist/index.js
+++ b/.github/actions/checkout/dist/index.js
@@ -2340,13 +2340,38 @@ function getSingleRefSpec(ref, commit) {
         return [`+${ref}:${ref}`];
     }
 }
+/**
+ * Returns the destination of a refspec, or an empty string when the refspec has
+ * no destination (a bare commit)
+ */
+function getRefSpecDestination(refSpec) {
+    const separator = refSpec.indexOf(':');
+    return separator < 0 ? '' : refSpec.substring(separator + 1);
+}
 function getRefSpec(ref, commit, additionalFetchRefs) {
     const result = [];
-    const singleRefSpec = getSingleRefSpec(ref, commit);
-    result.push(...singleRefSpec);
+    const destinations = new Set();
+    // git refuses to fetch two different sources into the same destination, so
+    // keep only the first refspec for any given destination. The ref being
+    // checked out comes first and wins: when the workflow pins a commit on main,
+    // its `+<commit>:refs/remotes/origin/main` would otherwise collide with
+    // `+refs/heads/main:refs/remotes/origin/main` from additional-fetch-refs
+    const appendRefSpecs = (refSpecs) => {
+        for (const refSpec of refSpecs) {
+            const destination = getRefSpecDestination(refSpec);
+            if (destination) {
+                if (destinations.has(destination)) {
+                    core.info(`Skipping refspec '${refSpec}', '${destination}' is already fetched by another refspec`);
+                    continue;
+                }
+                destinations.add(destination);
+            }
+            result.push(refSpec);
+        }
+    };
+    appendRefSpecs(getSingleRefSpec(ref, commit));
     for (const additionalRef of additionalFetchRefs) {
-        const additionalRefSpec = getSingleRefSpec(additionalRef, '');
-        result.push(...additionalRefSpec);
+        appendRefSpecs(getSingleRefSpec(additionalRef, ''));
     }
     return result;
 }

--- a/.github/actions/checkout/src/ref-helper.ts
+++ b/.github/actions/checkout/src/ref-helper.ts
@@ -127,17 +127,47 @@ export function getSingleRefSpec(ref: string, commit: string): string[] {
   }
 }
 
+/**
+ * Returns the destination of a refspec, or an empty string when the refspec has
+ * no destination (a bare commit)
+ */
+function getRefSpecDestination(refSpec: string): string {
+  const separator = refSpec.indexOf(':')
+  return separator < 0 ? '' : refSpec.substring(separator + 1)
+}
+
 export function getRefSpec(
   ref: string,
   commit: string,
   additionalFetchRefs: string[]
 ): string[] {
   const result: string[] = []
-  const singleRefSpec: string[] = getSingleRefSpec(ref, commit)
-  result.push(...singleRefSpec)
+  const destinations = new Set<string>()
+
+  // git refuses to fetch two different sources into the same destination, so
+  // keep only the first refspec for any given destination. The ref being
+  // checked out comes first and wins: when the workflow pins a commit on main,
+  // its `+<commit>:refs/remotes/origin/main` would otherwise collide with
+  // `+refs/heads/main:refs/remotes/origin/main` from additional-fetch-refs
+  const appendRefSpecs = (refSpecs: string[]): void => {
+    for (const refSpec of refSpecs) {
+      const destination = getRefSpecDestination(refSpec)
+      if (destination) {
+        if (destinations.has(destination)) {
+          core.info(
+            `Skipping refspec '${refSpec}', '${destination}' is already fetched by another refspec`
+          )
+          continue
+        }
+        destinations.add(destination)
+      }
+      result.push(refSpec)
+    }
+  }
+
+  appendRefSpecs(getSingleRefSpec(ref, commit))
   for (const additionalRef of additionalFetchRefs) {
-    const additionalRefSpec = getSingleRefSpec(additionalRef, '')
-    result.push(...additionalRefSpec)
+    appendRefSpecs(getSingleRefSpec(additionalRef, ''))
   }
   return result
 }

--- a/.github/workflows/checkout-test.yml
+++ b/.github/workflows/checkout-test.yml
@@ -114,6 +114,24 @@ jobs:
           additional-fetch-refs: |
             refs/heads/main
 
+      # An additional fetch ref pointing at the ref being checked out. Both
+      # refspecs resolve to the same destination, and git refuses to fetch two
+      # different sources into one destination, so the additional one has to be
+      # dropped. This is what a push to main hits with the default
+      # additional-fetch-refs
+      - name: Additional fetch refs colliding with the checked out ref
+        uses: ./.github/actions/checkout/
+        with:
+          path: .github/actions/checkout/colliding-fetch-refs
+          additional-fetch-refs: |
+            ${{ github.ref }}
+
+      - name: Verify additional fetch refs colliding with the checked out ref
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ github.sha }}
+        run: __test__/verify-colliding-fetch-refs.sh
+
       # Sparse checkout
       - name: Sparse checkout
         uses: ./.github/actions/checkout/


### PR DESCRIPTION
Fixes https://github.com/pytorch/torchtitan/issues/4049.

The bug is in #7670, which added `additional-fetch-refs` and a `getRefSpec` that concatenates the additional refspecs onto the one for the ref being checked out without checking whether their destinations collide.

It surfaces whenever the action's `ref` input is empty and the event ref is a branch that also appears in `additional-fetch-refs` — which includes the `refs/heads/main` default, so a caller need not pass anything. With `ref` empty the action resolves it to both `ref = refs/heads/main` and `commit = <sha>`, and `getRefSpec` emits `+<sha>:refs/remotes/origin/main` for the ref being checked out plus `+refs/heads/main:refs/remotes/origin/main` for the additional ref. Two sources, one destination:

```
fatal: Cannot fetch both 681fd4b5... and refs/heads/main to refs/remotes/origin/main
```

So this has been broken for direct consumers of the action since #7670 — including this repo's own `checkout-test.yml`, whose "Additional fetch refs" step leaves `ref` empty: its last green push-to-`main` run is the commit before #7670, and every one since has failed. PR runs are unaffected because they check out `refs/pull/N/merge`.

#8413 is how torchtitan ran into it. Dropping `|| github.ref` from the Nova reusable workflows meant `ref` reaches the action empty when the caller doesn't pin one; previously `github.ref` filled it in, which left `commit` empty and made the two refspecs identical — git accepts that. Pinning the commit made them differ.

`getRefSpec` now keeps the first refspec for each destination. The ref being checked out is appended first and wins, so `origin/main` still exists for scripts that diff against it — at the pinned commit rather than the branch tip, which is what #8413 was after. Bare-commit refspecs have no destination and are never de-duped.

No change needed in torchtitan or other callers: `linux_job_v2/v3` use `./test-infra/.github/actions/checkout` from the tree at `test-infra-ref`, and de-duping fixes the collision for every caller rather than only the ones that pass `additional-fetch-refs: ""`.