### PR TITLE
[CRCR] Add nightly results view to per-repo dashboard

### DIFF
--- a/torchci/clickhouse_queries/crcr_nightly_dashboard/params.json
+++ b/torchci/clickhouse_queries/crcr_nightly_dashboard/params.json
@@ -1,4 +1,12 @@
 {
-  "repo": "String",
-  "days": "UInt64"
+  "params": {
+    "repo": "String",
+    "days": "UInt64"
+  },
+  "tests": [
+    {
+      "repo": "<company>/<repo>",
+      "days": "7"
+    }
+  ]
 }

--- a/torchci/clickhouse_queries/crcr_nightly_dashboard/params.json
+++ b/torchci/clickhouse_queries/crcr_nightly_dashboard/params.json
@@ -1,0 +1,4 @@
+{
+  "repo": "String",
+  "days": "UInt64"
+}

--- a/torchci/clickhouse_queries/crcr_nightly_dashboard/query.sql
+++ b/torchci/clickhouse_queries/crcr_nightly_dashboard/query.sql
@@ -1,0 +1,42 @@
+SELECT
+    upstream_repo,
+    pytorch_head_sha,
+    workflow_name,
+    job_name,
+    check_run_id,
+    run_id,
+    run_attempt,
+    status,
+    conclusion,
+    started_at,
+    completed_at,
+    duration_seconds,
+    total_tests,
+    passed_tests,
+    failed_tests,
+    skipped_tests,
+    workflow_run_url,
+    artifact_url,
+    queue_time,
+    execution_time
+FROM
+    default.crcr_workflow_job FINAL
+WHERE
+    downstream_repo = {repo: String}
+    AND started_at > now() - INTERVAL {days: UInt64} DAY
+    AND event_type = 'nightly'
+    AND (run_id, job_name, run_attempt) IN (
+        SELECT
+            run_id,
+            job_name,
+            max(run_attempt) AS max_attempt
+        FROM default.crcr_workflow_job FINAL
+        WHERE
+            downstream_repo = {repo: String}
+            AND started_at > now() - INTERVAL {days: UInt64} DAY
+            AND event_type = 'nightly'
+        GROUP BY run_id, job_name
+    )
+ORDER BY
+    started_at DESC
+LIMIT 500

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -1028,118 +1028,118 @@ function CrcrNightlyMatrix({
       <NightlySummaryCards data={data} />
       <div style={{ overflowX: "auto" }}>
         <table
-        style={{
-          borderCollapse: "collapse",
-          fontSize: "0.85rem",
-          width: "100%",
-        }}
-      >
-        <colgroup>
-          <col style={{ width: 80 }} />
-          <col style={{ width: 60 }} />
-          <col style={{ width: 340 }} />
-          {columns.map((col) => (
-            <col key={col.name} style={{ width: 18 }} />
-          ))}
-        </colgroup>
-        <thead>
-          <tr>
-            <th style={headerBaseStyle}>Time</th>
-            <th style={headerBaseStyle}>SHA</th>
-            <th style={headerBaseStyle}>Commit</th>
+          style={{
+            borderCollapse: "collapse",
+            fontSize: "0.85rem",
+            width: "100%",
+          }}
+        >
+          <colgroup>
+            <col style={{ width: 80 }} />
+            <col style={{ width: 60 }} />
+            <col style={{ width: 340 }} />
             {columns.map((col) => (
-              <th key={col.name} style={jobHeaderStyle}>
-                <div
-                  style={{
-                    ...jobHeaderNameStyle,
-                    fontWeight: col.type === "group" ? 700 : 400,
-                  }}
-                >
-                  {col.name}
-                </div>
-              </th>
+              <col key={col.name} style={{ width: 18 }} />
             ))}
-          </tr>
-        </thead>
-        <tbody>
-          {matrix.rows.map((row) => {
-            const commit = commitInfoMap.get(row.sha);
-            const commitTitle =
-              commit?.title || `nightly (${row.sha.substring(0, 12)})`;
-            return (
-              <tr
-                key={row.sha}
-                style={{ borderBottom: "1px solid #30363d" }}
-              >
-                <td style={cellStyle}>
-                  <LocalTimeDisplay timestamp={row.latestTime} />
-                </td>
-                <td style={cellStyle}>
-                  <a
-                    href={`https://github.com/${row.upstreamRepo}/commit/${row.sha}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    style={{ color: "#58a6ff", textDecoration: "none" }}
+          </colgroup>
+          <thead>
+            <tr>
+              <th style={headerBaseStyle}>Time</th>
+              <th style={headerBaseStyle}>SHA</th>
+              <th style={headerBaseStyle}>Commit</th>
+              {columns.map((col) => (
+                <th key={col.name} style={jobHeaderStyle}>
+                  <div
+                    style={{
+                      ...jobHeaderNameStyle,
+                      fontWeight: col.type === "group" ? 700 : 400,
+                    }}
                   >
-                    {row.sha.substring(0, 7)}
-                  </a>
-                </td>
-                <td style={{ ...cellStyle, maxWidth: 340 }}>
-                  <Tooltip title={commitTitle}>
+                    {col.name}
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {matrix.rows.map((row) => {
+              const commit = commitInfoMap.get(row.sha);
+              const commitTitle =
+                commit?.title || `nightly (${row.sha.substring(0, 12)})`;
+              return (
+                <tr
+                  key={row.sha}
+                  style={{ borderBottom: "1px solid #30363d" }}
+                >
+                  <td style={cellStyle}>
+                    <LocalTimeDisplay timestamp={row.latestTime} />
+                  </td>
+                  <td style={cellStyle}>
                     <a
                       href={`https://github.com/${row.upstreamRepo}/commit/${row.sha}`}
                       target="_blank"
                       rel="noopener noreferrer"
-                      style={{
-                        color: "#58a6ff",
-                        textDecoration: "none",
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        whiteSpace: "nowrap",
-                        display: "block",
-                      }}
+                      style={{ color: "#58a6ff", textDecoration: "none" }}
                     >
-                      {commitTitle}
+                      {row.sha.substring(0, 7)}
                     </a>
-                  </Tooltip>
-                </td>
-                {columns.map((col) => {
-                  if (col.type === "group" && col.members) {
-                    const groupJobs = col.members
-                      .map((m) => row.jobs.get(m))
-                      .filter((j): j is CrcrJobRow => j != null);
+                  </td>
+                  <td style={{ ...cellStyle, maxWidth: 340 }}>
+                    <Tooltip title={commitTitle}>
+                      <a
+                        href={`https://github.com/${row.upstreamRepo}/commit/${row.sha}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={{
+                          color: "#58a6ff",
+                          textDecoration: "none",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                          display: "block",
+                        }}
+                      >
+                        {commitTitle}
+                      </a>
+                    </Tooltip>
+                  </td>
+                  {columns.map((col) => {
+                    if (col.type === "group" && col.members) {
+                      const groupJobs = col.members
+                        .map((m) => row.jobs.get(m))
+                        .filter((j): j is CrcrJobRow => j != null);
+                      return (
+                        <td
+                          key={col.name}
+                          style={{ ...cellStyle, textAlign: "center" }}
+                        >
+                          {groupJobs.length > 0 ? (
+                            <GroupedJobCell
+                              jobs={groupJobs}
+                              groupName={col.name}
+                            />
+                          ) : (
+                            "–"
+                          )}
+                        </td>
+                      );
+                    }
+                    const job = row.jobs.get(col.name);
                     return (
                       <td
                         key={col.name}
                         style={{ ...cellStyle, textAlign: "center" }}
                       >
-                        {groupJobs.length > 0 ? (
-                          <GroupedJobCell
-                            jobs={groupJobs}
-                            groupName={col.name}
-                          />
-                        ) : (
-                          "–"
-                        )}
+                        {job ? <JobCell job={job} /> : "–"}
                       </td>
                     );
-                  }
-                  const job = row.jobs.get(col.name);
-                  return (
-                    <td
-                      key={col.name}
-                      style={{ ...cellStyle, textAlign: "center" }}
-                    >
-                      {job ? <JobCell job={job} /> : "–"}
-                    </td>
-                  );
-                })}
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    </div>
+                  })}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
     </>
   );
 }
@@ -1205,9 +1205,7 @@ export default function CrcrBackendPage() {
     );
   }
 
-  const pageTitle = isNightly
-    ? `${repoFullName} : nightly`
-    : repoFullName;
+  const pageTitle = isNightly ? `${repoFullName} : nightly` : repoFullName;
 
   return (
     <>

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -184,9 +184,7 @@ function NightlySummaryCards({ data }: { data: CrcrJobRow[] }) {
     const successes = completed.filter(
       (j) => j.conclusion === "success"
     ).length;
-    const failures = completed.filter(
-      (j) => j.conclusion === "failure"
-    ).length;
+    const failures = completed.filter((j) => j.conclusion === "failure").length;
     const timedOut = completed.filter(
       (j) => j.conclusion === "timed_out"
     ).length;
@@ -1067,10 +1065,7 @@ function CrcrNightlyMatrix({
               const commitTitle =
                 commit?.title || `nightly (${row.sha.substring(0, 12)})`;
               return (
-                <tr
-                  key={row.sha}
-                  style={{ borderBottom: "1px solid #30363d" }}
-                >
+                <tr key={row.sha} style={{ borderBottom: "1px solid #30363d" }}>
                   <td style={cellStyle}>
                     <LocalTimeDisplay timestamp={row.latestTime} />
                   </td>

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -1019,11 +1019,12 @@ export default function CrcrBackendPage() {
 
   const repoFullName = org && repo ? `${org}/${repo}` : "";
 
-  const summaryUrl = repoFullName
-    ? `/api/clickhouse/crcr_backend_summary?parameters=${encodeURIComponent(
-        JSON.stringify({ repo: repoFullName, days: String(days) })
-      )}`
-    : null;
+  const summaryUrl =
+    repoFullName && !isNightly
+      ? `/api/clickhouse/crcr_backend_summary?parameters=${encodeURIComponent(
+          JSON.stringify({ repo: repoFullName, days: String(days) })
+        )}`
+      : null;
   const { data: summaryData } = useSWR<SummaryStats[]>(
     summaryUrl,
     fetcherHandleError,

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -40,7 +40,7 @@ const CrcrPinnedContext = createContext<[Highlight, any]>([
 
 interface CrcrJobRow {
   upstream_repo: string;
-  pr_number: number;
+  pr_number?: number;
   pytorch_head_sha: string;
   workflow_name: string;
   job_name: string;
@@ -807,6 +807,205 @@ function CrcrMatrix({
   );
 }
 
+// ---- Nightly Matrix Table ----
+
+interface NightlyRow {
+  sha: string;
+  upstreamRepo: string;
+  latestTime: string;
+  jobs: Map<string, CrcrJobRow>;
+}
+
+function buildNightlyMatrix(data: CrcrJobRow[]): {
+  jobNames: string[];
+  rows: NightlyRow[];
+} {
+  const jobNamesSet = new Set<string>();
+  const shaMap = new Map<string, NightlyRow>();
+
+  for (const job of data) {
+    jobNamesSet.add(job.job_name);
+    const sha = job.pytorch_head_sha || "unknown";
+    let row = shaMap.get(sha);
+    if (!row) {
+      row = {
+        sha,
+        upstreamRepo: job.upstream_repo ?? "pytorch/pytorch",
+        latestTime: job.started_at,
+        jobs: new Map(),
+      };
+      shaMap.set(sha, row);
+    }
+    if (job.started_at > row.latestTime) {
+      row.latestTime = job.started_at;
+    }
+    const existing = row.jobs.get(job.job_name);
+    if (!existing || job.run_attempt > existing.run_attempt) {
+      row.jobs.set(job.job_name, job);
+    }
+  }
+
+  const jobNames = Array.from(jobNamesSet).sort();
+  const rows = Array.from(shaMap.values()).sort(
+    (a, b) =>
+      new Date(b.latestTime).getTime() - new Date(a.latestTime).getTime()
+  );
+  return { jobNames, rows };
+}
+
+function CrcrNightlyMatrix({
+  repoFullName,
+  days,
+}: {
+  repoFullName: string;
+  days: number;
+}) {
+  const url = `/api/clickhouse/crcr_nightly_dashboard?parameters=${encodeURIComponent(
+    JSON.stringify({ repo: repoFullName, days: String(days) })
+  )}`;
+  const { data, error } = useSWR<CrcrJobRow[]>(url, fetcherHandleError, {
+    refreshInterval: 60_000,
+  });
+
+  const { matrix, columns } = useMemo(() => {
+    if (!data) return { matrix: null, columns: [] };
+    const full = buildNightlyMatrix(data);
+    return {
+      matrix: full,
+      columns: detectGroups(full.jobNames),
+    };
+  }, [data]);
+
+  if (error) {
+    return (
+      <Typography color="error">
+        Failed to load nightly dashboard: {error.message}
+      </Typography>
+    );
+  }
+  if (!data || !matrix) {
+    return <Skeleton variant="rectangular" height={400} />;
+  }
+  if (data.length === 0) {
+    return (
+      <Typography color="text.secondary" sx={{ py: 4, textAlign: "center" }}>
+        No nightly results for {repoFullName} in the last {days} days.
+      </Typography>
+    );
+  }
+
+  return (
+    <div style={{ overflowX: "auto" }}>
+      <table
+        style={{
+          borderCollapse: "collapse",
+          fontSize: "0.85rem",
+          width: "100%",
+        }}
+      >
+        <colgroup>
+          <col style={{ width: 80 }} />
+          <col style={{ width: 60 }} />
+          <col style={{ width: 340 }} />
+          {columns.map((col) => (
+            <col key={col.name} style={{ width: 18 }} />
+          ))}
+        </colgroup>
+        <thead>
+          <tr>
+            <th style={headerBaseStyle}>Time</th>
+            <th style={headerBaseStyle}>SHA</th>
+            <th style={headerBaseStyle}>Commit</th>
+            {columns.map((col) => (
+              <th key={col.name} style={jobHeaderStyle}>
+                <div
+                  style={{
+                    ...jobHeaderNameStyle,
+                    fontWeight: col.type === "group" ? 700 : 400,
+                  }}
+                >
+                  {col.name}
+                </div>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {matrix.rows.map((row) => (
+            <tr
+              key={row.sha}
+              style={{ borderBottom: "1px solid #30363d" }}
+            >
+              <td style={cellStyle}>
+                <LocalTimeDisplay timestamp={row.latestTime} />
+              </td>
+              <td style={cellStyle}>
+                <a
+                  href={`https://github.com/${row.upstreamRepo}/commit/${row.sha}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ color: "#58a6ff", textDecoration: "none" }}
+                >
+                  {row.sha.substring(0, 7)}
+                </a>
+              </td>
+              <td style={{ ...cellStyle, maxWidth: 340 }}>
+                <a
+                  href={`https://github.com/${row.upstreamRepo}/commit/${row.sha}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title={`nightly release (${row.sha})`}
+                  style={{
+                    color: "#58a6ff",
+                    textDecoration: "none",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    display: "block",
+                  }}
+                >
+                  {`nightly release (${row.sha.substring(0, 20)}...)`}
+                </a>
+              </td>
+              {columns.map((col) => {
+                if (col.type === "group" && col.members) {
+                  const groupJobs = col.members
+                    .map((m) => row.jobs.get(m))
+                    .filter((j): j is CrcrJobRow => j != null);
+                  return (
+                    <td
+                      key={col.name}
+                      style={{ ...cellStyle, textAlign: "center" }}
+                    >
+                      {groupJobs.length > 0 ? (
+                        <GroupedJobCell
+                          jobs={groupJobs}
+                          groupName={col.name}
+                        />
+                      ) : (
+                        "–"
+                      )}
+                    </td>
+                  );
+                }
+                const job = row.jobs.get(col.name);
+                return (
+                  <td
+                    key={col.name}
+                    style={{ ...cellStyle, textAlign: "center" }}
+                  >
+                    {job ? <JobCell job={job} /> : "–"}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 // ---- Main Page ----
 
 export default function CrcrBackendPage() {
@@ -815,6 +1014,8 @@ export default function CrcrBackendPage() {
 
   const page = parseInt(router.query.page as string) || 1;
   const days = parseInt(router.query.days as string) || 7;
+  const eventType = (router.query.event as string) || "pr";
+  const isNightly = eventType === "nightly";
 
   const repoFullName = org && repo ? `${org}/${repo}` : "";
 
@@ -865,10 +1066,14 @@ export default function CrcrBackendPage() {
     );
   }
 
+  const pageTitle = isNightly
+    ? `${repoFullName} : nightly`
+    : repoFullName;
+
   return (
     <>
       <Head>
-        <title>{repoFullName} — CRCR CI | PyTorch HUD</title>
+        <title>{pageTitle} — CRCR CI | PyTorch HUD</title>
       </Head>
       <CrcrPinnedContext.Provider value={[pinnedTooltip, setPinnedTooltip]}>
         <div onClick={handleGlobalClick}>
@@ -879,7 +1084,22 @@ export default function CrcrBackendPage() {
               alignItems="center"
             >
               <Stack spacing={0.5}>
-                <Typography variant="h4">{repoFullName}</Typography>
+                <Typography variant="h4">
+                  {repoFullName}
+                  {isNightly && (
+                    <Typography
+                      component="span"
+                      variant="h4"
+                      sx={{
+                        color: "text.secondary",
+                        fontWeight: 300,
+                        mx: 1,
+                      }}
+                    >
+                      : nightly
+                    </Typography>
+                  )}
+                </Typography>
                 <Stack direction="row" spacing={2} alignItems="center">
                   <NextLink href="/crcr" passHref legacyBehavior>
                     <Link variant="body2" underline="hover">
@@ -915,25 +1135,32 @@ export default function CrcrBackendPage() {
               </Stack>
             </Box>
 
-            {stats ? (
-              <SummaryCards stats={stats} />
-            ) : (
-              <Skeleton variant="rectangular" height={140} />
+            {!isNightly && (
+              <>
+                {stats ? (
+                  <SummaryCards stats={stats} />
+                ) : (
+                  <Skeleton variant="rectangular" height={140} />
+                )}
+              </>
             )}
 
             <Typography variant="body2" color="text.secondary">
-              Rows = PyTorch PRs (50 per page), columns = downstream CI jobs.
-              Click a cell to pin its tooltip, click a column header to
-              highlight the column, or click a row to highlight it. Press Escape
-              to dismiss.
+              {isNightly
+                ? "Rows = nightly CI runs (one per SHA), columns = build & test stages. Click a cell to pin its tooltip, click a column header to highlight the column, or click a row to highlight it. Press Escape to dismiss."
+                : "Rows = PyTorch PRs (50 per page), columns = downstream CI jobs. Click a cell to pin its tooltip, click a column header to highlight the column, or click a row to highlight it. Press Escape to dismiss."}
             </Typography>
 
-            <CrcrMatrix
-              repoFullName={repoFullName}
-              days={days}
-              page={page}
-              onPageChange={(p) => updateQuery({ page: p })}
-            />
+            {isNightly ? (
+              <CrcrNightlyMatrix repoFullName={repoFullName} days={days} />
+            ) : (
+              <CrcrMatrix
+                repoFullName={repoFullName}
+                days={days}
+                page={page}
+                onPageChange={(p) => updateQuery({ page: p })}
+              />
+            )}
           </Stack>
         </div>
       </CrcrPinnedContext.Provider>

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -9,6 +9,7 @@ import {
   SelectChangeEvent,
   Skeleton,
   Stack,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import { durationDisplay } from "components/common/TimeUtils";

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -410,17 +410,19 @@ function buildMatrix(data: CrcrJobRow[]): {
   const prMap = new Map<number, MatrixRow>();
 
   for (const job of data) {
+    const prNum = job.pr_number ?? 0;
+    if (prNum <= 0) continue;
     jobNamesSet.add(job.job_name);
-    let row = prMap.get(job.pr_number);
+    let row = prMap.get(prNum);
     if (!row) {
       row = {
-        prNumber: job.pr_number,
+        prNumber: prNum,
         sha: job.pytorch_head_sha,
         upstreamRepo: job.upstream_repo ?? "pytorch/pytorch",
         latestTime: job.started_at,
         jobs: new Map(),
       };
-      prMap.set(job.pr_number, row);
+      prMap.set(prNum, row);
     }
     // Track latest started_at for this PR
     if (job.started_at > row.latestTime) {

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -21,6 +21,7 @@ import Head from "next/head";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
 import {
+  CSSProperties,
   createContext,
   useCallback,
   useContext,
@@ -1113,6 +1114,7 @@ function CrcrNightlyMatrix({
                             <GroupedJobCell
                               jobs={groupJobs}
                               groupName={col.name}
+                              sha={row.sha}
                             />
                           ) : (
                             "–"
@@ -1126,7 +1128,7 @@ function CrcrNightlyMatrix({
                         key={col.name}
                         style={{ ...cellStyle, textAlign: "center" }}
                       >
-                        {job ? <JobCell job={job} /> : "–"}
+                        {job ? <JobCell job={job} sha={row.sha} /> : "–"}
                       </td>
                     );
                   })}

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -555,6 +555,78 @@ function usePrInfo(
   }, [data]);
 }
 
+// ---- Commit Info Hook (for nightly view) ----
+
+interface CommitInfo {
+  sha: string;
+  title: string;
+  author: string;
+}
+
+function useCommitInfo(
+  upstreamRepo: string,
+  shas: string[]
+): Map<string, CommitInfo> {
+  const dedupedShas = useMemo(
+    () => Array.from(new Set(shas.filter(Boolean))).slice(0, 50),
+    [shas]
+  );
+  const url =
+    upstreamRepo && dedupedShas.length > 0
+      ? `/api/crcr/commit-info?repo=${encodeURIComponent(
+          upstreamRepo
+        )}&shas=${encodeURIComponent(dedupedShas.join(","))}`
+      : null;
+  const { data } = useSWR<CommitInfo[]>(url, fetcherHandleError, {
+    revalidateOnFocus: false,
+  });
+
+  return useMemo(() => {
+    const map = new Map<string, CommitInfo>();
+    if (data) {
+      for (const c of data) {
+        map.set(c.sha, c);
+      }
+    }
+    return map;
+  }, [data]);
+}
+
+// ---- Table Styles (matching main HUD) ----
+
+const headerBaseStyle: CSSProperties = {
+  fontFamily: "sans-serif",
+  fontSize: "0.75rem",
+  fontWeight: 600,
+  padding: "4px 6px",
+  whiteSpace: "nowrap",
+  textAlign: "left",
+  borderBottom: "1px solid #30363d",
+};
+
+const jobHeaderStyle: CSSProperties = {
+  fontFamily: "sans-serif",
+  height: 120,
+  whiteSpace: "nowrap",
+  padding: 0,
+  borderBottom: "1px solid #30363d",
+  position: "relative",
+};
+
+const jobHeaderNameStyle: CSSProperties = {
+  transform: "translate(5px, 45px) rotate(315deg)",
+  transformOrigin: "left bottom",
+  width: 12,
+  fontWeight: 400,
+  fontSize: "0.75em",
+};
+
+const cellStyle: CSSProperties = {
+  padding: "3px 6px",
+  whiteSpace: "nowrap",
+  fontSize: "0.8rem",
+  verticalAlign: "middle",
+};
 // ---- PR Matrix Table ----
 
 function CrcrMatrix({
@@ -878,6 +950,13 @@ function CrcrNightlyMatrix({
     };
   }, [data]);
 
+  const upstreamRepo = matrix?.rows[0]?.upstreamRepo ?? "pytorch/pytorch";
+  const nightlyShas = useMemo(
+    () => (matrix?.rows ?? []).map((r) => r.sha),
+    [matrix]
+  );
+  const commitInfoMap = useCommitInfo(upstreamRepo, nightlyShas);
+
   if (error) {
     return (
       <Typography color="error">
@@ -933,75 +1012,81 @@ function CrcrNightlyMatrix({
           </tr>
         </thead>
         <tbody>
-          {matrix.rows.map((row) => (
-            <tr
-              key={row.sha}
-              style={{ borderBottom: "1px solid #30363d" }}
-            >
-              <td style={cellStyle}>
-                <LocalTimeDisplay timestamp={row.latestTime} />
-              </td>
-              <td style={cellStyle}>
-                <a
-                  href={`https://github.com/${row.upstreamRepo}/commit/${row.sha}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  style={{ color: "#58a6ff", textDecoration: "none" }}
-                >
-                  {row.sha.substring(0, 7)}
-                </a>
-              </td>
-              <td style={{ ...cellStyle, maxWidth: 340 }}>
-                <a
-                  href={`https://github.com/${row.upstreamRepo}/commit/${row.sha}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  title={`nightly release (${row.sha})`}
-                  style={{
-                    color: "#58a6ff",
-                    textDecoration: "none",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
-                    display: "block",
-                  }}
-                >
-                  {`nightly release (${row.sha.substring(0, 20)}...)`}
-                </a>
-              </td>
-              {columns.map((col) => {
-                if (col.type === "group" && col.members) {
-                  const groupJobs = col.members
-                    .map((m) => row.jobs.get(m))
-                    .filter((j): j is CrcrJobRow => j != null);
+          {matrix.rows.map((row) => {
+            const commit = commitInfoMap.get(row.sha);
+            const commitTitle =
+              commit?.title || `nightly (${row.sha.substring(0, 12)})`;
+            return (
+              <tr
+                key={row.sha}
+                style={{ borderBottom: "1px solid #30363d" }}
+              >
+                <td style={cellStyle}>
+                  <LocalTimeDisplay timestamp={row.latestTime} />
+                </td>
+                <td style={cellStyle}>
+                  <a
+                    href={`https://github.com/${row.upstreamRepo}/commit/${row.sha}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{ color: "#58a6ff", textDecoration: "none" }}
+                  >
+                    {row.sha.substring(0, 7)}
+                  </a>
+                </td>
+                <td style={{ ...cellStyle, maxWidth: 340 }}>
+                  <Tooltip title={commitTitle}>
+                    <a
+                      href={`https://github.com/${row.upstreamRepo}/commit/${row.sha}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{
+                        color: "#58a6ff",
+                        textDecoration: "none",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                        display: "block",
+                      }}
+                    >
+                      {commitTitle}
+                    </a>
+                  </Tooltip>
+                </td>
+                {columns.map((col) => {
+                  if (col.type === "group" && col.members) {
+                    const groupJobs = col.members
+                      .map((m) => row.jobs.get(m))
+                      .filter((j): j is CrcrJobRow => j != null);
+                    return (
+                      <td
+                        key={col.name}
+                        style={{ ...cellStyle, textAlign: "center" }}
+                      >
+                        {groupJobs.length > 0 ? (
+                          <GroupedJobCell
+                            jobs={groupJobs}
+                            groupName={col.name}
+                          />
+                        ) : (
+                          "–"
+                        )}
+                      </td>
+                    );
+                  }
+                  const job = row.jobs.get(col.name);
                   return (
                     <td
                       key={col.name}
                       style={{ ...cellStyle, textAlign: "center" }}
                     >
-                      {groupJobs.length > 0 ? (
-                        <GroupedJobCell
-                          jobs={groupJobs}
-                          groupName={col.name}
-                        />
-                      ) : (
-                        "–"
-                      )}
+                      {job ? <JobCell job={job} /> : "–"}
                     </td>
                   );
-                }
-                const job = row.jobs.get(col.name);
-                return (
-                  <td
-                    key={col.name}
-                    style={{ ...cellStyle, textAlign: "center" }}
-                  >
-                    {job ? <JobCell job={job} /> : "–"}
-                  </td>
-                );
-              })}
-            </tr>
-          ))}
+                })}
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -178,6 +178,54 @@ function SummaryCards({ stats }: { stats: SummaryStats }) {
   );
 }
 
+function NightlySummaryCards({ data }: { data: CrcrJobRow[] }) {
+  const stats = useMemo(() => {
+    const completed = data.filter((j) => j.status === "completed");
+    const successes = completed.filter(
+      (j) => j.conclusion === "success"
+    ).length;
+    const failures = completed.filter(
+      (j) => j.conclusion === "failure"
+    ).length;
+    const timedOut = completed.filter(
+      (j) => j.conclusion === "timed_out"
+    ).length;
+    const total = completed.length;
+    const passRate = total > 0 ? successes / total : 0;
+    const uniqueShas = new Set(data.map((j) => j.pytorch_head_sha)).size;
+    return { successes, failures, timedOut, total, passRate, uniqueShas };
+  }, [data]);
+
+  const passColor =
+    stats.passRate >= 1.0
+      ? "#2e7d32"
+      : stats.passRate >= 0.9
+      ? "#ed6c02"
+      : "#d32f2f";
+
+  return (
+    <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+      <StatCard
+        label="Pass Rate"
+        value={`${(stats.passRate * 100).toFixed(1)}%`}
+        sub={`${stats.successes}/${stats.total} jobs`}
+        color={passColor}
+      />
+      <StatCard
+        label="Nightly Runs"
+        value={stats.uniqueShas}
+        sub="unique SHAs tested"
+      />
+      <StatCard
+        label="Failures"
+        value={stats.failures}
+        sub={stats.timedOut > 0 ? `+ ${stats.timedOut} timed out` : ""}
+        color={stats.failures > 0 ? "#d32f2f" : undefined}
+      />
+    </Box>
+  );
+}
+
 // ---- Job Cell (colored character, matching main HUD style) ----
 
 const conclusionCssColor: Record<string, string> = {
@@ -976,8 +1024,10 @@ function CrcrNightlyMatrix({
   }
 
   return (
-    <div style={{ overflowX: "auto" }}>
-      <table
+    <>
+      <NightlySummaryCards data={data} />
+      <div style={{ overflowX: "auto" }}>
+        <table
         style={{
           borderCollapse: "collapse",
           fontSize: "0.85rem",
@@ -1090,6 +1140,7 @@ function CrcrNightlyMatrix({
         </tbody>
       </table>
     </div>
+    </>
   );
 }
 

--- a/torchci/pages/crcr/index.tsx
+++ b/torchci/pages/crcr/index.tsx
@@ -291,7 +291,13 @@ function L1Section({ repos }: { repos: AllowlistEntry[] }) {
   );
 }
 
-function NightlyTable({ nightlyData }: { nightlyData: NightlyMetricsRow[] }) {
+function NightlyTable({
+  nightlyData,
+  days,
+}: {
+  nightlyData: NightlyMetricsRow[];
+  days: number;
+}) {
   return (
     <TableContainer component={Paper} elevation={1}>
       <Table size="small">
@@ -350,7 +356,7 @@ function NightlyTable({ nightlyData }: { nightlyData: NightlyMetricsRow[] }) {
                 </TableCell>
                 <TableCell>
                   <NextLink
-                    href={`/crcr/${org}/${repo}?event=nightly`}
+                    href={`/crcr/${org}/${repo}?event=nightly&days=${days}`}
                     passHref
                     legacyBehavior
                   >
@@ -795,7 +801,7 @@ export default function CrcrSummaryPage() {
                 <Typography variant="h6" sx={{ mt: 2 }}>
                   Nightly CI Runs — Last {days} Days
                 </Typography>
-                <NightlyTable nightlyData={nightlyData} />
+                <NightlyTable nightlyData={nightlyData} days={days} />
               </>
             ) : (
               <Paper

--- a/torchci/pages/crcr/index.tsx
+++ b/torchci/pages/crcr/index.tsx
@@ -350,7 +350,7 @@ function NightlyTable({ nightlyData }: { nightlyData: NightlyMetricsRow[] }) {
                 </TableCell>
                 <TableCell>
                   <NextLink
-                    href={`/crcr/${org}/${repo}`}
+                    href={`/crcr/${org}/${repo}?event=nightly`}
                     passHref
                     legacyBehavior
                   >


### PR DESCRIPTION
## Summary

- Adds `?event=nightly` query parameter support to the per-repo CRCR dashboard page (`/crcr/{org}/{repo}`)
- When `event=nightly`, the page shows nightly CI results grouped by SHA with Time/SHA/Commit columns (no PR number or author)
- The CRCR summary page's nightly tab now links repos to `/crcr/{org}/{repo}?event=nightly` so navigation is context-aware
- Creates a new `crcr_nightly_dashboard` ClickHouse query that filters by `event_type = 'nightly'` and deduplicates by `max(run_attempt)` per `run_id + job_name`

### Navigation flow

| Source | Link Target |
|--------|-------------|
| CRCR Summary → Pull Requests tab → click repo | `/crcr/{org}/{repo}` (default, PR results) |
| CRCR Summary → Nightly tab → click repo | `/crcr/{org}/{repo}?event=nightly` (nightly results) |

### Mockup

- [Nightly per-repo mockup](https://subinz1.github.io/CRCR/oot-hud-mockup-crcr-nightly.html)
- [CRCR Summary mockup](https://subinz1.github.io/CRCR/oot-hud-mockup-crcr-summary.html)

## Test plan

- [ ] Visit `/crcr/{org}/{repo}` — should show PR-based results (default behavior unchanged)
- [ ] Visit `/crcr/{org}/{repo}?event=nightly` — should show nightly results grouped by SHA
- [ ] CRCR summary nightly tab repo links navigate to `?event=nightly`
- [ ] Nightly view hides PR/Author columns and stat cards
- [ ] Time range selector works for nightly view
- [ ] Empty state displays correctly when no nightly data exists