### PR TITLE
[CRCR] Base relay health on last 5 PR pass rates

### DIFF
--- a/torchci/clickhouse_queries/crcr_health_last_prs/params.json
+++ b/torchci/clickhouse_queries/crcr_health_last_prs/params.json
@@ -1,0 +1,10 @@
+{
+  "params": {
+    "count": "UInt64"
+  },
+  "tests": [
+    {
+      "count": "5"
+    }
+  ]
+}

--- a/torchci/clickhouse_queries/crcr_health_last_prs/query.sql
+++ b/torchci/clickhouse_queries/crcr_health_last_prs/query.sql
@@ -16,8 +16,7 @@ WHERE
     AND status = 'completed'
     AND pr_number > 0
     AND pr_number IN (
-        SELECT
-            pr_number
+        SELECT pr_number
         FROM
             default.crcr_workflow_job FINAL
         WHERE

--- a/torchci/clickhouse_queries/crcr_health_last_prs/query.sql
+++ b/torchci/clickhouse_queries/crcr_health_last_prs/query.sql
@@ -1,0 +1,36 @@
+SELECT
+    pr_number,
+    max(started_at) AS last_run,
+    countIf(
+        conclusion = 'success'
+        OR (job_name LIKE '%xfail%' AND conclusion = 'failure')
+        OR (job_name LIKE '%xcancel%' AND conclusion = 'cancelled')
+        OR (job_name LIKE '%xtimeout%' AND conclusion = 'timed_out')
+    ) AS successes,
+    count() AS total,
+    if(total > 0, successes / total, 0) AS pass_rate
+FROM
+    default.crcr_workflow_job FINAL
+WHERE
+    downstream_repo = 'pytorch/crcr-test'
+    AND status = 'completed'
+    AND pr_number > 0
+    AND pr_number IN (
+        SELECT
+            pr_number
+        FROM
+            default.crcr_workflow_job FINAL
+        WHERE
+            downstream_repo = 'pytorch/crcr-test'
+            AND status = 'completed'
+            AND pr_number > 0
+        GROUP BY
+            pr_number
+        ORDER BY
+            max(started_at) DESC
+        LIMIT {count: UInt64}
+    )
+GROUP BY
+    pr_number
+ORDER BY
+    last_run DESC

--- a/torchci/pages/crcr/index.tsx
+++ b/torchci/pages/crcr/index.tsx
@@ -511,7 +511,7 @@ export default function CrcrSummaryPage() {
   const healthUrl =
     `/api/clickhouse/crcr_health_last_prs?parameters=` +
     encodeURIComponent(JSON.stringify({ count: "5" }));
-  const { data: healthPrs } = useSWR<HealthPrRow[]>(
+  const { data: healthPrs, error: healthError } = useSWR<HealthPrRow[]>(
     healthUrl,
     fetcherHandleError,
     { refreshInterval: 60_000 }
@@ -607,7 +607,7 @@ export default function CrcrSummaryPage() {
   }, [ciData, metricsMap, allowlist, days]);
 
   const isLoading = !ciData && !ciError && !allowlist && !alError;
-  const hasError = ciError || alError || nightlyError;
+  const hasError = ciError || alError || nightlyError || healthError;
 
   return (
     <>
@@ -662,6 +662,7 @@ export default function CrcrSummaryPage() {
             {ciError?.message ||
               alError?.message ||
               nightlyError?.message ||
+              healthError?.message ||
               "Failed to load data"}
           </Typography>
         )}

--- a/torchci/pages/crcr/index.tsx
+++ b/torchci/pages/crcr/index.tsx
@@ -55,6 +55,14 @@ interface NightlyMetricsRow {
   latest_sha: string;
 }
 
+interface HealthPrRow {
+  pr_number: number;
+  last_run: string;
+  successes: number;
+  total: number;
+  pass_rate: number;
+}
+
 type EventTab = "pr" | "nightly";
 
 type Level = "L1" | "L2" | "L3" | "L4";
@@ -435,15 +443,15 @@ function StatCard({
 }
 
 function CrcrTestHealthCard({
-  metrics,
+  healthPrs,
 }: {
-  metrics: CiMetricsRow | undefined;
+  healthPrs: HealthPrRow[] | undefined;
 }) {
-  if (!metrics) return null;
-  const pct = (metrics.pass_rate * 100).toFixed(1) + "%";
-  const isHealthy = metrics.pass_rate >= 1.0;
-  const borderColor = isHealthy ? "#2e7d32" : "#ed6c02";
-  const label = isHealthy ? "Healthy" : "Degraded";
+  if (!healthPrs || healthPrs.length === 0) return null;
+  const allPassed = healthPrs.every((pr) => pr.pass_rate >= 1.0);
+  const passedCount = healthPrs.filter((pr) => pr.pass_rate >= 1.0).length;
+  const borderColor = allPassed ? "#2e7d32" : "#ed6c02";
+  const label = allPassed ? "Healthy" : "Degraded";
   return (
     <NextLink href="/crcr/pytorch/crcr-test" passHref legacyBehavior>
       <Paper
@@ -468,8 +476,7 @@ function CrcrTestHealthCard({
           {label}
         </Typography>
         <Typography variant="caption" color="text.secondary">
-          {pct} · {metrics.successes}/{metrics.total} jobs passed ·
-          pytorch/crcr-test
+          {passedCount}/{healthPrs.length} recent PRs passed · pytorch/crcr-test
         </Typography>
       </Paper>
     </NextLink>
@@ -500,6 +507,15 @@ export default function CrcrSummaryPage() {
   const { data: nightlyData, error: nightlyError } = useSWR<
     NightlyMetricsRow[]
   >(nightlyUrl, fetcherHandleError, { refreshInterval: 60_000 });
+
+  const healthUrl =
+    `/api/clickhouse/crcr_health_last_prs?parameters=` +
+    encodeURIComponent(JSON.stringify({ count: "5" }));
+  const { data: healthPrs } = useSWR<HealthPrRow[]>(
+    healthUrl,
+    fetcherHandleError,
+    { refreshInterval: 60_000 }
+  );
 
   const nightlyRepoCount = nightlyData?.length ?? 0;
 
@@ -655,7 +671,7 @@ export default function CrcrSummaryPage() {
         {stats && (
           <Stack spacing={2}>
             <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
-              <CrcrTestHealthCard metrics={metricsMap.get(CRCR_HEALTH_REPO)} />
+              <CrcrTestHealthCard healthPrs={healthPrs} />
               <StatCard
                 label="Total Probe Runs"
                 value={stats.totalRuns}


### PR DESCRIPTION
## Summary

Changes the CRCR Relay Health card on the summary page (`hud.pytorch.org/crcr`) to evaluate health based on whether the **last 5 PR-level crcr-test runs all passed**, instead of the aggregate pass rate over the entire time window.

### Before
- Health = `total_successes / total_runs` across all jobs in the time window
- A high historical pass rate could mask recent regressions

### After
- Health = "Healthy" only if all 5 most recent PR runs have 100% pass rate
- "Degraded" if any of the last 5 PRs had a failure
- Subtitle shows `X/5 recent PRs passed` for quick context

### Changes
- New `crcr_health_last_prs` ClickHouse query: fetches the 5 most recent distinct PRs for `pytorch/crcr-test`, computes per-PR pass rates with expected-outcome handling (`xfail`, `xcancel`, `xtimeout`)
- Updated `CrcrTestHealthCard` component to use the new per-PR health data instead of the aggregate metrics

Fixes #8424

## Test plan
- Visit `/crcr` — Health card should show "Healthy" only when all 5 recent PRs passed
- If any of the last 5 PRs had unexpected failures, card should show "Degraded"
- Subtitle displays `X/5 recent PRs passed · pytorch/crcr-test`