### PR TITLE
Add ROCm pip index mirroring for rocm7.14 dependencies

### DIFF
--- a/.github/workflows/update-s3-dependencies.yml
+++ b/.github/workflows/update-s3-dependencies.yml
@@ -30,6 +30,7 @@ on:
           - triton
           - torchtune
           - torch_xpu
+          - torch_rocm
           - vllm
       target:
         description: 'Target to create (e.g., rocm7.2, cu130) - only for create-target mode'

--- a/s3_management/update_dependencies.py
+++ b/s3_management/update_dependencies.py
@@ -1031,9 +1031,7 @@ def upload_package_using_simple_index(
     else:
         source_label = "PyPI"
 
-    print(
-        f"Processing {pkg_name} using {source_label} Simple Index: {source_url}"
-    )
+    print(f"Processing {pkg_name} using {source_label} Simple Index: {source_url}")
 
     # Parse the index and get raw HTML
     try:

--- a/s3_management/update_dependencies.py
+++ b/s3_management/update_dependencies.py
@@ -592,6 +592,34 @@ PACKAGES_PER_PROJECT: Dict[str, List[Dict[str, str]]] = {
             "target": "cu132",
         },
     ],
+    "rocm": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-core": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-libraries": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx1010": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx1011": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx1012": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx1030": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx1031": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx1032": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx1033": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx1034": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx1035": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx1036": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx1100": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx1101": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx1102": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx1103": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx1150": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx1151": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx1152": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx1153": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx1200": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx1201": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx1250": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx908": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx90a": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx942": [{"project": "torch_rocm", "target": "rocm7.14"}],
+    "rocm-sdk-device-gfx950": [{"project": "torch_rocm", "target": "rocm7.14"}],
     "arpeggio": [{"project": "triton"}],
     "caliper-reader": [{"project": "triton"}],
     "contourpy": [{"project": "triton"}],
@@ -786,12 +814,19 @@ def is_nvidia_package(pkg_name: str) -> bool:
     return pkg_name.startswith("nvidia-") or pkg_name.startswith("cuda-")
 
 
+def is_amd_package(pkg_name: str) -> bool:
+    """Check if a package is from AMD and should use repo.amd.com"""
+    name = pkg_name.lower()
+    return "rocm" in name or "amd" in name
+
+
 def get_package_source_url(pkg_name: str) -> str:
     """Get the source URL for a package based on its type"""
     if is_nvidia_package(pkg_name):
         return f"https://pypi.nvidia.com/{pkg_name}/"
-    else:
-        return f"https://pypi.org/simple/{pkg_name}/"
+    if is_amd_package(pkg_name):
+        return f"https://repo.amd.com/rocm/whl-multi-arch/{pkg_name}/"
+    return f"https://pypi.org/simple/{pkg_name}/"
 
 
 def download(url: str) -> bytes:
@@ -989,10 +1024,15 @@ def upload_package_using_simple_index(
     Works for both NVIDIA and non-NVIDIA packages.
     """
     source_url = get_package_source_url(pkg_name)
-    is_nvidia = is_nvidia_package(pkg_name)
+    if is_nvidia_package(pkg_name):
+        source_label = "NVIDIA"
+    elif is_amd_package(pkg_name):
+        source_label = "AMD"
+    else:
+        source_label = "PyPI"
 
     print(
-        f"Processing {pkg_name} using {'NVIDIA' if is_nvidia else 'PyPI'} Simple Index: {source_url}"
+        f"Processing {pkg_name} using {source_label} Simple Index: {source_url}"
     )
 
     # Parse the index and get raw HTML
@@ -1025,20 +1065,26 @@ def get_packages_for_target(target: str) -> List[str]:
     Get packages from PACKAGES_PER_PROJECT that should be initialized for a target.
 
     Returns packages where:
-    - project is "torch" AND
+    - project is "torch" (or "torch_rocm" for ROCm targets) AND
     - either no target is specified (universal packages like filelock, numpy)
     - or the target matches the specified target
     - nvidia/cuda packages are only included for CUDA targets (cu*)
+    - amd/rocm packages are only included for ROCm targets (rocm*)
     """
     is_cuda_target = target.startswith("cu")
+    is_rocm_target = target.startswith("rocm")
+    allowed_projects = ("torch", "torch_rocm") if is_rocm_target else ("torch",)
     packages = []
     for pkg_name, pkg_configs in PACKAGES_PER_PROJECT.items():
         # Skip nvidia/cuda packages for non-CUDA targets
         if not is_cuda_target and is_nvidia_package(pkg_name):
             continue
+        # Skip amd/rocm packages for non-ROCm targets
+        if not is_rocm_target and is_amd_package(pkg_name):
+            continue
 
         for config in pkg_configs:
-            if config.get("project") != "torch":
+            if config.get("project") not in allowed_projects:
                 continue
             pkg_target = config.get("target", "")
             # Include if no target specified (universal) or target matches


### PR DESCRIPTION
## Summary

Mirror ROCm SDK packages from AMD's multi-arch pip index (`https://repo.amd.com/rocm/whl-multi-arch/`) into download.pytorch.org dependency indexes for the `rocm7.14` target.

- Add `torch_rocm` workflow option to `update-s3-dependencies.yml`
- Register 28 ROCm packages under `torch_rocm` / `rocm7.14` in `PACKAGES_PER_PROJECT` (`rocm`, `rocm-sdk-core`, `rocm-sdk-libraries`, and all 25 `rocm-sdk-device-*` packages currently on the AMD index)
- Route AMD packages via `is_amd_package()` and `get_package_source_url()`
- Extend `get_packages_for_target()` so ROCm packages are included only for `rocm*` targets and `create-target` works for ROCm

## Test plan

- [x] Verified AMD URL routing:
```bash
python3 -c "from s3_management.update_dependencies import get_package_source_url, is_amd_package; assert is_amd_package('rocm-sdk-core'); assert get_package_source_url('rocm-sdk-core') == 'https://repo.amd.com/rocm/whl-multi-arch/rocm-sdk-core/'"
```
- [x] Dry-run torch_rocm update (all 28 packages fetched from AMD index):
```bash
python3 s3_management/update_dependencies.py --package torch_rocm --dry-run
```
- [ ] After merge: trigger `Update S3 HTML dependencies` workflow with `package=torch_rocm`, `dryrun=enabled`, then `disabled`
- [ ] Confirm `https://download.pytorch.org/whl/nightly/rocm7.14/rocm-sdk-core/index.html` serves absolute links to `repo.amd.com`

Authored with assistance from Cursor

Made with [Cursor](https://cursor.com)