### PR TITLE
Autorevert advisor: resolve multiple verdicts via a voting quorum

### DIFF
--- a/aws/lambda/pytorch-auto-revert/SIGNAL_ACTIONS.md
+++ b/aws/lambda/pytorch-auto-revert/SIGNAL_ACTIONS.md
@@ -18,7 +18,7 @@ This document specifies the Actions layer that consumes extracted Signals with t
 
 Immutable run-scoped metadata shared by all actions in the same run:
 
-- `ts`: DateTime captured at run start; identical across all rows inserted for the run
+- `ts`: DateTime captured at run start; shared by all `revert`/`restart` rows inserted for the run. `advisor` dispatch rows are the exception: each carries a per-dispatch (second-offset) timestamp so a same-tick quorum does not collapse under the `autorevert_events_v2` ReplacingMergeTree sort key.
 - `repo_full_name`: e.g., `pytorch/pytorch`
 - `workflows`: list of workflow display names
 - `lookback_hours`: window used for extraction
@@ -45,7 +45,7 @@ Immutable run-scoped metadata shared by all actions in the same run:
 
 ## ClickHouse Logging
 
-Two tables, sharing the same `ts` per CLI/lambda run.
+Two tables, sharing the same `ts` per CLI/lambda run — except `advisor` dispatch rows in `autorevert_events_v2`, which use per-dispatch timestamps.
 
 ### `autorevert_events_v2`
 
@@ -64,7 +64,7 @@ Two tables, sharing the same `ts` per CLI/lambda run.
 
 - Purpose: persist the HUD-like state for the whole run for auditability
 - Notable columns:
-  - `ts` DateTime — run timestamp (matches `autorevert_events_v2.ts`)
+  - `ts` DateTime — run timestamp (matches the per-run `ts` on `autorevert_events_v2` `revert`/`restart` rows; `advisor` dispatch rows there use per-dispatch timestamps)
   - `state` String — JSON-encoded model of the HUD grid and outcomes
   - `params` String DEFAULT '' — optional, free-form
   - `dry_run` UInt8 — run-level convenience flag; 1 when the run performed no side effects

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
-from typing import Callable, List, Optional, Set, Tuple, Union
+from typing import Callable, List, Optional, Sequence, Set, Tuple, Union
 
 from .bisection_planner import GapBisectionPlanner
 
@@ -101,6 +101,10 @@ class DispatchAdvisor:
     # The advisor JSON layer relabels them so the model is asked "did the
     # suspect commit introduce this failing test?".
     is_born_red: bool = False
+    # Quorum target: how many advisor runs should exist for this signal.
+    # execute_advisor (signal_actions) dispatches `target_total - already_dispatched`
+    # more, so raising this is what lets the quorum keep expanding.
+    target_total: int = 2
 
 
 @dataclass
@@ -136,6 +140,40 @@ class Ineligible:
     reason: IneligibleReason
     message: str = ""
     advisor: Optional[DispatchAdvisor] = None
+
+
+class AdvisorDecision(Enum):
+    """Quorum decision over the advisor verdicts collected for one signal.
+
+    - REVERT: enough confident revertish votes to act.
+    - BLOCK: a confident veto verdict (not_related / infra_issue / garbage)
+      forbids autorevert for this signal.
+    - ABSTAIN: no actionable quorum yet — fall through to heuristics and keep
+      collecting votes.
+    """
+
+    REVERT = "revert"
+    BLOCK = "block"
+    ABSTAIN = "abstain"
+
+
+@dataclass(frozen=True)
+class QuorumResult:
+    """Outcome of resolving advisor verdicts for one (suspect, signal).
+
+    - decision: what to do (revert / block / abstain).
+    - dispatch_target: how many advisor runs SHOULD exist — 3 once the votes
+      disagree (>=2 votes spanning >=2 verdict classes), else 2. Independent of
+      confidence, so agreement data keeps accruing even after a veto decides.
+    - representative: the vote driving an actionable decision (the acting
+      revertish vote or the blocking veto), else None.
+    - block_reason: the IneligibleReason for a BLOCK decision, else None.
+    """
+
+    decision: AdvisorDecision
+    dispatch_target: int
+    representative: Optional[AIAdvisorResult]
+    block_reason: Optional[IneligibleReason]
 
 
 class SignalEvent:
@@ -187,6 +225,7 @@ class SignalCommit:
         timestamp: datetime,
         events: List[SignalEvent],
         advisor_result: Optional[AIAdvisorResult] = None,
+        advisor_verdicts: Tuple[AIAdvisorResult, ...] = (),
     ):
         self.head_sha = head_sha
         self.timestamp = timestamp
@@ -200,6 +239,11 @@ class SignalCommit:
             self.statuses[e.status] = self.statuses.get(e.status, 0) + 1
         # Optional AI advisor result for this (commit, signal) pair
         self.advisor_result = advisor_result
+        # All advisor verdicts for this (commit, signal), one per advisor run,
+        # already deduped by run_id upstream. `advisor_result` is the single
+        # latest of these (kept for the HUD / state logger); the quorum
+        # resolver consumes this full list.
+        self.advisor_verdicts = advisor_verdicts
 
     def replace(self, **changes) -> "SignalCommit":
         """Return a copy with selected fields replaced (`dataclasses.replace`-style).
@@ -212,6 +256,7 @@ class SignalCommit:
             "timestamp": changes.pop("timestamp", self.timestamp),
             "events": changes.pop("events", self.events),
             "advisor_result": changes.pop("advisor_result", self.advisor_result),
+            "advisor_verdicts": changes.pop("advisor_verdicts", self.advisor_verdicts),
         }
         if changes:
             raise TypeError(
@@ -605,64 +650,88 @@ class Signal:
             advisor_verdict=advisor_result,
         )
 
+    def _advisor_quorum(self, partition: "PartitionedCommits") -> "QuorumResult":
+        """Resolve the advisor quorum from the suspect commit's votes.
+
+        Reads every verdict attached to the suspect (partition.failed[-1]) that
+        matches this signal's key and delegates the decision to the pure
+        `resolve_advisor_quorum` resolver.
+        """
+        suspect = partition.failed[-1]
+        votes = [v for v in suspect.advisor_verdicts if v.signal_key == self.key]
+        return resolve_advisor_quorum(votes, datetime.now(timezone.utc))
+
+    def _build_dispatch_advisor(
+        self,
+        partition: "PartitionedCommits",
+        target_total: int,
+        *,
+        is_born_red: bool,
+    ) -> DispatchAdvisor:
+        """Build a DispatchAdvisor for the current partition with a quorum target."""
+        return DispatchAdvisor(
+            suspect_commit=partition.failed[-1].head_sha,
+            failed_commits=tuple(c.head_sha for c in partition.failed),
+            successful_commits=tuple(c.head_sha for c in partition.successful),
+            is_born_red=is_born_red,
+            target_total=target_total,
+        )
+
     def _check_advisor_verdict(
-        self, partition: "PartitionedCommits"
+        self,
+        partition: "PartitionedCommits",
+        quorum: "QuorumResult",
+        *,
+        is_born_red: bool,
     ) -> Optional[Union[AutorevertPattern, Ineligible]]:
-        """Check if an AI advisor verdict is available for the suspect commit.
+        """Map a resolved advisor quorum to an actionable outcome.
 
         Returns:
-            - AutorevertPattern if advisor says "revert" or "related" with sufficient confidence
-            - Ineligible if advisor says "not_related"/"infra_issue", or "garbage" (within 2h window)
-            - None if no verdict, verdict is "unsure", or confidence below threshold
+            - AutorevertPattern on REVERT (representative verdict recorded so the
+              PR comment / state logger keep working).
+            - Ineligible on BLOCK, carrying a DispatchAdvisor so the quorum keeps
+              running (2nd, and 3rd on disagreement) to collect agreement data
+              even while blocked.
+            - None on ABSTAIN — the caller falls through / (re)dispatches.
+
+        `infra_issue` is kept distinct from `not_related` (same "not the
+        suspect's fault" effect, faithful reason). `garbage` only blocks inside
+        its 2h window; the resolver already enforced that, so a BLOCK here is
+        always a live veto.
         """
-        suspected = partition.failed[-1]
-        result = suspected.advisor_result
-        if result is None:
-            return None
-
-        # Only act on the verdict if it matches this signal
-        if result.signal_key != self.key:
-            return None
-
-        # Ignore low-confidence verdicts
-        if result.confidence < self.ADVISOR_CONFIDENCE_THRESHOLD:
-            return None
-
-        if result.verdict in (AdvisorVerdict.REVERT, AdvisorVerdict.RELATED):
-            return self._build_autorevert_pattern(partition, advisor_result=result)
-
-        # `infra_issue` (CI environment failed before producing a real
-        # code-level outcome) is not the suspect's fault, so it is handled
-        # exactly like `not_related`: block this signal from autorevert. Kept as
-        # a distinct IneligibleReason so the cause is recorded.
-        if result.verdict in (AdvisorVerdict.NOT_RELATED, AdvisorVerdict.INFRA_ISSUE):
-            if result.verdict == AdvisorVerdict.INFRA_ISSUE:
-                reason, label = IneligibleReason.ADVISOR_INFRA_ISSUE, "infra issue"
-            else:
-                reason, label = IneligibleReason.ADVISOR_NOT_RELATED, "not related"
-            return Ineligible(
-                reason,
-                f"AI advisor says {label} (confidence={result.confidence:.2f})",
+        if quorum.decision == AdvisorDecision.REVERT:
+            return self._build_autorevert_pattern(
+                partition, advisor_result=quorum.representative
             )
 
-        if result.verdict == AdvisorVerdict.GARBAGE:
-            # Garbage (invalid/corrupt signal) blocks the signal for 2 hours
-            # since the verdict timestamp, then falls through so a fresh run can
-            # re-confirm.
-            from datetime import timezone
-
-            now = datetime.now(timezone.utc)
-            verdict_age = now - result.timestamp.replace(tzinfo=timezone.utc)
-            if verdict_age.total_seconds() < 2 * 3600:
-                return Ineligible(
-                    IneligibleReason.ADVISOR_GARBAGE,
+        if quorum.decision == AdvisorDecision.BLOCK:
+            block_reason = quorum.block_reason
+            # The resolver always pairs a BLOCK decision with a block_reason.
+            assert block_reason is not None
+            rep = quorum.representative
+            confidence = rep.confidence if rep is not None else 0.0
+            if block_reason == IneligibleReason.ADVISOR_GARBAGE:
+                age_min = 0
+                if rep is not None:
+                    age = datetime.now(timezone.utc) - _as_utc(rep.timestamp)
+                    age_min = int(age.total_seconds() / 60)
+                message = (
                     f"AI advisor says garbage signal, suppressed for 2h "
-                    f"(confidence={result.confidence:.2f}, "
-                    f"age={int(verdict_age.total_seconds() / 60)}min)",
+                    f"(confidence={confidence:.2f}, age={age_min}min)"
                 )
-            # Garbage window expired — fall through to normal processing
+            elif block_reason == IneligibleReason.ADVISOR_INFRA_ISSUE:
+                message = f"AI advisor says infra issue (confidence={confidence:.2f})"
+            else:
+                message = f"AI advisor says not related (confidence={confidence:.2f})"
+            return Ineligible(
+                block_reason,
+                message,
+                advisor=self._build_dispatch_advisor(
+                    partition, quorum.dispatch_target, is_born_red=is_born_red
+                ),
+            )
 
-        # "unsure" or expired garbage → continue normally
+        # ABSTAIN (includes no votes yet) → caller handles fall-through/dispatch.
         return None
 
     def _handle_no_successes(self) -> Union[AutorevertPattern, Ineligible]:
@@ -703,19 +772,20 @@ class Signal:
                 f"{len(born_red.failed)})",
             )
 
-        # If the advisor already weighed in on the suspect, use that verdict.
-        advisor_decision = self._check_advisor_verdict(born_red)
+        # If the advisor quorum already reached a decision (revert/block), act
+        # on it; otherwise fall through to (re)dispatch and keep collecting.
+        quorum = self._advisor_quorum(born_red)
+        advisor_decision = self._check_advisor_verdict(
+            born_red, quorum, is_born_red=True
+        )
         if advisor_decision is not None:
             return advisor_decision
 
-        # No verdict yet — request one. `successful_commits` carry the implicit
-        # baseline (commits where the signal didn't exist); `is_born_red=True`
-        # tells the advisor JSON builder to relabel them accordingly.
-        advisor = DispatchAdvisor(
-            suspect_commit=born_red.failed[-1].head_sha,
-            failed_commits=tuple(c.head_sha for c in born_red.failed),
-            successful_commits=tuple(c.head_sha for c in born_red.successful),
-            is_born_red=True,
+        # No actionable quorum yet — request the next run. `successful_commits`
+        # carry the implicit baseline (commits where the signal didn't exist);
+        # `is_born_red=True` tells the advisor JSON builder to relabel them.
+        advisor = self._build_dispatch_advisor(
+            born_red, quorum.dispatch_target, is_born_red=True
         )
         return Ineligible(
             IneligibleReason.NO_SUCCESSES,
@@ -752,25 +822,28 @@ class Signal:
                 "insufficient history to form failed/unknown/successful partitions",
             )
 
-        # --- AI advisor verdict check (before flakiness and other heuristics) ---
-        advisor_decision = self._check_advisor_verdict(partition)
+        # --- AI advisor quorum check (before flakiness and other heuristics) ---
+        quorum = self._advisor_quorum(partition)
+        advisor_decision = self._check_advisor_verdict(
+            partition, quorum, is_born_red=False
+        )
         if advisor_decision is not None:
             return advisor_decision
 
         # Advisor dispatch eligibility: partition exists with sufficient data and
         # no unknown commits between failed and successful partitions.
         # Unknown commits mean the partition boundary is uncertain —
-        # wait for restarts to resolve before dispatching advisor.
+        # wait for restarts to resolve before dispatching advisor. The quorum's
+        # dispatch_target lets the pair widen to 3 once the collected votes
+        # disagree.
         advisor = None
         if (
             partition.failure_events_count() >= 2
             and partition.success_events_count() >= 1
             and not partition.unknown
         ):
-            advisor = DispatchAdvisor(
-                suspect_commit=partition.failed[-1].head_sha,
-                failed_commits=tuple(c.head_sha for c in partition.failed),
-                successful_commits=tuple(c.head_sha for c in partition.successful),
+            advisor = self._build_dispatch_advisor(
+                partition, quorum.dispatch_target, is_born_red=False
             )
 
         # Flakiness check — placed after advisor check/dispatch so that
@@ -878,3 +951,95 @@ class Signal:
 
         # all invariants validated, confirmed not infra, pattern exists
         return self._build_autorevert_pattern(partition)
+
+
+def _verdict_class(verdict: AdvisorVerdict) -> object:
+    """Agreement class for a verdict.
+
+    REVERT and RELATED collapse into one "revertish" class (the lambda treats
+    them identically on trunk); every other verdict is its own class. Used only
+    to observe agreement/disagreement, never to decide the action.
+    """
+    if verdict in (AdvisorVerdict.REVERT, AdvisorVerdict.RELATED):
+        return "revertish"
+    return verdict
+
+
+def _as_utc(dt: datetime) -> datetime:
+    """Interpret a naive datetime as UTC; leave aware datetimes unchanged."""
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+def resolve_advisor_quorum(
+    votes: Sequence[AIAdvisorResult], now: datetime
+) -> QuorumResult:
+    """Resolve advisor verdicts into a quorum decision (single source of truth).
+
+    Precondition: `votes` is already deduped by run_id (one vote per advisor
+    run); this function does NOT dedup. Robust to any vote count (0..N) —
+    never raises, never indexes blindly.
+
+    dispatch_target (confidence-independent agreement observation): 3 when the
+    votes disagree (>=2 votes spanning >=2 verdict classes), else 2.
+
+    decision (asymmetric single-vote veto):
+      1. A single confident veto blocks — priority not_related > infra_issue >
+         garbage (garbage only inside its 2h window).
+      2. Else >=2 confident revertish votes revert.
+      3. Else abstain.
+    Confident = confidence >= Signal.ADVISOR_CONFIDENCE_THRESHOLD.
+    """
+    threshold = Signal.ADVISOR_CONFIDENCE_THRESHOLD
+
+    # Agreement observation over ALL votes, regardless of confidence.
+    classes = {_verdict_class(v.verdict) for v in votes}
+    dispatch_target = 3 if (len(votes) >= 2 and len(classes) >= 2) else 2
+
+    confident = [v for v in votes if v.confidence >= threshold]
+
+    def pick(candidates: List[AIAdvisorResult]) -> AIAdvisorResult:
+        # Highest confidence, tie-break latest timestamp.
+        return max(candidates, key=lambda v: (v.confidence, _as_utc(v.timestamp)))
+
+    def block(
+        reason: IneligibleReason, candidates: List[AIAdvisorResult]
+    ) -> QuorumResult:
+        return QuorumResult(
+            decision=AdvisorDecision.BLOCK,
+            dispatch_target=dispatch_target,
+            representative=pick(candidates),
+            block_reason=reason,
+        )
+
+    not_related = [v for v in confident if v.verdict == AdvisorVerdict.NOT_RELATED]
+    if not_related:
+        return block(IneligibleReason.ADVISOR_NOT_RELATED, not_related)
+
+    infra = [v for v in confident if v.verdict == AdvisorVerdict.INFRA_ISSUE]
+    if infra:
+        return block(IneligibleReason.ADVISOR_INFRA_ISSUE, infra)
+
+    garbage = [
+        v
+        for v in confident
+        if v.verdict == AdvisorVerdict.GARBAGE
+        and (_as_utc(now) - _as_utc(v.timestamp)).total_seconds() < 2 * 3600
+    ]
+    if garbage:
+        return block(IneligibleReason.ADVISOR_GARBAGE, garbage)
+
+    r_plus = [v for v in confident if _verdict_class(v.verdict) == "revertish"]
+    if len(r_plus) >= 2:
+        return QuorumResult(
+            decision=AdvisorDecision.REVERT,
+            dispatch_target=dispatch_target,
+            representative=pick(r_plus),
+            block_reason=None,
+        )
+
+    return QuorumResult(
+        decision=AdvisorDecision.ABSTAIN,
+        dispatch_target=dispatch_target,
+        representative=None,
+        block_reason=None,
+    )

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_actions.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_actions.py
@@ -4,7 +4,7 @@ import logging
 import re
 from collections import defaultdict
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Dict, FrozenSet, Iterable, List, Optional, Tuple, Union
 
@@ -146,23 +146,31 @@ class ActionLogger:
                 res = CHCliFactory().client.query(q, {"repo": repo, "sha": commit_sha})
                 return len(res.result_rows) > 0
 
-    def prior_advisor_exists(
+    def advisor_count_for_signal(
         self, *, repo: str, commit_sha: str, signal_key: str
-    ) -> bool:
-        """Return True if an advisor was already dispatched for this commit + signal."""
+    ) -> int:
+        """Return count of successfully-launched advisor dispatches for this commit + signal.
+
+        Counts only `failed = 0` rows: a failed workflow_dispatch POST is still
+        logged (failed=1, dry_run=0) but launches no advisor run and yields no
+        verdict, so counting it would permanently consume a quorum slot the
+        born-red path has no heuristic backstop to recover from.
+        """
         q = (
-            "SELECT 1 FROM misc.autorevert_events_v2 "
+            "SELECT count() FROM misc.autorevert_events_v2 "
             "WHERE repo = {repo:String} AND action = 'advisor' "
             "AND commit_sha = {sha:String} "
             "AND has(source_signal_keys, {key:String}) "
-            "AND dry_run = 0 LIMIT 1"
+            "AND dry_run = 0 AND failed = 0"
         )
         for attempt in RetryWithBackoff():
             with attempt:
                 res = CHCliFactory().client.query(
                     q, {"repo": repo, "sha": commit_sha, "key": signal_key}
                 )
-                return len(res.result_rows) > 0
+                if res.result_rows:
+                    return int(res.result_rows[0][0])
+                return 0
 
     def advisor_count_for_commit(
         self, *, repo: str, commit_sha: str, workflow: str
@@ -608,9 +616,12 @@ class SignalActionProcessor:
         dispatch_advisor: "DispatchAdvisor",
         ctx: RunContext,
     ) -> bool:
-        """Dispatch AI advisor workflow for a signal (shadow mode: fire-and-forget).
+        """Dispatch AI advisor workflow(s) for a signal (shadow mode: fire-and-forget).
 
-        Returns True if an event row was inserted (passed dedup).
+        Fires up to `dispatch_advisor.target_total` runs for the (suspect commit,
+        signal) pair, counting non-dry-run advisor rows already in the ledger so
+        the quorum converges idempotently across ticks. Returns True if at least
+        one event row was inserted.
         """
         from .utils import AdvisorAction
 
@@ -620,36 +631,56 @@ class SignalActionProcessor:
         commit_sha = dispatch_advisor.suspect_commit
         dry_run = not ctx.advisor_action.side_effects
 
-        if self._logger.prior_advisor_exists(
+        # Only fire the runs still missing for this (commit, signal). Counting
+        # non-dry-run rows makes this idempotent: once the target is met, later
+        # ticks fire nothing.
+        already_dispatched = self._logger.advisor_count_for_signal(
             repo=ctx.repo_full_name,
             commit_sha=commit_sha,
             signal_key=signal.key,
-        ):
+        )
+        to_fire = max(0, dispatch_advisor.target_total - already_dispatched)
+        if to_fire == 0:
             logging.info(
-                "[v2][action] advisor for sha %s key=%s: skipping existing",
+                "[v2][action] advisor for sha %s key=%s: target met (%d/%d), nothing to fire",
                 commit_sha[:8],
                 signal.key,
+                already_dispatched,
+                dispatch_advisor.target_total,
             )
             return False
 
-        # Cap: max 8 advisor dispatches per (workflow, commit) to limit cost
+        # Cap: max 8 advisor dispatches per (workflow, commit) to limit cost.
+        # Clamp the delta so the (commit, workflow) total never exceeds the cap.
         ADVISOR_CAP_PER_WORKFLOW_COMMIT = 8
-        count = self._logger.advisor_count_for_commit(
+        already_at_commit = self._logger.advisor_count_for_commit(
             repo=ctx.repo_full_name,
             commit_sha=commit_sha,
             workflow=signal.workflow_name,
         )
-        if count >= ADVISOR_CAP_PER_WORKFLOW_COMMIT:
+        if already_at_commit >= ADVISOR_CAP_PER_WORKFLOW_COMMIT:
             logging.info(
                 "[v2][action] advisor for sha %s wf=%s: cap reached (%d/%d)",
                 commit_sha[:8],
                 signal.workflow_name,
-                count,
+                already_at_commit,
                 ADVISOR_CAP_PER_WORKFLOW_COMMIT,
             )
             return False
+        remaining_cap = ADVISOR_CAP_PER_WORKFLOW_COMMIT - already_at_commit
+        if to_fire > remaining_cap:
+            logging.info(
+                "[v2][action] advisor for sha %s wf=%s: clamping dispatch %d->%d (already %d, cap %d)",
+                commit_sha[:8],
+                signal.workflow_name,
+                to_fire,
+                remaining_cap,
+                already_at_commit,
+                ADVISOR_CAP_PER_WORKFLOW_COMMIT,
+            )
+            to_fire = remaining_cap
 
-        # Find PR number for the suspect commit
+        # Find PR number for the suspect commit (shared across all runs)
         pr_number = 0
         try:
             result = self._find_pr_by_sha(commit_sha, ctx)
@@ -663,7 +694,7 @@ class SignalActionProcessor:
                 exc_info=True,
             )
 
-        # Build signal pattern JSON and write to /tmp for debugging
+        # Build signal pattern JSON (shared across all runs) and write to /tmp for debugging
         signal_pattern_json = self._build_signal_pattern_json(
             signal=signal,
             dispatch_advisor=dispatch_advisor,
@@ -688,54 +719,62 @@ class SignalActionProcessor:
                 exc_info=True,
             )
 
-        ok = True
-        notes = ""
-        if not dry_run:
-            try:
-                factory = GHClientFactory()
-                gh_client = factory.client
-                repo = gh_client.get_repo(ctx.repo_full_name)
-                workflow = repo.get_workflow("claude-autorevert-advisor.yml")
-                # /dispatches is non-idempotent — route the POST through dispatch_client
-                # (retry=0) so a 5xx from GitHub does not silently spawn duplicate runs.
-                proper_workflow_create_dispatch(
-                    workflow,
-                    ref="main",
-                    inputs={
-                        "suspect_commit": commit_sha,
-                        "pr_number": str(pr_number),
-                        "signal_pattern": signal_pattern_json,
-                    },
-                    requester=factory.dispatch_client.requester,
-                )
-            except Exception as exc:
-                ok = False
-                notes = f"dispatch error: {exc}"
-                logging.warning(  # noqa: G200
-                    "[v2][action] advisor dispatch failed for sha %s: %s",
-                    commit_sha[:8],
-                    str(exc),
-                )
+        # Each row needs a distinct ts: the ledger is a ReplacingMergeTree keyed
+        # (repo, commit_sha, action, ts) at second resolution, so same-second rows
+        # for one (commit, action) collapse into one and undercount the quorum.
+        # A per-run second offset off a single base keeps them distinct.
+        base_now = datetime.now(timezone.utc)
+        for i in range(to_fire):
+            ok = True
+            notes = ""
+            if not dry_run:
+                try:
+                    factory = GHClientFactory()
+                    gh_client = factory.client
+                    repo = gh_client.get_repo(ctx.repo_full_name)
+                    workflow = repo.get_workflow("claude-autorevert-advisor.yml")
+                    # /dispatches is non-idempotent — route the POST through dispatch_client
+                    # (retry=0) so a 5xx from GitHub does not silently spawn duplicate runs.
+                    proper_workflow_create_dispatch(
+                        workflow,
+                        ref="main",
+                        inputs={
+                            "suspect_commit": commit_sha,
+                            "pr_number": str(pr_number),
+                            "signal_pattern": signal_pattern_json,
+                        },
+                        requester=factory.dispatch_client.requester,
+                    )
+                except Exception as exc:
+                    ok = False
+                    notes = f"dispatch error: {exc}"
+                    logging.warning(  # noqa: G200
+                        "[v2][action] advisor dispatch failed for sha %s: %s",
+                        commit_sha[:8],
+                        str(exc),
+                    )
 
-        self._logger.insert_event(
-            repo=ctx.repo_full_name,
-            ts=ctx.ts,
-            action="advisor",
-            commit_sha=commit_sha,
-            workflows=[signal.workflow_name],
-            source_signal_keys=[signal.key],
-            dry_run=dry_run,
-            failed=not ok,
-            notes=notes,
-        )
-        logging.info(
-            "[v2][action] advisor for sha %s key=%s: %s",
-            commit_sha[:8],
-            signal.key,
-            "dispatched"
-            if (not dry_run and ok)
-            else ("failed" if not ok else "logged (dry_run)"),
-        )
+            self._logger.insert_event(
+                repo=ctx.repo_full_name,
+                ts=base_now + timedelta(seconds=i),
+                action="advisor",
+                commit_sha=commit_sha,
+                workflows=[signal.workflow_name],
+                source_signal_keys=[signal.key],
+                dry_run=dry_run,
+                failed=not ok,
+                notes=notes,
+            )
+            logging.info(
+                "[v2][action] advisor for sha %s key=%s (%d/%d): %s",
+                commit_sha[:8],
+                signal.key,
+                i + 1,
+                to_fire,
+                "dispatched"
+                if (not dry_run and ok)
+                else ("failed" if not ok else "logged (dry_run)"),
+            )
         return True
 
     @staticmethod

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction.py
@@ -225,9 +225,10 @@ class SignalExtractor:
     ) -> List[Signal]:
         """Fetch advisor verdicts from CH and attach to SignalCommit objects.
 
-        For each (commit_sha, signal_key) pair that has a verdict in
-        misc.autorevert_advisor_verdicts, sets the advisor_result field
-        on the corresponding SignalCommit.
+        For each (commit_sha, signal_key) pair with verdicts in
+        misc.autorevert_advisor_verdicts, attaches the full per-run vote list
+        (deduped by run_id upstream) to advisor_verdicts and the single latest
+        (max timestamp) vote to advisor_result on the corresponding SignalCommit.
         """
         head_shas = [sha for sha, _ in commits]
         signal_keys = list({s.key for s in signals})
@@ -245,20 +246,29 @@ class SignalExtractor:
             new_commits: List[SignalCommit] = []
             for c in s.commits:
                 key = (c.head_sha.strip(), s.key)
-                v = verdicts.get(key)
-                if v is not None:
-                    verdict_str, confidence, ts = v
-                    try:
-                        advisor_verdict = AdvisorVerdict(verdict_str)
-                    except ValueError:
-                        advisor_verdict = AdvisorVerdict.UNSURE
-                    advisor_result = AIAdvisorResult(
-                        verdict=advisor_verdict,
-                        confidence=confidence,
-                        timestamp=ts,
-                        signal_key=s.key,
+                votes = verdicts.get(key)
+                if votes:
+                    results: List[AIAdvisorResult] = []
+                    for verdict_str, confidence, ts in votes:
+                        try:
+                            advisor_verdict = AdvisorVerdict(verdict_str)
+                        except ValueError:
+                            advisor_verdict = AdvisorVerdict.UNSURE
+                        results.append(
+                            AIAdvisorResult(
+                                verdict=advisor_verdict,
+                                confidence=confidence,
+                                timestamp=ts,
+                                signal_key=s.key,
+                            )
+                        )
+                    latest = max(results, key=lambda r: r.timestamp)
+                    new_commits.append(
+                        c.replace(
+                            advisor_result=latest,
+                            advisor_verdicts=tuple(results),
+                        )
                     )
-                    new_commits.append(c.replace(advisor_result=advisor_result))
                 else:
                     new_commits.append(c)
             out.append(s.replace(commits=new_commits))

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_datasource.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/signal_extraction_datasource.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import time
 from datetime import datetime, timedelta
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from .clickhouse_client_helper import CHCliFactory
 from .signal_extraction_types import (
@@ -320,32 +320,40 @@ class SignalExtractionDatasource:
         head_shas: List[Sha],
         signal_keys: List[str],
         lookback_hours: int,
-    ) -> Dict[tuple[str, str], tuple[str, float, datetime]]:
+    ) -> Dict[Tuple[str, str], List[Tuple[str, float, datetime]]]:
         """Fetch AI advisor verdicts from misc.autorevert_advisor_verdicts.
 
         Queries by both commit SHAs AND signal keys to minimize data transferred.
 
-        Returns a dict keyed by (commit_sha, signal_key) → (verdict, confidence, timestamp).
-        When multiple verdicts exist for the same (commit, signal), the most recent is used.
+        Returns a dict keyed by (commit_sha, signal_key) → list of
+        (verdict, confidence, timestamp), one entry per distinct advisor run in
+        the window. Rows are deduped by run_id — a run_attempt retry counts as a
+        single vote, represented by its highest-run_attempt row — and each list
+        is ordered by timestamp ascending.
         """
         if not head_shas or not signal_keys:
             return {}
 
         log = logging.getLogger(__name__)
         t0 = time.perf_counter()
+        # `run_id` is the GitHub Actions run id written by the external
+        # claude-autorevert-advisor.yml workflow (pytorch/pytorch): unique per
+        # advisor run, so the quorum counts exactly one vote per distinct run_id.
         query = """
         SELECT
             toString(suspect_commit) AS suspect_commit,
             signal_key,
             verdict,
             confidence,
-            timestamp
+            timestamp,
+            run_id,
+            run_attempt
         FROM misc.autorevert_advisor_verdicts
         WHERE repo = {repo:String}
           AND suspect_commit IN {shas:Array(String)}
           AND signal_key IN {keys:Array(String)}
           AND timestamp > now() - INTERVAL {hours:UInt32} HOUR
-        ORDER BY suspect_commit, signal_key, timestamp DESC
+        ORDER BY suspect_commit, signal_key, run_id, run_attempt
         """
         params = {
             "repo": repo_full_name,
@@ -353,18 +361,40 @@ class SignalExtractionDatasource:
             "keys": signal_keys,
             "hours": lookback_hours,
         }
-        results: Dict[tuple[str, str], tuple[str, float, datetime]] = {}
+        results: Dict[Tuple[str, str], List[Tuple[str, float, datetime]]] = {}
         for attempt in RetryWithBackoff():
             with attempt:
                 res = CHCliFactory().client.query(query, parameters=params)
+                # Collapse run_attempt retries: one advisor run (run_id) is a
+                # single vote, represented by its highest-run_attempt row.
+                latest_by_run: Dict[
+                    Tuple[str, str, int], Tuple[int, Tuple[str, float, datetime]]
+                ] = {}
                 for r in res.result_rows:
-                    key = (str(r[0]).strip(), str(r[1]))
-                    if key not in results:  # keep most recent (ORDER BY ... DESC)
-                        results[key] = (str(r[2]), float(r[3]), r[4])
+                    sha = str(r[0]).strip()
+                    signal_key = str(r[1])
+                    run_id = int(r[5])
+                    run_attempt = int(r[6])
+                    run_key = (sha, signal_key, run_id)
+                    prev = latest_by_run.get(run_key)
+                    if prev is None or run_attempt > prev[0]:
+                        latest_by_run[run_key] = (
+                            run_attempt,
+                            (str(r[2]), float(r[3]), r[4]),
+                        )
+                results = {}
+                for (sha, signal_key, _run_id), (
+                    _run_attempt,
+                    vote,
+                ) in latest_by_run.items():
+                    results.setdefault((sha, signal_key), []).append(vote)
+                for votes in results.values():
+                    votes.sort(key=lambda v: v[2])
 
         dt = time.perf_counter() - t0
         log.info(
-            "[extract] Advisor verdicts fetched: %d for %d commits in %.2fs",
+            "[extract] Advisor verdicts fetched: %d across %d keys for %d commits in %.2fs",
+            sum(len(v) for v in results.values()),
             len(results),
             len(head_shas),
             dt,

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_advisor_quorum.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_advisor_quorum.py
@@ -1,0 +1,287 @@
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from pytorch_auto_revert.signal import (
+    AdvisorDecision,
+    AdvisorVerdict,
+    AIAdvisorResult,
+    IneligibleReason,
+    QuorumResult,
+    resolve_advisor_quorum,
+    Signal,
+)
+
+
+# Verdict shorthands used across the table below.
+REVERT = AdvisorVerdict.REVERT
+RELATED = AdvisorVerdict.RELATED
+NOT_RELATED = AdvisorVerdict.NOT_RELATED
+UNSURE = AdvisorVerdict.UNSURE
+GARBAGE = AdvisorVerdict.GARBAGE
+INFRA = AdvisorVerdict.INFRA_ISSUE
+
+THRESHOLD = Signal.ADVISOR_CONFIDENCE_THRESHOLD
+
+
+class TestResolveAdvisorQuorum(unittest.TestCase):
+    """Exhaustive unit tests for the pure `resolve_advisor_quorum` resolver.
+
+    Every case asserts BOTH `.decision` and `.dispatch_target`, plus
+    representative / block_reason where they carry meaning. Votes are assumed
+    already deduped by run_id — the resolver never dedups.
+    """
+
+    def setUp(self) -> None:
+        self.now = datetime(2026, 8, 4, 12, 0, 0, tzinfo=timezone.utc)
+
+    def _v(
+        self,
+        verdict: AdvisorVerdict,
+        confidence: float = 0.95,
+        *,
+        mins_ago: int = 1,
+        key: str = "k",
+    ) -> AIAdvisorResult:
+        return AIAdvisorResult(
+            verdict=verdict,
+            confidence=confidence,
+            timestamp=self.now - timedelta(minutes=mins_ago),
+            signal_key=key,
+        )
+
+    def _resolve(self, votes) -> QuorumResult:
+        return resolve_advisor_quorum(votes, self.now)
+
+    # ---- vote-count sweep: 0 / 1 / 2 / 3 ----
+
+    def test_zero_votes_abstain_target_2(self):
+        res = self._resolve([])
+        self.assertEqual(res.decision, AdvisorDecision.ABSTAIN)
+        self.assertEqual(res.dispatch_target, 2)
+        self.assertIsNone(res.representative)
+        self.assertIsNone(res.block_reason)
+
+    def test_single_revert_abstains_needs_two(self):
+        res = self._resolve([self._v(REVERT)])
+        self.assertEqual(res.decision, AdvisorDecision.ABSTAIN)
+        self.assertEqual(res.dispatch_target, 2)
+        self.assertIsNone(res.representative)
+
+    def test_single_related_abstains_needs_two(self):
+        res = self._resolve([self._v(RELATED)])
+        self.assertEqual(res.decision, AdvisorDecision.ABSTAIN)
+        self.assertEqual(res.dispatch_target, 2)
+
+    def test_two_revert_revert_target_2(self):
+        res = self._resolve([self._v(REVERT), self._v(REVERT)])
+        self.assertEqual(res.decision, AdvisorDecision.REVERT)
+        self.assertEqual(res.dispatch_target, 2)
+        self.assertIsNotNone(res.representative)
+        self.assertEqual(res.representative.verdict, REVERT)
+        self.assertIsNone(res.block_reason)
+
+    def test_two_related_revert_target_2(self):
+        res = self._resolve([self._v(RELATED), self._v(RELATED)])
+        self.assertEqual(res.decision, AdvisorDecision.REVERT)
+        self.assertEqual(res.dispatch_target, 2)
+
+    def test_revert_plus_related_is_one_class_revert(self):
+        # REVERT and RELATED collapse into the "revertish" class → agreement,
+        # so target stays 2 while the 2-of-N revert gate fires.
+        res = self._resolve([self._v(REVERT), self._v(RELATED)])
+        self.assertEqual(res.decision, AdvisorDecision.REVERT)
+        self.assertEqual(res.dispatch_target, 2)
+
+    def test_two_unsure_abstain_target_2(self):
+        res = self._resolve([self._v(UNSURE), self._v(UNSURE)])
+        self.assertEqual(res.decision, AdvisorDecision.ABSTAIN)
+        self.assertEqual(res.dispatch_target, 2)
+
+    def test_three_revert_same_class_target_2(self):
+        # 3 votes but all one class → no disagreement → target stays 2.
+        res = self._resolve([self._v(REVERT), self._v(REVERT), self._v(REVERT)])
+        self.assertEqual(res.decision, AdvisorDecision.REVERT)
+        self.assertEqual(res.dispatch_target, 2)
+
+    # ---- single-vote vetoes (asymmetric) ----
+
+    def test_not_related_veto_blocks(self):
+        res = self._resolve([self._v(NOT_RELATED)])
+        self.assertEqual(res.decision, AdvisorDecision.BLOCK)
+        self.assertEqual(res.block_reason, IneligibleReason.ADVISOR_NOT_RELATED)
+        self.assertEqual(res.dispatch_target, 2)
+        self.assertEqual(res.representative.verdict, NOT_RELATED)
+
+    def test_infra_issue_veto_blocks(self):
+        res = self._resolve([self._v(INFRA)])
+        self.assertEqual(res.decision, AdvisorDecision.BLOCK)
+        self.assertEqual(res.block_reason, IneligibleReason.ADVISOR_INFRA_ISSUE)
+        self.assertEqual(res.dispatch_target, 2)
+
+    def test_garbage_within_2h_veto_blocks(self):
+        res = self._resolve([self._v(GARBAGE, mins_ago=60)])
+        self.assertEqual(res.decision, AdvisorDecision.BLOCK)
+        self.assertEqual(res.block_reason, IneligibleReason.ADVISOR_GARBAGE)
+        self.assertEqual(res.dispatch_target, 2)
+
+    def test_garbage_just_under_2h_blocks(self):
+        res = self._resolve([self._v(GARBAGE, mins_ago=119)])
+        self.assertEqual(res.decision, AdvisorDecision.BLOCK)
+        self.assertEqual(res.block_reason, IneligibleReason.ADVISOR_GARBAGE)
+
+    def test_garbage_over_2h_is_not_veto(self):
+        res = self._resolve([self._v(GARBAGE, mins_ago=180)])
+        self.assertEqual(res.decision, AdvisorDecision.ABSTAIN)
+        self.assertEqual(res.dispatch_target, 2)
+        self.assertIsNone(res.block_reason)
+
+    def test_garbage_exactly_2h_is_not_veto(self):
+        # Boundary: age == 2h is NOT strictly < 2h → no veto.
+        res = self._resolve([self._v(GARBAGE, mins_ago=120)])
+        self.assertEqual(res.decision, AdvisorDecision.ABSTAIN)
+
+    # ---- confidence gating ----
+
+    def test_low_confidence_revert_pair_abstains(self):
+        res = self._resolve([self._v(REVERT, 0.5), self._v(REVERT, 0.5)])
+        self.assertEqual(res.decision, AdvisorDecision.ABSTAIN)
+        self.assertEqual(res.dispatch_target, 2)
+
+    def test_low_confidence_veto_ignored(self):
+        res = self._resolve([self._v(NOT_RELATED, 0.5)])
+        self.assertEqual(res.decision, AdvisorDecision.ABSTAIN)
+        self.assertEqual(res.dispatch_target, 2)
+
+    def test_mixed_confidence_revert_needs_two_confident(self):
+        # Only one confident revert → not enough for the 2-of-N gate.
+        res = self._resolve([self._v(REVERT, 0.95), self._v(REVERT, 0.5)])
+        self.assertEqual(res.decision, AdvisorDecision.ABSTAIN)
+        self.assertEqual(res.dispatch_target, 2)
+
+    def test_threshold_boundary_inclusive(self):
+        # Exactly at threshold counts as confident.
+        res = self._resolve([self._v(REVERT, THRESHOLD), self._v(REVERT, THRESHOLD)])
+        self.assertEqual(res.decision, AdvisorDecision.REVERT)
+
+    def test_just_below_threshold_abstains(self):
+        res = self._resolve(
+            [self._v(REVERT, THRESHOLD - 0.01), self._v(REVERT, THRESHOLD - 0.01)]
+        )
+        self.assertEqual(res.decision, AdvisorDecision.ABSTAIN)
+
+    # ---- disagreement widens dispatch_target to 3 ----
+
+    def test_revert_plus_unsure_abstain_target_3(self):
+        res = self._resolve([self._v(REVERT), self._v(UNSURE)])
+        self.assertEqual(res.decision, AdvisorDecision.ABSTAIN)
+        self.assertEqual(res.dispatch_target, 3)
+
+    def test_not_related_plus_revert_block_target_3(self):
+        res = self._resolve([self._v(NOT_RELATED), self._v(REVERT)])
+        self.assertEqual(res.decision, AdvisorDecision.BLOCK)
+        self.assertEqual(res.block_reason, IneligibleReason.ADVISOR_NOT_RELATED)
+        self.assertEqual(res.dispatch_target, 3)
+
+    def test_infra_plus_unsure_block_target_3(self):
+        res = self._resolve([self._v(INFRA), self._v(UNSURE)])
+        self.assertEqual(res.decision, AdvisorDecision.BLOCK)
+        self.assertEqual(res.block_reason, IneligibleReason.ADVISOR_INFRA_ISSUE)
+        self.assertEqual(res.dispatch_target, 3)
+
+    def test_dispatch_target_is_confidence_independent(self):
+        # Two low-confidence votes across two classes → still target 3, even
+        # though neither vote is confident enough to decide anything.
+        res = self._resolve([self._v(REVERT, 0.5), self._v(NOT_RELATED, 0.5)])
+        self.assertEqual(res.decision, AdvisorDecision.ABSTAIN)
+        self.assertEqual(res.dispatch_target, 3)
+
+    # ---- asymmetric veto beats a revert quorum ----
+
+    def test_veto_beats_two_revert(self):
+        res = self._resolve([self._v(REVERT), self._v(REVERT), self._v(NOT_RELATED)])
+        self.assertEqual(res.decision, AdvisorDecision.BLOCK)
+        self.assertEqual(res.block_reason, IneligibleReason.ADVISOR_NOT_RELATED)
+        self.assertEqual(res.dispatch_target, 3)
+
+    # ---- veto priority: not_related > infra_issue > garbage ----
+
+    def test_veto_priority_not_related_first(self):
+        res = self._resolve(
+            [self._v(GARBAGE, mins_ago=10), self._v(INFRA), self._v(NOT_RELATED)]
+        )
+        self.assertEqual(res.block_reason, IneligibleReason.ADVISOR_NOT_RELATED)
+
+    def test_veto_priority_infra_before_garbage(self):
+        res = self._resolve([self._v(GARBAGE, mins_ago=10), self._v(INFRA)])
+        self.assertEqual(res.block_reason, IneligibleReason.ADVISOR_INFRA_ISSUE)
+
+    # ---- representative selection ----
+
+    def test_representative_highest_confidence(self):
+        low = self._v(NOT_RELATED, 0.90)
+        high = self._v(NOT_RELATED, 0.99)
+        res = self._resolve([low, high])
+        self.assertIs(res.representative, high)
+
+    def test_representative_tie_break_latest_timestamp(self):
+        older = self._v(NOT_RELATED, 0.95, mins_ago=100)
+        newer = self._v(NOT_RELATED, 0.95, mins_ago=1)
+        res = self._resolve([older, newer])
+        self.assertIs(res.representative, newer)
+
+    def test_revert_representative_highest_confidence(self):
+        lo = self._v(REVERT, 0.90)
+        hi = self._v(RELATED, 0.98)
+        res = self._resolve([lo, hi])
+        self.assertEqual(res.decision, AdvisorDecision.REVERT)
+        self.assertIs(res.representative, hi)
+
+    # ---- robustness with more than 3 votes (accidental over-dispatch) ----
+
+    def test_many_votes_revert_no_veto(self):
+        votes = [
+            self._v(REVERT, 0.95),
+            self._v(REVERT, 0.95),
+            self._v(UNSURE, 0.95),
+            self._v(NOT_RELATED, 0.5),  # low-conf veto is ignored
+            self._v(GARBAGE, 0.5, mins_ago=10),
+        ]
+        res = self._resolve(votes)
+        self.assertEqual(res.decision, AdvisorDecision.REVERT)
+        self.assertEqual(res.dispatch_target, 3)
+
+    def test_many_votes_confident_veto_wins(self):
+        votes = [
+            self._v(REVERT, 0.95),
+            self._v(REVERT, 0.95),
+            self._v(RELATED, 0.95),
+            self._v(INFRA, 0.95),  # confident veto short-circuits
+            self._v(UNSURE, 0.95),
+        ]
+        res = self._resolve(votes)
+        self.assertEqual(res.decision, AdvisorDecision.BLOCK)
+        self.assertEqual(res.block_reason, IneligibleReason.ADVISOR_INFRA_ISSUE)
+        self.assertEqual(res.dispatch_target, 3)
+
+    def test_seven_unsure_votes_abstain_target_2(self):
+        # Many votes, all one non-revertish class → agreement, target 2.
+        res = self._resolve([self._v(UNSURE) for _ in range(7)])
+        self.assertEqual(res.decision, AdvisorDecision.ABSTAIN)
+        self.assertEqual(res.dispatch_target, 2)
+
+    # ---- naive timestamps are treated as UTC (no crash on mixed awareness) ----
+
+    def test_naive_timestamps_supported(self):
+        naive = AIAdvisorResult(
+            verdict=GARBAGE,
+            confidence=0.95,
+            timestamp=datetime(2026, 8, 4, 11, 30, 0),  # naive, 30min before now
+            signal_key="k",
+        )
+        res = resolve_advisor_quorum([naive], self.now)
+        self.assertEqual(res.decision, AdvisorDecision.BLOCK)
+        self.assertEqual(res.block_reason, IneligibleReason.ADVISOR_GARBAGE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal.py
@@ -617,6 +617,8 @@ class TestDispatchAdvisor(unittest.TestCase):
         self.assertEqual(res.advisor.suspect_commit, "sha_fail")
         self.assertEqual(res.advisor.failed_commits, ("sha_fail",))
         self.assertEqual(res.advisor.successful_commits, ("sha_base",))
+        # No votes yet → the initial pair (target 2).
+        self.assertEqual(res.advisor.target_total, 2)
 
     def test_advisor_not_emitted_when_unknown_gap_exists(self):
         """When partition has unknown commits between failed and successful, no advisor is emitted."""
@@ -816,6 +818,7 @@ class TestDispatchAdvisor(unittest.TestCase):
             self.assertEqual(advisor.failed_commits, ("fail_1", "fail_2"))
             self.assertEqual(advisor.successful_commits, ("succ_1", "succ_2"))
             self.assertEqual(advisor.suspect_commit, "fail_2")
+            self.assertEqual(advisor.target_total, 2)
 
 
 class TestAdvisorVerdictIntegration(unittest.TestCase):
@@ -833,15 +836,23 @@ class TestAdvisorVerdictIntegration(unittest.TestCase):
         )
 
     def _make_signal_with_advisor(
-        self, verdict: AdvisorVerdict, confidence: float = 0.95
+        self, verdict: AdvisorVerdict, confidence: float = 0.95, *, count: int = 1
     ) -> Signal:
         """Build a signal with 3 failures and 2 successes where the suspect
-        commit has an advisor result."""
-        advisor_result = AIAdvisorResult(
-            verdict=verdict,
-            confidence=confidence,
-            timestamp=self.t0,
-            signal_key="job",
+        commit carries `count` advisor votes of the given verdict/confidence.
+
+        A single confident veto (not_related/infra_issue/garbage) blocks; the
+        revert quorum needs two revertish votes, so revert/related cases pass
+        count=2.
+        """
+        votes = tuple(
+            AIAdvisorResult(
+                verdict=verdict,
+                confidence=confidence,
+                timestamp=self.t0,
+                signal_key="job",
+            )
+            for _ in range(count)
         )
         c_newest = SignalCommit(
             head_sha="sha_newest",
@@ -857,7 +868,7 @@ class TestAdvisorVerdictIntegration(unittest.TestCase):
             head_sha="sha_mid",
             timestamp=ts(self.t0, 0),
             events=[self._ev("job", SignalStatus.FAILURE, 4)],
-            advisor_result=advisor_result,
+            advisor_verdicts=votes,
         )
         c_base = SignalCommit(
             head_sha="sha_old",
@@ -874,18 +885,21 @@ class TestAdvisorVerdictIntegration(unittest.TestCase):
         )
 
     def test_advisor_revert_produces_autorevert_pattern(self):
-        """When advisor says 'revert', produce AutorevertPattern immediately."""
-        s = self._make_signal_with_advisor(AdvisorVerdict.REVERT)
+        """Two confident 'revert' votes (2-of-N quorum) produce AutorevertPattern."""
+        s = self._make_signal_with_advisor(AdvisorVerdict.REVERT, count=2)
         res = s.process_valid_autorevert_pattern()
         self.assertIsInstance(res, AutorevertPattern)
         self.assertEqual(res.suspected_commit, "sha_mid")
         self.assertEqual(res.older_successful_commit, "sha_old")
         self.assertEqual(res.newer_failing_commits, ["sha_newest", "sha_newer"])
+        # Representative verdict recorded for the PR comment / state logger.
+        self.assertIsNotNone(res.advisor_verdict)
+        self.assertEqual(res.advisor_verdict.verdict, AdvisorVerdict.REVERT)
 
     def test_advisor_related_produces_autorevert_pattern(self):
-        """When advisor says 'related' (context-neutral successor to 'revert'),
+        """Two confident 'related' votes (context-neutral successor to 'revert')
         produce AutorevertPattern just like 'revert'."""
-        s = self._make_signal_with_advisor(AdvisorVerdict.RELATED)
+        s = self._make_signal_with_advisor(AdvisorVerdict.RELATED, count=2)
         res = s.process_valid_autorevert_pattern()
         self.assertIsInstance(res, AutorevertPattern)
         self.assertEqual(res.suspected_commit, "sha_mid")
@@ -893,11 +907,14 @@ class TestAdvisorVerdictIntegration(unittest.TestCase):
         self.assertEqual(res.newer_failing_commits, ["sha_newest", "sha_newer"])
 
     def test_advisor_not_related_produces_ineligible(self):
-        """When advisor says 'not_related', return Ineligible."""
+        """A single confident 'not_related' veto blocks, and still emits a
+        DispatchAdvisor so the quorum keeps running."""
         s = self._make_signal_with_advisor(AdvisorVerdict.NOT_RELATED)
         res = s.process_valid_autorevert_pattern()
         self.assertIsInstance(res, Ineligible)
         self.assertEqual(res.reason, IneligibleReason.ADVISOR_NOT_RELATED)
+        self.assertIsNotNone(res.advisor)
+        self.assertEqual(res.advisor.target_total, 2)
 
     def test_advisor_garbage_produces_ineligible_within_2h(self):
         """When advisor says 'garbage' and verdict is < 2h old, suppress signal."""
@@ -916,7 +933,7 @@ class TestAdvisorVerdictIntegration(unittest.TestCase):
                 self._ev("job", SignalStatus.FAILURE, 5),
                 self._ev("job", SignalStatus.FAILURE, 6),
             ],
-            advisor_result=advisor_result,
+            advisor_verdicts=(advisor_result,),
         )
         c_base = SignalCommit(
             head_sha="sha_base",
@@ -954,7 +971,7 @@ class TestAdvisorVerdictIntegration(unittest.TestCase):
             head_sha="sha_mid",
             timestamp=ts(self.t0, 0),
             events=[self._ev("job", SignalStatus.FAILURE, 4)],
-            advisor_result=advisor_result,
+            advisor_verdicts=(advisor_result,),
         )
         c_base = SignalCommit(
             head_sha="sha_old",
@@ -974,11 +991,14 @@ class TestAdvisorVerdictIntegration(unittest.TestCase):
         self.assertIsInstance(res, AutorevertPattern)
 
     def test_advisor_infra_issue_produces_ineligible(self):
-        """infra_issue is treated like not_related: block the signal, no revert."""
+        """infra_issue is treated like not_related: block the signal, no revert.
+        Kept distinct as ADVISOR_INFRA_ISSUE, and still emits a DispatchAdvisor."""
         s = self._make_signal_with_advisor(AdvisorVerdict.INFRA_ISSUE)
         res = s.process_valid_autorevert_pattern()
         self.assertIsInstance(res, Ineligible)
         self.assertEqual(res.reason, IneligibleReason.ADVISOR_INFRA_ISSUE)
+        self.assertIsNotNone(res.advisor)
+        self.assertEqual(res.advisor.target_total, 2)
 
     def test_advisor_infra_issue_does_not_expire(self):
         """Unlike garbage, infra_issue has no 2h window — an old verdict still blocks."""
@@ -1003,7 +1023,7 @@ class TestAdvisorVerdictIntegration(unittest.TestCase):
             head_sha="sha_mid",
             timestamp=ts(self.t0, 0),
             events=[self._ev("job", SignalStatus.FAILURE, 4)],
-            advisor_result=advisor_result,
+            advisor_verdicts=(advisor_result,),
         )
         c_base = SignalCommit(
             head_sha="sha_old",
@@ -1038,8 +1058,10 @@ class TestAdvisorVerdictIntegration(unittest.TestCase):
         self.assertIsInstance(res, AutorevertPattern)
 
     def test_advisor_high_confidence_revert_acts(self):
-        """Advisor 'revert' at exactly the threshold acts."""
-        s = self._make_signal_with_advisor(AdvisorVerdict.REVERT, confidence=0.9)
+        """A revert quorum at exactly the confidence threshold (0.89 <= 0.9) acts."""
+        s = self._make_signal_with_advisor(
+            AdvisorVerdict.REVERT, confidence=0.9, count=2
+        )
         res = s.process_valid_autorevert_pattern()
         self.assertIsInstance(res, AutorevertPattern)
         self.assertEqual(res.suspected_commit, "sha_mid")
@@ -1066,7 +1088,7 @@ class TestAdvisorVerdictIntegration(unittest.TestCase):
             head_sha="sha_mid",
             timestamp=ts(self.t0, 0),
             events=[self._ev("job", SignalStatus.FAILURE, 4)],
-            advisor_result=advisor_result,
+            advisor_verdicts=(advisor_result,),
         )
         c_base = SignalCommit(
             head_sha="sha_old",
@@ -1108,7 +1130,7 @@ class TestAdvisorVerdictIntegration(unittest.TestCase):
                 self._ev("job", SignalStatus.SUCCESS, 2),
                 self._ev("job", SignalStatus.FAILURE, 3),
             ],
-            advisor_result=advisor_result,
+            advisor_verdicts=(advisor_result, advisor_result),
         )
         c_base = SignalCommit(
             head_sha="sha_base",
@@ -1159,6 +1181,88 @@ class TestAdvisorVerdictIntegration(unittest.TestCase):
         )
         res = s.process_valid_autorevert_pattern()
         self.assertIsInstance(res, AutorevertPattern)
+
+    def test_disagreeing_votes_widen_dispatch_target_to_3(self):
+        """Votes spanning two classes (revert + unsure) abstain but widen the
+        emitted DispatchAdvisor target to 3 so the quorum collects a 3rd run."""
+        votes = (
+            AIAdvisorResult(
+                verdict=AdvisorVerdict.REVERT,
+                confidence=0.95,
+                timestamp=self.t0,
+                signal_key="job",
+            ),
+            AIAdvisorResult(
+                verdict=AdvisorVerdict.UNSURE,
+                confidence=0.95,
+                timestamp=self.t0,
+                signal_key="job",
+            ),
+        )
+        c_fail = SignalCommit(
+            head_sha="sha_fail",
+            timestamp=ts(self.t0, 0),
+            events=[
+                self._ev("job", SignalStatus.FAILURE, 5),
+                self._ev("job", SignalStatus.FAILURE, 6),
+            ],
+            advisor_verdicts=votes,
+        )
+        c_base = SignalCommit(
+            head_sha="sha_base",
+            timestamp=ts(self.t0, -10),
+            events=[self._ev("job", SignalStatus.SUCCESS, 3)],
+        )
+        s = Signal(key="job", workflow_name="wf", commits=[c_fail, c_base])
+        res = s.process_valid_autorevert_pattern()
+        self.assertNotIsInstance(res, AutorevertPattern)
+        self.assertIsNotNone(res.advisor)
+        self.assertEqual(res.advisor.target_total, 3)
+
+    def test_block_keeps_dispatching_and_widens_target_on_disagreement(self):
+        """A confident veto blocks even alongside a revert vote (asymmetric
+        veto); the emitted DispatchAdvisor widens to target 3 (two classes)."""
+        votes = (
+            AIAdvisorResult(
+                verdict=AdvisorVerdict.NOT_RELATED,
+                confidence=0.95,
+                timestamp=self.t0,
+                signal_key="job",
+            ),
+            AIAdvisorResult(
+                verdict=AdvisorVerdict.REVERT,
+                confidence=0.95,
+                timestamp=self.t0,
+                signal_key="job",
+            ),
+        )
+        c_newest = SignalCommit(
+            head_sha="sha_newest",
+            timestamp=ts(self.t0, 0),
+            events=[self._ev("job", SignalStatus.FAILURE, 7)],
+        )
+        c_suspected = SignalCommit(
+            head_sha="sha_mid",
+            timestamp=ts(self.t0, 0),
+            events=[self._ev("job", SignalStatus.FAILURE, 4)],
+            advisor_verdicts=votes,
+        )
+        c_base = SignalCommit(
+            head_sha="sha_old",
+            timestamp=ts(self.t0, 0),
+            events=[
+                self._ev("job", SignalStatus.SUCCESS, 3),
+                self._ev("job", SignalStatus.SUCCESS, 6),
+            ],
+        )
+        s = Signal(
+            key="job", workflow_name="wf", commits=[c_newest, c_suspected, c_base]
+        )
+        res = s.process_valid_autorevert_pattern()
+        self.assertIsInstance(res, Ineligible)
+        self.assertEqual(res.reason, IneligibleReason.ADVISOR_NOT_RELATED)
+        self.assertIsNotNone(res.advisor)
+        self.assertEqual(res.advisor.target_total, 3)
 
 
 class TestSignalReplace(unittest.TestCase):
@@ -1265,6 +1369,14 @@ class TestSignalCommitReplace(unittest.TestCase):
             confidence=0.9,
             timestamp=datetime(2025, 8, 19, 12, 0, 0),
             signal_key="k",
+        ),
+        "advisor_verdicts": (
+            AIAdvisorResult(
+                verdict=AdvisorVerdict.NOT_RELATED,
+                confidence=0.5,
+                timestamp=datetime(2025, 8, 19, 12, 0, 0),
+                signal_key="k",
+            ),
         ),
     }
 
@@ -1519,7 +1631,7 @@ class TestBornRedTestSignal(unittest.TestCase):
             head_sha="f2",
             timestamp=ts(self.t0, -10),
             events=[self._ev("t", SignalStatus.FAILURE, -10, job_id=12)],
-            advisor_result=verdict,
+            advisor_verdicts=(verdict, verdict),
         )
         commits = [self._fail("f1", 0, job_id=11), suspect, self._empty("e1", -20)]
         res = self._test_signal(commits).process_valid_autorevert_pattern()
@@ -1543,12 +1655,16 @@ class TestBornRedTestSignal(unittest.TestCase):
             head_sha="f2",
             timestamp=ts(self.t0, -10),
             events=[self._ev("t", SignalStatus.FAILURE, -10, job_id=12)],
-            advisor_result=verdict,
+            advisor_verdicts=(verdict,),
         )
         commits = [self._fail("f1", 0, job_id=11), suspect, self._empty("e1", -20)]
         res = self._test_signal(commits).process_valid_autorevert_pattern()
         self.assertIsInstance(res, Ineligible)
         self.assertEqual(res.reason, IneligibleReason.ADVISOR_NOT_RELATED)
+        # Even blocked, the born-red quorum keeps running to collect agreement.
+        self.assertIsNotNone(res.advisor)
+        self.assertTrue(res.advisor.is_born_red)
+        self.assertEqual(res.advisor.target_total, 2)
 
 
 if __name__ == "__main__":

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_actions.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_actions.py
@@ -469,18 +469,63 @@ class TestCommentIssueRevert(unittest.TestCase):
         )
 
 
-class FakeLoggerWithAdvisorDedup(FakeLogger):
-    """FakeLogger that tracks advisor dedup checks."""
+class TestAdvisorCountQueries(unittest.TestCase):
+    """The two advisor-count queries handle failed dispatches asymmetrically.
 
-    def __init__(self, *, advisor_exists: bool = False, advisor_count: int = 0):
+    - Signal-level quorum count excludes failed dispatches (`failed = 0`): a
+      failed workflow_dispatch POST is logged (failed=1, dry_run=0) but launches
+      no advisor run, so counting it would permanently consume a quorum slot the
+      born-red path has no heuristic backstop to recover from. Filtering it out
+      means the failed attempt is retried on a later tick.
+    - Per-(commit, workflow) cost cap counts ALL attempts (including failed) so a
+      storm of failing POSTs still bounds cost.
+    """
+
+    @patch("pytorch_auto_revert.signal_actions.CHCliFactory")
+    def test_signal_count_filters_failed_zero(self, mock_ch_factory):
+        mock_client = Mock()
+        mock_client.query.return_value = Mock(result_rows=[[3]])
+        mock_ch_factory.return_value.client = mock_client
+
+        count = ActionLogger().advisor_count_for_signal(
+            repo="pytorch/pytorch", commit_sha="deadbeef", signal_key="k"
+        )
+        self.assertEqual(count, 3)
+        query = mock_client.query.call_args[0][0]
+        self.assertIn("failed = 0", query)
+
+    @patch("pytorch_auto_revert.signal_actions.CHCliFactory")
+    def test_commit_cap_count_includes_failed(self, mock_ch_factory):
+        mock_client = Mock()
+        mock_client.query.return_value = Mock(result_rows=[[5]])
+        mock_ch_factory.return_value.client = mock_client
+
+        count = ActionLogger().advisor_count_for_commit(
+            repo="pytorch/pytorch", commit_sha="deadbeef", workflow="trunk"
+        )
+        self.assertEqual(count, 5)
+        query = mock_client.query.call_args[0][0]
+        self.assertNotIn("failed = 0", query)
+
+
+class FakeLoggerWithAdvisorDedup(FakeLogger):
+    """FakeLogger stubbing the advisor count lookups used by execute_advisor.
+
+    - signal_count: prior non-dry-run advisor rows for this (commit, signal),
+      which drives the quorum delta.
+    - advisor_count: prior advisor rows for this (commit, workflow), which
+      drives the cost cap.
+    """
+
+    def __init__(self, *, signal_count: int = 0, advisor_count: int = 0):
         super().__init__()
-        self._advisor_exists = advisor_exists
+        self._signal_count = signal_count
         self._advisor_count = advisor_count
 
-    def prior_advisor_exists(
+    def advisor_count_for_signal(
         self, *, repo: str, commit_sha: str, signal_key: str
-    ) -> bool:
-        return self._advisor_exists
+    ) -> int:
+        return self._signal_count
 
     def advisor_count_for_commit(
         self, *, repo: str, commit_sha: str, workflow: str
@@ -491,7 +536,7 @@ class FakeLoggerWithAdvisorDedup(FakeLogger):
 class TestExecuteAdvisor(unittest.TestCase):
     """Tests for SignalActionProcessor.execute_advisor."""
 
-    def _make_signal_and_advisor(self):
+    def _make_signal_and_advisor(self, *, target_total: int = 2):
         from datetime import datetime
 
         from pytorch_auto_revert.signal import (
@@ -529,6 +574,7 @@ class TestExecuteAdvisor(unittest.TestCase):
             suspect_commit="sha_fail",
             failed_commits=("sha_fail",),
             successful_commits=("sha_base",),
+            target_total=target_total,
         )
         return signal, advisor
 
@@ -568,10 +614,12 @@ class TestExecuteAdvisor(unittest.TestCase):
         self.assertFalse(result)
         self.assertEqual(len(proc._logger.insert_calls), 0)
 
-    def test_skip_when_prior_advisor_exists(self):
+    def test_skip_when_target_already_met(self):
+        # target_total=2 with 2 prior dispatches → delta is 0, fire nothing
+        # (idempotent once the quorum target is satisfied).
         proc = SignalActionProcessor()
-        proc._logger = FakeLoggerWithAdvisorDedup(advisor_exists=True)
-        signal, advisor = self._make_signal_and_advisor()
+        proc._logger = FakeLoggerWithAdvisorDedup(signal_count=2)
+        signal, advisor = self._make_signal_and_advisor(target_total=2)
         ctx = RunContext(
             ts=datetime.now(timezone.utc),
             notify_issue_number=123456,
@@ -604,12 +652,14 @@ class TestExecuteAdvisor(unittest.TestCase):
         )
         result = proc.execute_advisor(signal=signal, dispatch_advisor=advisor, ctx=ctx)
         self.assertTrue(result)
-        self.assertEqual(len(proc._logger.insert_calls), 1)
-        call = proc._logger.insert_calls[0]
-        # call is (repo, ts, action, commit_sha, workflows, signal_keys, dry_run, failed, notes)
-        self.assertEqual(call[2], "advisor")  # action
-        self.assertEqual(call[3], "sha_fail")  # commit_sha
-        self.assertTrue(call[6])  # dry_run=True for LOG mode
+        # LOG mode counts only dry_run=0 rows, so it re-intends the full target
+        # each tick: target_total=2 → 2 dry-run rows, no GitHub dispatch.
+        self.assertEqual(len(proc._logger.insert_calls), 2)
+        for call in proc._logger.insert_calls:
+            # call is (repo, ts, action, commit_sha, workflows, signal_keys, dry_run, failed, notes)
+            self.assertEqual(call[2], "advisor")  # action
+            self.assertEqual(call[3], "sha_fail")  # commit_sha
+            self.assertTrue(call[6])  # dry_run=True for LOG mode
         # No GitHub dispatch should have been called
         mock_gh_factory.assert_not_called()
 
@@ -640,19 +690,137 @@ class TestExecuteAdvisor(unittest.TestCase):
         )
         result = proc.execute_advisor(signal=signal, dispatch_advisor=advisor, ctx=ctx)
         self.assertTrue(result)
-        # Verify dispatch was called
-        mock_dispatch.assert_called_once()
+        # target_total=2 with none prior → 2 dispatches + 2 CH rows this tick.
+        self.assertEqual(mock_dispatch.call_count, 2)
         dispatch_args = mock_dispatch.call_args
         self.assertEqual(dispatch_args[1]["ref"], "main")
         inputs = dispatch_args[1]["inputs"]
         self.assertEqual(inputs["suspect_commit"], "sha_fail")
         self.assertEqual(inputs["pr_number"], "42")
         self.assertIn("signal_key", inputs["signal_pattern"])
-        # Verify CH event logged
+        # Verify CH events logged (one per fired run)
+        self.assertEqual(len(proc._logger.insert_calls), 2)
+        for call in proc._logger.insert_calls:
+            self.assertEqual(call[2], "advisor")
+            self.assertFalse(call[6])  # dry_run=False for RUN mode
+
+    def _run_ctx(self, advisor_action):
+        return RunContext(
+            ts=datetime.now(timezone.utc),
+            notify_issue_number=123456,
+            repo_full_name="pytorch/pytorch",
+            workflows=["trunk"],
+            lookback_hours=24,
+            revert_action=RevertAction.LOG,
+            restart_action=RestartAction.SKIP,
+            advisor_action=advisor_action,
+        )
+
+    @patch("pytorch_auto_revert.signal_actions.proper_workflow_create_dispatch")
+    @patch("pytorch_auto_revert.signal_actions.GHClientFactory")
+    def test_fires_full_target_when_none_dispatched(
+        self, mock_gh_factory, mock_dispatch
+    ):
+        proc = SignalActionProcessor()
+        proc._logger = FakeLoggerWithAdvisorDedup(signal_count=0)
+        proc._find_pr_by_sha = Mock(return_value=None)
+        signal, advisor = self._make_signal_and_advisor(target_total=2)
+        result = proc.execute_advisor(
+            signal=signal,
+            dispatch_advisor=advisor,
+            ctx=self._run_ctx(AdvisorAction.RUN),
+        )
+        self.assertTrue(result)
+        self.assertEqual(mock_dispatch.call_count, 2)
+        self.assertEqual(len(proc._logger.insert_calls), 2)
+
+    @patch("pytorch_auto_revert.signal_actions.proper_workflow_create_dispatch")
+    @patch("pytorch_auto_revert.signal_actions.GHClientFactory")
+    def test_fires_delta_when_partially_dispatched(
+        self, mock_gh_factory, mock_dispatch
+    ):
+        proc = SignalActionProcessor()
+        proc._logger = FakeLoggerWithAdvisorDedup(signal_count=1)
+        proc._find_pr_by_sha = Mock(return_value=None)
+        signal, advisor = self._make_signal_and_advisor(target_total=2)
+        result = proc.execute_advisor(
+            signal=signal,
+            dispatch_advisor=advisor,
+            ctx=self._run_ctx(AdvisorAction.RUN),
+        )
+        self.assertTrue(result)
+        self.assertEqual(mock_dispatch.call_count, 1)
         self.assertEqual(len(proc._logger.insert_calls), 1)
-        call = proc._logger.insert_calls[0]
-        self.assertEqual(call[2], "advisor")
-        self.assertFalse(call[6])  # dry_run=False for RUN mode
+
+    @patch("pytorch_auto_revert.signal_actions.GHClientFactory")
+    def test_idempotent_when_target_already_met(self, mock_gh_factory):
+        # target=2 with 2 prior dispatches → fire nothing; no GitHub calls.
+        proc = SignalActionProcessor()
+        proc._logger = FakeLoggerWithAdvisorDedup(signal_count=2)
+        signal, advisor = self._make_signal_and_advisor(target_total=2)
+        result = proc.execute_advisor(
+            signal=signal,
+            dispatch_advisor=advisor,
+            ctx=self._run_ctx(AdvisorAction.RUN),
+        )
+        self.assertFalse(result)
+        self.assertEqual(len(proc._logger.insert_calls), 0)
+        mock_gh_factory.assert_not_called()
+
+    @patch("pytorch_auto_revert.signal_actions.proper_workflow_create_dispatch")
+    @patch("pytorch_auto_revert.signal_actions.GHClientFactory")
+    def test_widened_target_fires_remaining(self, mock_gh_factory, mock_dispatch):
+        # Quorum widened to 3 (votes disagreed) with 2 already dispatched → 1 more.
+        proc = SignalActionProcessor()
+        proc._logger = FakeLoggerWithAdvisorDedup(signal_count=2)
+        proc._find_pr_by_sha = Mock(return_value=None)
+        signal, advisor = self._make_signal_and_advisor(target_total=3)
+        result = proc.execute_advisor(
+            signal=signal,
+            dispatch_advisor=advisor,
+            ctx=self._run_ctx(AdvisorAction.RUN),
+        )
+        self.assertTrue(result)
+        self.assertEqual(mock_dispatch.call_count, 1)
+        self.assertEqual(len(proc._logger.insert_calls), 1)
+
+    @patch("pytorch_auto_revert.signal_actions.proper_workflow_create_dispatch")
+    @patch("pytorch_auto_revert.signal_actions.GHClientFactory")
+    def test_cap_clamps_delta(self, mock_gh_factory, mock_dispatch):
+        # target wants 2 but only 1 slot remains under the per-(commit, workflow)
+        # cap of 8 (7 already) → clamp the delta to 1.
+        proc = SignalActionProcessor()
+        proc._logger = FakeLoggerWithAdvisorDedup(signal_count=0, advisor_count=7)
+        proc._find_pr_by_sha = Mock(return_value=None)
+        signal, advisor = self._make_signal_and_advisor(target_total=2)
+        result = proc.execute_advisor(
+            signal=signal,
+            dispatch_advisor=advisor,
+            ctx=self._run_ctx(AdvisorAction.RUN),
+        )
+        self.assertTrue(result)
+        self.assertEqual(mock_dispatch.call_count, 1)
+        self.assertEqual(len(proc._logger.insert_calls), 1)
+
+    @patch("pytorch_auto_revert.signal_actions.proper_workflow_create_dispatch")
+    @patch("pytorch_auto_revert.signal_actions.GHClientFactory")
+    def test_each_fired_event_has_distinct_ts(self, mock_gh_factory, mock_dispatch):
+        # Ledger is a ReplacingMergeTree keyed (repo, commit_sha, action, ts) at
+        # second resolution: same-tick rows must not share a ts or they collapse.
+        proc = SignalActionProcessor()
+        proc._logger = FakeLoggerWithAdvisorDedup(signal_count=0)
+        proc._find_pr_by_sha = Mock(return_value=None)
+        signal, advisor = self._make_signal_and_advisor(target_total=2)
+        proc.execute_advisor(
+            signal=signal,
+            dispatch_advisor=advisor,
+            ctx=self._run_ctx(AdvisorAction.RUN),
+        )
+        self.assertEqual(len(proc._logger.insert_calls), 2)
+        ts0 = proc._logger.insert_calls[0][1]
+        ts1 = proc._logger.insert_calls[1][1]
+        self.assertNotEqual(ts0, ts1)
+        self.assertEqual(ts1 - ts0, timedelta(seconds=1))
 
 
 class TestBuildSignalPatternJson(unittest.TestCase):
@@ -1400,7 +1568,7 @@ class TestAttachAdvisorVerdicts(unittest.TestCase):
         # Mock datasource to return a verdict for (sha_aaa, test_key)
         extractor._datasource = Mock()
         extractor._datasource.fetch_advisor_verdicts.return_value = {
-            ("sha_aaa", "test_key"): ("revert", 0.95, t0),
+            ("sha_aaa", "test_key"): [("revert", 0.95, t0)],
         }
 
         commits = [(Sha("sha_aaa"), t0), (Sha("sha_bbb"), t0)]
@@ -1518,7 +1686,7 @@ class TestAttachAdvisorVerdicts(unittest.TestCase):
         extractor = SignalExtractor(workflows=["wf"], lookback_hours=16)
         extractor._datasource = Mock()
         extractor._datasource.fetch_advisor_verdicts.return_value = {
-            ("sha_aaa", "k"): ("bogus_verdict", 0.5, t0),
+            ("sha_aaa", "k"): [("bogus_verdict", 0.5, t0)],
         }
 
         result = extractor._attach_advisor_verdicts([signal], [(Sha("sha_aaa"), t0)])
@@ -1559,7 +1727,7 @@ class TestAttachAdvisorVerdicts(unittest.TestCase):
         extractor = SignalExtractor(workflows=["trunk"], lookback_hours=16)
         extractor._datasource = Mock()
         extractor._datasource.fetch_advisor_verdicts.return_value = {
-            ("sha_aaa", "test/foo.py::test_bar"): ("revert", 0.95, t0),
+            ("sha_aaa", "test/foo.py::test_bar"): [("revert", 0.95, t0)],
         }
         out = extractor._attach_advisor_verdicts([signal], [(Sha("sha_aaa"), t0)])
         self.assertEqual(out[0].test_file, "test/foo.py")

--- a/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_extraction.py
+++ b/aws/lambda/pytorch-auto-revert/pytorch_auto_revert/tests/test_signal_extraction.py
@@ -1,6 +1,7 @@
 import unittest
 from datetime import datetime, timedelta
 from typing import Iterable, List, Optional
+from unittest.mock import MagicMock, patch
 
 from pytorch_auto_revert.signal import SignalStatus
 from pytorch_auto_revert.signal_extraction import SignalExtractor
@@ -73,6 +74,8 @@ class FakeDatasource(SignalExtractionDatasource):
         return [r for r in self._tests if int(r.job_id) in ids]
 
     def fetch_advisor_verdicts(self, **kwargs):
+        # Injected shape mirrors the real datasource:
+        # Dict[(commit_sha, signal_key), List[(verdict, confidence, timestamp)]].
         return self._advisor_verdicts
 
 
@@ -991,22 +994,26 @@ class TestSignalExtraction(unittest.TestCase):
         base = jobs[0].base_name
         # Advisor says revert for C2 on the job signal
         advisor_verdicts = {
-            ("C2", base): ("revert", 0.95, self.t0),
+            ("C2", base): [("revert", 0.95, self.t0)],
         }
         signals = self._extract(jobs, tests=[], advisor_verdicts=advisor_verdicts)
         sig = self._find_job_signal(signals, "trunk", base)
         self.assertIsNotNone(sig)
 
-        # C2 should have advisor_result
+        # C2 should have advisor_result and the full vote list
         c2 = next(c for c in sig.commits if c.head_sha == "C2")
         self.assertIsNotNone(c2.advisor_result)
         self.assertEqual(c2.advisor_result.verdict.value, "revert")
         self.assertAlmostEqual(c2.advisor_result.confidence, 0.95)
         self.assertEqual(c2.advisor_result.signal_key, base)
+        self.assertEqual(len(c2.advisor_verdicts), 1)
+        self.assertEqual(c2.advisor_verdicts[0].verdict.value, "revert")
+        self.assertEqual(c2.advisor_verdicts[0].signal_key, base)
 
-        # C1 should NOT have advisor_result
+        # C1 should NOT have advisor_result and carry no votes
         c1 = next(c for c in sig.commits if c.head_sha == "C1")
         self.assertIsNone(c1.advisor_result)
+        self.assertEqual(c1.advisor_verdicts, ())
 
     def test_advisor_verdict_not_attached_to_wrong_signal(self):
         """Advisor verdict for signal A is not attached to signal B."""
@@ -1031,15 +1038,16 @@ class TestSignalExtraction(unittest.TestCase):
         base = jobs[0].base_name
         # Advisor verdict is for a completely different signal key
         advisor_verdicts = {
-            ("C2", "some_other_signal"): ("not_related", 0.99, self.t0),
+            ("C2", "some_other_signal"): [("not_related", 0.99, self.t0)],
         }
         signals = self._extract(jobs, tests=[], advisor_verdicts=advisor_verdicts)
         sig = self._find_job_signal(signals, "trunk", base)
         self.assertIsNotNone(sig)
 
-        # C2 should NOT have advisor_result (wrong signal key)
+        # C2 should NOT have advisor_result or votes (wrong signal key)
         c2 = next(c for c in sig.commits if c.head_sha == "C2")
         self.assertIsNone(c2.advisor_result)
+        self.assertEqual(c2.advisor_verdicts, ())
 
     def test_advisor_verdict_on_test_signal(self):
         """Advisor verdict is attached to test-track signals."""
@@ -1084,7 +1092,7 @@ class TestSignalExtraction(unittest.TestCase):
         ]
         test_key = "test_foo.py::test_bar"
         advisor_verdicts = {
-            ("C2", test_key): ("garbage", 0.92, self.t0),
+            ("C2", test_key): [("garbage", 0.92, self.t0)],
         }
         signals = self._extract(jobs, tests, advisor_verdicts=advisor_verdicts)
         sig = self._find_test_signal(signals, "trunk", test_key)
@@ -1094,6 +1102,116 @@ class TestSignalExtraction(unittest.TestCase):
         self.assertIsNotNone(c2.advisor_result)
         self.assertEqual(c2.advisor_result.verdict.value, "garbage")
         self.assertEqual(c2.advisor_result.signal_key, test_key)
+        self.assertEqual(len(c2.advisor_verdicts), 1)
+        self.assertEqual(c2.advisor_verdicts[0].verdict.value, "garbage")
+        self.assertEqual(c2.advisor_verdicts[0].signal_key, test_key)
+
+    def test_advisor_verdicts_multiple_attach_all_and_latest(self):
+        """Multiple votes attach as advisor_verdicts; advisor_result is the latest."""
+        jobs = [
+            J(
+                sha="C2",
+                run=200,
+                job=1,
+                attempt=1,
+                started_at=ts(self.t0, 10),
+                conclusion="failure",
+            ),
+            J(
+                sha="C1",
+                run=100,
+                job=2,
+                attempt=1,
+                started_at=ts(self.t0, 5),
+                conclusion="success",
+            ),
+        ]
+        base = jobs[0].base_name
+        # Three independent runs' votes for the same (commit, signal), passed in
+        # non-chronological order to prove advisor_result picks the max timestamp.
+        advisor_verdicts = {
+            ("C2", base): [
+                ("unsure", 0.40, ts(self.t0, 5)),
+                ("revert", 0.95, ts(self.t0, 30)),  # latest
+                ("not_related", 0.60, ts(self.t0, 15)),
+            ],
+        }
+        signals = self._extract(jobs, tests=[], advisor_verdicts=advisor_verdicts)
+        sig = self._find_job_signal(signals, "trunk", base)
+        self.assertIsNotNone(sig)
+
+        c2 = next(c for c in sig.commits if c.head_sha == "C2")
+        # All three votes attached, each carrying this signal's key
+        self.assertEqual(len(c2.advisor_verdicts), 3)
+        self.assertEqual(
+            {v.verdict.value for v in c2.advisor_verdicts},
+            {"unsure", "revert", "not_related"},
+        )
+        self.assertTrue(all(v.signal_key == base for v in c2.advisor_verdicts))
+        # advisor_result is the max-timestamp vote (revert @ +30 min)
+        self.assertEqual(c2.advisor_result.verdict.value, "revert")
+        self.assertEqual(c2.advisor_result.timestamp, ts(self.t0, 30))
+        self.assertAlmostEqual(c2.advisor_result.confidence, 0.95)
+
+    def test_advisor_verdicts_empty_leaves_defaults(self):
+        """No verdicts -> advisor_result stays None and advisor_verdicts stays ()."""
+        jobs = [
+            J(
+                sha="C2",
+                run=200,
+                job=1,
+                attempt=1,
+                started_at=ts(self.t0, 10),
+                conclusion="failure",
+            ),
+            J(
+                sha="C1",
+                run=100,
+                job=2,
+                attempt=1,
+                started_at=ts(self.t0, 5),
+                conclusion="success",
+            ),
+        ]
+        base = jobs[0].base_name
+        signals = self._extract(jobs, tests=[], advisor_verdicts={})
+        sig = self._find_job_signal(signals, "trunk", base)
+        self.assertIsNotNone(sig)
+        for c in sig.commits:
+            self.assertIsNone(c.advisor_result)
+            self.assertEqual(c.advisor_verdicts, ())
+
+    @patch("pytorch_auto_revert.signal_extraction_datasource.CHCliFactory")
+    def test_fetch_advisor_verdicts_dedup_by_run_id(self, mock_factory):
+        """run_attempt retries of one run_id collapse to a single latest-attempt vote."""
+        # Rows as ClickHouse returns them:
+        # (suspect_commit, signal_key, verdict, confidence, timestamp, run_id, run_attempt)
+        rows = [
+            ("C2", "sigA", "unsure", 0.30, ts(self.t0, 1), 5001, 1),
+            ("C2", "sigA", "revert", 0.90, ts(self.t0, 5), 5001, 2),  # retry wins
+            ("C2", "sigA", "not_related", 0.80, ts(self.t0, 3), 5002, 1),  # other run
+        ]
+        mock_res = MagicMock()
+        mock_res.result_rows = rows
+        mock_factory.return_value.client.query.return_value = mock_res
+
+        ds = SignalExtractionDatasource()
+        out = ds.fetch_advisor_verdicts(
+            repo_full_name="pytorch/pytorch",
+            head_shas=[Sha("C2")],
+            signal_keys=["sigA"],
+            lookback_hours=24,
+        )
+        # Two run_attempts of run 5001 collapse to one vote; run 5002 is the second.
+        self.assertEqual(list(out.keys()), [("C2", "sigA")])
+        votes = out[("C2", "sigA")]
+        self.assertEqual(len(votes), 2)
+        # Ordered by timestamp ASC: 5002 @ +3 min, then 5001 retry @ +5 min
+        self.assertEqual([v[0] for v in votes], ["not_related", "revert"])
+        # run 5001 represented by its highest attempt (revert@0.90), not unsure@0.30
+        self.assertEqual(votes[1][0], "revert")
+        self.assertAlmostEqual(votes[1][1], 0.90)
+        self.assertEqual(votes[1][2], ts(self.t0, 5))
 
     def test_test_signal_with_empty_file_has_no_test_module(self):
         # When tests.all_test_runs has empty `file` for a row, TestRow.test_id


### PR DESCRIPTION
**Impact:** pytorch auto-revert lambda ai advisor
**Risk:** medium

## What
The autorevert advisor now collects *multiple* verdicts per (suspect commit, signal) and resolves them with a quorum instead of acting on a single latest verdict. A pure `resolve_advisor_quorum` resolver decides REVERT / BLOCK / ABSTAIN: two confident revertish votes are required to revert, while any single confident veto (`not_related` / `infra_issue` / in-window `garbage`) blocks. The dispatcher fires enough advisor runs to reach a per-signal target (2, widening to 3 when the collected votes disagree), converging idempotently across ticks.

## Why
A single advisor run is one sampled LLM judgement — noisy, and occasionally confidently wrong. Requiring agreement before reverting reduces false reverts, and the asymmetric veto keeps the safety bias (easy to block, harder to act). Keeping the quorum running even after a BLOCK lets us collect agreement data to inform whether the veto should later become symmetric.

# Notes
- **Asymmetry is intentional and interim.** A single vote can veto; two are needed to act. `dispatch_target` is confidence-independent so agreement data keeps accruing even after a decision. Symmetry is deferred pending that data.
- **ClickHouse `ts` semantics change for advisor rows.** `advisor` dispatch rows in `autorevert_events_v2` now carry per-dispatch (second-offset) timestamps rather than the shared per-run `ts`; otherwise same-tick quorum rows collapse under the ReplacingMergeTree sort key. `revert`/`restart` rows are unchanged. `SIGNAL_ACTIONS.md` documents this.
- **Vote counting is deliberate.** The signal-level quorum count filters `failed = 0` (a failed dispatch POST launches no run, so it must be retried, not counted as a slot); the per-(commit, workflow) cost cap of 8 still counts all attempts and clamps the delta.
- **Dedup by `run_id`** happens in the datasource — `run_attempt` retries of one run collapse to a single latest-attempt vote; the resolver assumes already-deduped input.
- No schema migration required. Advisor remains fire-and-forget/shadow; `advisor_result` (latest single vote) is retained for the HUD/state logger.