### PR TITLE
[CI] Add --clear for uv virtual env creation in upload-benchmark-results

### DIFF
--- a/.github/actions/upload-benchmark-results/action.yml
+++ b/.github/actions/upload-benchmark-results/action.yml
@@ -35,7 +35,7 @@ runs:
       run: |
         set -eux
 
-        uv venv "${RUNNER_TEMP}/benchmark-upload-venv"
+        uv venv --clear "${RUNNER_TEMP}/benchmark-upload-venv"
 
         export VIRTUAL_ENV="${RUNNER_TEMP}/benchmark-upload-venv"
         echo "VIRTUAL_ENV=${RUNNER_TEMP}/benchmark-upload-venv" >> $GITHUB_ENV


### PR DESCRIPTION
Found some uv virtual env creation failure due to existed folder on some XPU self-hosted runners. Refer https://github.com/pytorch/pytorch/actions/runs/31090087074/job/92584051161#step:24:120