### PR TITLE
Fix Python 3.15 validation on Linux, Windows and macOS

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -28,7 +28,7 @@ get_python_config() {
             CONDA_EXTRA_PARAM=" -c conda-forge/label/python_rc -c conda-forge"
             ;;
         # Note: 3.15 / 3.15t are intentionally absent here. They are provisioned
-        # via uv (CPython 3.15.0b1) in the interpreter-setup branch below and
+        # via uv (CPython 3.15.0b4) in the interpreter-setup branch below and
         # never reach the conda create path that reads CONDA_EXTRA_PARAM.
         *)
             PYTHON_V=${MATRIX_PYTHON_VERSION}
@@ -321,19 +321,24 @@ fi
 
 # Setup the Python environment.
 #
-# Python 3.15 is still pre-release. The cp315/cp315t wheels are built against
-# CPython 3.15.0b1 (see pytorch .ci/docker/common/install_cpython.sh), but
-# conda-forge only ships 3.15.0a8 -- the pre-release ABI differs, so installing
-# the wheel under the conda interpreter segfaults on "import torch". Provision
-# the matching 3.15.0b1 interpreter with uv (from python-build-standalone)
+# Python 3.15 is still pre-release, and conda-forge's default channel does not
+# carry it, so provision the interpreter with uv (from python-build-standalone)
 # instead of conda. A --seed venv provides pip so the rest of the flow (pip3
 # install, smoke tests) is unchanged.
+#
+# Pin b4, NOT b1: `import torch` segfaults under the 3.15.0b1 build. The crash is
+# pybind11 3.0.4's gil_scoped_acquire teardown in python_tracer::init(), reached
+# from torch._C._autograd_init():
+#     THPAutograd_initExtension -> python_tracer::init()
+#       -> ~gil_scoped_acquire() -> dec_ref() -> PyThreadState_Clear -> SIGSEGV
+# Verified with the cp315 nightly on both interpreters: b1 segfaults, b4 imports
+# and runs (matmul/autograd, and 3.15t with the GIL genuinely disabled).
 USING_UV_VENV="no"
 if [[ ${MATRIX_PYTHON_VERSION} == "3.15" || ${MATRIX_PYTHON_VERSION} == "3.15t" ]]; then
     USING_UV_VENV="yes"
-    UV_PYTHON="3.15.0b1"
+    UV_PYTHON="3.15.0b4"
     if [[ ${MATRIX_PYTHON_VERSION} == "3.15t" ]]; then
-        UV_PYTHON="3.15.0b1+freethreaded"
+        UV_PYTHON="3.15.0b4+freethreaded"
     fi
     curl -LsSf https://astral.sh/uv/install.sh | sh
     source "${HOME}/.local/bin/env"

--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -200,7 +200,19 @@ run_smoke_tests() {
 
     # For pip install also test with latest numpy
     if [[ ${MATRIX_PACKAGE_TYPE} == 'wheel' ]]; then
-        pip3 install numpy --upgrade --force-reinstall
+        # PyPI publishes no cp315/cp315t numpy wheels, so a plain
+        # `pip install numpy` falls back to building from source: slow on Linux
+        # and macOS, and a hard failure on Windows, where MSVC cannot find
+        # stdalign.h ("fatal error C1083") while compiling numpy's SIMD headers.
+        # Preview wheels for every platform, Windows included, are on the
+        # nightly index -- take those instead, and never a source build.
+        if [[ ${MATRIX_PYTHON_VERSION} == "3.15" || ${MATRIX_PYTHON_VERSION} == "3.15t" ]]; then
+            pip3 install --pre numpy --upgrade --force-reinstall \
+                --only-binary=:all: \
+                --index-url https://download.pytorch.org/whl/nightly
+        else
+            pip3 install numpy --upgrade --force-reinstall
+        fi
         ${PYTHON_RUN} ./smoke_test/smoke_test.py ${test_suffix} ${compile_check}
     fi
 

--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -215,11 +215,23 @@ test_cuda_device() {
     fi
 }
 
-# Cleanup conda environment
+# Cleanup the environment created for this run.
+#
+# ENV_NAME is a conda env name on the conda path but a venv *directory* on the
+# uv path, so `conda env remove -n` would fail with EnvironmentLocationNotFound
+# and, under `set -e`, fail the whole job after the tests had already passed.
 cleanup_conda_env() {
     if [[ ${TARGET_OS} != linux* ]]; then
-        conda deactivate
-        conda env remove -n "${ENV_NAME}"
+        if [[ ${USING_UV_VENV} == 'yes' ]]; then
+            # `deactivate` is a function defined by the venv activate script.
+            if declare -F deactivate > /dev/null; then
+                deactivate
+            fi
+            rm -rf "${ENV_NAME}"
+        else
+            conda deactivate
+            conda env remove -n "${ENV_NAME}"
+        fi
     fi
 }
 
@@ -316,7 +328,9 @@ fi
 # the matching 3.15.0b1 interpreter with uv (from python-build-standalone)
 # instead of conda. A --seed venv provides pip so the rest of the flow (pip3
 # install, smoke tests) is unchanged.
+USING_UV_VENV="no"
 if [[ ${MATRIX_PYTHON_VERSION} == "3.15" || ${MATRIX_PYTHON_VERSION} == "3.15t" ]]; then
+    USING_UV_VENV="yes"
     UV_PYTHON="3.15.0b1"
     if [[ ${MATRIX_PYTHON_VERSION} == "3.15t" ]]; then
         UV_PYTHON="3.15.0b1+freethreaded"
@@ -324,7 +338,12 @@ if [[ ${MATRIX_PYTHON_VERSION} == "3.15" || ${MATRIX_PYTHON_VERSION} == "3.15t" 
     curl -LsSf https://astral.sh/uv/install.sh | sh
     source "${HOME}/.local/bin/env"
     uv venv --seed --python "${UV_PYTHON}" "${ENV_NAME}"
-    source "${ENV_NAME}/bin/activate"
+    # uv lays the venv out the platform way: Scripts/ on Windows, bin/ elsewhere.
+    if [[ ${TARGET_OS} == 'windows' ]]; then
+        source "${ENV_NAME}/Scripts/activate"
+    else
+        source "${ENV_NAME}/bin/activate"
+    fi
 else
     update_conda
     get_python_config
@@ -334,7 +353,11 @@ fi
 
 # Save original PATH for macos-arm64 workaround
 export OLD_PATH=${PATH}
-if [[ ${TARGET_OS} == 'macos-arm64' ]]; then
+# This promotes the *conda* env's bin to the front of PATH. On the uv path there
+# is no conda env to promote: CONDA_PREFIX still points at base (python 3.14),
+# so prepending it shadows the venv's python3/pip3 and the run would install and
+# validate the wrong interpreter instead of 3.15.
+if [[ ${TARGET_OS} == 'macos-arm64' && ${USING_UV_VENV} == 'no' ]]; then
     export PATH="${CONDA_PREFIX}/bin:${PATH}"
 fi
 


### PR DESCRIPTION
## What

Makes Python 3.15 / 3.15t binary validation actually work, on every platform.
#8427 put 3.15 in the default matrix for all OSes, which exposed the uv-based
interpreter setup in `validate_binaries.sh` — previously Linux-only — to Windows
and macOS. Four bugs, all in that one script:

**1. Wrong interpreter pinned (all platforms).** `import torch` segfaults with
every published cp315 wheel under CPython **3.15.0b1**, which is what the script
provisioned. The crash is pybind11 3.0.4's `gil_scoped_acquire` teardown in
`python_tracer::init()`, reached from `torch._C._autograd_init()`:

```
torch/autograd/__init__.py:653          if not torch._C._autograd_init():
 └ THPAutograd_initExtension            torch/csrc/autograd/init.cpp:761
    └ python_tracer::init()             torch/csrc/autograd/profiler_python.cpp:1637
       └ pybind11::gil_scoped_acquire::~gil_scoped_acquire()
          └ ::dec_ref() -> PyThreadState_Clear -> SIGSEGV
```

The same wheel imports and runs fine under **3.15.0b4**, so the pin moves to b4.
Verified locally on both interpreters, and with the oldest (`dev20260724`) and
newest (`dev20260805`) cp315 nightlies.

**2. Windows could not activate the venv.** uv lays a venv out as `Scripts/`, not
`bin/` — it says so in the log line right above the failure:

```
Activate with: conda-env-31013667966\Scripts\activate
+ source conda-env-31013667966/bin/activate
validate_binaries.sh: line 327: .../bin/activate: No such file or directory
```

**3. macOS silently validated the wrong Python.** The `macos-arm64` workaround
prepends `${CONDA_PREFIX}/bin` to PATH. On the uv path no conda env is activated,
so `CONDA_PREFIX` still pointed at base (**python 3.14**) and shadowed the venv.
The job did not error — it installed and smoke-tested torch under 3.14, i.e. the
3.15 leg was reporting 3.14 results. The prepend is now skipped on the uv path.

**4. Cleanup failed after a green run.** `ENV_NAME` is a conda env name on the
conda path but a venv *directory* on the uv path, so `conda env remove -n` fails
with `EnvironmentLocationNotFound` and, under `set -e`, fails the job after the
tests passed. The uv path now deactivates and `rm -rf`s the directory.

**5. numpy built from source on Windows.** PyPI publishes no cp315/cp315t numpy
wheels, so the smoke-test step's `pip install numpy --upgrade` falls back to a
source build — slow on Linux/macOS, fatal on Windows:

```
numpy/_core/src/common/simd/simd.h(4): fatal error C1083:
    Cannot open include file: 'stdalign.h': No such file or directory
```

`download.pytorch.org/whl/nightly` already carries preview cp315 and cp315t numpy
wheels for every platform including `win_amd64`, so 3.15 pulls numpy from there
with `--only-binary=:all:` to forbid a source fallback. Other Python versions
keep using PyPI unchanged.

The conda path for 3.10–3.14t is untouched throughout.

## Test plan

Validated end-to-end with a temporary commit that pointed the workflow checkouts
at this branch and forced PR builds to 3.15 (that commit has been **removed**;
this PR is now the three real commits, one file).

Final run — **every 3.15 leg green**:

| platform | 3.15 legs |
|---|---|
| linux | **7/7** — cpu, cuda 12.6 / 13.0 / 13.2, rocm 7.1 / 7.2, xpu |
| linux-aarch64 | **4/4** — cpu, cuda 12.6 / 13.0 / 13.2 |
| win | **5/5** — cpu, cuda 12.6 / 13.0 / 13.2, xpu |
| mac-arm64 | green |

Also: `bash -n` clean; `shellcheck -S warning` reports only the pre-existing
line-181 finding; the 11 matrix unit tests pass.

## Follow-ups (not in this PR)

- None of the four `validate-*-binaries.yml` workflows pass `test-infra-ref`, so
  `generate_binary_build_matrix.yml` defaults it to `main` and the `*_job.yml`
  templates to `""`. Both the matrix generator and `validate_binaries.sh` are
  therefore always taken from `main` — **no PR touching this script can test
  itself** without a temporary commit like the one used above. Worth fixing
  properly.
- PR-limited runs validate a single Python version, so **3.15t got no CI
  coverage** here. It was verified locally on b4 (GIL genuinely disabled, matmul
  correct, and cp315t numpy wheels exist on the nightly index).
- The pybind11 `gil_scoped_acquire` fragility behind the b1 segfault is real and
  still worth reporting upstream, even though b4 avoids it.
