### PR TITLE
[CRCR] Fix scrollbar appearing on tooltip hover

### DIFF
--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -752,7 +752,7 @@ function CrcrMatrix({
 
   return (
     <>
-      <div style={{ overflowX: "auto" }}>
+      <div style={{ overflowX: "auto", overflowY: "visible" }}>
         <table className={hudStyles.hudTable}>
           <colgroup>
             <col className={hudStyles.colTime} />
@@ -1026,7 +1026,7 @@ function CrcrNightlyMatrix({
   return (
     <>
       <NightlySummaryCards data={data} />
-      <div style={{ overflowX: "auto" }}>
+      <div style={{ overflowX: "auto", overflowY: "visible" }}>
         <table
           style={{
             borderCollapse: "collapse",


### PR DESCRIPTION
## Summary

Fixes vertical and horizontal scrollbars appearing when hovering over job cells on the CRCR per-repo dashboard page (`/crcr/{org}/{repo}`).

The table wrapper uses `overflowX: auto` for horizontal scrolling, but the `TooltipTarget` component renders with `position: absolute` inside a `position: relative` parent. When the tooltip popup appears, it expands the scrollable area vertically, causing both scrollbars to flash on hover.

Setting `overflowY: visible` on the wrapper lets the tooltip escape the container without triggering a vertical scrollbar.

Applies to both the PR matrix and nightly matrix table wrappers.

## Test plan
- Hover over any green/red job cell on `/crcr/{org}/{repo}` — no scrollbars should appear
- Click a cell to pin its tooltip — no scrollbars
- Horizontal scrolling still works when the table is wider than the viewport