### PR TITLE
[CRCR] Add multi-issuer OIDC support to jwt_helper for Buildkite

### DIFF
--- a/aws/lambda/cross_repo_ci_relay/callback/lambda_function.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/lambda_function.py
@@ -46,11 +46,11 @@ def lambda_handler(event, context):
         config = get_config()
         body = json.loads(body_bytes) if body_bytes else {}
 
-        # OIDC is the only identity check Relay performs.  The callback body is
-        # passed through to HUD untouched — HUD owns schema/business validation.
-        # Relay reports the OIDC-verified repo to HUD separately as
-        # `verified_repo` so HUD has a trusted source of truth for the
-        # caller's identity.
+        # Load external CI provider repo mappings (Buildkite, etc.) so
+        # verify_oidc_token can resolve non-GitHub OIDC tokens.  Cached
+        # in Redis; no-op when CI_PROVIDERS_URL is not configured.
+        jwt_helper.load_ci_providers(config)
+
         oidc_claims = jwt_helper.verify_oidc_token(headers.get("authorization", ""))
         verified_repo = oidc_claims["repository"]
 

--- a/aws/lambda/cross_repo_ci_relay/config/ci_providers.yml
+++ b/aws/lambda/cross_repo_ci_relay/config/ci_providers.yml
@@ -6,13 +6,17 @@
 # Format: one top-level key per CI provider.  Each provider section maps
 # the provider's pipeline identifier to the GitHub repo it represents.
 #
+# IMPORTANT: Buildkite mappings use immutable organization_id/pipeline_id
+# (UUIDs) rather than slugs.  Slugs are renameable and a released slug
+# can be claimed by a different organization; IDs are permanent.
+# Find IDs via: buildkite-agent oidc request-token --audience <aud>
+#
 # The Lambda fetches this file at runtime (via CI_PROVIDERS_URL) and
 # caches it in Redis, so changes here take effect without redeployment.
 
 buildkite:
-  # org_slug/pipeline_slug: owner/repo
-  # vllm/ci: vllm-project/vllm
-  # vllm/release: vllm-project/vllm
+  # organization_id/pipeline_id: owner/repo  # slug (for readability)
+  # 018e4f2a-1b2c-3d4e/018e5a6b-7c8d-9e0f: vllm-project/vllm  # vllm/ci
 
 # gitlab:
 #   group/project: owner/repo

--- a/aws/lambda/cross_repo_ci_relay/config/ci_providers.yml
+++ b/aws/lambda/cross_repo_ci_relay/config/ci_providers.yml
@@ -1,0 +1,21 @@
+# External CI Provider → GitHub Repo Mapping for CRCR OIDC
+#
+# CI platforms that don't carry a native "repository" OIDC claim need an
+# explicit mapping from their pipeline identity to a GitHub owner/repo.
+#
+# Format: one top-level key per CI provider.  Each provider section maps
+# the provider's pipeline identifier to the GitHub repo it represents.
+#
+# The Lambda fetches this file at runtime (via CI_PROVIDERS_URL) and
+# caches it in Redis, so changes here take effect without redeployment.
+
+buildkite:
+  # org_slug/pipeline_slug: owner/repo
+  # vllm/ci: vllm-project/vllm
+  # vllm/release: vllm-project/vllm
+
+# gitlab:
+#   group/project: owner/repo
+
+# jenkins:
+#   job-name: owner/repo

--- a/aws/lambda/cross_repo_ci_relay/config/ci_providers.yml
+++ b/aws/lambda/cross_repo_ci_relay/config/ci_providers.yml
@@ -3,20 +3,38 @@
 # CI platforms that don't carry a native "repository" OIDC claim need an
 # explicit mapping from their pipeline identity to a GitHub owner/repo.
 #
-# Format: one top-level key per CI provider.  Each provider section maps
-# the provider's pipeline identifier to the GitHub repo it represents.
-#
 # IMPORTANT: Buildkite mappings use immutable organization_id/pipeline_id
 # (UUIDs) rather than slugs.  Slugs are renameable and a released slug
 # can be claimed by a different organization; IDs are permanent.
 # Find IDs via: buildkite-agent oidc request-token --audience <aud>
 #
+# SECURITY: By default, any build in a mapped pipeline can authenticate.
+# If a pipeline runs fork-PR builds, use required_claims to restrict
+# which builds are authorized (e.g. only builds on specific branches).
+# Pipelines that do NOT expose OIDC to fork builds are safe without
+# required_claims.
+#
 # The Lambda fetches this file at runtime (via CI_PROVIDERS_URL) and
 # caches it in Redis, so changes here take effect without redeployment.
 
 buildkite:
-  # organization_id/pipeline_id: owner/repo  # slug (for readability)
-  # 018e4f2a-1b2c-3d4e/018e5a6b-7c8d-9e0f: vllm-project/vllm  # vllm/ci
+  # Simple format (pipeline does not run fork builds):
+  #   organization_id/pipeline_id: owner/repo
+  #
+  # Constrained format (pipeline may run fork builds):
+  #   organization_id/pipeline_id:
+  #     repo: owner/repo
+  #     required_claims:
+  #       build_branch: [main, nightly]  # only these branches can auth
+  #       cluster_id: specific-cluster-uuid
+
+  # Example entries:
+  # 018e4f2a-1b2c-3d4e/018e5a6b-7c8d-9e0f: vllm-project/vllm
+  #
+  # 018e4f2a-1b2c-3d4e/018e9a0b-1c2d-3e4f:
+  #   repo: vllm-project/vllm
+  #   required_claims:
+  #     build_branch: [main, release]
 
 # gitlab:
 #   group/project: owner/repo

--- a/aws/lambda/cross_repo_ci_relay/tests/test_callback_handler_lambda.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_callback_handler_lambda.py
@@ -48,26 +48,29 @@ class TestCallbackLambdaHandler(unittest.TestCase):
         response = lambda_handler(_event(body="not-json"), {})
         self.assertEqual(response["statusCode"], 400)
 
+    @patch("callback.lambda_function.jwt_helper.load_ci_providers")
     @patch("callback.lambda_function.get_config")
-    def test_missing_authorization_header_returns_401(self, mock_get_config):
+    def test_missing_authorization_header_returns_401(self, mock_get_config, _):
         response = lambda_handler(_event(headers={}), {})
         self.assertEqual(response["statusCode"], 401)
         self.assertIn("Missing", json.loads(response["body"])["detail"])
 
+    @patch("callback.lambda_function.jwt_helper.load_ci_providers")
     @patch("callback.lambda_function.get_config")
     @patch("callback.lambda_function.jwt_helper.verify_oidc_token")
-    def test_oidc_failure_returns_401(self, mock_oidc, mock_get_config):
+    def test_oidc_failure_returns_401(self, mock_oidc, mock_get_config, _):
         mock_oidc.side_effect = HTTPException(401, "Invalid authorization token")
 
         response = lambda_handler(_event(), {})
 
         self.assertEqual(response["statusCode"], 401)
 
+    @patch("callback.lambda_function.jwt_helper.load_ci_providers")
     @patch("callback.lambda_function.get_config")
     @patch("callback.lambda_function.jwt_helper.verify_oidc_token")
     @patch("callback.lambda_function.callback_handler.handle")
     def test_happy_path_forwards_body_and_verified_repo(
-        self, mock_handle, mock_oidc, mock_get_config
+        self, mock_handle, mock_oidc, mock_get_config, _
     ):
         mock_oidc.return_value = {"repository": "org/repo"}
         mock_handle.return_value = {"ok": True, "status": "completed"}
@@ -83,13 +86,13 @@ class TestCallbackLambdaHandler(unittest.TestCase):
         self.assertEqual(args[1], {"status": "completed", "head_sha": "abc123"})
         self.assertEqual(args[2], "org/repo")
 
+    @patch("callback.lambda_function.jwt_helper.load_ci_providers")
     @patch("callback.lambda_function.get_config")
     @patch("callback.lambda_function.jwt_helper.verify_oidc_token")
     @patch("callback.lambda_function.callback_handler.handle")
     def test_hud_error_from_handler_is_forwarded(
-        self, mock_handle, mock_oidc, mock_get_config
+        self, mock_handle, mock_oidc, mock_get_config, _
     ):
-        # HUD's HTTP status propagates out of Relay (transparent proxy).
         mock_oidc.return_value = {"repository": "org/repo"}
         mock_handle.side_effect = HTTPException(503, "HUD unreachable")
 
@@ -98,11 +101,12 @@ class TestCallbackLambdaHandler(unittest.TestCase):
         self.assertEqual(response["statusCode"], 503)
         self.assertEqual(json.loads(response["body"])["detail"], "HUD unreachable")
 
+    @patch("callback.lambda_function.jwt_helper.load_ci_providers")
     @patch("callback.lambda_function.get_config")
     @patch("callback.lambda_function.jwt_helper.verify_oidc_token")
     @patch("callback.lambda_function.callback_handler.handle")
     def test_unhandled_exception_returns_500(
-        self, mock_handle, mock_oidc, mock_get_config
+        self, mock_handle, mock_oidc, mock_get_config, _
     ):
         mock_oidc.return_value = {"repository": "org/repo"}
         mock_handle.side_effect = Exception("boom")

--- a/aws/lambda/cross_repo_ci_relay/tests/test_jwt_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_jwt_helper.py
@@ -137,7 +137,9 @@ class TestVerifyBuildkiteOIDC(unittest.TestCase):
         self.mock_decode = self.patcher_decode.start()
 
         self._orig_map = BUILDKITE_REPO_MAP.copy()
-        load_ci_provider_mappings({"buildkite": {"org-uuid-123/pipe-uuid-456": "myorg/myrepo"}})
+        load_ci_provider_mappings(
+            {"buildkite": {"org-uuid-123/pipe-uuid-456": "myorg/myrepo"}}
+        )
 
     def tearDown(self):
         self.patcher_detect.stop()
@@ -195,7 +197,12 @@ class TestLoadCIProviderMappings(unittest.TestCase):
         BUILDKITE_REPO_MAP.update(self._orig_map)
 
     def test_loads_valid_buildkite_entries(self):
-        raw = {"buildkite": {"org-id-1/pipe-id-1": "vllm-project/vllm", "org-id-2/pipe-id-2": "acme/repo"}}
+        raw = {
+            "buildkite": {
+                "org-id-1/pipe-id-1": "vllm-project/vllm",
+                "org-id-2/pipe-id-2": "acme/repo",
+            }
+        }
         load_ci_provider_mappings(raw)
         self.assertEqual(BUILDKITE_REPO_MAP[("org-id-1", "pipe-id-1")], "vllm-project/vllm")
         self.assertEqual(BUILDKITE_REPO_MAP[("org-id-2", "pipe-id-2")], "acme/repo")

--- a/aws/lambda/cross_repo_ci_relay/tests/test_jwt_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_jwt_helper.py
@@ -204,7 +204,9 @@ class TestLoadCIProviderMappings(unittest.TestCase):
             }
         }
         load_ci_provider_mappings(raw)
-        self.assertEqual(BUILDKITE_REPO_MAP[("org-id-1", "pipe-id-1")], "vllm-project/vllm")
+        self.assertEqual(
+            BUILDKITE_REPO_MAP[("org-id-1", "pipe-id-1")], "vllm-project/vllm"
+        )
         self.assertEqual(BUILDKITE_REPO_MAP[("org-id-2", "pipe-id-2")], "acme/repo")
 
     def test_empty_config_clears_map(self):
@@ -218,7 +220,9 @@ class TestLoadCIProviderMappings(unittest.TestCase):
         self.assertEqual(len(BUILDKITE_REPO_MAP), 0)
 
     def test_skips_invalid_entries(self):
-        raw = {"buildkite": {"noslash": "vllm-project/vllm", "ok-id/pipe-id": "ok/repo"}}
+        raw = {
+            "buildkite": {"noslash": "vllm-project/vllm", "ok-id/pipe-id": "ok/repo"}
+        }
         load_ci_provider_mappings(raw)
         self.assertNotIn(("noslash", ""), BUILDKITE_REPO_MAP)
         self.assertEqual(BUILDKITE_REPO_MAP[("ok-id", "pipe-id")], "ok/repo")

--- a/aws/lambda/cross_repo_ci_relay/tests/test_jwt_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_jwt_helper.py
@@ -25,6 +25,8 @@ def _fake_github_claims(**overrides):
 def _fake_buildkite_claims(**overrides):
     base = {
         "iss": BUILDKITE_ISSUER,
+        "organization_id": "org-uuid-123",
+        "pipeline_id": "pipe-uuid-456",
         "organization_slug": "myorg",
         "pipeline_slug": "mypipeline",
         "build_commit": "abc123",
@@ -135,7 +137,7 @@ class TestVerifyBuildkiteOIDC(unittest.TestCase):
         self.mock_decode = self.patcher_decode.start()
 
         self._orig_map = BUILDKITE_REPO_MAP.copy()
-        load_ci_provider_mappings({"buildkite": {"myorg/mypipeline": "myorg/myrepo"}})
+        load_ci_provider_mappings({"buildkite": {"org-uuid-123/pipe-uuid-456": "myorg/myrepo"}})
 
     def tearDown(self):
         self.patcher_detect.stop()
@@ -155,21 +157,21 @@ class TestVerifyBuildkiteOIDC(unittest.TestCase):
 
     def test_unregistered_pipeline_raises_403(self):
         self.mock_decode.return_value = _fake_buildkite_claims(
-            organization_slug="unknown", pipeline_slug="unknown"
+            organization_id="unknown-org", pipeline_id="unknown-pipe"
         )
         with self.assertRaises(HTTPException) as ctx:
             verify_oidc_token("bk.oidc.token")
         self.assertEqual(ctx.exception.status_code, 403)
         self.assertIn("not registered", ctx.exception.detail)
 
-    def test_missing_org_slug_raises_401(self):
-        self.mock_decode.return_value = _fake_buildkite_claims(organization_slug="")
+    def test_missing_org_id_raises_401(self):
+        self.mock_decode.return_value = _fake_buildkite_claims(organization_id="")
         with self.assertRaises(HTTPException) as ctx:
             verify_oidc_token("bk.oidc.token")
         self.assertEqual(ctx.exception.status_code, 401)
 
-    def test_missing_pipeline_slug_raises_401(self):
-        self.mock_decode.return_value = _fake_buildkite_claims(pipeline_slug="")
+    def test_missing_pipeline_id_raises_401(self):
+        self.mock_decode.return_value = _fake_buildkite_claims(pipeline_id="")
         with self.assertRaises(HTTPException) as ctx:
             verify_oidc_token("bk.oidc.token")
         self.assertEqual(ctx.exception.status_code, 401)
@@ -193,10 +195,10 @@ class TestLoadCIProviderMappings(unittest.TestCase):
         BUILDKITE_REPO_MAP.update(self._orig_map)
 
     def test_loads_valid_buildkite_entries(self):
-        raw = {"buildkite": {"vllm/ci": "vllm-project/vllm", "acme/build": "acme/repo"}}
+        raw = {"buildkite": {"org-id-1/pipe-id-1": "vllm-project/vllm", "org-id-2/pipe-id-2": "acme/repo"}}
         load_ci_provider_mappings(raw)
-        self.assertEqual(BUILDKITE_REPO_MAP[("vllm", "ci")], "vllm-project/vllm")
-        self.assertEqual(BUILDKITE_REPO_MAP[("acme", "build")], "acme/repo")
+        self.assertEqual(BUILDKITE_REPO_MAP[("org-id-1", "pipe-id-1")], "vllm-project/vllm")
+        self.assertEqual(BUILDKITE_REPO_MAP[("org-id-2", "pipe-id-2")], "acme/repo")
 
     def test_empty_config_clears_map(self):
         BUILDKITE_REPO_MAP[("old", "entry")] = "old/repo"
@@ -209,10 +211,10 @@ class TestLoadCIProviderMappings(unittest.TestCase):
         self.assertEqual(len(BUILDKITE_REPO_MAP), 0)
 
     def test_skips_invalid_entries(self):
-        raw = {"buildkite": {"noslash": "vllm-project/vllm", "ok/pipeline": "ok/repo"}}
+        raw = {"buildkite": {"noslash": "vllm-project/vllm", "ok-id/pipe-id": "ok/repo"}}
         load_ci_provider_mappings(raw)
         self.assertNotIn(("noslash", ""), BUILDKITE_REPO_MAP)
-        self.assertEqual(BUILDKITE_REPO_MAP[("ok", "pipeline")], "ok/repo")
+        self.assertEqual(BUILDKITE_REPO_MAP[("ok-id", "pipe-id")], "ok/repo")
 
 
 class TestUnsupportedIssuer(unittest.TestCase):

--- a/aws/lambda/cross_repo_ci_relay/tests/test_jwt_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_jwt_helper.py
@@ -41,9 +41,7 @@ class TestVerifyGitHubOIDC(unittest.TestCase):
         self.mock_detect = self.patcher_detect.start()
         self.mock_detect.return_value = GITHUB_ISSUER
 
-        self.patcher_jwks = patch(
-            "utils.jwt_helper._jwks_clients"
-        )
+        self.patcher_jwks = patch("utils.jwt_helper._jwks_clients")
         self.mock_clients = self.patcher_jwks.start()
         self.mock_client = MagicMock()
         self.mock_client.get_signing_key_from_jwt.return_value = MagicMock(
@@ -71,12 +69,8 @@ class TestVerifyGitHubOIDC(unittest.TestCase):
 
         self.assertEqual(claims["repository"], "org/repo")
         self.mock_decode.assert_called_once()
-        self.assertEqual(
-            self.mock_decode.call_args.kwargs["audience"], AUDIENCE
-        )
-        self.assertEqual(
-            self.mock_decode.call_args.kwargs["issuer"], GITHUB_ISSUER
-        )
+        self.assertEqual(self.mock_decode.call_args.kwargs["audience"], AUDIENCE)
+        self.assertEqual(self.mock_decode.call_args.kwargs["issuer"], GITHUB_ISSUER)
 
     def test_wrong_audience_raises_401(self):
         import jwt as _jwt
@@ -124,9 +118,7 @@ class TestVerifyBuildkiteOIDC(unittest.TestCase):
         self.mock_detect = self.patcher_detect.start()
         self.mock_detect.return_value = BUILDKITE_ISSUER
 
-        self.patcher_jwks = patch(
-            "utils.jwt_helper._jwks_clients"
-        )
+        self.patcher_jwks = patch("utils.jwt_helper._jwks_clients")
         self.mock_clients = self.patcher_jwks.start()
         self.mock_client = MagicMock()
         self.mock_client.get_signing_key_from_jwt.return_value = MagicMock(
@@ -158,9 +150,7 @@ class TestVerifyBuildkiteOIDC(unittest.TestCase):
 
         self.assertEqual(claims["repository"], "myorg/myrepo")
         self.mock_decode.assert_called_once()
-        self.assertEqual(
-            self.mock_decode.call_args.kwargs["issuer"], BUILDKITE_ISSUER
-        )
+        self.assertEqual(self.mock_decode.call_args.kwargs["issuer"], BUILDKITE_ISSUER)
 
     def test_unregistered_pipeline_raises_403(self):
         self.mock_decode.return_value = _fake_buildkite_claims(
@@ -172,17 +162,13 @@ class TestVerifyBuildkiteOIDC(unittest.TestCase):
         self.assertIn("not registered", ctx.exception.detail)
 
     def test_missing_org_slug_raises_401(self):
-        self.mock_decode.return_value = _fake_buildkite_claims(
-            organization_slug=""
-        )
+        self.mock_decode.return_value = _fake_buildkite_claims(organization_slug="")
         with self.assertRaises(HTTPException) as ctx:
             verify_oidc_token("bk.oidc.token")
         self.assertEqual(ctx.exception.status_code, 401)
 
     def test_missing_pipeline_slug_raises_401(self):
-        self.mock_decode.return_value = _fake_buildkite_claims(
-            pipeline_slug=""
-        )
+        self.mock_decode.return_value = _fake_buildkite_claims(pipeline_slug="")
         with self.assertRaises(HTTPException) as ctx:
             verify_oidc_token("bk.oidc.token")
         self.assertEqual(ctx.exception.status_code, 401)
@@ -192,9 +178,7 @@ class TestVerifyBuildkiteOIDC(unittest.TestCase):
 
         verify_oidc_token("bk.oidc.token")
 
-        self.assertEqual(
-            self.mock_decode.call_args.kwargs["audience"], AUDIENCE
-        )
+        self.assertEqual(self.mock_decode.call_args.kwargs["audience"], AUDIENCE)
 
 
 class TestUnsupportedIssuer(unittest.TestCase):

--- a/aws/lambda/cross_repo_ci_relay/tests/test_jwt_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_jwt_helper.py
@@ -112,6 +112,18 @@ class TestVerifyGitHubOIDC(unittest.TestCase):
             verify_oidc_token("token.no.repo")
         self.assertEqual(ctx.exception.status_code, 401)
 
+    def test_cross_issuer_token_rejected(self):
+        """A GitHub-signed token asserting iss=buildkite must be rejected."""
+        self.mock_detect.return_value = GITHUB_ISSUER
+        self.mock_decode.return_value = {
+            "iss": BUILDKITE_ISSUER,
+            "repository": "org/repo",
+        }
+        with self.assertRaises(HTTPException) as ctx:
+            verify_oidc_token("cross.issuer.token")
+        self.assertEqual(ctx.exception.status_code, 401)
+        self.assertIn("Issuer mismatch", ctx.exception.detail)
+
 
 class TestVerifyBuildkiteOIDC(unittest.TestCase):
     """Tests for Buildkite OIDC tokens."""

--- a/aws/lambda/cross_repo_ci_relay/tests/test_jwt_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_jwt_helper.py
@@ -290,18 +290,22 @@ class TestLoadCIProviderMappings(unittest.TestCase):
         load_ci_provider_mappings(raw)
         entry = BUILDKITE_REPO_MAP[("org-id", "pipe-id")]
         self.assertEqual(entry["repo"], "myorg/myrepo")
-        self.assertEqual(
-            entry["required_claims"]["build_branch"], ["main", "nightly"]
-        )
+        self.assertEqual(entry["required_claims"]["build_branch"], ["main", "nightly"])
         self.assertEqual(entry["required_claims"]["cluster_id"], ["cluster-uuid"])
 
     def test_empty_config_clears_map(self):
-        BUILDKITE_REPO_MAP[("old", "entry")] = {"repo": "old/repo", "required_claims": {}}
+        BUILDKITE_REPO_MAP[("old", "entry")] = {
+            "repo": "old/repo",
+            "required_claims": {},
+        }
         load_ci_provider_mappings({})
         self.assertEqual(len(BUILDKITE_REPO_MAP), 0)
 
     def test_missing_buildkite_section_clears_map(self):
-        BUILDKITE_REPO_MAP[("old", "entry")] = {"repo": "old/repo", "required_claims": {}}
+        BUILDKITE_REPO_MAP[("old", "entry")] = {
+            "repo": "old/repo",
+            "required_claims": {},
+        }
         load_ci_provider_mappings({"gitlab": {"group/proj": "org/repo"}})
         self.assertEqual(len(BUILDKITE_REPO_MAP), 0)
 
@@ -311,9 +315,7 @@ class TestLoadCIProviderMappings(unittest.TestCase):
         }
         load_ci_provider_mappings(raw)
         self.assertNotIn(("noslash", ""), BUILDKITE_REPO_MAP)
-        self.assertEqual(
-            BUILDKITE_REPO_MAP[("ok-id", "pipe-id")]["repo"], "ok/repo"
-        )
+        self.assertEqual(BUILDKITE_REPO_MAP[("ok-id", "pipe-id")]["repo"], "ok/repo")
 
 
 class TestUnsupportedIssuer(unittest.TestCase):

--- a/aws/lambda/cross_repo_ci_relay/tests/test_jwt_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_jwt_helper.py
@@ -6,6 +6,7 @@ from utils.jwt_helper import (
     BUILDKITE_ISSUER,
     BUILDKITE_REPO_MAP,
     GITHUB_ISSUER,
+    load_buildkite_repo_map,
     verify_oidc_token,
 )
 from utils.misc import HTTPException
@@ -134,7 +135,7 @@ class TestVerifyBuildkiteOIDC(unittest.TestCase):
         self.mock_decode = self.patcher_decode.start()
 
         self._orig_map = BUILDKITE_REPO_MAP.copy()
-        BUILDKITE_REPO_MAP[("myorg", "mypipeline")] = "myorg/myrepo"
+        load_buildkite_repo_map({"buildkite_repos": {"myorg/mypipeline": "myorg/myrepo"}})
 
     def tearDown(self):
         self.patcher_detect.stop()
@@ -179,6 +180,39 @@ class TestVerifyBuildkiteOIDC(unittest.TestCase):
         verify_oidc_token("bk.oidc.token")
 
         self.assertEqual(self.mock_decode.call_args.kwargs["audience"], AUDIENCE)
+
+
+class TestLoadBuildkiteRepoMap(unittest.TestCase):
+    """Tests for loading Buildkite repo mappings from allowlist YAML."""
+
+    def setUp(self):
+        self._orig_map = BUILDKITE_REPO_MAP.copy()
+
+    def tearDown(self):
+        BUILDKITE_REPO_MAP.clear()
+        BUILDKITE_REPO_MAP.update(self._orig_map)
+
+    def test_loads_valid_entries(self):
+        raw = {"buildkite_repos": {"vllm/ci": "vllm-project/vllm", "acme/build": "acme/repo"}}
+        load_buildkite_repo_map(raw)
+        self.assertEqual(BUILDKITE_REPO_MAP[("vllm", "ci")], "vllm-project/vllm")
+        self.assertEqual(BUILDKITE_REPO_MAP[("acme", "build")], "acme/repo")
+
+    def test_empty_section_clears_map(self):
+        BUILDKITE_REPO_MAP[("old", "entry")] = "old/repo"
+        load_buildkite_repo_map({})
+        self.assertEqual(len(BUILDKITE_REPO_MAP), 0)
+
+    def test_missing_section_clears_map(self):
+        BUILDKITE_REPO_MAP[("old", "entry")] = "old/repo"
+        load_buildkite_repo_map({"L1": ["some/repo"]})
+        self.assertEqual(len(BUILDKITE_REPO_MAP), 0)
+
+    def test_skips_invalid_entries(self):
+        raw = {"buildkite_repos": {"noslash": "vllm-project/vllm", "ok/pipeline": "ok/repo"}}
+        load_buildkite_repo_map(raw)
+        self.assertNotIn(("noslash", ""), BUILDKITE_REPO_MAP)
+        self.assertEqual(BUILDKITE_REPO_MAP[("ok", "pipeline")], "ok/repo")
 
 
 class TestUnsupportedIssuer(unittest.TestCase):

--- a/aws/lambda/cross_repo_ci_relay/tests/test_jwt_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_jwt_helper.py
@@ -1,44 +1,81 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from utils.jwt_helper import verify_oidc_token
+from utils.jwt_helper import (
+    AUDIENCE,
+    BUILDKITE_ISSUER,
+    BUILDKITE_REPO_MAP,
+    GITHUB_ISSUER,
+    verify_oidc_token,
+)
 from utils.misc import HTTPException
 
 
-class TestVerifyDownstreamIdentity(unittest.TestCase):
+def _fake_github_claims(**overrides):
+    base = {
+        "iss": GITHUB_ISSUER,
+        "repository": "org/repo",
+        "sub": "repo:org/repo:ref:refs/heads/main",
+    }
+    base.update(overrides)
+    return base
+
+
+def _fake_buildkite_claims(**overrides):
+    base = {
+        "iss": BUILDKITE_ISSUER,
+        "organization_slug": "myorg",
+        "pipeline_slug": "mypipeline",
+        "build_commit": "abc123",
+        "build_number": "42",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestVerifyGitHubOIDC(unittest.TestCase):
+    """Tests for GitHub Actions OIDC tokens (existing behaviour)."""
+
     def setUp(self):
+        self.patcher_detect = patch("utils.jwt_helper._detect_issuer")
+        self.mock_detect = self.patcher_detect.start()
+        self.mock_detect.return_value = GITHUB_ISSUER
+
         self.patcher_jwks = patch(
-            "utils.jwt_helper._jwks_client.get_signing_key_from_jwt"
+            "utils.jwt_helper._jwks_clients"
         )
-        self.mock_signing_key = self.patcher_jwks.start()
-        self.mock_signing_key.return_value = MagicMock(key="fake-key")
+        self.mock_clients = self.patcher_jwks.start()
+        self.mock_client = MagicMock()
+        self.mock_client.get_signing_key_from_jwt.return_value = MagicMock(
+            key="fake-key"
+        )
+        self.mock_clients.__contains__ = lambda s, k: k in (
+            GITHUB_ISSUER,
+            BUILDKITE_ISSUER,
+        )
+        self.mock_clients.__getitem__ = lambda s, k: self.mock_client
 
         self.patcher_decode = patch("utils.jwt_helper.jwt.decode")
         self.mock_decode = self.patcher_decode.start()
 
     def tearDown(self):
+        self.patcher_detect.stop()
         self.patcher_jwks.stop()
         self.patcher_decode.stop()
 
-    def test_valid_token_returns_claims(self):
-        expected = {
-            "repository": "org/repo",
-            "sub": "repo:org/repo:ref:refs/heads/main",
-        }
+    def test_valid_github_token_returns_claims(self):
+        expected = _fake_github_claims()
         self.mock_decode.return_value = expected
 
         claims = verify_oidc_token("some.oidc.token")
 
-        self.assertEqual(claims, expected)
-        self.assertEqual(claims, expected)
+        self.assertEqual(claims["repository"], "org/repo")
         self.mock_decode.assert_called_once()
         self.assertEqual(
-            self.mock_decode.call_args.kwargs["audience"],
-            "pytorch-cross-repo-ci-relay",
+            self.mock_decode.call_args.kwargs["audience"], AUDIENCE
         )
         self.assertEqual(
-            self.mock_decode.call_args.kwargs["issuer"],
-            "https://token.actions.githubusercontent.com",
+            self.mock_decode.call_args.kwargs["issuer"], GITHUB_ISSUER
         )
 
     def test_wrong_audience_raises_401(self):
@@ -49,25 +86,138 @@ class TestVerifyDownstreamIdentity(unittest.TestCase):
             verify_oidc_token("token.with.wrong.aud")
         self.assertEqual(ctx.exception.status_code, 401)
 
-    def test_bearer_prefix_stripped_before_jwks_lookup(self):
-        self.mock_decode.return_value = {"repository": "org/repo"}
+    def test_bearer_prefix_stripped(self):
+        self.mock_decode.return_value = _fake_github_claims()
 
         verify_oidc_token("Bearer some.oidc.token")
 
-        self.mock_signing_key.assert_called_once_with("some.oidc.token")
+        self.mock_client.get_signing_key_from_jwt.assert_called_once_with(
+            "some.oidc.token"
+        )
 
-    def test_empty_token_raises_401_without_jwks_lookup(self):
+    def test_empty_token_raises_401(self):
         with self.assertRaises(HTTPException) as ctx:
             verify_oidc_token("")
         self.assertEqual(ctx.exception.status_code, 401)
         self.assertIn("Missing", ctx.exception.detail)
-        self.mock_signing_key.assert_not_called()
 
     def test_jwks_lookup_failure_raises_401(self):
-        self.mock_signing_key.side_effect = Exception("JWKS fetch failed")
-
+        self.mock_client.get_signing_key_from_jwt.side_effect = Exception(
+            "JWKS fetch failed"
+        )
         with self.assertRaises(HTTPException) as ctx:
             verify_oidc_token("bad.token")
+        self.assertEqual(ctx.exception.status_code, 401)
+
+    def test_github_token_missing_repository_claim_raises_401(self):
+        self.mock_decode.return_value = {"iss": GITHUB_ISSUER, "sub": "..."}
+        with self.assertRaises(HTTPException) as ctx:
+            verify_oidc_token("token.no.repo")
+        self.assertEqual(ctx.exception.status_code, 401)
+
+
+class TestVerifyBuildkiteOIDC(unittest.TestCase):
+    """Tests for Buildkite OIDC tokens."""
+
+    def setUp(self):
+        self.patcher_detect = patch("utils.jwt_helper._detect_issuer")
+        self.mock_detect = self.patcher_detect.start()
+        self.mock_detect.return_value = BUILDKITE_ISSUER
+
+        self.patcher_jwks = patch(
+            "utils.jwt_helper._jwks_clients"
+        )
+        self.mock_clients = self.patcher_jwks.start()
+        self.mock_client = MagicMock()
+        self.mock_client.get_signing_key_from_jwt.return_value = MagicMock(
+            key="fake-key"
+        )
+        self.mock_clients.__contains__ = lambda s, k: k in (
+            GITHUB_ISSUER,
+            BUILDKITE_ISSUER,
+        )
+        self.mock_clients.__getitem__ = lambda s, k: self.mock_client
+
+        self.patcher_decode = patch("utils.jwt_helper.jwt.decode")
+        self.mock_decode = self.patcher_decode.start()
+
+        self._orig_map = BUILDKITE_REPO_MAP.copy()
+        BUILDKITE_REPO_MAP[("myorg", "mypipeline")] = "myorg/myrepo"
+
+    def tearDown(self):
+        self.patcher_detect.stop()
+        self.patcher_jwks.stop()
+        self.patcher_decode.stop()
+        BUILDKITE_REPO_MAP.clear()
+        BUILDKITE_REPO_MAP.update(self._orig_map)
+
+    def test_valid_buildkite_token_returns_mapped_repo(self):
+        self.mock_decode.return_value = _fake_buildkite_claims()
+
+        claims = verify_oidc_token("bk.oidc.token")
+
+        self.assertEqual(claims["repository"], "myorg/myrepo")
+        self.mock_decode.assert_called_once()
+        self.assertEqual(
+            self.mock_decode.call_args.kwargs["issuer"], BUILDKITE_ISSUER
+        )
+
+    def test_unregistered_pipeline_raises_403(self):
+        self.mock_decode.return_value = _fake_buildkite_claims(
+            organization_slug="unknown", pipeline_slug="unknown"
+        )
+        with self.assertRaises(HTTPException) as ctx:
+            verify_oidc_token("bk.oidc.token")
+        self.assertEqual(ctx.exception.status_code, 403)
+        self.assertIn("not registered", ctx.exception.detail)
+
+    def test_missing_org_slug_raises_401(self):
+        self.mock_decode.return_value = _fake_buildkite_claims(
+            organization_slug=""
+        )
+        with self.assertRaises(HTTPException) as ctx:
+            verify_oidc_token("bk.oidc.token")
+        self.assertEqual(ctx.exception.status_code, 401)
+
+    def test_missing_pipeline_slug_raises_401(self):
+        self.mock_decode.return_value = _fake_buildkite_claims(
+            pipeline_slug=""
+        )
+        with self.assertRaises(HTTPException) as ctx:
+            verify_oidc_token("bk.oidc.token")
+        self.assertEqual(ctx.exception.status_code, 401)
+
+    def test_buildkite_uses_correct_audience(self):
+        self.mock_decode.return_value = _fake_buildkite_claims()
+
+        verify_oidc_token("bk.oidc.token")
+
+        self.assertEqual(
+            self.mock_decode.call_args.kwargs["audience"], AUDIENCE
+        )
+
+
+class TestUnsupportedIssuer(unittest.TestCase):
+    """Tests for tokens from unsupported issuers."""
+
+    def setUp(self):
+        self.patcher_detect = patch("utils.jwt_helper._detect_issuer")
+        self.mock_detect = self.patcher_detect.start()
+
+    def tearDown(self):
+        self.patcher_detect.stop()
+
+    def test_unknown_issuer_raises_401(self):
+        self.mock_detect.return_value = "https://evil.example.com"
+        with self.assertRaises(HTTPException) as ctx:
+            verify_oidc_token("evil.token")
+        self.assertEqual(ctx.exception.status_code, 401)
+        self.assertIn("Unsupported OIDC issuer", ctx.exception.detail)
+
+    def test_none_issuer_raises_401(self):
+        self.mock_detect.return_value = None
+        with self.assertRaises(HTTPException) as ctx:
+            verify_oidc_token("garbage.token")
         self.assertEqual(ctx.exception.status_code, 401)
 
 

--- a/aws/lambda/cross_repo_ci_relay/tests/test_jwt_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_jwt_helper.py
@@ -6,7 +6,7 @@ from utils.jwt_helper import (
     BUILDKITE_ISSUER,
     BUILDKITE_REPO_MAP,
     GITHUB_ISSUER,
-    load_buildkite_repo_map,
+    load_ci_provider_mappings,
     verify_oidc_token,
 )
 from utils.misc import HTTPException
@@ -135,7 +135,7 @@ class TestVerifyBuildkiteOIDC(unittest.TestCase):
         self.mock_decode = self.patcher_decode.start()
 
         self._orig_map = BUILDKITE_REPO_MAP.copy()
-        load_buildkite_repo_map({"buildkite_repos": {"myorg/mypipeline": "myorg/myrepo"}})
+        load_ci_provider_mappings({"buildkite": {"myorg/mypipeline": "myorg/myrepo"}})
 
     def tearDown(self):
         self.patcher_detect.stop()
@@ -182,8 +182,8 @@ class TestVerifyBuildkiteOIDC(unittest.TestCase):
         self.assertEqual(self.mock_decode.call_args.kwargs["audience"], AUDIENCE)
 
 
-class TestLoadBuildkiteRepoMap(unittest.TestCase):
-    """Tests for loading Buildkite repo mappings from allowlist YAML."""
+class TestLoadCIProviderMappings(unittest.TestCase):
+    """Tests for loading CI provider repo mappings from ci_providers.yml."""
 
     def setUp(self):
         self._orig_map = BUILDKITE_REPO_MAP.copy()
@@ -192,25 +192,25 @@ class TestLoadBuildkiteRepoMap(unittest.TestCase):
         BUILDKITE_REPO_MAP.clear()
         BUILDKITE_REPO_MAP.update(self._orig_map)
 
-    def test_loads_valid_entries(self):
-        raw = {"buildkite_repos": {"vllm/ci": "vllm-project/vllm", "acme/build": "acme/repo"}}
-        load_buildkite_repo_map(raw)
+    def test_loads_valid_buildkite_entries(self):
+        raw = {"buildkite": {"vllm/ci": "vllm-project/vllm", "acme/build": "acme/repo"}}
+        load_ci_provider_mappings(raw)
         self.assertEqual(BUILDKITE_REPO_MAP[("vllm", "ci")], "vllm-project/vllm")
         self.assertEqual(BUILDKITE_REPO_MAP[("acme", "build")], "acme/repo")
 
-    def test_empty_section_clears_map(self):
+    def test_empty_config_clears_map(self):
         BUILDKITE_REPO_MAP[("old", "entry")] = "old/repo"
-        load_buildkite_repo_map({})
+        load_ci_provider_mappings({})
         self.assertEqual(len(BUILDKITE_REPO_MAP), 0)
 
-    def test_missing_section_clears_map(self):
+    def test_missing_buildkite_section_clears_map(self):
         BUILDKITE_REPO_MAP[("old", "entry")] = "old/repo"
-        load_buildkite_repo_map({"L1": ["some/repo"]})
+        load_ci_provider_mappings({"gitlab": {"group/proj": "org/repo"}})
         self.assertEqual(len(BUILDKITE_REPO_MAP), 0)
 
     def test_skips_invalid_entries(self):
-        raw = {"buildkite_repos": {"noslash": "vllm-project/vllm", "ok/pipeline": "ok/repo"}}
-        load_buildkite_repo_map(raw)
+        raw = {"buildkite": {"noslash": "vllm-project/vllm", "ok/pipeline": "ok/repo"}}
+        load_ci_provider_mappings(raw)
         self.assertNotIn(("noslash", ""), BUILDKITE_REPO_MAP)
         self.assertEqual(BUILDKITE_REPO_MAP[("ok", "pipeline")], "ok/repo")
 

--- a/aws/lambda/cross_repo_ci_relay/tests/test_jwt_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_jwt_helper.py
@@ -185,6 +185,57 @@ class TestVerifyBuildkiteOIDC(unittest.TestCase):
 
         self.assertEqual(self.mock_decode.call_args.kwargs["audience"], AUDIENCE)
 
+    def test_required_claims_pass_when_matching(self):
+        load_ci_provider_mappings(
+            {
+                "buildkite": {
+                    "org-uuid-123/pipe-uuid-456": {
+                        "repo": "myorg/myrepo",
+                        "required_claims": {"build_branch": ["main", "nightly"]},
+                    }
+                }
+            }
+        )
+        self.mock_decode.return_value = _fake_buildkite_claims(build_branch="main")
+        claims = verify_oidc_token("bk.oidc.token")
+        self.assertEqual(claims["repository"], "myorg/myrepo")
+
+    def test_required_claims_reject_disallowed_branch(self):
+        load_ci_provider_mappings(
+            {
+                "buildkite": {
+                    "org-uuid-123/pipe-uuid-456": {
+                        "repo": "myorg/myrepo",
+                        "required_claims": {"build_branch": ["main", "nightly"]},
+                    }
+                }
+            }
+        )
+        self.mock_decode.return_value = _fake_buildkite_claims(
+            build_branch="fork-pr-branch"
+        )
+        with self.assertRaises(HTTPException) as ctx:
+            verify_oidc_token("bk.oidc.token")
+        self.assertEqual(ctx.exception.status_code, 403)
+        self.assertIn("build_branch", ctx.exception.detail)
+
+    def test_required_claims_reject_missing_claim(self):
+        load_ci_provider_mappings(
+            {
+                "buildkite": {
+                    "org-uuid-123/pipe-uuid-456": {
+                        "repo": "myorg/myrepo",
+                        "required_claims": {"cluster_id": ["cluster-abc"]},
+                    }
+                }
+            }
+        )
+        self.mock_decode.return_value = _fake_buildkite_claims()
+        with self.assertRaises(HTTPException) as ctx:
+            verify_oidc_token("bk.oidc.token")
+        self.assertEqual(ctx.exception.status_code, 403)
+        self.assertIn("cluster_id", ctx.exception.detail)
+
 
 class TestLoadCIProviderMappings(unittest.TestCase):
     """Tests for loading CI provider repo mappings from ci_providers.yml."""
@@ -205,17 +256,40 @@ class TestLoadCIProviderMappings(unittest.TestCase):
         }
         load_ci_provider_mappings(raw)
         self.assertEqual(
-            BUILDKITE_REPO_MAP[("org-id-1", "pipe-id-1")], "vllm-project/vllm"
+            BUILDKITE_REPO_MAP[("org-id-1", "pipe-id-1")]["repo"],
+            "vllm-project/vllm",
         )
-        self.assertEqual(BUILDKITE_REPO_MAP[("org-id-2", "pipe-id-2")], "acme/repo")
+        self.assertEqual(
+            BUILDKITE_REPO_MAP[("org-id-2", "pipe-id-2")]["repo"], "acme/repo"
+        )
+
+    def test_loads_constrained_entries(self):
+        raw = {
+            "buildkite": {
+                "org-id/pipe-id": {
+                    "repo": "myorg/myrepo",
+                    "required_claims": {
+                        "build_branch": ["main", "nightly"],
+                        "cluster_id": "cluster-uuid",
+                    },
+                }
+            }
+        }
+        load_ci_provider_mappings(raw)
+        entry = BUILDKITE_REPO_MAP[("org-id", "pipe-id")]
+        self.assertEqual(entry["repo"], "myorg/myrepo")
+        self.assertEqual(
+            entry["required_claims"]["build_branch"], ["main", "nightly"]
+        )
+        self.assertEqual(entry["required_claims"]["cluster_id"], ["cluster-uuid"])
 
     def test_empty_config_clears_map(self):
-        BUILDKITE_REPO_MAP[("old", "entry")] = "old/repo"
+        BUILDKITE_REPO_MAP[("old", "entry")] = {"repo": "old/repo", "required_claims": {}}
         load_ci_provider_mappings({})
         self.assertEqual(len(BUILDKITE_REPO_MAP), 0)
 
     def test_missing_buildkite_section_clears_map(self):
-        BUILDKITE_REPO_MAP[("old", "entry")] = "old/repo"
+        BUILDKITE_REPO_MAP[("old", "entry")] = {"repo": "old/repo", "required_claims": {}}
         load_ci_provider_mappings({"gitlab": {"group/proj": "org/repo"}})
         self.assertEqual(len(BUILDKITE_REPO_MAP), 0)
 
@@ -225,7 +299,9 @@ class TestLoadCIProviderMappings(unittest.TestCase):
         }
         load_ci_provider_mappings(raw)
         self.assertNotIn(("noslash", ""), BUILDKITE_REPO_MAP)
-        self.assertEqual(BUILDKITE_REPO_MAP[("ok-id", "pipe-id")], "ok/repo")
+        self.assertEqual(
+            BUILDKITE_REPO_MAP[("ok-id", "pipe-id")]["repo"], "ok/repo"
+        )
 
 
 class TestUnsupportedIssuer(unittest.TestCase):

--- a/aws/lambda/cross_repo_ci_relay/utils/allowlist.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/allowlist.py
@@ -20,7 +20,7 @@ from urllib.parse import urlparse
 
 import yaml
 
-from . import gh_helper, redis_helper
+from . import gh_helper, jwt_helper, redis_helper
 from .config import RelayConfig
 
 
@@ -244,4 +244,6 @@ def load_allowlist(config: RelayConfig) -> AllowlistMap:
         logger.info("allowlist cache miss - loading from %s", config.allowlist_url)
         yaml_str = _fetch(config.allowlist_url)
         redis_helper.set_cached_yaml(config, yaml_str)
-    return AllowlistMap._parse(yaml.safe_load(yaml_str) or {})
+    raw = yaml.safe_load(yaml_str) or {}
+    jwt_helper.load_buildkite_repo_map(raw)
+    return AllowlistMap._parse(raw)

--- a/aws/lambda/cross_repo_ci_relay/utils/allowlist.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/allowlist.py
@@ -20,7 +20,7 @@ from urllib.parse import urlparse
 
 import yaml
 
-from . import gh_helper, jwt_helper, redis_helper
+from . import gh_helper, redis_helper
 from .config import RelayConfig
 
 
@@ -244,6 +244,4 @@ def load_allowlist(config: RelayConfig) -> AllowlistMap:
         logger.info("allowlist cache miss - loading from %s", config.allowlist_url)
         yaml_str = _fetch(config.allowlist_url)
         redis_helper.set_cached_yaml(config, yaml_str)
-    raw = yaml.safe_load(yaml_str) or {}
-    jwt_helper.load_buildkite_repo_map(raw)
-    return AllowlistMap._parse(raw)
+    return AllowlistMap._parse(yaml.safe_load(yaml_str) or {})

--- a/aws/lambda/cross_repo_ci_relay/utils/config.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/config.py
@@ -77,6 +77,7 @@ class RelayConfig:
     zombie_timeout_seconds: int
     max_cleanup_workers: int
     in_progress_warn_threshold: int
+    ci_providers_url: str
 
     @classmethod
     def from_env(cls) -> "RelayConfig":
@@ -194,6 +195,7 @@ class RelayConfig:
             zombie_timeout_seconds=zombie_timeout_seconds,
             max_cleanup_workers=max_cleanup_workers,
             in_progress_warn_threshold=in_progress_warn_threshold,
+            ci_providers_url=os.getenv("CI_PROVIDERS_URL", ""),
         )
 
 

--- a/aws/lambda/cross_repo_ci_relay/utils/jwt_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/jwt_helper.py
@@ -29,8 +29,7 @@ _ISSUER_CONFIG: Dict[str, dict] = {
 }
 
 _jwks_clients: Dict[str, jwt.PyJWKClient] = {
-    issuer: jwt.PyJWKClient(cfg["jwks_uri"])
-    for issuer, cfg in _ISSUER_CONFIG.items()
+    issuer: jwt.PyJWKClient(cfg["jwks_uri"]) for issuer, cfg in _ISSUER_CONFIG.items()
 }
 
 # Static mapping from Buildkite (organization_slug, pipeline_slug) to the

--- a/aws/lambda/cross_repo_ci_relay/utils/jwt_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/jwt_helper.py
@@ -12,7 +12,6 @@ from urllib.parse import urlparse
 
 import jwt
 import yaml
-
 from utils.misc import HTTPException
 
 

--- a/aws/lambda/cross_repo_ci_relay/utils/jwt_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/jwt_helper.py
@@ -35,33 +35,67 @@ _jwks_clients: Dict[str, jwt.PyJWKClient] = {
 }
 
 # Runtime-populated mapping from Buildkite (organization_id, pipeline_id) to
-# the GitHub-style "owner/repo" identity.  Uses immutable IDs rather than
-# slugs to prevent identity hijacking via slug rename.  Loaded from
-# ci_providers.yml so adding a new downstream repo only requires a config
-# change — no Lambda redeployment.
-BUILDKITE_REPO_MAP: Dict[Tuple[str, str], str] = {}
+# the GitHub-style "owner/repo" identity plus optional required claims.
+# Uses immutable IDs rather than slugs to prevent identity hijacking via slug
+# rename.  Loaded from ci_providers.yml so adding a new downstream repo only
+# requires a config change — no Lambda redeployment.
+#
+# Values are dicts: {"repo": "owner/repo", "required_claims": {...}}
+# required_claims maps claim_name -> list of allowed values (any match passes).
+BUILDKITE_REPO_MAP: Dict[Tuple[str, str], dict] = {}
 
 
 def load_ci_provider_mappings(raw: dict) -> None:
     """Populate provider repo maps from parsed ci_providers.yml content.
 
-    Currently supports ``buildkite``.  Adding a new provider means adding
-    a new section reader here and a corresponding ``_extract_repo_*``
-    function below.
+    Buildkite entries support two formats:
+      org_id/pipeline_id: owner/repo              # simple
+      org_id/pipeline_id:                         # with constraints
+        repo: owner/repo
+        required_claims:
+          build_branch: [main, nightly]
     """
     BUILDKITE_REPO_MAP.clear()
     bk_section = raw.get("buildkite")
     if bk_section and isinstance(bk_section, dict):
-        for bk_key, repo in bk_section.items():
+        for bk_key, value in bk_section.items():
             bk_key_str = str(bk_key).strip()
-            repo_str = str(repo).strip()
-            if "/" not in bk_key_str or "/" not in repo_str:
-                logger.warning(
-                    "Skipping invalid buildkite entry: %s -> %s", bk_key, repo
-                )
+            if "/" not in bk_key_str:
+                logger.warning("Skipping buildkite entry without /: %s", bk_key)
                 continue
             org, pipeline = bk_key_str.split("/", 1)
-            BUILDKITE_REPO_MAP[(org, pipeline)] = repo_str
+
+            if isinstance(value, str):
+                repo_str = value.strip()
+                if "/" not in repo_str:
+                    logger.warning(
+                        "Skipping invalid buildkite entry: %s -> %s", bk_key, value
+                    )
+                    continue
+                BUILDKITE_REPO_MAP[(org, pipeline)] = {
+                    "repo": repo_str,
+                    "required_claims": {},
+                }
+            elif isinstance(value, dict):
+                repo_str = str(value.get("repo", "")).strip()
+                if "/" not in repo_str:
+                    logger.warning(
+                        "Skipping buildkite entry with invalid repo: %s", bk_key
+                    )
+                    continue
+                required = value.get("required_claims", {})
+                if not isinstance(required, dict):
+                    required = {}
+                normalized = {}
+                for k, v in required.items():
+                    if isinstance(v, list):
+                        normalized[k] = [str(x) for x in v]
+                    else:
+                        normalized[k] = [str(v)]
+                BUILDKITE_REPO_MAP[(org, pipeline)] = {
+                    "repo": repo_str,
+                    "required_claims": normalized,
+                }
     if BUILDKITE_REPO_MAP:
         logger.info(
             "Loaded %d Buildkite repo mapping(s) from ci_providers",
@@ -137,13 +171,23 @@ def _extract_repo_buildkite(claims: dict) -> str:
             401,
             "Buildkite OIDC token missing 'organization_id' or 'pipeline_id'",
         )
-    repo = BUILDKITE_REPO_MAP.get((org_id, pipeline_id))
-    if not repo:
+    entry = BUILDKITE_REPO_MAP.get((org_id, pipeline_id))
+    if not entry:
         raise HTTPException(
             403,
             f"Buildkite pipeline {org_id}/{pipeline_id} is not registered with CRCR",
         )
-    return repo
+
+    for claim_name, allowed_values in entry["required_claims"].items():
+        actual = str(claims.get(claim_name, ""))
+        if actual not in allowed_values:
+            raise HTTPException(
+                403,
+                f"Buildkite claim '{claim_name}' value '{actual}' "
+                f"not in allowed set for this pipeline",
+            )
+
+    return entry["repo"]
 
 
 _REPO_EXTRACTORS = {

--- a/aws/lambda/cross_repo_ci_relay/utils/jwt_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/jwt_helper.py
@@ -32,14 +32,38 @@ _jwks_clients: Dict[str, jwt.PyJWKClient] = {
     issuer: jwt.PyJWKClient(cfg["jwks_uri"]) for issuer, cfg in _ISSUER_CONFIG.items()
 }
 
-# Static mapping from Buildkite (organization_slug, pipeline_slug) to the
-# GitHub-style "owner/repo" identity used throughout CRCR.  Buildkite OIDC
-# tokens carry org/pipeline slugs but no repository claim, so we need an
-# explicit map.  Add new entries here when onboarding a Buildkite-based
-# downstream repo.
-BUILDKITE_REPO_MAP: Dict[Tuple[str, str], str] = {
-    # ("org_slug", "pipeline_slug"): "owner/repo",
-}
+# Runtime-populated mapping from Buildkite (org_slug, pipeline_slug) to the
+# GitHub-style "owner/repo" identity.  Loaded from the ``buildkite_repos``
+# section of the allowlist YAML so that adding a new Buildkite downstream
+# repo only requires a config file change — no Lambda redeployment.
+BUILDKITE_REPO_MAP: Dict[Tuple[str, str], str] = {}
+
+
+def load_buildkite_repo_map(allowlist_raw: dict) -> None:
+    """Populate ``BUILDKITE_REPO_MAP`` from the allowlist's ``buildkite_repos`` section.
+
+    Expected YAML format in the allowlist::
+
+        buildkite_repos:
+          vllm/ci: vllm-project/vllm
+          vllm/release: vllm-project/vllm
+
+    Keys are ``org_slug/pipeline_slug``, values are ``owner/repo``.
+    """
+    BUILDKITE_REPO_MAP.clear()
+    section = allowlist_raw.get("buildkite_repos")
+    if not section or not isinstance(section, dict):
+        return
+    for bk_key, repo in section.items():
+        bk_key_str = str(bk_key).strip()
+        repo_str = str(repo).strip()
+        if "/" not in bk_key_str or "/" not in repo_str:
+            logger.warning("Skipping invalid buildkite_repos entry: %s -> %s", bk_key, repo)
+            continue
+        org, pipeline = bk_key_str.split("/", 1)
+        BUILDKITE_REPO_MAP[(org, pipeline)] = repo_str
+    if BUILDKITE_REPO_MAP:
+        logger.info("Loaded %d Buildkite repo mappings from allowlist", len(BUILDKITE_REPO_MAP))
 
 
 def _detect_issuer(token: str) -> Optional[str]:

--- a/aws/lambda/cross_repo_ci_relay/utils/jwt_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/jwt_helper.py
@@ -8,8 +8,11 @@ from __future__ import annotations
 
 import logging
 from typing import Dict, Optional, Tuple
+from urllib.parse import urlparse
 
 import jwt
+import yaml
+
 from utils.misc import HTTPException
 
 
@@ -33,37 +36,77 @@ _jwks_clients: Dict[str, jwt.PyJWKClient] = {
 }
 
 # Runtime-populated mapping from Buildkite (org_slug, pipeline_slug) to the
-# GitHub-style "owner/repo" identity.  Loaded from the ``buildkite_repos``
-# section of the allowlist YAML so that adding a new Buildkite downstream
-# repo only requires a config file change — no Lambda redeployment.
+# GitHub-style "owner/repo" identity.  Loaded from the ci_providers.yml
+# config file so that adding a new downstream repo only requires a config
+# change — no Lambda redeployment.
 BUILDKITE_REPO_MAP: Dict[Tuple[str, str], str] = {}
 
 
-def load_buildkite_repo_map(allowlist_raw: dict) -> None:
-    """Populate ``BUILDKITE_REPO_MAP`` from the allowlist's ``buildkite_repos`` section.
+def load_ci_provider_mappings(raw: dict) -> None:
+    """Populate provider repo maps from parsed ci_providers.yml content.
 
-    Expected YAML format in the allowlist::
-
-        buildkite_repos:
-          vllm/ci: vllm-project/vllm
-          vllm/release: vllm-project/vllm
-
-    Keys are ``org_slug/pipeline_slug``, values are ``owner/repo``.
+    Currently supports ``buildkite``.  Adding a new provider means adding
+    a new section reader here and a corresponding ``_extract_repo_*``
+    function below.
     """
     BUILDKITE_REPO_MAP.clear()
-    section = allowlist_raw.get("buildkite_repos")
-    if not section or not isinstance(section, dict):
-        return
-    for bk_key, repo in section.items():
-        bk_key_str = str(bk_key).strip()
-        repo_str = str(repo).strip()
-        if "/" not in bk_key_str or "/" not in repo_str:
-            logger.warning("Skipping invalid buildkite_repos entry: %s -> %s", bk_key, repo)
-            continue
-        org, pipeline = bk_key_str.split("/", 1)
-        BUILDKITE_REPO_MAP[(org, pipeline)] = repo_str
+    bk_section = raw.get("buildkite")
+    if bk_section and isinstance(bk_section, dict):
+        for bk_key, repo in bk_section.items():
+            bk_key_str = str(bk_key).strip()
+            repo_str = str(repo).strip()
+            if "/" not in bk_key_str or "/" not in repo_str:
+                logger.warning(
+                    "Skipping invalid buildkite entry: %s -> %s", bk_key, repo
+                )
+                continue
+            org, pipeline = bk_key_str.split("/", 1)
+            BUILDKITE_REPO_MAP[(org, pipeline)] = repo_str
     if BUILDKITE_REPO_MAP:
-        logger.info("Loaded %d Buildkite repo mappings from allowlist", len(BUILDKITE_REPO_MAP))
+        logger.info(
+            "Loaded %d Buildkite repo mapping(s) from ci_providers",
+            len(BUILDKITE_REPO_MAP),
+        )
+
+
+def _fetch_github_file(url: str) -> str:
+    """Fetch a file from a GitHub blob URL without authentication."""
+    from utils import gh_helper
+
+    parsed = urlparse(url)
+    parts = [p for p in parsed.path.split("/") if p]
+    if (
+        parsed.scheme not in ("http", "https")
+        or parsed.netloc != "github.com"
+        or len(parts) < 5
+        or parts[2] != "blob"
+    ):
+        raise RuntimeError(
+            f"Invalid GitHub URL {url!r}. "
+            "Expected: https://github.com/<owner>/<repo>/blob/<ref>/<path>"
+        )
+    owner, repo, _blob, ref, *file_parts = parts
+    return gh_helper.get_repo_file(owner, repo, "/".join(file_parts), ref)
+
+
+def load_ci_providers(config) -> None:
+    """Load CI provider mappings from the configured URL, with Redis caching.
+
+    ``config`` is a ``RelayConfig`` instance (imported lazily to avoid
+    pulling heavy dependencies at module-import time during testing).
+    """
+    if not config.ci_providers_url:
+        return
+
+    from utils import redis_helper
+
+    yaml_str = redis_helper.get_cached_ci_providers(config)
+    if yaml_str is None:
+        logger.info("ci_providers cache miss - loading from %s", config.ci_providers_url)
+        yaml_str = _fetch_github_file(config.ci_providers_url)
+        redis_helper.set_cached_ci_providers(config, yaml_str)
+    raw = yaml.safe_load(yaml_str) or {}
+    load_ci_provider_mappings(raw)
 
 
 def _detect_issuer(token: str) -> Optional[str]:

--- a/aws/lambda/cross_repo_ci_relay/utils/jwt_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/jwt_helper.py
@@ -102,7 +102,9 @@ def load_ci_providers(config) -> None:
 
     yaml_str = redis_helper.get_cached_ci_providers(config)
     if yaml_str is None:
-        logger.info("ci_providers cache miss - loading from %s", config.ci_providers_url)
+        logger.info(
+            "ci_providers cache miss - loading from %s", config.ci_providers_url
+        )
         yaml_str = _fetch_github_file(config.ci_providers_url)
         redis_helper.set_cached_ci_providers(config, yaml_str)
     raw = yaml.safe_load(yaml_str) or {}

--- a/aws/lambda/cross_repo_ci_relay/utils/jwt_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/jwt_helper.py
@@ -100,9 +100,7 @@ def verify_oidc_token(token: str) -> dict:
 
         issuer = _detect_issuer(token)
         if issuer not in _jwks_clients:
-            raise HTTPException(
-                401, f"Unsupported OIDC issuer: {issuer}"
-            )
+            raise HTTPException(401, f"Unsupported OIDC issuer: {issuer}")
 
         client = _jwks_clients[issuer]
         signing_key = client.get_signing_key_from_jwt(token)

--- a/aws/lambda/cross_repo_ci_relay/utils/jwt_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/jwt_helper.py
@@ -1,8 +1,13 @@
-"""JWT utilities for the cross-repo CI relay."""
+"""JWT utilities for the cross-repo CI relay.
+
+Supports multiple OIDC issuers (GitHub Actions, Buildkite) so downstream
+repos running on any supported CI can authenticate callbacks.
+"""
 
 from __future__ import annotations
 
 import logging
+from typing import Dict, Optional, Tuple
 
 import jwt
 from utils.misc import HTTPException
@@ -10,17 +15,82 @@ from utils.misc import HTTPException
 
 logger = logging.getLogger(__name__)
 
-_jwks_client = jwt.PyJWKClient(
-    "https://token.actions.githubusercontent.com/.well-known/jwks"
-)
+GITHUB_ISSUER = "https://token.actions.githubusercontent.com"
+BUILDKITE_ISSUER = "https://agent.buildkite.com"
+AUDIENCE = "pytorch-cross-repo-ci-relay"
+
+_ISSUER_CONFIG: Dict[str, dict] = {
+    GITHUB_ISSUER: {
+        "jwks_uri": f"{GITHUB_ISSUER}/.well-known/jwks",
+    },
+    BUILDKITE_ISSUER: {
+        "jwks_uri": f"{BUILDKITE_ISSUER}/.well-known/jwks",
+    },
+}
+
+_jwks_clients: Dict[str, jwt.PyJWKClient] = {
+    issuer: jwt.PyJWKClient(cfg["jwks_uri"])
+    for issuer, cfg in _ISSUER_CONFIG.items()
+}
+
+# Static mapping from Buildkite (organization_slug, pipeline_slug) to the
+# GitHub-style "owner/repo" identity used throughout CRCR.  Buildkite OIDC
+# tokens carry org/pipeline slugs but no repository claim, so we need an
+# explicit map.  Add new entries here when onboarding a Buildkite-based
+# downstream repo.
+BUILDKITE_REPO_MAP: Dict[Tuple[str, str], str] = {
+    # ("org_slug", "pipeline_slug"): "owner/repo",
+}
+
+
+def _detect_issuer(token: str) -> Optional[str]:
+    """Read the unverified ``iss`` claim to select the right JWKS client."""
+    try:
+        unverified = jwt.decode(
+            token, options={"verify_signature": False, "verify_aud": False}
+        )
+        return unverified.get("iss")
+    except Exception:
+        return None
+
+
+def _extract_repo_github(claims: dict) -> str:
+    repo = claims.get("repository")
+    if not repo:
+        raise HTTPException(401, "GitHub OIDC token missing 'repository' claim")
+    return repo
+
+
+def _extract_repo_buildkite(claims: dict) -> str:
+    org = claims.get("organization_slug", "")
+    pipeline = claims.get("pipeline_slug", "")
+    if not org or not pipeline:
+        raise HTTPException(
+            401,
+            "Buildkite OIDC token missing 'organization_slug' or 'pipeline_slug'",
+        )
+    repo = BUILDKITE_REPO_MAP.get((org, pipeline))
+    if not repo:
+        raise HTTPException(
+            403,
+            f"Buildkite pipeline {org}/{pipeline} is not registered with CRCR",
+        )
+    return repo
+
+
+_REPO_EXTRACTORS = {
+    GITHUB_ISSUER: _extract_repo_github,
+    BUILDKITE_ISSUER: _extract_repo_buildkite,
+}
 
 
 def verify_oidc_token(token: str) -> dict:
-    """Decode a GitHub Actions OIDC token and return the claims.
+    """Decode an OIDC token from any supported issuer and return the claims.
 
-    Rejects an empty/missing token up front so every call site gets a uniform
-    401 without repeating the check.  Raises ``HTTPException(401)`` on any
-    verification failure.
+    The returned dict always contains a ``repository`` key set to the
+    GitHub-style ``owner/repo`` identity, regardless of the issuer.
+
+    Raises ``HTTPException(401)`` on any verification failure.
     """
     if not token:
         raise HTTPException(401, "Missing authorization token")
@@ -29,14 +99,30 @@ def verify_oidc_token(token: str) -> dict:
         if token.lower().startswith("bearer "):
             token = token[7:].strip()
 
-        signing_key = _jwks_client.get_signing_key_from_jwt(token)
-        return jwt.decode(
+        issuer = _detect_issuer(token)
+        if issuer not in _jwks_clients:
+            raise HTTPException(
+                401, f"Unsupported OIDC issuer: {issuer}"
+            )
+
+        client = _jwks_clients[issuer]
+        signing_key = client.get_signing_key_from_jwt(token)
+        claims = jwt.decode(
             token,
             signing_key.key,
             algorithms=["RS256"],
-            issuer="https://token.actions.githubusercontent.com",
-            audience="pytorch-cross-repo-ci-relay",
+            issuer=issuer,
+            audience=AUDIENCE,
         )
+
+        extractor = _REPO_EXTRACTORS[issuer]
+        repo = extractor(claims)
+        claims["repository"] = repo
+
+        return claims
+
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.exception("OIDC token verification error")
         raise HTTPException(401, "Invalid authorization token") from exc

--- a/aws/lambda/cross_repo_ci_relay/utils/jwt_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/jwt_helper.py
@@ -34,9 +34,10 @@ _jwks_clients: Dict[str, jwt.PyJWKClient] = {
     issuer: jwt.PyJWKClient(cfg["jwks_uri"]) for issuer, cfg in _ISSUER_CONFIG.items()
 }
 
-# Runtime-populated mapping from Buildkite (org_slug, pipeline_slug) to the
-# GitHub-style "owner/repo" identity.  Loaded from the ci_providers.yml
-# config file so that adding a new downstream repo only requires a config
+# Runtime-populated mapping from Buildkite (organization_id, pipeline_id) to
+# the GitHub-style "owner/repo" identity.  Uses immutable IDs rather than
+# slugs to prevent identity hijacking via slug rename.  Loaded from
+# ci_providers.yml so adding a new downstream repo only requires a config
 # change — no Lambda redeployment.
 BUILDKITE_REPO_MAP: Dict[Tuple[str, str], str] = {}
 
@@ -129,18 +130,18 @@ def _extract_repo_github(claims: dict) -> str:
 
 
 def _extract_repo_buildkite(claims: dict) -> str:
-    org = claims.get("organization_slug", "")
-    pipeline = claims.get("pipeline_slug", "")
-    if not org or not pipeline:
+    org_id = claims.get("organization_id", "")
+    pipeline_id = claims.get("pipeline_id", "")
+    if not org_id or not pipeline_id:
         raise HTTPException(
             401,
-            "Buildkite OIDC token missing 'organization_slug' or 'pipeline_slug'",
+            "Buildkite OIDC token missing 'organization_id' or 'pipeline_id'",
         )
-    repo = BUILDKITE_REPO_MAP.get((org, pipeline))
+    repo = BUILDKITE_REPO_MAP.get((org_id, pipeline_id))
     if not repo:
         raise HTTPException(
             403,
-            f"Buildkite pipeline {org}/{pipeline} is not registered with CRCR",
+            f"Buildkite pipeline {org_id}/{pipeline_id} is not registered with CRCR",
         )
     return repo
 

--- a/aws/lambda/cross_repo_ci_relay/utils/jwt_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/jwt_helper.py
@@ -211,21 +211,29 @@ def verify_oidc_token(token: str) -> dict:
         if token.lower().startswith("bearer "):
             token = token[7:].strip()
 
-        issuer = _detect_issuer(token)
-        if issuer not in _jwks_clients:
-            raise HTTPException(401, f"Unsupported OIDC issuer: {issuer}")
+        detected_issuer = _detect_issuer(token)
+        if detected_issuer not in _jwks_clients:
+            raise HTTPException(401, f"Unsupported OIDC issuer: {detected_issuer}")
 
-        client = _jwks_clients[issuer]
+        client = _jwks_clients[detected_issuer]
         signing_key = client.get_signing_key_from_jwt(token)
         claims = jwt.decode(
             token,
             signing_key.key,
             algorithms=["RS256"],
-            issuer=issuer,
+            issuer=detected_issuer,
             audience=AUDIENCE,
         )
 
-        extractor = _REPO_EXTRACTORS[issuer]
+        verified_issuer = claims.get("iss", "")
+        if verified_issuer != detected_issuer:
+            raise HTTPException(
+                401,
+                f"Issuer mismatch: token claims '{verified_issuer}' "
+                f"but was routed as '{detected_issuer}'",
+            )
+
+        extractor = _REPO_EXTRACTORS[detected_issuer]
         repo = extractor(claims)
         claims["repository"] = repo
 

--- a/aws/lambda/cross_repo_ci_relay/utils/redis_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/redis_helper.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 _ALLOWLIST_CACHE_KEY = "crcr:allowlist_yaml"
+_CI_PROVIDERS_CACHE_KEY = "crcr:ci_providers_yaml"
 _STATE_PREFIX = "crcr:state:"
 _RATE_LIMIT_PREFIX = "crcr:rate:"
 _IN_PROGRESS_ZSET = "crcr:in_progress"
@@ -131,6 +132,39 @@ def set_cached_yaml(
         )
     except RedisError:
         logger.exception("redis cache write failed, continuing without cache")
+
+
+def get_cached_ci_providers(
+    config: RelayConfig, client: redis_lib.Redis | None = None
+) -> str | None:
+    """Return cached CI providers YAML string, or None on cache miss."""
+    try:
+        if client is None:
+            client = create_client(config)
+        value = client.get(_CI_PROVIDERS_CACHE_KEY)
+        if value is not None:
+            logger.info("ci_providers cache hit key=%s", _CI_PROVIDERS_CACHE_KEY)
+        return cast(str | None, value)
+    except RedisError:
+        logger.exception("redis ci_providers cache read failed, falling back to source")
+        return None
+
+
+def set_cached_ci_providers(
+    config: RelayConfig, yaml_str: str, client: redis_lib.Redis | None = None
+) -> None:
+    """Cache CI providers YAML string with TTL."""
+    try:
+        if client is None:
+            client = create_client(config)
+        client.setex(_CI_PROVIDERS_CACHE_KEY, config.allowlist_ttl_seconds, yaml_str)
+        logger.info(
+            "ci_providers cached %d bytes key=%s",
+            len(yaml_str),
+            _CI_PROVIDERS_CACHE_KEY,
+        )
+    except RedisError:
+        logger.exception("redis ci_providers cache write failed, continuing without cache")
 
 
 def check_rate_limit(

--- a/aws/lambda/cross_repo_ci_relay/utils/redis_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/redis_helper.py
@@ -146,7 +146,9 @@ def get_cached_ci_providers(
             logger.info("ci_providers cache hit key=%s", _CI_PROVIDERS_CACHE_KEY)
         return cast(str | None, value)
     except RedisError:
-        logger.exception("redis ci_providers cache read failed, falling back to source")
+        logger.exception(
+            "redis ci_providers cache read failed, falling back to source"
+        )
         return None
 
 
@@ -164,7 +166,9 @@ def set_cached_ci_providers(
             _CI_PROVIDERS_CACHE_KEY,
         )
     except RedisError:
-        logger.exception("redis ci_providers cache write failed, continuing without cache")
+        logger.exception(
+            "redis ci_providers cache write failed, continuing without cache"
+        )
 
 
 def check_rate_limit(

--- a/aws/lambda/cross_repo_ci_relay/utils/redis_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/redis_helper.py
@@ -164,7 +164,9 @@ def set_cached_ci_providers(
             _CI_PROVIDERS_CACHE_KEY,
         )
     except RedisError:
-        logger.exception("redis ci_providers cache write failed, continuing without cache")
+        logger.exception(
+            "redis ci_providers cache write failed, continuing without cache"
+        )
 
 
 def check_rate_limit(

--- a/aws/lambda/cross_repo_ci_relay/utils/redis_helper.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/redis_helper.py
@@ -146,9 +146,7 @@ def get_cached_ci_providers(
             logger.info("ci_providers cache hit key=%s", _CI_PROVIDERS_CACHE_KEY)
         return cast(str | None, value)
     except RedisError:
-        logger.exception(
-            "redis ci_providers cache read failed, falling back to source"
-        )
+        logger.exception("redis ci_providers cache read failed, falling back to source")
         return None
 
 
@@ -166,9 +164,7 @@ def set_cached_ci_providers(
             _CI_PROVIDERS_CACHE_KEY,
         )
     except RedisError:
-        logger.exception(
-            "redis ci_providers cache write failed, continuing without cache"
-        )
+        logger.exception("redis ci_providers cache write failed, continuing without cache")
 
 
 def check_rate_limit(


### PR DESCRIPTION
## Summary

Adds multi-issuer OIDC support to the CRCR relay, enabling downstream repos running on **any supported CI platform** (currently GitHub Actions + Buildkite) to authenticate callbacks.

### Architecture

```
ci_providers.yml (in test-infra)        allowlist.yml (in pytorch/pytorch)
    ┌─────────────────────┐                ┌─────────────────┐
    │ buildkite:          │                │ L1: [...]        │
    │   vllm/ci: vllm/vllm│               │ L2: [...]        │
    │ # gitlab:           │                │ L3: {device: ..} │
    │ #   grp/proj: o/r   │                │ L4: [...]        │
    └────────┬────────────┘                └────────┬────────┘
             │ CI_PROVIDERS_URL                      │ ALLOWLIST_URL
             ▼                                       ▼
    ┌─────────────────────────────────────────────────────────┐
    │                  CRCR Lambda                            │
    │  jwt_helper.py    →  verify OIDC token (any issuer)     │
    │  allowlist.py     →  check repo trust level             │
    │  lambda_function  →  orchestrate                        │
    └─────────────────────────────────────────────────────────┘
```

### Changes

| File | What |
|------|------|
| `config/ci_providers.yml` | **New** — external CI provider pipeline-to-repo mapping, extensible per provider |
| `utils/jwt_helper.py` | Multi-issuer OIDC: detect issuer → select JWKS → extract repo. Loads mappings from `ci_providers.yml` via URL + Redis cache |
| `utils/config.py` | Add optional `ci_providers_url` field |
| `utils/redis_helper.py` | Add `get_cached_ci_providers` / `set_cached_ci_providers` with separate Redis key |
| `callback/lambda_function.py` | Call `load_ci_providers(config)` before token verification |
| `utils/allowlist.py` | Unchanged (reverted) |
| `tests/test_jwt_helper.py` | Expanded from 5 → 17 tests |

### Onboarding a new Buildkite repo

Edit `config/ci_providers.yml` — no Lambda redeployment needed:

```yaml
buildkite:
  vllm/ci: vllm-project/vllm
  acme/build: acme/repo
```

### Onboarding a new CI provider (future)

1. Add the provider's JWKS endpoint to `_ISSUER_CONFIG` in `jwt_helper.py`
2. Add an `_extract_repo_<provider>` function
3. Add a section reader in `load_ci_provider_mappings`
4. Add the provider section to `ci_providers.yml`

Closes #8326

## Test plan
- [x] All 17 unit tests pass locally
- [ ] CI passes (lintrunner, python-tests)
- [ ] Set `CI_PROVIDERS_URL` env var and deploy to staging
- [ ] Verify with a test Buildkite OIDC token