### PR TITLE
[CRCR] Align per-repo page styling and fix tooltip behavior

### DIFF
--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -21,7 +21,6 @@ import Head from "next/head";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
 import {
-  CSSProperties,
   createContext,
   useCallback,
   useContext,
@@ -640,41 +639,6 @@ function useCommitInfo(
   }, [data]);
 }
 
-// ---- Table Styles (matching main HUD) ----
-
-const headerBaseStyle: CSSProperties = {
-  fontFamily: "sans-serif",
-  fontSize: "0.75rem",
-  fontWeight: 600,
-  padding: "4px 6px",
-  whiteSpace: "nowrap",
-  textAlign: "left",
-  borderBottom: "1px solid #30363d",
-};
-
-const jobHeaderStyle: CSSProperties = {
-  fontFamily: "sans-serif",
-  height: 120,
-  whiteSpace: "nowrap",
-  padding: 0,
-  borderBottom: "1px solid #30363d",
-  position: "relative",
-};
-
-const jobHeaderNameStyle: CSSProperties = {
-  transform: "translate(5px, 45px) rotate(315deg)",
-  transformOrigin: "left bottom",
-  width: 12,
-  fontWeight: 400,
-  fontSize: "0.75em",
-};
-
-const cellStyle: CSSProperties = {
-  padding: "3px 6px",
-  whiteSpace: "nowrap",
-  fontSize: "0.8rem",
-  verticalAlign: "middle",
-};
 // ---- PR Matrix Table ----
 
 function CrcrMatrix({
@@ -774,9 +738,7 @@ function CrcrMatrix({
               {columns.map((col) => (
                 <th
                   key={col.name}
-                  className={`${hudStyles.jobHeader} ${
-                    pinnedId.name === col.name ? hudStyles.highlight : ""
-                  }`}
+                  className={hudStyles.jobHeader}
                   style={{ cursor: "pointer" }}
                   onClick={(e) => {
                     e.stopPropagation();
@@ -1004,6 +966,7 @@ function CrcrNightlyMatrix({
     [matrix]
   );
   const commitInfoMap = useCommitInfo(upstreamRepo, nightlyShas);
+  const [pinnedId, setPinnedId] = useContext(CrcrPinnedContext);
 
   if (error) {
     return (
@@ -1027,35 +990,49 @@ function CrcrNightlyMatrix({
     <>
       <NightlySummaryCards data={data} />
       <div style={{ overflowX: "auto", overflowY: "visible" }}>
-        <table
-          style={{
-            borderCollapse: "collapse",
-            fontSize: "0.85rem",
-            width: "100%",
-          }}
-        >
+        <table className={hudStyles.hudTable}>
           <colgroup>
-            <col style={{ width: 80 }} />
-            <col style={{ width: 60 }} />
-            <col style={{ width: 340 }} />
+            <col className={hudStyles.colTime} />
+            <col className={hudStyles.colSha} />
+            <col className={hudStyles.colCommit} />
             {columns.map((col) => (
-              <col key={col.name} style={{ width: 18 }} />
+              <col key={col.name} className={hudStyles.colJob} />
             ))}
           </colgroup>
           <thead>
             <tr>
-              <th style={headerBaseStyle}>Time</th>
-              <th style={headerBaseStyle}>SHA</th>
-              <th style={headerBaseStyle}>Commit</th>
+              <th className={hudStyles.regularHeader}>Time</th>
+              <th className={hudStyles.regularHeader}>SHA</th>
+              <th className={hudStyles.regularHeader}>Commit</th>
               {columns.map((col) => (
-                <th key={col.name} style={jobHeaderStyle}>
+                <th
+                  key={col.name}
+                  className={hudStyles.jobHeader}
+                  style={{ cursor: "pointer" }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setPinnedId({
+                      sha: undefined,
+                      name:
+                        pinnedId.name === col.name ? undefined : col.name,
+                    });
+                  }}
+                >
                   <div
+                    className={hudStyles.jobHeaderName}
                     style={{
-                      ...jobHeaderNameStyle,
                       fontWeight: col.type === "group" ? 700 : 400,
                     }}
                   >
-                    {col.name}
+                    <span
+                      className={
+                        pinnedId.name === col.name
+                          ? hudStyles.highlight
+                          : ""
+                      }
+                    >
+                      {col.name}
+                    </span>
                   </div>
                 </th>
               ))}
@@ -1066,41 +1043,52 @@ function CrcrNightlyMatrix({
               const commit = commitInfoMap.get(row.sha);
               const commitTitle =
                 commit?.title || `nightly (${row.sha.substring(0, 12)})`;
+              const isRowHighlighted = pinnedId.sha === row.sha;
+              const rowClass = isRowHighlighted ? hudStyles.highlight : "";
               return (
-                <tr key={row.sha} style={{ borderBottom: "1px solid #30363d" }}>
-                  <td style={cellStyle}>
+                <tr
+                  key={row.sha}
+                  className={rowClass}
+                  onClick={(e) => {
+                    if (
+                      pinnedId.name !== undefined ||
+                      pinnedId.sha !== undefined
+                    ) {
+                      return;
+                    }
+                    e.stopPropagation();
+                    setPinnedId({ sha: row.sha, name: undefined });
+                  }}
+                  style={{ cursor: "pointer" }}
+                >
+                  <td className={hudStyles.jobMetadata}>
                     <LocalTimeDisplay timestamp={row.latestTime} />
                   </td>
-                  <td style={cellStyle}>
-                    <a
-                      href={`https://github.com/${row.upstreamRepo}/commit/${row.sha}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      style={{ color: "#58a6ff", textDecoration: "none" }}
-                    >
-                      {row.sha.substring(0, 7)}
-                    </a>
+                  <td className={hudStyles.jobMetadata}>
+                    <span className={hudStyles.mono}>
+                      <a
+                        href={`https://github.com/${row.upstreamRepo}/commit/${row.sha}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {row.sha.substring(0, 7)}
+                      </a>
+                    </span>
                   </td>
-                  <td style={{ ...cellStyle, maxWidth: 340 }}>
+                  <td className={hudStyles.jobMetadataTruncated}>
                     <Tooltip title={commitTitle}>
                       <a
                         href={`https://github.com/${row.upstreamRepo}/commit/${row.sha}`}
                         target="_blank"
                         rel="noopener noreferrer"
-                        style={{
-                          color: "#58a6ff",
-                          textDecoration: "none",
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          whiteSpace: "nowrap",
-                          display: "block",
-                        }}
                       >
                         {commitTitle}
                       </a>
                     </Tooltip>
                   </td>
                   {columns.map((col) => {
+                    const colHighlight =
+                      pinnedId.name === col.name ? hudStyles.highlight : "";
                     if (col.type === "group" && col.members) {
                       const groupJobs = col.members
                         .map((m) => row.jobs.get(m))
@@ -1108,7 +1096,8 @@ function CrcrNightlyMatrix({
                       return (
                         <td
                           key={col.name}
-                          style={{ ...cellStyle, textAlign: "center" }}
+                          className={`${hudStyles.jobMetadata} ${colHighlight}`}
+                          style={{ textAlign: "center" }}
                         >
                           {groupJobs.length > 0 ? (
                             <GroupedJobCell
@@ -1126,7 +1115,8 @@ function CrcrNightlyMatrix({
                     return (
                       <td
                         key={col.name}
-                        style={{ ...cellStyle, textAlign: "center" }}
+                        className={`${hudStyles.jobMetadata} ${colHighlight}`}
+                        style={{ textAlign: "center" }}
                       >
                         {job ? <JobCell job={job} sha={row.sha} /> : "–"}
                       </td>

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -752,7 +752,7 @@ function CrcrMatrix({
 
   return (
     <>
-      <div style={{ overflowX: "auto" }}>
+      <div style={{ overflowX: "auto", overflowY: "visible" }}>
         <table className={hudStyles.hudTable}>
           <colgroup>
             <col className={hudStyles.colTime} />
@@ -1026,7 +1026,7 @@ function CrcrNightlyMatrix({
   return (
     <>
       <NightlySummaryCards data={data} />
-      <div style={{ overflowX: "auto" }}>
+      <div style={{ overflowX: "auto", overflowY: "visible" }}>
         <table
           style={{
             borderCollapse: "collapse",

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -9,7 +9,6 @@ import {
   SelectChangeEvent,
   Skeleton,
   Stack,
-  Tooltip,
   Typography,
 } from "@mui/material";
 import { durationDisplay } from "components/common/TimeUtils";
@@ -1072,16 +1071,17 @@ function CrcrNightlyMatrix({
                       </a>
                     </span>
                   </td>
-                  <td className={hudStyles.jobMetadataTruncated}>
-                    <Tooltip title={commitTitle}>
+                  <td className={hudStyles.jobMetadata}>
+                    <div className={hudStyles.jobMetadataTruncated}>
                       <a
                         href={`https://github.com/${row.upstreamRepo}/commit/${row.sha}`}
                         target="_blank"
                         rel="noopener noreferrer"
+                        title={commitTitle}
                       >
                         {commitTitle}
                       </a>
-                    </Tooltip>
+                    </div>
                   </td>
                   {columns.map((col) => {
                     const colHighlight =

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -1025,9 +1025,7 @@ function CrcrNightlyMatrix({
                   >
                     <span
                       className={
-                        pinnedId.name === col.name
-                          ? hudStyles.highlight
-                          : ""
+                        pinnedId.name === col.name ? hudStyles.highlight : ""
                       }
                     >
                       {col.name}

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -236,8 +236,16 @@ const conclusionCssColor: Record<string, string> = {
   neutral: "var(--color-grey, #8b949e)",
 };
 
+function jobUrl(job: CrcrJobRow): string {
+  if (job.workflow_run_url && job.check_run_id) {
+    return `${job.workflow_run_url}/job/${job.check_run_id}`;
+  }
+  return job.workflow_run_url || "";
+}
+
 function JobCellTooltipContent({ job }: { job: CrcrJobRow }) {
   const conclusion = job.status === "completed" ? job.conclusion : job.status;
+  const url = jobUrl(job);
   const lines = [
     `Job: ${job.job_name}`,
     `Status: ${conclusion}`,
@@ -256,10 +264,10 @@ function JobCellTooltipContent({ job }: { job: CrcrJobRow }) {
   return (
     <div style={{ whiteSpace: "pre-line", fontSize: "0.8rem" }}>
       {lines.join("\n")}
-      {job.workflow_run_url && (
+      {url && (
         <div style={{ marginTop: 4 }}>
           <a
-            href={job.workflow_run_url}
+            href={url}
             target="_blank"
             rel="noopener noreferrer"
             style={{ color: "var(--link-color, #58a6ff)" }}
@@ -401,11 +409,12 @@ function GroupedJobCell({
       </div>
       {jobs.map((j) => {
         const c = j.status === "completed" ? j.conclusion : j.status;
+        const url = jobUrl(j);
         return (
           <div key={j.job_name}>
-            {j.workflow_run_url ? (
+            {url ? (
               <a
-                href={j.workflow_run_url}
+                href={url}
                 target="_blank"
                 rel="noopener noreferrer"
                 style={{ color: "var(--link-color, #58a6ff)" }}

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -793,13 +793,15 @@ function CrcrMatrix({
                     <LocalTimeDisplay timestamp={row.latestTime} />
                   </td>
                   <td className={hudStyles.jobMetadata}>
-                    <a
-                      href={`https://github.com/${row.upstreamRepo}/commit/${row.sha}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {row.sha ? row.sha.substring(0, 7) : "–"}
-                    </a>
+                    <span className={hudStyles.mono}>
+                      <a
+                        href={`https://github.com/${row.upstreamRepo}/commit/${row.sha}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {row.sha ? row.sha.substring(0, 7) : "–"}
+                      </a>
+                    </span>
                   </td>
                   <td className={hudStyles.jobMetadata}>
                     <div className={hudStyles.jobMetadataTruncated}>

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -1013,8 +1013,7 @@ function CrcrNightlyMatrix({
                     e.stopPropagation();
                     setPinnedId({
                       sha: undefined,
-                      name:
-                        pinnedId.name === col.name ? undefined : col.name,
+                      name: pinnedId.name === col.name ? undefined : col.name,
                     });
                   }}
                 >


### PR DESCRIPTION
## Summary

Aligns both PR and nightly per-repo dashboard pages (`/crcr/{org}/{repo}`) with the main HUD styling, and fixes tooltip-related issues.

### 1. Fix scrollbar on tooltip hover

The table wrapper uses `overflowX: auto` for horizontal scrolling, but the `TooltipTarget` popup (`position: absolute`) expands the scrollable area vertically, causing both scrollbars to flash on hover. Setting `overflowY: visible` on both table wrappers lets the tooltip escape the container without triggering scrollbars.

### 2. Align column/row highlighting with main HUD

- **PR matrix header**: Was applying `hudStyles.highlight` to both the `<th>` and the inner `<span>`, causing a double-highlight. Removed highlight from `<th>` to match main HUD.
- **Nightly matrix**: Converted from inline styles to `hudStyles` CSS classes and added column/row highlighting via `CrcrPinnedContext`.

### 3. Align nightly matrix with PR matrix styling

Replaced all inline style constants (`headerBaseStyle`, `jobHeaderStyle`, `jobHeaderNameStyle`, `cellStyle`) with `hudStyles` CSS classes (`hudTable`, `regularHeader`, `jobHeader`, `jobHeaderName`, `colTime`, `colSha`, `colCommit`, `colJob`, `jobMetadata`, `jobMetadataTruncated`, `mono`). Both matrices now use identical styling.

### 4. Link "Show log" to specific job

Tooltip "Show log" link now navigates to the specific job (`workflow_run_url/job/check_run_id`) instead of the workflow run overview page.

### Cleanup

- Removed unused `CSSProperties` import
- Removed unused MUI `Tooltip` import (replaced with native `title` attribute)
- Added `hudStyles.mono` to SHA cell in PR matrix for consistency

| Commit | What |
|--------|------|
| `016880f` | Fix scrollbar on tooltip hover (`overflowY: visible`) |
| `1ef362f` | Align highlighting + convert nightly to hudStyles |
| `f5df5d1` | Fix Prettier ternary formatting |
| `1936683` | Fix Prettier className ternary |
| `67067fd` | Replace MUI Tooltip with native `title` in nightly |
| `fa28915` | Add `mono` class to SHA cell in PR matrix |
| `90a76d6` | Link "Show log" to specific job via `check_run_id` |

## Test plan

- [ ] Hover over job cell — no scrollbars appear
- [ ] Click a cell to pin tooltip — "Show log" links to the specific job
- [ ] Click a column header — yellow highlight through entire column
- [ ] Click a row — yellow highlight on entire row
- [ ] Press Escape or click elsewhere — highlight dismissed
- [ ] SHA column renders in monospace on both PR and nightly views
- [ ] All above works on both PR view and nightly view (`?event=nightly`)