### PR TITLE
[CI] Fix empty wheel artifact checks

### DIFF
--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -300,7 +300,7 @@ jobs:
           if [[ -n "${UPLOAD_ARTIFACT_NAME}" ]]; then
             # If the default execution path is followed then we should get a wheel in the dist/ folder
             # attempt to just grab whatever is in there and scoop it all up
-            if find "dist/" -name "*.whl" >/dev/null 2>/dev/null; then
+            if compgen -G "dist/*.whl" >/dev/null; then
               mv -v dist/*.whl "${RUNNER_ARTIFACT_DIR}/"
             fi
             if [[ -d "artifacts-to-be-uploaded" ]]; then

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -300,9 +300,11 @@ jobs:
           if [[ -n "${UPLOAD_ARTIFACT_NAME}" ]]; then
             # If the default execution path is followed then we should get a wheel in the dist/ folder
             # attempt to just grab whatever is in there and scoop it all up
-            if compgen -G "dist/*.whl" >/dev/null; then
-              mv -v dist/*.whl "${RUNNER_ARTIFACT_DIR}/"
-            fi
+            for wheel in dist/*.whl; do
+              if [[ -f "${wheel}" ]]; then
+                mv -v "${wheel}" "${RUNNER_ARTIFACT_DIR}/"
+              fi
+            done
             if [[ -d "artifacts-to-be-uploaded" ]]; then
               mv -v artifacts-to-be-uploaded/* "${RUNNER_ARTIFACT_DIR}/"
             fi

--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -330,9 +330,11 @@ jobs:
           if [[ -n "${UPLOAD_ARTIFACT_NAME}" ]]; then
             # If the default execution path is followed then we should get a wheel in the dist/ folder
             # attempt to just grab whatever is in there and scoop it all up
-            if compgen -G "dist/*.whl" >/dev/null; then
-              mv -v dist/*.whl "${RUNNER_ARTIFACT_DIR}/"
-            fi
+            for wheel in dist/*.whl; do
+              if [[ -f "${wheel}" ]]; then
+                mv -v "${wheel}" "${RUNNER_ARTIFACT_DIR}/"
+              fi
+            done
             if [[ -d "artifacts-to-be-uploaded" ]]; then
               mv -v artifacts-to-be-uploaded/* "${RUNNER_ARTIFACT_DIR}/"
             fi

--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -330,7 +330,7 @@ jobs:
           if [[ -n "${UPLOAD_ARTIFACT_NAME}" ]]; then
             # If the default execution path is followed then we should get a wheel in the dist/ folder
             # attempt to just grab whatever is in there and scoop it all up
-            if find "dist/" -name "*.whl" >/dev/null 2>/dev/null; then
+            if compgen -G "dist/*.whl" >/dev/null; then
               mv -v dist/*.whl "${RUNNER_ARTIFACT_DIR}/"
             fi
             if [[ -d "artifacts-to-be-uploaded" ]]; then

--- a/.github/workflows/linux_job_v3.yml
+++ b/.github/workflows/linux_job_v3.yml
@@ -248,9 +248,11 @@ jobs:
           if [[ -n "${UPLOAD_ARTIFACT_NAME}" ]]; then
             # If the default execution path is followed then we should get a wheel in the dist/ folder
             # attempt to just grab whatever is in there and scoop it all up
-            if compgen -G "dist/*.whl" >/dev/null; then
-              mv -v dist/*.whl "${RUNNER_ARTIFACT_DIR}/"
-            fi
+            for wheel in dist/*.whl; do
+              if [[ -f "${wheel}" ]]; then
+                mv -v "${wheel}" "${RUNNER_ARTIFACT_DIR}/"
+              fi
+            done
             if [[ -d "artifacts-to-be-uploaded" ]]; then
               mv -v artifacts-to-be-uploaded/* "${RUNNER_ARTIFACT_DIR}/"
             fi

--- a/.github/workflows/linux_job_v3.yml
+++ b/.github/workflows/linux_job_v3.yml
@@ -248,7 +248,7 @@ jobs:
           if [[ -n "${UPLOAD_ARTIFACT_NAME}" ]]; then
             # If the default execution path is followed then we should get a wheel in the dist/ folder
             # attempt to just grab whatever is in there and scoop it all up
-            if find "dist/" -name "*.whl" >/dev/null 2>/dev/null; then
+            if compgen -G "dist/*.whl" >/dev/null; then
               mv -v dist/*.whl "${RUNNER_ARTIFACT_DIR}/"
             fi
             if [[ -d "artifacts-to-be-uploaded" ]]; then

--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -195,7 +195,7 @@ jobs:
         run: |
           # If the default execution path is followed then we should get a wheel in the dist/ folder
           # attempt to just grab whatever is in there and scoop it all up
-          if find "dist/" -name "*.whl" >/dev/null 2>/dev/null; then
+          if compgen -G "dist/*.whl" >/dev/null; then
             mv -v dist/*.whl "${RUNNER_ARTIFACT_DIR}/"
           fi
           if [[ -d "artifacts-to-be-uploaded" ]]; then

--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -195,9 +195,11 @@ jobs:
         run: |
           # If the default execution path is followed then we should get a wheel in the dist/ folder
           # attempt to just grab whatever is in there and scoop it all up
-          if compgen -G "dist/*.whl" >/dev/null; then
-            mv -v dist/*.whl "${RUNNER_ARTIFACT_DIR}/"
-          fi
+          for wheel in dist/*.whl; do
+            if [[ -f "${wheel}" ]]; then
+              mv -v "${wheel}" "${RUNNER_ARTIFACT_DIR}/"
+            fi
+          done
           if [[ -d "artifacts-to-be-uploaded" ]]; then
             mv -v artifacts-to-be-uploaded/* "${RUNNER_ARTIFACT_DIR}/"
           fi

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -186,9 +186,11 @@ jobs:
         run: |
           # If the default execution path is followed then we should get a wheel in the dist/ folder
           # attempt to just grab whatever is in there and scoop it all up
-          if compgen -G "dist/*.whl" >/dev/null; then
-            mv -v dist/*.whl "${RUNNER_ARTIFACT_DIR}/"
-          fi
+          for wheel in dist/*.whl; do
+            if [[ -f "${wheel}" ]]; then
+              mv -v "${wheel}" "${RUNNER_ARTIFACT_DIR}/"
+            fi
+          done
           if [[ -d "artifacts-to-be-uploaded" ]]; then
             mv -v artifacts-to-be-uploaded/* "${RUNNER_ARTIFACT_DIR}/"
           fi

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -186,7 +186,7 @@ jobs:
         run: |
           # If the default execution path is followed then we should get a wheel in the dist/ folder
           # attempt to just grab whatever is in there and scoop it all up
-          if find "dist/" -name "*.whl" >/dev/null 2>/dev/null; then
+          if compgen -G "dist/*.whl" >/dev/null; then
             mv -v dist/*.whl "${RUNNER_ARTIFACT_DIR}/"
           fi
           if [[ -d "artifacts-to-be-uploaded" ]]; then


### PR DESCRIPTION
There was a bug in artifact preparation where `find "dist/" -name "*.whl"` returned success whenever `dist/` existed, even if it contained no wheels. The following `mv dist/*.whl` then failed and obscured the earlier build failure. This was observed in https://github.com/meta-pytorch/monarch/actions/runs/30938873470/job/92093926645.

This change iterates over `dist/*.whl` and moves entries only when `[[ -f "${wheel}" ]]` succeeds. Missing and empty `dist/` directories are no-ops, while an actual `mv` error still fails the artifact preparation step.

Test plan:
- Ran the repository actionlint on the five changed workflows.
- Verified missing, empty, and populated `dist/` behavior under Bash, including a wheel filename containing spaces.
- Verified that a real `mv` failure is propagated.