### PR TITLE
Add ROCm packages to PACKAGE_LINKS_ALLOW_LIST

### DIFF
--- a/s3_management/manage_v2.py
+++ b/s3_management/manage_v2.py
@@ -548,6 +548,37 @@ PACKAGE_LINKS_ALLOW_LIST = {
         "mkl",
         "pyelftools",
         "pyzes",
+        # torch_rocm packages, mirrored from repo.amd.com by
+        # update_dependencies.py (see PACKAGES_PER_PROJECT entries with
+        # project "torch_rocm"). Keep the two lists in sync.
+        "rocm",
+        "rocm-sdk-core",
+        "rocm-sdk-libraries",
+        "rocm-sdk-device-gfx1010",
+        "rocm-sdk-device-gfx1011",
+        "rocm-sdk-device-gfx1012",
+        "rocm-sdk-device-gfx1030",
+        "rocm-sdk-device-gfx1031",
+        "rocm-sdk-device-gfx1032",
+        "rocm-sdk-device-gfx1033",
+        "rocm-sdk-device-gfx1034",
+        "rocm-sdk-device-gfx1035",
+        "rocm-sdk-device-gfx1036",
+        "rocm-sdk-device-gfx1100",
+        "rocm-sdk-device-gfx1101",
+        "rocm-sdk-device-gfx1102",
+        "rocm-sdk-device-gfx1103",
+        "rocm-sdk-device-gfx1150",
+        "rocm-sdk-device-gfx1151",
+        "rocm-sdk-device-gfx1152",
+        "rocm-sdk-device-gfx1153",
+        "rocm-sdk-device-gfx1200",
+        "rocm-sdk-device-gfx1201",
+        "rocm-sdk-device-gfx1250",
+        "rocm-sdk-device-gfx908",
+        "rocm-sdk-device-gfx90a",
+        "rocm-sdk-device-gfx942",
+        "rocm-sdk-device-gfx950",
     ]
 }
 


### PR DESCRIPTION
## What

Adds the 28 ROCm dependency packages introduced by #8436 to
`PACKAGE_LINKS_ALLOW_LIST` in `s3_management/manage_v2.py`.

#8436 taught `update_dependencies.py` to mirror the rocm7.14 dependency wheels
from `repo.amd.com/rocm/whl-multi-arch`, adding 28 entries to
`PACKAGES_PER_PROJECT` under project `torch_rocm`. Packages in
`PACKAGE_LINKS_ALLOW_LIST` get their `index.html` **copied down from the parent
prefix** rather than regenerated from wheel listings — e.g.
`whl/nightly/rocm-sdk-core/index.html` → `whl/nightly/rocm7.14/rocm-sdk-core/index.html`
— which is what lets a subdirectory index point at externally sourced packages.
The `nvidia-*` and Intel/XPU dependency packages are already handled this way;
the ROCm ones were missed.

## The packages

```
rocm
rocm-sdk-core
rocm-sdk-libraries
rocm-sdk-device-gfx908   gfx90a   gfx942   gfx950
rocm-sdk-device-gfx1010  gfx1011  gfx1012
rocm-sdk-device-gfx1030  gfx1031  gfx1032  gfx1033  gfx1034  gfx1035  gfx1036
rocm-sdk-device-gfx1100  gfx1101  gfx1102  gfx1103
rocm-sdk-device-gfx1150  gfx1151  gfx1152  gfx1153
rocm-sdk-device-gfx1200  gfx1201  gfx1250
```

Rather than transcribe these from the diff by hand, I generated them from the
merged source: every `PACKAGES_PER_PROJECT` key with a config whose `project` is
`torch_rocm`. So the two lists cannot drift from a typo here.

## Test plan

Checked by parsing both files with `ast` after the change:

```
torch_rocm packages in update_dependencies.py : 28
of those now in PACKAGE_LINKS_ALLOW_LIST      : 28
missing                                       : none
total allow-list entries                      : 95   (67 -> 95)
duplicates                                    : none
```

- `python -m py_compile s3_management/manage_v2.py` passes
- `black --check` reports the file unchanged
- `flake8` output is byte-identical to `main`'s (the existing E501/B023 findings
  are pre-existing and far below the edited region)

Data-only change; no logic touched.

## Note

`PACKAGE_ALLOW_LIST` deliberately does **not** get these entries — it does not
carry the `nvidia-*` or Intel dependency packages either, so this matches the
established pattern for mirrored third-party deps.
