### PR TITLE
[viable/strict] Match required checks exactly (re.fullmatch)

### DIFF
--- a/tools/scripts/fetch_latest_green_commit.py
+++ b/tools/scripts/fetch_latest_green_commit.py
@@ -114,7 +114,8 @@ def is_green(
 ) -> Tuple[bool, str]:
     workflow_checks = get_commit_results(commit, results)
 
-    regex = {check: False for check in requires}
+    # Skip empty entries; fullmatch("") never matches a real workflow name.
+    regex = {check: False for check in requires if check}
 
     for check in workflow_checks:
         jobName = check["name"]
@@ -125,7 +126,9 @@ def is_green(
         workflow_name = check["workflowName"]
         conclusion = check["conclusion"]
         for required_check in regex:
-            if re.match(required_check, workflow_name, flags=re.IGNORECASE):
+            # Full match: "pull" won't also match "pull-test-sandbox".
+            # Explicit regex still works (e.g. "^Apple$").
+            if re.fullmatch(required_check, workflow_name, flags=re.IGNORECASE):
                 if conclusion not in ["success", "skipped"]:
                     return (
                         False,

--- a/tools/tests/test_fetch_latest_green_commit.py
+++ b/tools/tests/test_fetch_latest_green_commit.py
@@ -18,9 +18,13 @@ workflow_names = [
     "Close stale pull requests",
     "Update S3 HTML indices for download.pytorch.org",
     "Create Release",
+    "Apple",
+    "pull-test-sandbox",
 ]
 
-requires = ["pull", "trunk", "lint", "linux-binary"]
+# Matched with re.fullmatch: exact name ("lint" matches "Lint" via IGNORECASE)
+# or explicit regex ("^Apple$"). "pull" must NOT match "pull-test-sandbox".
+requires = ["pull", "trunk", "lint", "linux-binary-libtorch-pre-cxx11", "^Apple$"]
 
 
 def set_workflow_job_status(
@@ -117,7 +121,7 @@ class TestPrintCommits(TestCase):
         workflow_checks = set_workflow_job_status(
             workflow_checks, "docker-release-builds", "skipped"
         )
-        self.assertTrue(is_green("sha", requires, workflow_checks))
+        self.assertTrue(is_green("sha", requires, workflow_checks)[0])
 
     @mock.patch(
         "tools.scripts.fetch_latest_green_commit.get_commit_results",
@@ -163,8 +167,69 @@ class TestPrintCommits(TestCase):
         self.assertFalse(result[0])
         self.assertEqual(
             result[1],
-            "missing required workflows: pull, trunk, lint, linux-binary",
+            "missing required workflows: pull, trunk, lint, "
+            "linux-binary-libtorch-pre-cxx11, ^Apple$",
         )
+
+    @mock.patch(
+        "tools.scripts.fetch_latest_green_commit.get_commit_results",
+        return_value=TestChecks().make_test_checks(),
+    )
+    def test_prefix_does_not_match(
+        self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any
+    ) -> None:
+        """A required "pull" must not match "pull-test-sandbox"."""
+        workflow_checks = mock_get_commit_results()
+        workflow_checks = set_workflow_job_status(
+            workflow_checks, "pull-test-sandbox", "failed"
+        )
+        result = is_green("sha", requires, workflow_checks)
+        self.assertTrue(result[0])
+
+    @mock.patch(
+        "tools.scripts.fetch_latest_green_commit.get_commit_results",
+        return_value=TestChecks().make_test_checks(),
+    )
+    def test_regex_required_check(
+        self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any
+    ) -> None:
+        """An explicit regex required check (ex: "^Apple$") still matches."""
+        workflow_checks = mock_get_commit_results()
+        workflow_checks = set_workflow_job_status(workflow_checks, "Apple", "failed")
+        result = is_green("sha", requires, workflow_checks)
+        self.assertFalse(result[0])
+        self.assertEqual(result[1], "Apple was not successful, test/job failed")
+
+    @mock.patch(
+        "tools.scripts.fetch_latest_green_commit.get_commit_results",
+        return_value=[
+            WorkflowCheck(
+                workflowName="pull-test-sandbox",
+                name="test/job",
+                jobName="job",
+                conclusion="success",
+            )._asdict()
+        ],
+    )
+    def test_prefix_success_does_not_satisfy(
+        self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any
+    ) -> None:
+        """A prefix-named workflow does not satisfy an exact required check."""
+        result = is_green("sha", ["pull"], mock_get_commit_results())
+        self.assertFalse(result[0])
+        self.assertEqual(result[1], "missing required workflows: pull")
+
+    @mock.patch(
+        "tools.scripts.fetch_latest_green_commit.get_commit_results",
+        return_value=TestChecks().make_test_checks(),
+    )
+    def test_empty_required_check_ignored(
+        self, mock_get_commit_results: Any, mock_fetch_unstable_issues: Any
+    ) -> None:
+        """An empty required-check entry is skipped, not left unsatisfiable."""
+        workflow_checks = mock_get_commit_results()
+        result = is_green("sha", requires + [""], workflow_checks)
+        self.assertTrue(result[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #8439
* __->__ #8438

A bare required check like "pull" no longer prefix-matches unrelated
workflows (e.g. "pull-test-sandbox"); a successful such workflow no longer
satisfies the check either. Explicit regex patterns still work, and empty
entries are skipped so a stray one can't stall promotion. 

I think this makes sense to avoid suddenly pulling in an experimental workflow like
trunk-experiment or trunk-test, and suddenly it's blocking viable/strict often.

Test: python -m unittest tools.tests.test_fetch_latest_green_commit