### PR TITLE
[CRCR] Replace Flaky Jobs card with Timeout Rate and align Pass Rate colors with L3 criteria

### DIFF
--- a/torchci/clickhouse_queries/crcr_backend_summary/query.sql
+++ b/torchci/clickhouse_queries/crcr_backend_summary/query.sql
@@ -7,24 +7,11 @@ SELECT
     uniqExact(pr_number) AS total_prs,
     avg(queue_time) AS avg_queue_time_s,
     avg(execution_time) AS avg_exec_time_s,
-    -- Flaky: jobs where the same job_name has both success and failure
-    -- across different run_attempts for the same PR
-    uniqExactIf(
-        job_name,
-        job_name IN (
-            SELECT job_name
-            FROM default.crcr_workflow_job FINAL
-            WHERE
-                downstream_repo = {repo: String}
-                AND started_at > now() - INTERVAL {days: UInt64} DAY
-                AND status = 'completed'
-                AND pr_number > 0
-            GROUP BY pr_number, job_name
-            HAVING
-                countIf(conclusion = 'success') > 0
-                AND countIf(conclusion = 'failure') > 0
-        )
-    ) AS flaky_jobs
+    if(
+        total_jobs > 0,
+        timed_out / total_jobs,
+        0
+    ) AS timeout_rate
 FROM
     default.crcr_workflow_job FINAL
 WHERE

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -102,9 +102,9 @@ function StatCard({
 
 function SummaryCards({ stats }: { stats: SummaryStats }) {
   const passColor =
-    stats.pass_rate >= 0.95
+    stats.pass_rate >= 1.0
       ? "#2e7d32"
-      : stats.pass_rate >= 0.8
+      : stats.pass_rate >= 0.9
       ? "#ed6c02"
       : "#d32f2f";
 

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -58,7 +58,7 @@ interface SummaryStats {
   total_prs: number;
   avg_queue_time_s: number | null;
   avg_exec_time_s: number | null;
-  flaky_jobs: number;
+  timeout_rate: number;
 }
 
 // ---- Summary Stat Cards ----
@@ -149,10 +149,16 @@ function SummaryCards({ stats }: { stats: SummaryStats }) {
           sub="start to completion"
         />
         <StatCard
-          label="Flaky Jobs"
-          value={stats.flaky_jobs}
-          sub="same job: pass + fail across attempts"
-          color={stats.flaky_jobs > 0 ? "#ed6c02" : undefined}
+          label="Timeout Rate"
+          value={`${(stats.timeout_rate * 100).toFixed(1)}%`}
+          sub={`${stats.timed_out} timed out / ${stats.total_jobs} jobs`}
+          color={
+            stats.timeout_rate >= 0.1
+              ? "#d32f2f"
+              : stats.timeout_rate > 0
+              ? "#ed6c02"
+              : undefined
+          }
         />
       </Box>
     </Stack>


### PR DESCRIPTION
## Summary

Two changes to the CRCR per-repo dashboard page (`/crcr/{org}/{repo}`), aligning stat card thresholds with the L3 promotion criteria proposed in [pytorch/rfcs#102](https://github.com/pytorch/rfcs/pull/102).

### 1. Replace Flaky Jobs card → Timeout Rate

**ClickHouse query** (`crcr_backend_summary/query.sql`):
- Removed the complex flaky-job subquery (correlated subquery scanning the table twice)
- Added `timeout_rate = timed_out / total_jobs`

**Frontend card**:
- Shows percentage (e.g., `0.0%`, `1.2%`)
- Sub-text: `X timed out / Y jobs`
- Color: green (0%), orange (>0% but <10%), red (≥10% — exceeds L3 threshold)

### 2. Align Pass Rate color thresholds

Updated to match L3 criteria (`job pass rate > 90%`):
- **Green**: 100%
- **Orange**: 90–99.9% (meets L3)
- **Red**: < 90% (below L3)

Previously: ≥95% green, ≥80% orange, <80% red.

## Context

The L3 criteria in [pytorch/rfcs#102](https://github.com/pytorch/rfcs/pull/102) defines:
- **Timeout rate < 10%** as an infrastructure reliability signal
- **Job pass rate > 90%** as a test quality signal

These cards make L3 readiness directly visible on the per-repo dashboard.

## Test plan
- [ ] Verify `crcr_backend_summary` query returns `timeout_rate` correctly
- [ ] Verify Timeout Rate card renders with proper color coding
- [ ] Verify Pass Rate card shows red when < 90%, orange when 90–99.9%, green at 100%