### PR TITLE
[CRCR] Align nightly matrix table headers with PR matrix

### DIFF
--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -9,7 +9,6 @@ import {
   SelectChangeEvent,
   Skeleton,
   Stack,
-  Tooltip,
   Typography,
 } from "@mui/material";
 import { durationDisplay } from "components/common/TimeUtils";
@@ -21,7 +20,6 @@ import Head from "next/head";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
 import {
-  CSSProperties,
   createContext,
   useCallback,
   useContext,
@@ -640,41 +638,6 @@ function useCommitInfo(
   }, [data]);
 }
 
-// ---- Table Styles (matching main HUD) ----
-
-const headerBaseStyle: CSSProperties = {
-  fontFamily: "sans-serif",
-  fontSize: "0.75rem",
-  fontWeight: 600,
-  padding: "4px 6px",
-  whiteSpace: "nowrap",
-  textAlign: "left",
-  borderBottom: "1px solid #30363d",
-};
-
-const jobHeaderStyle: CSSProperties = {
-  fontFamily: "sans-serif",
-  height: 120,
-  whiteSpace: "nowrap",
-  padding: 0,
-  borderBottom: "1px solid #30363d",
-  position: "relative",
-};
-
-const jobHeaderNameStyle: CSSProperties = {
-  transform: "translate(5px, 45px) rotate(315deg)",
-  transformOrigin: "left bottom",
-  width: 12,
-  fontWeight: 400,
-  fontSize: "0.75em",
-};
-
-const cellStyle: CSSProperties = {
-  padding: "3px 6px",
-  whiteSpace: "nowrap",
-  fontSize: "0.8rem",
-  verticalAlign: "middle",
-};
 // ---- PR Matrix Table ----
 
 function CrcrMatrix({
@@ -1004,6 +967,7 @@ function CrcrNightlyMatrix({
     [matrix]
   );
   const commitInfoMap = useCommitInfo(upstreamRepo, nightlyShas);
+  const [pinnedId, setPinnedId] = useContext(CrcrPinnedContext);
 
   if (error) {
     return (
@@ -1026,36 +990,49 @@ function CrcrNightlyMatrix({
   return (
     <>
       <NightlySummaryCards data={data} />
-      <div style={{ overflowX: "auto" }}>
-        <table
-          style={{
-            borderCollapse: "collapse",
-            fontSize: "0.85rem",
-            width: "100%",
-          }}
-        >
+      <div style={{ overflowX: "auto", overflowY: "visible" }}>
+        <table className={hudStyles.hudTable}>
           <colgroup>
-            <col style={{ width: 80 }} />
-            <col style={{ width: 60 }} />
-            <col style={{ width: 340 }} />
+            <col className={hudStyles.colTime} />
+            <col className={hudStyles.colSha} />
+            <col className={hudStyles.colCommit} />
             {columns.map((col) => (
-              <col key={col.name} style={{ width: 18 }} />
+              <col key={col.name} className={hudStyles.colJob} />
             ))}
           </colgroup>
           <thead>
             <tr>
-              <th style={headerBaseStyle}>Time</th>
-              <th style={headerBaseStyle}>SHA</th>
-              <th style={headerBaseStyle}>Commit</th>
+              <th className={hudStyles.regularHeader}>Time</th>
+              <th className={hudStyles.regularHeader}>SHA</th>
+              <th className={hudStyles.regularHeader}>Commit</th>
               {columns.map((col) => (
-                <th key={col.name} style={jobHeaderStyle}>
+                <th
+                  key={col.name}
+                  className={`${hudStyles.jobHeader} ${
+                    pinnedId.name === col.name ? hudStyles.highlight : ""
+                  }`}
+                  style={{ cursor: "pointer" }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setPinnedId({
+                      sha: undefined,
+                      name: pinnedId.name === col.name ? undefined : col.name,
+                    });
+                  }}
+                >
                   <div
+                    className={hudStyles.jobHeaderName}
                     style={{
-                      ...jobHeaderNameStyle,
                       fontWeight: col.type === "group" ? 700 : 400,
                     }}
                   >
-                    {col.name}
+                    <span
+                      className={
+                        pinnedId.name === col.name ? hudStyles.highlight : ""
+                      }
+                    >
+                      {col.name}
+                    </span>
                   </div>
                 </th>
               ))}
@@ -1066,41 +1043,51 @@ function CrcrNightlyMatrix({
               const commit = commitInfoMap.get(row.sha);
               const commitTitle =
                 commit?.title || `nightly (${row.sha.substring(0, 12)})`;
+              const isRowHighlighted = pinnedId.sha === row.sha;
+              const rowClass = isRowHighlighted ? hudStyles.highlight : "";
               return (
-                <tr key={row.sha} style={{ borderBottom: "1px solid #30363d" }}>
-                  <td style={cellStyle}>
+                <tr
+                  key={row.sha}
+                  className={rowClass}
+                  onClick={(e) => {
+                    if (
+                      pinnedId.name !== undefined ||
+                      pinnedId.sha !== undefined
+                    ) {
+                      return;
+                    }
+                    e.stopPropagation();
+                    setPinnedId({ sha: row.sha, name: undefined });
+                  }}
+                  style={{ cursor: "pointer" }}
+                >
+                  <td className={hudStyles.jobMetadata}>
                     <LocalTimeDisplay timestamp={row.latestTime} />
                   </td>
-                  <td style={cellStyle}>
+                  <td className={hudStyles.jobMetadata}>
                     <a
                       href={`https://github.com/${row.upstreamRepo}/commit/${row.sha}`}
                       target="_blank"
                       rel="noopener noreferrer"
-                      style={{ color: "#58a6ff", textDecoration: "none" }}
                     >
                       {row.sha.substring(0, 7)}
                     </a>
                   </td>
-                  <td style={{ ...cellStyle, maxWidth: 340 }}>
-                    <Tooltip title={commitTitle}>
+                  <td className={hudStyles.jobMetadata}>
+                    <div className={hudStyles.jobMetadataTruncated}>
                       <a
                         href={`https://github.com/${row.upstreamRepo}/commit/${row.sha}`}
                         target="_blank"
                         rel="noopener noreferrer"
-                        style={{
-                          color: "#58a6ff",
-                          textDecoration: "none",
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          whiteSpace: "nowrap",
-                          display: "block",
-                        }}
+                        title={commitTitle}
                       >
                         {commitTitle}
                       </a>
-                    </Tooltip>
+                    </div>
                   </td>
                   {columns.map((col) => {
+                    const colHighlight =
+                      pinnedId.name === col.name ? hudStyles.highlight : "";
                     if (col.type === "group" && col.members) {
                       const groupJobs = col.members
                         .map((m) => row.jobs.get(m))
@@ -1108,7 +1095,8 @@ function CrcrNightlyMatrix({
                       return (
                         <td
                           key={col.name}
-                          style={{ ...cellStyle, textAlign: "center" }}
+                          className={`${hudStyles.jobMetadata} ${colHighlight}`}
+                          style={{ textAlign: "center" }}
                         >
                           {groupJobs.length > 0 ? (
                             <GroupedJobCell
@@ -1126,7 +1114,8 @@ function CrcrNightlyMatrix({
                     return (
                       <td
                         key={col.name}
-                        style={{ ...cellStyle, textAlign: "center" }}
+                        className={`${hudStyles.jobMetadata} ${colHighlight}`}
+                        style={{ textAlign: "center" }}
                       >
                         {job ? <JobCell job={job} sha={row.sha} /> : "–"}
                       </td>


### PR DESCRIPTION
## Summary

Aligns the nightly per-repo matrix table with the PR matrix table so both use identical styling and interactions.

### Before
- Nightly matrix used **inline style constants** (`headerBaseStyle`, `jobHeaderStyle`, `jobHeaderNameStyle`, `cellStyle`)
- No column highlighting, no row highlighting
- MUI `Tooltip` for commit text truncation
- No `overflowY: visible` (tooltips caused scrollbars)

### After
- Both matrices use **`hudStyles` CSS classes** (`hudTable`, `regularHeader`, `jobHeader`, `jobHeaderName`, `colTime`, `colSha`, `colCommit`, `colJob`, `jobMetadata`, `jobMetadataTruncated`)
- Column highlighting (click header → yellow highlight)
- Row highlighting (click row → yellow highlight)
- `overflowY: visible` on table wrapper (prevents tooltip scrollbars)
- Removed unused `CSSProperties` import and MUI `Tooltip` import

| File | What |
|------|------|
| `torchci/pages/crcr/[org]/[repo].tsx` | Replace inline styles with hudStyles classes in nightly matrix; add highlighting; cleanup imports |

## Test plan

- [ ] CI passes (lintrunner, test)
- [ ] Nightly page (`/crcr/<org>/<repo>?event=nightly`) renders with same header style as PR page
- [ ] Column highlighting works on nightly matrix
- [ ] Row highlighting works on nightly matrix
- [ ] Escape key dismisses highlights