### PR TITLE
Harden the greenlight scan against argument injection via just `{{args}}`

### DIFF
--- a/.github/workflows/greenlight-review.yml
+++ b/.github/workflows/greenlight-review.yml
@@ -1,6 +1,6 @@
 name: Green Light Scan
 
-# Manually runs the greenlight scanner (`just review`): lists open pytorch/pytorch PRs
+# Manually runs the greenlight scanner (`greenlight review`): lists open pytorch/pytorch PRs
 # from trusted authors and dispatches greenlight-pr-review.yml for each new or changed
 # PR. Read-only on ClickHouse; dispatches the reviewer workflow via the App token.
 
@@ -138,4 +138,4 @@ jobs:
           if [ -n "$IN_REQUESTER" ]; then args+=(--requester "$IN_REQUESTER"); fi
           if [ -n "$IN_MAX" ]; then args+=(--max "$IN_MAX"); fi
           args+=(--ref "$IN_REF" --timeout-minutes "$IN_TIMEOUT" --log-level "$IN_LOG_LEVEL")
-          just review "${args[@]}"
+          mise exec -- uv run greenlight review "${args[@]}"

--- a/greenlight/justfile
+++ b/greenlight/justfile
@@ -2,6 +2,7 @@
 # https://just.systems/
 
 set shell := ["mise", "exec", "--", "bash", "-euo", "pipefail", "-c"]
+set positional-arguments
 
 # Show available recipes
 default:
@@ -13,11 +14,11 @@ setup:
 
 # Run the greenlight CLI
 run *args:
-    uv run greenlight {{args}}
+    uv run greenlight "$@"
 
 # Scan open PRs from trusted authors in pytorch/pytorch; dispatch the reviewer workflow for new/changed PRs
 review *args:
-    uv run greenlight review {{args}}
+    uv run greenlight review "$@"
 
 # Type-check source and tests, plus the greenlight-owned detector hook
 typecheck:


### PR DESCRIPTION
**Impact:** greenlight scan CI workflow
**Risk:** low

## What
Stop passing dispatch inputs through just's `{{args}}` interpolation. The justfile now uses `set positional-arguments` with `"$@"`, and the scan workflow invokes the CLI directly via `mise exec -- uv run greenlight review`.

## Why
`just review {{args}}` expands `{{args}}` back into the recipe's shell line, so the free-form `workflow_dispatch` inputs get re-parsed and re-split by the shell in the step that already holds the App token, ClickHouse creds, and AWS OIDC session. A crafted input could inject shell commands or smuggle extra CLI flags (e.g. flipping on `--allow-untrusted-author`). Quoting the arguments as positionals (`"$@"`) passes them verbatim with no re-splitting, closing the injection path while keeping the same argv the workflow already builds.

# Notes
The workflow calls `mise exec -- uv run greenlight review` rather than `just review` to keep the argv handling in one place; `just run`/`just review` still work locally and now forward arguments safely.