### PR TITLE
[CRCR] Fix pytorch_head_sha extraction for nightly callbacks

### DIFF
--- a/.github/actions/cross-repo-ci-relay-callback/report_callback.py
+++ b/.github/actions/cross-repo-ci-relay-callback/report_callback.py
@@ -99,7 +99,7 @@ def build_payload() -> str:
         "job_name": os.environ["JOB_NAME"],
         "check_run_id": check_run_id,
         "run_id": str(os.environ["RUN_ID"]),
-        "started_at": None if status == "completed" else current_time,
+        "started_at": current_time if is_self_report else (None if status == "completed" else current_time),
         "completed_at": None if status == "in_progress" else current_time,
     }
 

--- a/.github/actions/cross-repo-ci-relay-callback/report_callback.py
+++ b/.github/actions/cross-repo-ci-relay-callback/report_callback.py
@@ -99,7 +99,9 @@ def build_payload() -> str:
         "job_name": os.environ["JOB_NAME"],
         "check_run_id": check_run_id,
         "run_id": str(os.environ["RUN_ID"]),
-        "started_at": current_time if is_self_report else (None if status == "completed" else current_time),
+        "started_at": current_time
+        if is_self_report
+        else (None if status == "completed" else current_time),
         "completed_at": None if status == "in_progress" else current_time,
     }
 

--- a/torchci/lib/crcr/crcrUtils.ts
+++ b/torchci/lib/crcr/crcrUtils.ts
@@ -120,7 +120,7 @@ export function extractDynamoRecord(
     downstream_repo: trusted.verified_repo,
     upstream_repo: upstreamRepo,
     pr_number: pr?.number ?? 0,
-    pytorch_head_sha: pr?.head?.sha ?? "",
+    pytorch_head_sha: pr?.head?.sha ?? cb.payload?.head_sha ?? cb.delivery_id ?? "",
     delivery_id: cb.delivery_id,
     workflow_run_url: wf.url ?? "",
     workflow_name: wf.name,

--- a/torchci/lib/crcr/crcrUtils.ts
+++ b/torchci/lib/crcr/crcrUtils.ts
@@ -120,7 +120,8 @@ export function extractDynamoRecord(
     downstream_repo: trusted.verified_repo,
     upstream_repo: upstreamRepo,
     pr_number: pr?.number ?? 0,
-    pytorch_head_sha: pr?.head?.sha ?? cb.payload?.head_sha ?? cb.delivery_id ?? "",
+    pytorch_head_sha:
+      pr?.head?.sha ?? cb.payload?.head_sha ?? cb.delivery_id ?? "",
     delivery_id: cb.delivery_id,
     workflow_run_url: wf.url ?? "",
     workflow_name: wf.name,

--- a/torchci/test/crcrUtils.test.ts
+++ b/torchci/test/crcrUtils.test.ts
@@ -175,7 +175,25 @@ describe("extractDynamoRecord", () => {
       })
     );
     expect(record.pr_number).toBe(0);
-    expect(record.pytorch_head_sha).toBe("");
+    expect(record.pytorch_head_sha).toBe("delivery-abc-123");
+  });
+
+  test("uses payload.head_sha for nightly callbacks", () => {
+    const record = extractDynamoRecord(
+      makePayload({
+        callback: {
+          event_type: "nightly",
+          delivery_id: "abc123def456",
+          payload: {
+            repository: { full_name: "pytorch/pytorch" },
+            head_sha: "abc123def456",
+          },
+        },
+      })
+    );
+    expect(record.pytorch_head_sha).toBe("abc123def456");
+    expect(record.pr_number).toBe(0);
+    expect(record.event_type).toBe("nightly");
   });
 
   // --- completed status ---


### PR DESCRIPTION
## Summary

Nightly callbacks from downstream repos (e.g., `TorchedHat/pytorch-redhat-ci`) were being stored in ClickHouse with an empty `pytorch_head_sha`. This caused the nightly tab on the CRCR summary page (`/crcr`) to show "No nightly CI results reported yet" even though the callbacks were succeeding.

**Root cause**: The `extractDynamoRecord` function in `crcrUtils.ts` only reads `pytorch_head_sha` from `payload.pull_request.head.sha`. Nightly payloads have no `pull_request` object — the SHA is at `payload.head_sha` (set by `report_callback.py`) and also matches `delivery_id`.

**Fix**: Fall back to `payload.head_sha`, then `delivery_id` when `pull_request` is absent.

## Test plan

- Updated existing test to reflect new fallback behavior
- Added new test case for nightly callback SHA extraction
- Verify nightly data appears on the CRCR summary page after the next nightly run