### PR TITLE
Add run_id and emit_id to greenlight_pr_state replicator schema

### DIFF
--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -745,7 +745,9 @@ def greenlight_pr_state_adapter(table, bucket, key):
     `message` String,
     `eval_job` String,
     `agent_job` String,
-    `version` DateTime64(3)
+    `version` DateTime64(3),
+    `run_id` Int64,
+    `emit_id` String
     """
     general_adapter(table, bucket, key, schema, ["gzip", "none"], "JSONEachRow")
 


### PR DESCRIPTION
**Impact:** greenlight PR state replication into ClickHouse (`misc.greenlight_pr_state`) **Risk:** low

## What
Adds two columns — `run_id` (Int64) and `emit_id` (String) — to the schema the S3 replicator uses when ingesting `greenlight_pr_state` records.

## Why
The `greenlight_pr_state` table was changed to retain the full history of state changes for a PR rather than only the latest state. The new columns let each emitted record be attributed to its originating run and distinguished as a distinct emission, so history rows don't collapse together.

# Notes
The replicator reads via `JSONEachRow` (field-name mapping), so the incoming greenlight payloads must actually emit `run_id` and `emit_id`, and the target ClickHouse table must already have these columns for the insert to land.