### PR TITLE
Fix ROCm index URLs dropping the parent-directory hop

### DIFF
--- a/s3_management/update_dependencies.py
+++ b/s3_management/update_dependencies.py
@@ -2,6 +2,7 @@ import os
 import re
 import time
 from typing import Dict, List
+from urllib.parse import urljoin
 
 import boto3  # type: ignore[import-untyped]
 
@@ -836,13 +837,16 @@ def download(url: str) -> bytes:
         return conn.read()
 
 
-def replace_relative_links_with_absolute(html: str, base_url: str) -> str:
+def replace_relative_links_with_absolute(
+    html: str, base_url: str, resolve_relative_paths: bool = False
+) -> str:
     """
     Replace all relative links in HTML with absolute links.
 
     Args:
         html: HTML content as string
         base_url: Base URL to prepend to relative links
+        resolve_relative_paths: Resolve "../" segments against base_url (ROCm only)
 
     Returns:
         Modified HTML with absolute links
@@ -863,6 +867,10 @@ def replace_relative_links_with_absolute(html: str, base_url: str) -> str:
             or url.startswith("//")
         ):
             return full_match
+
+        # ROCm wheels sit flat in whl-multi-arch/, so AMD hrefs are "../<wheel>.whl"
+        if resolve_relative_paths:
+            return f'href="{urljoin(base_url, url)}"'
 
         # Remove leading ./ or /
         url = url.lstrip("./")
@@ -902,7 +910,9 @@ def upload_index_html(
 ) -> None:
     """Upload modified index.html to S3 and R2 with absolute links"""
     # Replace relative links with absolute links
-    modified_html = replace_relative_links_with_absolute(html, base_url)
+    modified_html = replace_relative_links_with_absolute(
+        html, base_url, resolve_relative_paths=is_amd_package(pkg_name)
+    )
 
     index_key = f"{prefix}/{pkg_name}/index.html"
 


### PR DESCRIPTION
## Problem

Follow-up to #8436. The ROCm indices it generates point at URLs that do not
exist. From
[whl/nightly/rocm7.14/rocm-sdk-device-gfx1010/](https://download.pytorch.org/whl/nightly/rocm7.14/rocm-sdk-device-gfx1010/):

```html
<a href="https://repo.amd.com/rocm/whl-multi-arch/rocm-sdk-device-gfx1010/rocm_sdk_device_gfx1010-7.13.0-py3-none-linux_x86_64.whl">
```

AMD serves a per-package *index* at `whl-multi-arch/<package>/`, but stores the
*wheels* flat in `whl-multi-arch/`:

| URL | result |
|---|---|
| `.../whl-multi-arch/rocm-sdk-device-gfx1010/rocm_sdk_device_gfx1010-7.13.0-...whl` (published) | **403** |
| `.../whl-multi-arch/rocm_sdk_device_gfx1010-7.13.0-...whl` (actual location) | 206 |

Every link in every ROCm package index is currently broken.

## Cause

AMD's index hrefs carry the parent hop:

```html
<a href="../rocm_sdk_device_gfx1010-7.13.0-py3-none-linux_x86_64.whl">
```

`replace_relative_links_with_absolute()` normalised them with:

```python
url = url.lstrip("./")
url = url.lstrip("/")
```

`str.lstrip("./")` strips leading `.` and `/` **characters**, not a prefix, so
`../x.whl` collapses to `x.whl`, which is then concatenated onto the package
URL — silently producing the 403 path.

## Fix

Resolve the href with `urllib.parse.urljoin`, which honours `../`.

**Scoped to ROCm** via the existing `is_amd_package()`: NVIDIA
(`pypi.nvidia.com/<pkg>/`, plain-filename hrefs) and PyPI (absolute
`files.pythonhosted.org` hrefs) do not use `../` and keep the existing code
path, so their generated indices are unchanged.

## Test plan

Ran the real AMD index HTML for 6 ROCm packages through the patched function and
HTTP range-requested every resulting URL:

```
rocm                       2/2 reachable
rocm-sdk-core              4/4 reachable
rocm-sdk-libraries         4/4 reachable
rocm-sdk-device-gfx1010    4/4 reachable
rocm-sdk-device-gfx942     2/2 reachable
rocm-sdk-device-gfx90a     3/3 reachable
-------------------------------------------
TOTAL after fix           19/19 reachable
currently published        0/4 reachable
```

Non-ROCm paths asserted byte-identical to today's output:

| index | href in | href out |
|---|---|---|
| NVIDIA | `x.whl#sha256=a` | `https://pypi.nvidia.com/nvidia-cublas-cu12/x.whl#sha256=a` |
| PyPI | `https://files.pythonhosted.org/...` | unchanged |

`black --check` clean, `flake8` clean, `py_compile` passes.

## After merge

The published indices are regenerated by the `update-s3-dependencies` workflow,
so the broken links will be corrected on its next run — no manual S3/R2 cleanup
needed.
