### PR TITLE
[HUD] Show unstable-marked jobs on the reliability page

### DIFF
--- a/torchci/clickhouse_queries/master_commit_red_jobs/params.json
+++ b/torchci/clickhouse_queries/master_commit_red_jobs/params.json
@@ -2,18 +2,31 @@
   "params": {
     "startTime": "DateTime64(3)",
     "stopTime": "DateTime64(3)",
-    "workflowNames": "Array(String)"
+    "workflowNames": "Array(String)",
+    "unstableOnly": "UInt8"
+  },
+  "defaults": {
+    "workflowNames": [],
+    "unstableOnly": 0
   },
   "tests": [
     {
       "startTime": "2025-03-18T21:09:47.987",
       "stopTime": "2025-03-25T21:09:47.987",
-      "workflowNames": ["pull"]
+      "workflowNames": ["pull"],
+      "unstableOnly": 0
     },
     {
       "startTime": "2025-03-18T21:09:47.987",
       "stopTime": "2025-03-25T21:09:47.987",
-      "workflowNames": ["lint", "pull", "trunk"]
+      "workflowNames": ["lint", "pull", "trunk"],
+      "unstableOnly": 0
+    },
+    {
+      "startTime": "2025-03-18T21:09:47.987",
+      "stopTime": "2025-03-25T21:09:47.987",
+      "workflowNames": [],
+      "unstableOnly": 1
     }
   ]
 }

--- a/torchci/clickhouse_queries/master_commit_red_jobs/query.sql
+++ b/torchci/clickhouse_queries/master_commit_red_jobs/query.sql
@@ -1,4 +1,6 @@
 -- This query is used to show failures on https://hud.pytorch.org/reliability/pytorch/pytorch
+-- {unstableOnly}=0 backs the workflow-scoped panels; {unstableOnly}=1 backs the
+-- "Unstable jobs" panel (see the WHERE branch below).
 WITH all_jobs AS (
     SELECT
         p.head_commit. 'timestamp' AS time,
@@ -41,9 +43,27 @@ WITH all_jobs AS (
       AND j.name != 'generate-test-matrix'
       AND j.name NOT LIKE '%rerun_disabled_tests%'
       AND j.name NOT LIKE '%filter%'
-      AND j.name NOT LIKE '%unstable%'
       AND j.name LIKE '%/%'
-      AND has({workflowNames: Array(String) }, lower(j.workflow_name))
+      -- Normal mode ({unstableOnly}=0): exclude unstable jobs, keep the requested
+      -- workflows. Unstable mode ({unstableOnly}=1): the dedicated "unstable"
+      -- workflow, plus any job marked unstable (including scheduled/nightly);
+      -- workflowNames is unused in that mode. Both modes drop workflow_run-chained
+      -- jobs via the shared line below.
+      AND (
+            (
+              {unstableOnly: UInt8} = 0
+              AND j.name NOT LIKE '%unstable%'
+              AND has({workflowNames: Array(String) }, lower(j.workflow_name))
+            )
+            OR
+            (
+              {unstableOnly: UInt8} = 1
+              AND (
+                    lower(j.workflow_name) = 'unstable'
+                    OR j.name LIKE '%unstable%'
+                  )
+            )
+          )
       AND j.workflow_event != 'workflow_run' -- Filter out worflow_run-triggered jobs, which have nothing to do with the SHA
       AND p.ref = 'refs/heads/main'
       AND p.repository. 'owner'.'name' = 'pytorch'

--- a/torchci/clickhouse_queries/master_commit_red_jobs/query.sql
+++ b/torchci/clickhouse_queries/master_commit_red_jobs/query.sql
@@ -45,10 +45,10 @@ WITH all_jobs AS (
       AND j.name NOT LIKE '%filter%'
       AND j.name LIKE '%/%'
       -- Normal mode ({unstableOnly}=0): exclude unstable jobs, keep the requested
-      -- workflows. Unstable mode ({unstableOnly}=1): the dedicated "unstable"
-      -- workflow, plus any job marked unstable (including scheduled/nightly);
-      -- workflowNames is unused in that mode. Both modes drop workflow_run-chained
-      -- jobs via the shared line below.
+      -- workflows. Unstable mode ({unstableOnly}=1): the union of the "unstable"
+      -- workflow and jobs whose name carries the runtime unstable marker;
+      -- workflowNames is unused there. Both modes drop workflow_run-chained jobs
+      -- via the shared line below.
       AND (
             (
               {unstableOnly: UInt8} = 0

--- a/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
+++ b/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
@@ -574,16 +574,14 @@ export default function Page() {
 
         <Grid size={{ xs: 6 }} height={ROW_HEIGHT}>
           {/*
-            Unstable jobs to watch: union of the dedicated "unstable" workflow and
-            any job marked unstable on main (any trigger; workflow_run-chained jobs
-            excluded). Same query as the other panels with unstableOnly=1, which
-            flips its unstable filter; workflowNames is unused in that mode.
+            Unstable jobs to watch: the union of unstable.yml and jobs whose name
+            carries the runtime unstable marker.
           */}
           <GroupReliabilityPanel
             title={"Unstable jobs"}
             subtitle={
-              UNSTABLE_WORKFLOWS.join(", ") +
-              " workflow + main jobs marked unstable"
+              UNSTABLE_WORKFLOWS.map((w) => `${w}.yml`).join(", ") +
+              " + jobs tagged unstable at runtime"
             }
             queryName={queryName}
             queryParams={{ unstableOnly: 1, ...queryParams }}

--- a/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
+++ b/torchci/pages/reliability/[repoOwner]/[repoName]/[[...page]].tsx
@@ -573,13 +573,20 @@ export default function Page() {
         </Grid>
 
         <Grid size={{ xs: 6 }} height={ROW_HEIGHT}>
+          {/*
+            Unstable jobs to watch: union of the dedicated "unstable" workflow and
+            any job marked unstable on main (any trigger; workflow_run-chained jobs
+            excluded). Same query as the other panels with unstableOnly=1, which
+            flips its unstable filter; workflowNames is unused in that mode.
+          */}
           <GroupReliabilityPanel
             title={"Unstable jobs"}
+            subtitle={
+              UNSTABLE_WORKFLOWS.join(", ") +
+              " workflow + main jobs marked unstable"
+            }
             queryName={queryName}
-            queryParams={{
-              workflowNames: UNSTABLE_WORKFLOWS,
-              ...queryParams,
-            }}
+            queryParams={{ unstableOnly: 1, ...queryParams }}
             metricName={metricName}
             metricHeaderName={metricHeaderName}
             filter={filter}


### PR DESCRIPTION
Previously, Unstable jobs panel feels a bit narrow since it was only including jobs part of the unstable workflow. Expand the query to also include jobs marked as unstable (e.g. with the Issue workflow). This provides a flow for users to monitor cordoned jobs and improvements in reliability.