### PR TITLE
Add Windows AMI CUDA 13.4

### DIFF
--- a/aws/ami/windows/scripts/Installers/Install-CUDA-Tools.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-CUDA-Tools.ps1
@@ -25,9 +25,6 @@ Switch ($cudaVersion) {
   "12.8" {
     $toolkitInstaller = "cuda_12.8.1_572.61_windows.exe"
   }
-  "12.9" {
-    $toolkitInstaller = "cuda_12.9.1_576.57_windows.exe"
-  }
   "13.0" {
     $cudnn_subfolder="cudnn-windows-x86_64-9.20.0.48_cuda13-archive"
     $toolkitInstaller = "cuda_13.0.0_windows.exe"

--- a/aws/ami/windows/scripts/Installers/Install-CUDA-Tools.ps1
+++ b/aws/ami/windows/scripts/Installers/Install-CUDA-Tools.ps1
@@ -38,6 +38,11 @@ Switch ($cudaVersion) {
     $toolkitInstaller = "cuda_13.2.1_windows.exe"
     $installerArgs = ""
   }
+  "13.4" {
+    $cudnn_subfolder="cudnn-windows-x86_64-9.20.0.48_cuda13-archive"
+    $toolkitInstaller = "cuda_13.4.0_windows_x86_64.exe"
+    $installerArgs = ""
+  }
 }
 
 

--- a/aws/ami/windows/windows.pkr.hcl
+++ b/aws/ami/windows/windows.pkr.hcl
@@ -107,13 +107,6 @@ build {
   }
 
   provisioner "powershell" {
-    environment_vars = ["CUDA_VERSION=12.9"]
-    scripts = [
-      "${path.root}/scripts/Installers/Install-CUDA-Tools.ps1",
-    ]
-  }
-
-  provisioner "powershell" {
     environment_vars = ["CUDA_VERSION=13.0"]
     scripts = [
       "${path.root}/scripts/Installers/Install-CUDA-Tools.ps1",

--- a/aws/ami/windows/windows.pkr.hcl
+++ b/aws/ami/windows/windows.pkr.hcl
@@ -127,6 +127,13 @@ build {
     ]
   }
 
+  provisioner "powershell" {
+    environment_vars = ["CUDA_VERSION=13.4"]
+    scripts = [
+      "${path.root}/scripts/Installers/Install-CUDA-Tools.ps1",
+    ]
+  }
+
   # Uninstall Windows Defender, it brings more trouble than it's worth. Do this
   # last as it screws up the installation of other services like sshd somehow
   provisioner "powershell" {


### PR DESCRIPTION
### Summary
Adds CUDA 13.4 to the Windows AMI build.

- Adds CUDA 13.4 toolkit and cuDNN configuration to Install-CUDA-Tools.ps1
- Provisions CUDA 13.4 in windows.pkr.hcl

### Validation
Ran packer validate
Ran packer fmt -check 

### Follow-up
[cuda_13.4.0_windows_x86_64.exe](https://packages.nvidia.com/prerelease/cuda/13.4.0/local_installers/cuda_13.4.0_windows_x86_64.exe) must be available in the ossci-windows S3 bucket before the AMI build can succeed. 

CC: @atalman @tinglvv @ptrblck 