### PR TITLE
[vllm-triage] Parse Buildkite logs into per-test failure signatures

### DIFF
--- a/.claude/skills/vllm-pytorch-ci-triage/CONFIDENCE.md
+++ b/.claude/skills/vllm-pytorch-ci-triage/CONFIDENCE.md
@@ -1,0 +1,31 @@
+# Confidence Scales
+
+## classification_confidence (per group)
+
+| Score | Meaning |
+|---|---|
+| 5 | Exact match to a cheat-sheet entry |
+| 4 | Strong pattern match (same exception class + framework frames) |
+| 3 | Reasonable inference from exception pattern |
+| 2 | Weak signal — exception is generic, routing based on context |
+| 1 | Guessing — no clear pattern match |
+
+## new_failure_confidence (per group)
+
+| Score | Meaning |
+|---|---|
+| 5 | Clearly a regression signature with no known variant |
+| 4 | Likely new — signature is distinctive |
+| 3 | Plausible but could be a flake or known issue variant |
+| 2 | Weak — generic exception that could appear in many contexts |
+| 1 | Likely a variant of an existing known issue |
+
+## shared_root_cause_confidence (per failure)
+
+| Score | Meaning |
+|---|---|
+| 5 | Identical exception signature to the group's root cause |
+| 4 | Same exception class + closely related message |
+| 3 | Same exception class, different message but likely related |
+| 2 | Different exception but plausibly the same underlying bug |
+| 1 | Grouped only by job proximity, low certainty |

--- a/.claude/skills/vllm-pytorch-ci-triage/GROUPING.md
+++ b/.claude/skills/vllm-pytorch-ci-triage/GROUPING.md
@@ -1,0 +1,23 @@
+# Grouping Guidance
+
+Goal: ONE group per root cause, not per failing job.
+## Common patterns
+
+- **Same exception across sharded jobs**: `Fusion E2E Test (H100) - 1/4`
+  through `4/4` all hit `MetaProxy` → one group.
+- **Same ImportError across test suites**: multiple jobs fail on
+  `ImportError: cannot import name 'X'` → one group.
+- **Different tests, same underlying op**: `test_gemm` and `test_fused_add`
+  both crash in the same custom op → one group if the exception chain
+  points to the same call site.
+
+## Anti-patterns
+
+Do NOT group failures just because they share a job-name prefix or test
+directory. Group by exception signature similarity.
+
+## Signature field
+
+Set `signature` to the representative exception string for the group —
+typically `ExceptionClass: message` from the most common failure in the
+group. This becomes the issue summary line.

--- a/.claude/skills/vllm-pytorch-ci-triage/ROUTING.md
+++ b/.claude/skills/vllm-pytorch-ci-triage/ROUTING.md
@@ -1,0 +1,36 @@
+# Repo Routing Cheat-Sheet
+
+Match exception patterns to repo. When multiple patterns match, prefer
+the more specific one.
+
+If no pattern exists, give your best guess based on your repo knowledge.
+
+
+| Error pattern | Repo |
+|---|---|
+| **Import errors — route by source package** | |
+| `ImportError` / `ModuleNotFoundError` from `torch.*` or `torch._inductor.*` | pytorch/pytorch |
+| `ImportError` / `ModuleNotFoundError` from `triton.*` | pytorch/pytorch (triton) |
+| `ImportError` / `ModuleNotFoundError` from `vllm.*` | vllm-project/vllm |
+| Import errors wrapped inside `RuntimeError: Engine core initialization failed` — unwrap to find the real `ImportError` underneath before routing | *(use rules above)* |
+| `torch.library.Library.impl ... already a kernel registered` | pytorch/pytorch |
+| `MetaProxy` in `prims.*` / Inductor | pytorch/pytorch |
+| `PassManager::run failed` inside `triton/` frames | pytorch/pytorch (triton) |
+| `Pointer argument cannot be accessed from Triton` | pytorch/pytorch (triton) |
+| `Cannot access data pointer of Tensor (FakeTensor…)` | pytorch/pytorch (AOTAutograd) |
+| `_pickle.PicklingError` on triton `launcher` | pytorch/pytorch (triton + AOT cache) |
+| `warm_artifacts_saved: got 0`, `KeyError: None` in standalone_compile | pytorch/pytorch (Inductor cache) |
+| `assert 'no' == 'yes'` in `test_dynamic_shapes_compilation` | pytorch/pytorch (Dynamo), but rerun first if GPU was OOM |
+| `torch.compile with fullgraph=True found no compiled frames` (when `TORCH_COMPILE_DISABLE=1` is in env) | vLLM-side fix usually correct; upstream interest if behavior change is intentional |
+| `RayChannelTimeoutError` on tp≥2 ray | pytorch/pytorch — likely torch.compile per-worker latency exceeds Ray channel timeout |
+| `Nondeterministic outputs detected` (B200-only) | pytorch/pytorch — Blackwell-specific kernel drift |
+| `assert torch.allclose(golden_output, vllm_output)` reward/PRM | pytorch/pytorch — numerical drift from triton update |
+| `compare_two_settings(... cpu-offload-gb ...)` → "Results are not the same" | pytorch/pytorch (CPU↔GPU dequantize parity) |
+| GSM8K accuracy collapses to 0.000 (not just degrades) | pytorch/pytorch — likely worker-side crash hidden behind unpickle error |
+| `Generated text "X" doesn't match expected pattern "Y"` on Qwen2-VL / Qwen3-VL LoRA | pytorch/pytorch — multimodal LoRA path numerical drift |
+| `AssertionError: expected size N==N, stride A==B` + `torch.ops.vllm.<X>` + "incorrect fake kernel" | **vllm-project/vllm** — fake kernel returns wrong shape |
+| Multi-modal per-model assertions (qwen2_vl, chameleon) | vllm-project/vllm first — may be torch-side once isolated |
+| Responses API assertion (`'incomplete' == 'completed'`) | vllm-project/vllm |
+| `test_lm_eval_accuracy_v1_engine` — measured below threshold | investigate both — often numerical drift from triton update |
+| `ValueError: Free memory on device cuda:N (X/Y GiB) … less than desired` (tagged `test_is_infra`) | infra (GPU contention) — rerun the job, do not file; can cascade dozens of unrelated tests, so the real failures may be a subset |
+| CUDA OOM (`torch.OutOfMemoryError` / `CUDA out of memory`) in tp≥2 or B200 fusion tests (runner had ~4–5 GiB free at start) | infra likely — **not** tagged `test_is_infra` (runtime OOM ≠ startup free-memory check); cross-check the same job on the same-day main build. If main OOMs the same way, it's contention — skip filing |

--- a/.claude/skills/vllm-pytorch-ci-triage/SKILL.md
+++ b/.claude/skills/vllm-pytorch-ci-triage/SKILL.md
@@ -7,6 +7,10 @@ description: Triage a failing vLLM Buildkite CI build for a PyTorch version-bump
 
 End-to-end workflow for triaging a vLLM CI run that tests a new torch/triton release and filing upstream issues for the real regressions. Derived from the multi-week triage of vLLM PR #40077 (torch 2.12.0 + triton 3.7.0) starting 2026-04-20 against Buildkite build #62138 → filed 16+ issues under umbrella `pytorch/pytorch#180899` over a series of daily runs (62138 → 62232 → 62495 → 62583 → 62848 → 63095). The workflow handles both first-time triage and ongoing daily monitoring.
 
+The `vllm_pytorch_ci_triage` package is pip-installed in this environment — import
+it directly (`from vllm_pytorch_ci_triage... import ...`). Do **not** add
+`sys.path.insert(...)`; there is no source checkout path in CI.
+
 ---
 
 ## Prerequisites
@@ -15,7 +19,9 @@ Both tokens must exist on disk with `600` perms. Do NOT paste into chat.
 
 ```bash
 # Buildkite API token — https://buildkite.com/user/api-access-tokens
-# Scopes: read_builds, read_build_logs. Must be a member of the `vllm` org.
+# Scopes: read_builds, read_build_logs (parse/diff), plus write_builds if you want
+# Step 4 auto-restart to work. A read-only token parses fine but CANNOT retry jobs.
+# Must be a member of the `vllm` org.
 umask 077 && printf '%s\n' 'bkua_...' > ~/.buildkite_token && chmod 600 ~/.buildkite_token
 
 # GitHub PAT — https://github.com/settings/tokens/new
@@ -31,41 +37,28 @@ Shell state does NOT persist between Bash tool calls — always read tokens per-
 
 ## Inputs the user usually provides
 
-- A failing Buildkite build URL, e.g. `https://buildkite.com/vllm/ci/builds/62138`
-- Optionally the PR (e.g. `vllm-project/vllm#40077`)
-- An umbrella issue (e.g. `pytorch/pytorch#180899`) — if present, append new issues to its checklist
+The **target build** (the one under test, running the new torch/triton) comes in one of two shapes:
 
-If only the Buildkite URL is given, the build JSON contains the commit, branch, and PR link.
+- **A torch-bump PR build**, e.g. `https://buildkite.com/vllm/ci/builds/62138`, usually with its PR
+  (e.g. `vllm-project/vllm#40077`). The build JSON contains the commit, branch, and PR link.
+- **A scheduled torch-nightly build on `main`** — when the user says "the most recent torch/pytorch
+  nightly CI run" and gives no PR. There is no PR here; the target is the newest `main` build whose
+  message is **`Full CI run torch nightly`** (distinct from the stable `Full CI run - nightly`).
+  Find it the same way as the baselines in Step 1:
+
+  ```bash
+  curl -sH "Authorization: Bearer $TOKEN" \
+    "https://api.buildkite.com/v2/organizations/vllm/pipelines/ci/builds?branch=main&per_page=100" \
+  | grep -B2 '"Full CI run torch nightly"'   # newest match is the target
+  ```
+
+Also usually provided:
+
+- An umbrella issue (e.g. `pytorch/pytorch#180899`) — if present, append new issues to its checklist
 
 ---
 
-## Workflow
-
-### Step 1 — Confirm build state, get totals
-
-```bash
-TOKEN=$(cat ~/.buildkite_token)
-curl -sH "Authorization: Bearer $TOKEN" \
-  "https://api.buildkite.com/v2/organizations/vllm/pipelines/ci/builds/<N>" > /tmp/bk_<N>.json
-```
-
-**Pitfall:** the anonymous JSON endpoint (`https://buildkite.com/vllm/ci/builds/<N>.json`) returns statistics only — `jobs: []` is empty without auth. Always use `api.buildkite.com`.
-
-Inspect `jobs[*].{name,state,soft_failed,exit_status,id,web_url,log_url}`.
-
-### Step 2 — Filter to BLOCKING failures only
-
-A vLLM "failed" job can be non-blocking (`soft_failed=True`). User told us to ignore those. Also exclude `waiting_failed` (downstream cascades).
-
-```python
-def hard_fails(path):
-    d = json.load(open(path))
-    return [(j['name'], j.get('exit_status'))
-            for j in d['jobs']
-            if j.get('state') == 'failed' and j.get('soft_failed') is False]
-```
-
-### Step 3 — Compare against recent full builds on main
+### Step 1 — Find the most recent full builds on main
 
 The full builds are commits on `main` whose message starts with `Full CI run - nightly` or `Full CI run - daily`. Pull the last ~week:
 
@@ -77,72 +70,108 @@ curl -sH "Authorization: Bearer $TOKEN" \
 
 Grep for `"Full CI run - nightly"` and `"Full CI run - daily"` in the message, then fetch each build's JSON with the same endpoint as step 1.
 
-**Compare SIGNATURES, not just job names.** A job-name overlap with main is *not* sufficient to drop a failure — main may fail the same job for an entirely different reason. Examples seen in this engagement:
+Match the hyphen: `Full CI run - nightly` (stable-torch baseline) is a **different** build from
+`Full CI run torch nightly` (the torch-nightly target from the Inputs section). Never pass the
+torch-nightly build as its own baseline.
 
-- `V1 Core + KV + Metrics` failed on both PR (62495) and main (62254). PR signature: `Expected: 0.54 \| Measured: 0.4806` (real accuracy regression). Main signature: `Server exited unexpectedly` (infra flake). Two different bugs sharing a job name.
-- `Entrypoints Integration (API Server openai - Part 3)` similarly: PR fails on `test_multi_chunk_streaming[Voxtral]`, main fails on `test_openapi_stateless` schemathesis.
+---
 
-Workflow: if a job-name overlaps with main, fetch the main log and compare the FAILED test ID + exception. Only drop if signatures match.
-
-Verify against ≥3 recent main builds before declaring a failure "new" — a single-build pass-or-fail isn't decisive (some jobs flake; some main builds get interrupted). Five-build crosscheck (5 × Full CI runs covering ~3 days) gives a confident verdict.
-
-**CRITICAL: an infra-killed main job is not a baseline.** A main-build job that exits with `exit_status=125` (`nvidia-container-cli` driver/container error), `started_at=None` + 0-byte log, or any other infra-kill signature **never actually ran the test** — treating it as "missing" or "passing" will produce false positives. If most/all recent main builds had a job killed by infra (especially the cluster of B200 nvidia-container-cli timeouts that hit many B200 jobs at once), the comparison is invalid:
-
-- **Do not file a "new on test PR" issue** based on this — the test could fail on torch 2.11 too, you just have no evidence either way.
-- **Ask the user (or the release manager) to retry the main nightly** for the specific job. A retried successful run on main is the only valid baseline.
-- Once retried main completes, compare signatures. Sometimes the failure on main matches the test PR exactly (i.e. it's a pre-existing vLLM bug, not a torch regression — retract).
-
-Real example (2026-05-05): `MoE Refactor Integration Test (B200 - TEMPORARY)` was hit by `exit 125` on every recent main build. Test PR 64468 ran it successfully and caught a GSM8K accuracy floor failure (0.2085 < 0.2100). I filed it as a torch 2.12 regression — wrongly. Once main 64432 was retried and actually ran the test, it produced the same signature with **0.2039** (worse than the test PR). Retracted as not_planned. The skill should reflect: when the main baseline is missing because of infra, *demand a rerun before filing*.
-
-### Step 4 — Pull logs for the survivors
-
-Log endpoint (plain-text variant):
+## Step 2: Pull and Parse the builds
 
 ```bash
-TOKEN=$(cat ~/.buildkite_token)
-# IMPORTANT: read token INTO a variable first; inline `$(cat ...)` inside a
-# backgrounded curl inside a `while read` loop silently fails (returns 0-byte
-# files). Lesson from first attempt that produced all-empty logs.
-for id in <JOB_IDS>; do
-  curl -sL -H "Authorization: Bearer $TOKEN" \
-    "https://api.buildkite.com/v2/organizations/vllm/pipelines/ci/builds/<N>/jobs/$id/log.txt" \
-    -o "/tmp/logs_<N>/$id.log" &
-done
-wait
+python -m vllm_pytorch_ci_triage.pipeline <build_number> \
+    --main-builds N,... [--output-dir DIR]
 ```
 
-### Step 5 — Strip ANSI + timestamp markers, extract root-cause lines
 
-Buildkite logs contain `\x1b_bk;t=...\x07` timestamp markers and ANSI color codes. Strip them first:
+`--main-builds` is the comma-separated list of main baseline build numbers to
+diff against (there is no auto-discovery — pick recent Full CI runs). Output is
+`agent_input.json` in `--output-dir` (default: cwd).
+
+---
+
+## Step 3: Read parsed logs
+
+The input file is too large to read directly. Load it with `load_failures`:
 
 ```python
-import re
-ANSI = re.compile(r'\x1b\[[0-9;?]*[a-zA-Z]')
-BKT  = re.compile(r'\x1b_bk;[^\x07]*\x07')
-def clean(s): return BKT.sub('', ANSI.sub('', s))
+from vllm_pytorch_ci_triage.output_object import load_failures
+
+jobs = load_failures("<input_file>")
 ```
 
-Useful signal patterns to scan cleaned logs for:
+This gives typed `JobFailure` objects — `job.log.pytest_results[*].test_failures[*]`
+with `.test_id`, `.exception_class`, `.exception_chain`, `.main_exception_chains`.
 
-- pytest summary line: `= \d+ failed`
-- Explicit `RuntimeError: ...` / `AssertionError: ...` / `ValueError: ...` (skip the generic `raise RuntimeError(` *frames* — they hide the real message)
-- `FAILED tests/.../...::test_name` lines (pytest verbose output)
-- Infra: `ECR`, `docker pull`, `Connection refused`, `no space left on device`, `exit status 137`
-- GPU contention: `Free memory on device cuda:0 (X/Y GiB) on startup is less than desired`
+Do NOT parse the input file multiple times.
 
-**Critical:** the literal "Engine core initialization failed. See root cause above." is never the root cause — scan upward for the *actual* exception line logged by the EngineCore worker process.
+### Input schema
 
-### Step 6 — Group by root cause
+The pipeline sends a JSON list of serialized `JobFailure` objects. Each has:
 
-The goal is ONE issue per root cause, not per failing job. From the 2026-04-20 triage, 22 failing non-CPU jobs grouped into 10 distinct root causes. Several causes produced >4 failing jobs each (e.g. Inductor MetaProxy → 4 Fusion E2E variants).
+```json
+{
+  "job_name": "Kernels DeepGEMM Test (H100)",
+  "job_id": "uuid",
+  "exit_status": 1,
+  "web_url": "https://buildkite.com/...",
+  "build_number": 77837,
+  "log": {
+    "pytest_results": [{
+      "test_failures": [{
+        "test_id": "tests/kernels/test_deepgemm.py::test_gemm",
+        "exception_class": "RuntimeError",
+        "exception_chain": "def test_gemm():\n>       run_gemm()\n\nE       RuntimeError: CUDA driver init failed\n\ntest_deepgemm.py:42: RuntimeError",
+        "test_is_infra": false,
+        "main_exception_chains": []
+      }],
+      "pytest_summary": "1 failed",
+      "expected_test_failure_count": 1
+    }],
+    "error_excerpt": "",
+    "job_is_infra": false,
+  }
+}
+```
 
-Separate out:
-- Infra/resource contention → **auto-restart** the affected jobs (see Step 6.5), don't file.
-- Test-case assertions that look like real regressions (e.g. `accuracy 0.48 < 0.54` threshold).
-- Torch/triton framework regressions → **pytorch/pytorch**.
-- vLLM-side application bugs (response APIs, multimodal) → **vllm-project/vllm**.
+Key fields:
+- `test_id` — pytest node ID
+- `exception_class` — exception type from the FAILED line
+- `exception_chain` — the **raw section body** from pytest's FAILURES output: the full
+  traceback text between `___` section headers, including source lines, `E` error lines,
+  file references, and chained exception connectors. This is the primary content for
+  root cause analysis.
+- `main_exception_chains` — when present (non-empty list), the same test failed on main
+  with the same `exception_class` but a different `exception_chain`. Contains the
+  main-side chains. Compare PR vs main chains to decide if this is genuinely new.
+- `test_is_infra` — per-test infra tag, set on each entry in `test_failures` from its
+  `exception_chain` (e.g. `Free memory … less than desired`, `exit status 137`). This is
+  the flag to read for a **pytest** failure.
+- `job_is_infra` — job/log-level infra tag, set **only on non-pytest failures** (empty
+  `pytest_results`, from `error_excerpt`). For a pytest job it is always `false` — do not
+  rely on it there; read the per-test `test_is_infra` instead.
 
-### Step 6.5 — Auto-restart transient-infra failures (do this automatically; do NOT file)
+**Infra tags are not filtered out.** A NEW infra-tagged test still appears in the input so
+you can auto-restart it (Step 4); it is not silently dropped, and it is not a regression to
+file. Route `test_is_infra`/`job_is_infra` failures to rerun, not to an issue.
+
+### Non-pytest failures
+
+Some `JobFailure` objects have `log.pytest_results = []` and `log.error_excerpt`
+populated instead. These are build failures, segfaults, or environment crashes that
+occurred before pytest ran (e.g. Docker image build failure, compilation error,
+import-time segfault). The `error_excerpt` field contains the full marker-stripped
+log text from the Buildkite job.
+
+Identify them by: `pytest_results` is empty, `error_excerpt` is non-empty.
+
+Each non-pytest failure contributes one `GroupMember` with
+`test_id="[build failure] <job_name>"` since there is no pytest node ID.
+
+Non-pytest failures bypass baseline comparison — they are always treated as novel.
+Analyze the `error_excerpt` text to identify the root cause.
+
+### Step 4 — Auto-restart transient-infra failures (do this automatically; do NOT file)
 
 Transient-infra jobs get **automatically retried** on the same build — this is a job-rerun,
 the one Buildkite write action the triage is allowed to take on its own (it never posts
@@ -174,7 +203,7 @@ Rate-limit discipline (REST API is **400/min**): fetch logs serially and space t
 (~0.5–1s apart, with exponential backoff on HTTP 429). A burst will get `429` and silently
 no-op. See the standalone example at the end of this section.
 
-**Within-build retry is infra-recovery, not a reproducibility test** (Step 12.4): retrying an
+**Within-build retry is infra-recovery, not a reproducibility test** (Step 13.1): retrying an
 infra job to get it onto a healthy agent is correct; but a retry that fails again does NOT
 prove a real regression (same image/agents). Only a *fresh build* proves reproducibility.
 
@@ -183,7 +212,59 @@ skipped set with reasons — silent restarts hide a persistently-broken fleet. I
 transient-infra signature dominates two consecutive runs, escalate: recommend a full rebuild
 on a healthy fleet rather than another round of same-build retries.
 
-### Step 7 — Draft and confirm before posting
+
+## Step 5: Triage near-misses
+
+Rate `new_failure_confidence` (1-5) per member as you decide. If a failure scores
+5 despite the near-miss, move it to step 6.
+
+For scale definitions, see [CONFIDENCE.md](CONFIDENCE.md).
+
+If `main_exception_chains` is empty, it is a new failure, rate `new_failure_confidence` as 5.
+
+Otherwise `main_exception_chains` is populated. This means the pipeline found the
+same test failing on main with the same exception class but a different traceback.
+
+Compare the PR `exception_chain` against each entry in `main_exception_chains`:
+- Cosmetic difference (address, tensor shape, line number, timing value) → `PRE_EXISTING`
+- Substantive difference (different error path, operation, module) → genuinely new
+
+All PRE_EXISTING failures go into a single group with classification `PRE_EXISTING`.
+No root cause analysis needed — they are not new regressions.
+
+## Step 6: Group remaining failures by root cause
+
+Only genuinely new failures reach this step.
+
+ONE group per root cause, not per job. From real data: 22 failing jobs
+grouped into 10 root causes.
+
+Use `exception_chain` (the raw traceback) as your primary source for root cause
+analysis. Use `exception_class` as a quick identifier.
+Same root cause across jobs = same group.
+
+Rate `shared_root_cause_confidence` (1-5) per member as you assign it to a group.
+
+For grouping patterns, see [GROUPING.md](GROUPING.md).
+
+## Step 7: Classify each group
+
+Match each group's exception pattern against the routing cheat-sheet in
+[ROUTING.md](ROUTING.md). Map repo to classification:
+
+- `pytorch/pytorch` → `TORCH_REGRESSION`
+- `pytorch/pytorch (triton)` → `TRITON_REGRESSION`
+- `vllm-project/vllm` → `VLLM_REGRESSION`
+
+Determine `area_tag` from the exception chain and stack frames in context.
+
+Rate per group as you route:
+- `classification_confidence` (1-5) — how sure the routing is correct
+- `new_failure_confidence` (1-5) — how confident this is genuinely new
+
+For scale definitions, see [CONFIDENCE.md](CONFIDENCE.md).
+
+### Step 8 — Draft and confirm before posting
 
 Public issues are high-blast-radius. ALWAYS:
 
@@ -208,7 +289,7 @@ Body sections to include:
 - **Question / diagnosis** — invite the maintainer to clarify intentional behavior change vs. regression.
 - **Links** — vLLM PR, Buildkite build, the specific failed job (click-through URL uses the job id as fragment: `…/builds/<N>#<job-uuid>`), umbrella issue.
 
-### Step 8 — Post via GitHub REST API
+### Step 9 — Post via GitHub REST API
 
 ```bash
 curl -s -X POST \
@@ -221,7 +302,7 @@ curl -s -X POST \
 
 **JSON body shape:** `{"title": "...", "body": "...markdown..."}`. Labels and assignees intentionally omitted — let maintainers triage.
 
-### Step 9 — Link to umbrella
+### Step 10 — Link to umbrella
 
 Fetch the umbrella body, find the last numbered checklist line (`^\d+\. \[[ x]\] https://github.com/pytorch/pytorch/issues/\d+`), insert the new link(s) with incremented numbers, PATCH:
 
@@ -235,7 +316,7 @@ curl -s -X PATCH \
 
 Always re-fetch the umbrella body before patching — other people may have edited it in between.
 
-### Step 10 — Post-filing corrections
+### Step 11 — Post-filing corrections
 
 Titles and bodies can be bulk-PATCHed; simple string replacements work fine:
 ```python
@@ -243,12 +324,12 @@ new_title = old_title.replace('pytorch-triton', 'triton')
 new_body  = old_body.replace('pytorch-triton', 'triton')
 ```
 
-### Step 11 — Recurring runs (daily monitoring)
+### Step 12 — Recurring runs (daily monitoring)
 
 Once the umbrella exists, subsequent test-PR builds are *not* "open new issues per failing job" — they're **delta analysis**. For each new build:
 
 1. Re-fetch the umbrella body and the JSON of every linked issue. Cache issue states (open/closed) keyed by number.
-2. **Auto-restart transient-infra failures first (Step 6.5).** Before classifying real signal,
+2. **Auto-restart transient-infra failures first (Step 4).** Before classifying real signal,
    retry every blocking-failed job that positively matches a transient-infra signature
    (CUDA-driver-init storm, nvidia-container-cli, exit 125, docker setup-hook, ECR rate-limit),
    skipping missing-image (`manifest unknown`), real regressions, and benign modes. This both
@@ -257,7 +338,7 @@ Once the umbrella exists, subsequent test-PR builds are *not* "open new issues p
 3. Match each hard-failed job in the new build against tracked-issue signatures (build a regex map from issue titles/bodies). Three buckets:
    - **Still reproducing**: tracked issue still hits → no new issue. If the user wants, PATCH the existing issue body to append the new build link to a Reproducibility section.
    - **Newly silent**: previously-failing job/test now passes. Don't immediately close — wait for ≥2 consecutive runs of "silent" before suggesting close.
-   - **Unmatched**: failing job whose signature isn't in any tracked issue. Cross-check against ≥3 main builds (per Step 3). If new on the torch-bump branch, draft + post a fresh issue and append to umbrella.
+   - **Unmatched**: failing job whose signature isn't in any tracked issue. Cross-check against ≥3 main builds (per Step 1). If new on the torch-bump branch, draft + post a fresh issue and append to umbrella.
 4. Maintain umbrella checklist hygiene: mark `[x]` on items that are closed upstream OR confirmed silent for ≥2 runs. Numbering continues — never reuse numbers.
 
 **Updating an existing issue's reproducibility list** (PATCH pattern):
@@ -279,7 +360,7 @@ Passes on same-day main builds (torch 2.11): <list of main build numbers>.
 new_body = body.replace(old, new)
 ```
 
-### Step 12 — "Closed upstream but still reproducing" check
+### Step 13 — "Closed upstream but still reproducing" check
 
 When a tracked issue's state flips to `closed` but the same signature keeps appearing in subsequent builds, the fix is in pytorch `main` but not yet in the test-channel wheel that vLLM CI pulls. Verify by comparing timestamps:
 
@@ -293,7 +374,7 @@ build.created_at
 
 If `build.created_at > closing_commit.created_at` but the failure persists, the wheel predates the fix. Recommendation: cherry-pick the fix to the release branch and rebuild the RC wheel. Don't reopen the issue — it really is fixed in main.
 
-### Step 12.4 — A within-build retry is NOT a reproducibility test
+### Step 13.1 — A within-build retry is NOT a reproducibility test
 
 **Critical lesson, do not skip.** When Buildkite shows a job failed and someone clicks "retry" on the same build, the retry runs on the **same Docker image, same wheels, same agent state, often the same agent machine**. It does not rebuild the image, does not re-pull torch wheels, does not refetch HF caches — it just re-executes the test script.
 
@@ -316,7 +397,7 @@ How to apply:
 - Treat retry-within-build as **necessary but not sufficient** for "reproducible".
 - If you've already filed an issue on a within-build-retry conclusion and a fresh build then passes, retract honestly and update the umbrella.
 
-### Step 12.5 — Reopen vs file new
+### Step 13.2 — Reopen vs file new
 
 Before drafting a "new" issue for an unmatched failure, search the umbrella's *closed* entries by exact failure-text fragment:
 
@@ -337,46 +418,7 @@ curl -X POST .../issues/<N>/comments -d @comment.json
 # Update umbrella: change `[x]` back to `[ ]` and add a "reopened YYYY-MM-DD" note
 ```
 
-### Step 12.6 — Custom-op stride/shape mismatch is almost always a vLLM-side fake-kernel bug, NOT a torch regression
-
-When you see this signature:
-```
-AssertionError: expected size N==N, stride A==B at dim=0
-Error in op: torch.ops.vllm.<X>.default
-This error most often comes from a incorrect fake (aka meta) kernel for a custom op.
-```
-
-**Default assumption:** vLLM's registered fake kernel for that custom op returns a different shape/stride than the runtime kernel. The check itself (`assert_size_stride`) is not new in any torch release — it's been there for years (see `pytorch/pytorch#177719` discussion to disable it for vLLM perf).
-
-Why torch X passes and torch Y fails on the *same* vLLM commit can mislead you here:
-- AOTAutograd cache hit may have bypassed recompile under torch X
-- `torch.Tag.needs_fixed_stride_order` only inserts the assert when Inductor sees a stride change
-- Torch Y might exercise a slightly different graph capture path
-
-Look for the root cause in vLLM, not torch:
-
-1. Find where the custom op is registered:
-   ```bash
-   git grep -rn "direct_register_custom_op" vllm/ | grep -E "op_name=.<your_op>."
-   git grep -rn "register_fake|fake_impl|impl_abstract" vllm/ | grep <op>
-   ```
-2. Read the `fake_impl=` function — what shape does it return?
-3. Read the actual implementation (`op_func=`) and any expert/dispatcher classes it calls — what shape do they actually allocate?
-4. Bisect with `git log --stat <last-passing>..<first-failing> -- <suspect dir>` to find the vLLM commit that introduced the mismatch.
-
-Real example from the gpt-oss MoE Blackwell triage:
-- Op: `torch.ops.vllm.moe_forward.default`
-- `_moe_forward_fake` returns `torch.empty_like(hidden_states)` → padded `hidden_dim` (3072)
-- `TrtLlmMxfp4Experts{Monolithic,Modular}` was changed by vllm-project/vllm#40960 to allocate at `hidden_dim_unpadded` (2880)
-- Inductor caught it with `assert_size_stride(buf, (s72, 3072), (3072, 1), 'torch.ops.vllm.moe_forward.default')`
-- **Fix is in vLLM**, not pytorch. Track at the vLLM repo, close any pytorch issue with `state_reason: not_planned`.
-
-Before filing the upstream issue, also search the vLLM repo for an existing report — community filings can land independently:
-```bash
-curl -s "https://api.github.com/search/issues?q=repo:vllm-project/vllm+is:issue+<distinctive_signature>"
-```
-
-### Step 13 — vLLM PR status comment
+### Step 14 — vLLM PR status comment
 
 When meaningful events happen (a fix lands, a batch of issues filed, an umbrella checklist update), post a comment on the vLLM test PR (e.g. `vllm-project/vllm#40077`) summarizing:
 
@@ -390,54 +432,15 @@ The comment is for human-readable status tracking by the release manager; keep i
 
 ---
 
-## Gotchas observed
+## Gotchas the parser does NOT catch
 
-- **Don't trust `jobs[*].state` alone.** `failed` + `soft_failed=True` is non-blocking. Always filter both.
-- **`waiting_failed`** jobs only mean "upstream I depended on failed" — they aren't independent signal.
-- **`started_at=None` + `exit_status=-1` + 0-byte log** = job never ran (infra cancelled/aborted before it started). Don't treat as a real signal — it's an infra event masquerading as `state=failed`. Ignore.
-- **"Engine core initialization failed. See root cause above."** is a red herring — the actual exception is logged several lines earlier by the `(EngineCore pid=...)` worker.
-- **GPU contention (~1 GiB free on an H100)** can cascade dozens of unrelated tests into `ValueError: Free memory ... less than desired`. If you see this pattern widely, recommend a job rerun before filing; the real failures may be a subset.
-- **CUDA OOM in tp=2 / B200 fusion tests** is *also* commonly infra (the runner had 4–5 GiB free at start when 5 GiB was needed). Cross-check the same job on the same-day main build — if main fails the same way with the same OOM signature, it's contention, not torch. Skip filing.
-- **Log timestamps differ per infrastructure:** dgxB200 nodes prefix with `_bk;t=…` only; mithril/aws nodes prefix with `[YYYY-MM-DDTHH:MM:SSZ]`. The ANSI-strip + BKT-strip pair handles both.
-- **PyPI vs test channel:** `ERROR: No matching distribution found for torch==2.12.0` isn't infra — the release isn't on PyPI yet. Tell the user; don't file a bug.
-- **`Python-only Installation` job has multiple unrelated failure modes:** (a) torch not on PyPI — expected, skip. (b) `metadata is still not available after N attempts` / `precompiled wheel for commit X is available` — vLLM's own precompiled-wheel infra hiccup, not torch. Both → ignore.
-- **Parallel curl in `while read` needs the token in a shell variable first**, not `$(cat …)` inline — otherwise backgrounded processes race the substitution and log files are 0 bytes.
-- **Buildkite REST API rate-limit is 400/min.** A burst of parallel-fetched logs will hit it; expect 161-byte error JSON instead of real logs. Switch to serial fetch (or `sleep 15` between bursts) when rate-limited.
-- **`exit_status=125` on multiple B200 jobs simultaneously, all with `nvidia-container-cli: initialization error: driver rpc error: timed out`** = B200 agent driver/container infra issue, not a regression. Recommend rerun, do not file. Often clusters across V1 attention, Fusion E2E, GPQA, LM Eval, MoE Refactor, Spec Decode B200 jobs at once.
-- **Same B200 infra cluster wipes out main-build coverage too.** When the *main* daily/nightly builds also have many B200 jobs killed by `exit 125 / nvidia-container-cli` (typical when the agent fleet has a bad day), do NOT use those main builds as a baseline. The pattern "test PR fails this job, main appears not to" is **inconclusive** — main never actually ran the test. ALWAYS ask the user (or release manager) to retry the corresponding main nightly job before drafting a new umbrella issue. Filing without that baseline produced a wrongful issue (#182549, retracted 2026-05-05): same Nemotron-Nano-30B-Fp8 GSM8K accuracy floor failed on both torch 2.11 (after main retry) and torch 2.12, but the torch 2.11 main builds had been killed by the B200 infra issue and looked "passing" by absence.
+The pipeline filters soft-fails, `waiting_failed`, never-ran jobs, marker/timestamp noise, and tags transient-infra signatures. The following are **not** filtered — you must apply them yourself when reading `agent_input.json`:
+
+- **PyPI vs test channel:** `ERROR: No matching distribution found for torch==2.12.0` isn't infra — the release isn't on PyPI yet. It arrives as a non-pytest failure (treated as novel). Tell the user; don't file a bug.
+- **`Python-only Installation` job has multiple unrelated failure modes:** (a) torch not on PyPI — expected, skip. (b) `metadata is still not available after N attempts` / `precompiled wheel for commit X is available` — vLLM's own precompiled-wheel infra hiccup, not torch. Both arrive as non-pytest failures (treated as novel) → ignore.
+- **An infra-killed main job is not a baseline.** A main-build job hit by `exit 125` / `nvidia-container-cli` (or otherwise never running the test) still counts as "job ran" for baseline purposes, so a PR failure with no matching main test gets classified `NEW` — a false positive. When the *main* daily/nightly builds also have many B200 jobs killed by infra, do NOT trust `main_exception_chains` being empty. "Test PR fails this job, main appears not to" is **inconclusive** — main never ran the test. Ask the user (or release manager) to retry the corresponding main nightly job before drafting a new umbrella issue. Filing without that baseline produced a wrongful issue (#182549, retracted 2026-05-05).
 - **Compile-on vs `--enforce-eager` CI gap:** fake-kernel / Inductor stride bugs only surface when compile is on. Many gpt-oss CI lanes (`tests/evals/gpt_oss/test_gpqa_correctness.py`, `--enforce-eager` parametrizations) bypass torch.compile entirely and never trace the fake kernel. If a custom-op stride mismatch only shows up on the torch-bump test PR, the bug almost certainly exists on main too — vLLM CI is just hiding it. When closing such an issue, mention this gap so vLLM can add coverage.
-- **Closed upstream ≠ fixed in CI.** The pytorch test-channel wheel is a snapshot; if the closing commit landed AFTER the wheel was built, the same signature keeps reproducing. Verify with timestamps before reopening — recommend a wheel rebuild instead.
 - **`Dockerfile.cpu` seeds `requirements/test/cpu.in` from `requirements/test/cuda.in`** (literal `COPY ... cuda.in cpu.in`), so the top-line `--extra-index-url https://download.pytorch.org/whl/test/cu130` carries over to the CPU build. Combined with `uv pip compile --torch-backend cpu` (which forces stable cpu channel), torch 2.12 wheels go missing. Fix: sed-rewrite the index-url to `whl/test/cpu` AND drop `--torch-backend cpu`.
 - **`uv --torch-backend <name>` overrides extra-index-url for torch.** Only stable channels (`cpu`, `cu128`, etc.) are presets — there is no `test-cpu` preset. To pin torch to the test channel, use `--extra-index-url` explicitly (or `UV_EXTRA_INDEX_URL` env) and *don't* pass `--torch-backend`.
 
 ---
-
-## Token ownership
-
-Tokens live in the user's home dir only. Never echo them to the conversation, never commit them, never include in issue bodies. If the user ever asks to rotate, remind them to delete the file + revoke at the provider UI.
-
-## Repo routing cheat-sheet
-
-| Error pattern | Repo |
-|---|---|
-| `torch.library.Library.impl ... already a kernel registered` | pytorch/pytorch |
-| `MetaProxy` in `prims.*` / Inductor | pytorch/pytorch |
-| `PassManager::run failed` inside `triton/` frames | pytorch/pytorch (triton) |
-| `Pointer argument cannot be accessed from Triton` | pytorch/pytorch (triton) |
-| `Cannot access data pointer of Tensor (FakeTensor…)` | pytorch/pytorch (AOTAutograd) |
-| `_pickle.PicklingError` on triton `launcher` | pytorch/pytorch (triton + AOT cache) |
-| `warm_artifacts_saved: got 0`, `KeyError: None` in standalone_compile | pytorch/pytorch (Inductor cache) |
-| `assert 'no' == 'yes'` in `test_dynamic_shapes_compilation` | pytorch/pytorch (Dynamo), but rerun first if GPU was OOM |
-| `torch.compile with fullgraph=True found no compiled frames` (when `TORCH_COMPILE_DISABLE=1` is in env) | vLLM-side fix usually correct (use `--enforce-eager` instead); upstream interest if behavior change is intentional |
-| `RayChannelTimeoutError: System error: Timed out waiting for object available to read` on tp≥2 ray | pytorch/pytorch — likely torch.compile per-worker latency exceeds Ray channel timeout |
-| `Failed: Nondeterministic outputs detected: N failed out of M trials` (B200-only) | pytorch/pytorch — Blackwell-specific kernel drift |
-| `assert torch.allclose(golden_output, vllm_output, ...)` failure on reward / PRM models | pytorch/pytorch — numerical drift from triton update |
-| `compare_two_settings(... cpu-offload-gb ...)` → "Results are not the same" | pytorch/pytorch (CPU↔GPU dequantize parity) |
-| GSM8K accuracy collapses to 0.000 (not just degrades) | pytorch/pytorch — likely worker-side crash hidden behind unpickle error |
-| `Generated text "X" doesn't match expected pattern "Y"` on Qwen2-VL / Qwen3-VL LoRA | pytorch/pytorch — multimodal LoRA path numerical drift (file separately if different LoRA target) |
-| `AssertionError: expected size N==N, stride A==B at dim=0` + `Error in op: torch.ops.vllm.<X>.default` + "incorrect fake (aka meta) kernel" hint | **vllm-project/vllm** — fake kernel registered via `direct_register_custom_op(..., fake_impl=...)` returns wrong shape. Find the registration site and the recent vLLM commit that changed the runtime allocation. Close any pytorch issue with `state_reason: not_planned`. |
-| Bulk `exit_status=125` + `nvidia-container-cli: initialization error: driver rpc error: timed out` across many B200 jobs | infra (B200 agent) — recommend rerun, do not file |
-| Multi-modal per-model assertions (qwen2_vl, chameleon) | vllm-project/vllm first — may be torch-side once isolated |
-| Responses API assertion (`'incomplete' == 'completed'`) | vllm-project/vllm |
-| `test_lm_eval_accuracy_v1_engine` — measured below threshold | investigate both — often numerical drift from triton update |
-| CUDA OOM in fusion-test parallel runs (~4–5 GiB free at start) | infra; check main same-day to confirm |

--- a/.claude/skills/vllm-pytorch-ci-triage/SKILL.md
+++ b/.claude/skills/vllm-pytorch-ci-triage/SKILL.md
@@ -76,100 +76,98 @@ torch-nightly build as its own baseline.
 
 ---
 
-## Step 2: Pull and Parse the builds
+## Step 2: Parse and compare (runs upstream — not you)
 
-```bash
-python -m vllm_pytorch_ci_triage.pipeline <build_number> \
-    --main-builds N,... [--output-dir DIR]
-```
+In the scheduled workflow this has already run before you start. The
+`torchci.vllm_torch_nightly_triage` job (on the runner, holding the ClickHouse and
+Buildkite secrets) does discovery, the job-level A/B, and log parsing, then writes the
+files you read in Step 3 — `report.md`, `report.json`, `cluster-logs/*.log`. You have
+no ClickHouse or Buildkite access and do not run this step yourself.
 
+How it decides regressions (job-level A/B over ClickHouse job metadata): it pairs the
+newest `Full CI run torch nightly` build with its same-commit, same-slot
+`Full CI run - nightly` / `- daily` baseline, then buckets each job:
 
-`--main-builds` is the comma-separated list of main baseline build numbers to
-diff against (there is no auto-discovery — pick recent Full CI runs). Output is
-`agent_input.json` in `--output-dir` (default: cwd).
+- `regressed` — fails on torch nightly, passes on the baseline.
+- `both` — fails on both (pre-existing, not torch).
+- `baseline_only` — fails only on the baseline.
+
+Only `regressed` clusters get a log fetched, parsed, and written to `cluster-logs/`.
 
 ---
 
-## Step 3: Read parsed logs
+## Step 3: Read the cluster logs
 
-The input file is too large to read directly. Load it with `load_failures`:
+You do not run the parser or fetch anything — Step 2 already produced the files. Your
+tools are `Read`, `Glob`, `Grep`, `Write`; there is no Python execution and no
+Buildkite / ClickHouse access. Read what is on disk in the triage input dir:
 
-```python
-from vllm_pytorch_ci_triage.output_object import load_failures
+- `report.md` — the A/B summary and the regressed clusters (see Step 5).
+- `report.json` — the same, structured: `torch_nightly_build`, `baseline_build`,
+  `commit`, and the `regressed` / `both` job lists.
+- `cluster-logs/*.log` — one representative log per regressed cluster, ANSI-stripped.T
+   This is your primary root-cause material.
 
-jobs = load_failures("<input_file>")
+### Cluster-log artifact format
+
+Every file opens with a header:
+
+```
+# cluster: <cluster key>
+# job: <job name>
+# url: <buildkite job url>
+# state: <state> exit_status: <n>
 ```
 
-This gives typed `JobFailure` objects — `job.log.pytest_results[*].test_failures[*]`
-with `.test_id`, `.exception_class`, `.exception_chain`, `.main_exception_chains`.
+**Parsed form** — pytest failures were extracted. The header is followed by
+`# parsed N failing test(s)` and one block per test:
 
-Do NOT parse the input file multiple times.
+```
+## tests/kernels/test_deepgemm.py::test_gemm
+exception_class: RuntimeError
+test_is_infra: false
 
-### Input schema
-
-The pipeline sends a JSON list of serialized `JobFailure` objects. Each has:
-
-```json
-{
-  "job_name": "Kernels DeepGEMM Test (H100)",
-  "job_id": "uuid",
-  "exit_status": 1,
-  "web_url": "https://buildkite.com/...",
-  "build_number": 77837,
-  "log": {
-    "pytest_results": [{
-      "test_failures": [{
-        "test_id": "tests/kernels/test_deepgemm.py::test_gemm",
-        "exception_class": "RuntimeError",
-        "exception_chain": "def test_gemm():\n>       run_gemm()\n\nE       RuntimeError: CUDA driver init failed\n\ntest_deepgemm.py:42: RuntimeError",
-        "test_is_infra": false,
-        "main_exception_chains": []
-      }],
-      "pytest_summary": "1 failed",
-      "expected_test_failure_count": 1
-    }],
-    "error_excerpt": "",
-    "job_is_infra": false,
-  }
-}
+def test_gemm():
+>       run_gemm()
+E       RuntimeError: CUDA driver init failed
+test_deepgemm.py:42: RuntimeError
 ```
 
-Key fields:
-- `test_id` — pytest node ID
-- `exception_class` — exception type from the FAILED line
-- `exception_chain` — the **raw section body** from pytest's FAILURES output: the full
-  traceback text between `___` section headers, including source lines, `E` error lines,
-  file references, and chained exception connectors. This is the primary content for
-  root cause analysis.
-- `main_exception_chains` — when present (non-empty list), the same test failed on main
-  with the same `exception_class` but a different `exception_chain`. Contains the
-  main-side chains. Compare PR vs main chains to decide if this is genuinely new.
-- `test_is_infra` — per-test infra tag, set on each entry in `test_failures` from its
-  `exception_chain` (e.g. `Free memory … less than desired`, `exit status 137`). This is
-  the flag to read for a **pytest** failure.
-- `job_is_infra` — job/log-level infra tag, set **only on non-pytest failures** (empty
-  `pytest_results`, from `error_excerpt`). For a pytest job it is always `false` — do not
-  rely on it there; read the per-test `test_is_infra` instead.
+- `## <test_id>` — pytest node ID.
+- `exception_class` — exception type from the FAILURES section.
+- `test_is_infra` — per-test transient-infra tag (CUDA-init, `exit status 137`,
+  `Free memory … less than desired`, …).
+- Everything after the blank line is the **raw section body** (the traceback): source
+  lines, `E` error lines, file refs, chained-exception connectors. This is the
+  `exception_chain` Step 6 refers to — your primary content for root cause.
 
-**Infra tags are not filtered out.** A NEW infra-tagged test still appears in the input so
-you can auto-restart it (Step 4); it is not silently dropped, and it is not a regression to
-file. Route `test_is_infra`/`job_is_infra` failures to rerun, not to an issue.
+**Fallback form** — no pytest failures were parsed (a build/crash before pytest ran,
+an empty parse, or the parser raising). The header is followed by:
 
-### Non-pytest failures
+```
+# parse_fallback: true (raw tail; scan upward for the real error)
+# parse_error: <message>        # only present if the parser raised
+# job_is_infra: <bool>
+# showing last <k> of <n> lines
 
-Some `JobFailure` objects have `log.pytest_results = []` and `log.error_excerpt`
-populated instead. These are build failures, segfaults, or environment crashes that
-occurred before pytest ran (e.g. Docker image build failure, compilation error,
-import-time segfault). The `error_excerpt` field contains the full marker-stripped
-log text from the Buildkite job.
+<the last k lines of the cleaned log>
+```
 
-Identify them by: `pytest_results` is empty, `error_excerpt` is non-empty.
+- `job_is_infra` — the fallback's job-level equivalent of `test_is_infra`.
+- The tail is the end of the whole cleaned log; the real error is usually a few lines
+  above the bottom. Scan **upward** past wrappers like
+  `Engine core initialization failed. See root cause above.` — that line is never the
+  root cause.
 
-Each non-pytest failure contributes one `GroupMember` with
-`test_id="[build failure] <job_name>"` since there is no pytest node ID.
+A fallback file is the old "non-pytest failure" case: Docker image build failure,
+compile error, import-time segfault. It has no pytest node ID — refer to it by its
+cluster / job name, and treat it as novel (baseline comparison already happened at the
+job level in Step 2).
 
-Non-pytest failures bypass baseline comparison — they are always treated as novel.
-Analyze the `error_excerpt` text to identify the root cause.
+**Infra is not a torch regression.** A cluster whose failures are all
+`test_is_infra: true` (or `job_is_infra: true`) is still present in the input; do not
+root-cause it as a regression — call it out as infra. (The cron agent files nothing and
+reruns nothing; job retry is the manual hand-run path in Step 4.)
 
 ### Step 4 — Auto-restart transient-infra failures (do this automatically; do NOT file)
 
@@ -213,24 +211,18 @@ transient-infra signature dominates two consecutive runs, escalate: recommend a 
 on a healthy fleet rather than another round of same-build retries.
 
 
-## Step 5: Triage near-misses
+## Step 5: NEW vs pre-existing
 
-Rate `new_failure_confidence` (1-5) per member as you decide. If a failure scores
-5 despite the near-miss, move it to step 6.
+Classification is decided **upstream** by the torch-nightly vs same-commit-baseline
+A/B. Each job is already bucketed in the report:
 
-For scale definitions, see [CONFIDENCE.md](CONFIDENCE.md).
+- `regressed` — fails on torch nightly, passes on the baseline → new, torch-attributable.
+- `both` — fails on both → `PRE_EXISTING`, not torch. No root-cause analysis needed.
+- `baseline_only` — fails only on the baseline → ignore.
 
-If `main_exception_chains` is empty, it is a new failure, rate `new_failure_confidence` as 5.
-
-Otherwise `main_exception_chains` is populated. This means the pipeline found the
-same test failing on main with the same exception class but a different traceback.
-
-Compare the PR `exception_chain` against each entry in `main_exception_chains`:
-- Cosmetic difference (address, tensor shape, line number, timing value) → `PRE_EXISTING`
-- Substantive difference (different error path, operation, module) → genuinely new
-
-All PRE_EXISTING failures go into a single group with classification `PRE_EXISTING`.
-No root cause analysis needed — they are not new regressions.
+Rate `new_failure_confidence` (1-5) per group from its bucket plus the infra /
+agent-concentration evidence in the report. For scale definitions, see
+[CONFIDENCE.md](CONFIDENCE.md).
 
 ## Step 6: Group remaining failures by root cause
 
@@ -434,11 +426,11 @@ The comment is for human-readable status tracking by the release manager; keep i
 
 ## Gotchas the parser does NOT catch
 
-The pipeline filters soft-fails, `waiting_failed`, never-ran jobs, marker/timestamp noise, and tags transient-infra signatures. The following are **not** filtered — you must apply them yourself when reading `agent_input.json`:
+The parser filters soft-fails, `waiting_failed`, never-ran jobs, marker/timestamp noise, and tags transient-infra signatures. The following are **not** filtered — apply them yourself when reading the `cluster-logs/*.log` files:
 
 - **PyPI vs test channel:** `ERROR: No matching distribution found for torch==2.12.0` isn't infra — the release isn't on PyPI yet. It arrives as a non-pytest failure (treated as novel). Tell the user; don't file a bug.
 - **`Python-only Installation` job has multiple unrelated failure modes:** (a) torch not on PyPI — expected, skip. (b) `metadata is still not available after N attempts` / `precompiled wheel for commit X is available` — vLLM's own precompiled-wheel infra hiccup, not torch. Both arrive as non-pytest failures (treated as novel) → ignore.
-- **An infra-killed main job is not a baseline.** A main-build job hit by `exit 125` / `nvidia-container-cli` (or otherwise never running the test) still counts as "job ran" for baseline purposes, so a PR failure with no matching main test gets classified `NEW` — a false positive. When the *main* daily/nightly builds also have many B200 jobs killed by infra, do NOT trust `main_exception_chains` being empty. "Test PR fails this job, main appears not to" is **inconclusive** — main never ran the test. Ask the user (or release manager) to retry the corresponding main nightly job before drafting a new umbrella issue. Filing without that baseline produced a wrongful issue (#182549, retracted 2026-05-05).
+- **An infra-killed baseline job is not a baseline.** The A/B buckets trust the baseline job's state. A baseline job hit by `exit 125` / `nvidia-container-cli` (or otherwise never running the tests) still lands in `BAD_STATES`, so the same job failing on torch nightly is bucketed `both` (pre-existing) — **masking a real regression** rather than surfacing it. (The failing baseline was infra, not the same test.) When the baseline build has many B200 jobs killed by infra, do NOT trust a `both` verdict on those jobs; the pair is **inconclusive** because the baseline never ran the test. Ask the user (or release manager) to retry the corresponding baseline job before concluding anything. The inverse mistake — treating a broken baseline as if the test passed there — produced a wrongful issue (#182549, retracted 2026-05-05).
 - **Compile-on vs `--enforce-eager` CI gap:** fake-kernel / Inductor stride bugs only surface when compile is on. Many gpt-oss CI lanes (`tests/evals/gpt_oss/test_gpqa_correctness.py`, `--enforce-eager` parametrizations) bypass torch.compile entirely and never trace the fake kernel. If a custom-op stride mismatch only shows up on the torch-bump test PR, the bug almost certainly exists on main too — vLLM CI is just hiding it. When closing such an issue, mention this gap so vLLM can add coverage.
 - **`Dockerfile.cpu` seeds `requirements/test/cpu.in` from `requirements/test/cuda.in`** (literal `COPY ... cuda.in cpu.in`), so the top-line `--extra-index-url https://download.pytorch.org/whl/test/cu130` carries over to the CPU build. Combined with `uv pip compile --torch-backend cpu` (which forces stable cpu channel), torch 2.12 wheels go missing. Fix: sed-rewrite the index-url to `whl/test/cpu` AND drop `--torch-backend cpu`.
 - **`uv --torch-backend <name>` overrides extra-index-url for torch.** Only stable channels (`cpu`, `cu128`, etc.) are presets — there is no `test-cpu` preset. To pin torch to the test channel, use `--extra-index-url` explicitly (or `UV_EXTRA_INDEX_URL` env) and *don't* pass `--torch-backend`.

--- a/tools/torchci/tests/conftest.py
+++ b/tools/torchci/tests/conftest.py
@@ -1,0 +1,85 @@
+"""Shared fixtures for bump-triage tests.
+
+All fixtures derived from real Buildkite build #77837 (vllm/ci, 2026-07-13,
+branch=main, state=failed). 25 hard failures including a CUDA driver init
+infra cluster (~20 jobs) and a nixl ImportError (6 jobs).
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture()
+def log_cuda_init_fail() -> str:
+    """Cleaned log tail: Cudagraph job failing with CUDA driver init error.
+
+    Root cause: RuntimeError: CUDA driver initialization failed.
+    4 failed, 10 passed, 2 skipped.
+    """
+    return (FIXTURES_DIR / "log_cudagraph_cuda_init_fail.txt").read_text()
+
+
+@pytest.fixture()
+def log_nixl_import() -> str:
+    """Cleaned log tail: NixlConnector job failing with ImportError.
+
+    Root cause: ImportError on nixl_ep_cpp (ABI mismatch).
+    1 failed, 16 warnings.
+    """
+    return (FIXTURES_DIR / "log_nixl_import_error.txt").read_text()
+
+
+@pytest.fixture()
+def log_engine_cuda_fail() -> str:
+    """Cleaned log tail: Engine job with 50 failures from CUDA init.
+
+    Root cause: RuntimeError: CUDA driver initialization failed.
+    50 failed, 67 passed, 2 skipped.
+    """
+    return (FIXTURES_DIR / "log_engine_cuda_init_fail.txt").read_text()
+
+
+@pytest.fixture()
+def raw_log_snippet() -> bytes:
+    """Raw (uncleaned) log bytes with ANSI escapes and BKT timestamp markers.
+
+    From DeepGEMM log around the pytest summary section.
+    Contains 29 ANSI escapes and 11 BKT markers.
+    """
+    return (FIXTURES_DIR / "raw_log_snippet.bin").read_bytes()
+
+
+@pytest.fixture()
+def raw_log_64854_elastic_ep() -> str:
+    """Full raw log from build #64854 Elastic EP Scaling Test.
+
+    2 failed: one bare assert, one AssertionError with message.
+    """
+    return (FIXTURES_DIR / "raw_log_64854_elastic_ep_scaling.txt").read_text()
+
+
+@pytest.fixture()
+def log_multi_root_cause_sentinels() -> str:
+    """Two sentinel tests with different root causes in the same session.
+
+    test_model_loading wraps ValueError: GPU memory exhausted on device 0
+    test_kernel_dispatch wraps TypeError: unsupported dtype bfloat16 for this kernel
+    Both FAILED lines show the same sentinel RuntimeError message.
+    """
+    return (FIXTURES_DIR / "log_multi_root_cause_sentinels.txt").read_text()
+
+
+@pytest.fixture()
+def log_dynamo_regression() -> str:
+    """Real log from build #72925 PyTorch Compilation Unit Tests.
+
+    Contains a real Dynamo regression: AttributeError on AlwaysHitShapeEnv
+    hidden behind the "Engine core initialization failed. See root cause
+    above" sentinel (~430 lines apart). From torch 2.13 umbrella #187471,
+    issue #187721.
+    """
+    return (FIXTURES_DIR / "log_dynamo_regression.txt").read_text()

--- a/tools/torchci/tests/fixtures/log_cudagraph_cuda_init_fail.txt
+++ b/tools/torchci/tests/fixtures/log_cudagraph_cuda_init_fail.txt
@@ -1,0 +1,100 @@
+[2026-07-13T19:39:31Z]                         break
+[2026-07-13T19:39:31Z]             else:
+[2026-07-13T19:39:31Z]                 stable_since = None
+[2026-07-13T19:39:31Z]                 stable_used_bytes = None
+[2026-07-13T19:39:31Z]
+[2026-07-13T19:39:31Z]             if dur_s >= timeout_s:
+[2026-07-13T19:39:31Z] >               raise ValueError(
+[2026-07-13T19:39:31Z]                     f"Memory of devices {devices=} not free after "
+[2026-07-13T19:39:31Z]                     f"{dur_s=:.02f} ({threshold=})"
+[2026-07-13T19:39:31Z]                 )
+[2026-07-13T19:39:31Z] E               ValueError: Memory of devices devices=[0] not free after dur_s=120.01 (threshold='device=0: 0.100')
+[2026-07-13T19:39:31Z]
+[2026-07-13T19:39:31Z] utils.py:1668: ValueError
+[2026-07-13T19:39:31Z] ------------------------------ Captured log call -------------------------------
+[2026-07-13T19:39:31Z] INFO     vllm.entrypoints.serve.utils.api_utils:api_utils.py:273 non-default args: {'trust_remote_code': True, 'max_model_len': 1024, 'gpu_memory_utilization': 0.45, 'max_num_seqs': 256, 'disable_log_stats': True, 'compilation_config': {'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': [], 'ir_enable_torch_wrap': None, 'splitting_ops': None, 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': None, 'compile_ranges_endpoints': None, 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_DECODE_ONLY: (2, 0)>, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': None, 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': None, 'pass_config': {}, 'max_cudagraph_capture_size': None, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': None, 'static_all_moe_layers': []}, 'attention_config': AttentionConfig(backend=<AttentionBackendEnum.FLASH_ATTN: 'vllm.v1.attention.backends.flash_attn.FlashAttentionBackend'>, flash_attn_version=2, use_prefill_decode_attention=False, flash_attn_max_num_splits_for_cuda_graph=16, tq_max_kv_splits_for_cuda_graph=32, use_trtllm_attention=None, disable_flashinfer_q_quantization=False, mla_prefill_backend=None, use_prefill_query_quantization=False, use_fp4_indexer_cache=False, indexer_kv_dtype='bf16', use_non_causal=False, flex_attn_block_m=None, flex_attn_block_n=None, flex_attn_q_block_size=None, flex_attn_kv_block_size=None), 'model': 'Qwen/Qwen2-1.5B-Instruct'}
+[2026-07-13T19:39:31Z] INFO     vllm.config.model:model.py:619 Resolved architecture: Qwen2ForCausalLM
+[2026-07-13T19:39:31Z] INFO     vllm.config.model:model.py:1770 Using max model len 1024
+[2026-07-13T19:39:31Z] INFO     vllm.config.kernel:kernel.py:292 Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
+[2026-07-13T19:39:31Z] =============================== warnings summary ===============================
+[2026-07-13T19:39:31Z] <frozen importlib._bootstrap>:488
+[2026-07-13T19:39:31Z]   <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute
+[2026-07-13T19:39:31Z]
+[2026-07-13T19:39:31Z] <frozen importlib._bootstrap>:488
+[2026-07-13T19:39:31Z]   <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute
+[2026-07-13T19:39:31Z]
+[2026-07-13T19:39:31Z] ../../usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: 14 warnings
+[2026-07-13T19:39:31Z]   /usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
+[2026-07-13T19:39:31Z]     warnings.warn(
+[2026-07-13T19:39:31Z]
+[2026-07-13T19:39:31Z] tests/v1/cudagraph/test_cudagraph_mode.py::test_backend_and_cudagraph_mode_combo[FA2-FULL-True]
+[2026-07-13T19:39:31Z] tests/v1/cudagraph/test_cudagraph_mode.py::test_backend_and_cudagraph_mode_combo[FA2-FULL_AND_PIECEWISE-True]
+[2026-07-13T19:39:31Z]   /usr/lib/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=336) is multi-threaded, use of fork() may lead to deadlocks in the child.
+[2026-07-13T19:39:31Z]     self.pid = os.fork()
+[2026-07-13T19:39:31Z]
+[2026-07-13T19:39:31Z] -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+[2026-07-13T19:39:31Z] =========================== short test summary info ============================
+[2026-07-13T19:39:31Z] FAILED v1/cudagraph/test_cudagraph_mode.py::test_backend_and_cudagraph_mode_combo[FA2-FULL-True] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:31Z] FAILED v1/cudagraph/test_cudagraph_mode.py::test_backend_and_cudagraph_mode_combo[FA2-FULL_AND_PIECEWISE-True] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:31Z] FAILED v1/cudagraph/test_cudagraph_mode.py::test_cudagraph_compilation_combo[FA2-FULL-3-True] - ValueError: Memory of devices devices=[0] not free after dur_s=120.01 (threshold='device=0: 0.100')
+[2026-07-13T19:39:31Z] FAILED v1/cudagraph/test_cudagraph_mode.py::test_cudagraph_compilation_combo[FA2-FULL_DECODE_ONLY-3-True] - ValueError: Memory of devices devices=[0] not free after dur_s=120.01 (threshold='device=0: 0.100')
+[2026-07-13T19:39:31Z] ======= 4 failed, 10 passed, 2 skipped, 18 warnings in 669.01s (0:11:09) =======
+[2026-07-13T19:39:33Z] sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
++++ :test_tube: Command (3/3): pytest -v -s v1/cudagraph/test_breakable_cudagraph.py
+[2026-07-13T19:39:46Z] W0713 19:39:46.081000 2956 torch/_opaque_base.py:6] torch._opaque_base is deprecated, use torch._custom_class_base instead
+[2026-07-13T19:39:46Z] W0713 19:39:46.081000 2956 torch/_library/opaque_object.py:288] register_opaque_type is deprecated, use register_custom_class instead
+[2026-07-13T19:39:46Z] W0713 19:39:46.081000 2956 torch/_library/opaque_object.py:211] typ='value' is deprecated, use typ='constant' instead
+[2026-07-13T19:39:50Z] ============================= test session starts ==============================
+[2026-07-13T19:39:50Z] platform linux -- Python 3.12.13, pytest-9.1.0, pluggy-1.5.0 -- /usr/bin/python3
+[2026-07-13T19:39:51Z] cachedir: .pytest_cache
+[2026-07-13T19:39:51Z] hypothesis profile 'ci' -> database=None, deadline=None, print_blob=True, derandomize=True, suppress_health_check=[HealthCheck.too_slow]
+[2026-07-13T19:39:51Z] rootdir: /vllm-workspace
+[2026-07-13T19:39:51Z] configfile: pyproject.toml
+[2026-07-13T19:39:51Z] plugins: anyio-4.14.1, buildkite-test-collector-0.1.9, hypothesis-6.131.0, asyncio-1.4.0, cov-6.3.0, forked-1.6.0, mock-3.14.0, rerunfailures-14.0, shard-0.1.2, timeout-2.3.1, schemathesis-4.21.6
+[2026-07-13T19:39:51Z] asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+[2026-07-13T19:39:51Z] collecting ...
+collected 12 items
+[2026-07-13T19:39:51Z] Running 12 items in this shard: tests/v1/cudagraph/test_breakable_cudagraph.py::test_decorator_passthrough_outside_capture, tests/v1/cudagraph/test_breakable_cudagraph.py::test_current_is_none_when_inactive, tests/v1/cudagraph/test_breakable_cudagraph.py::test_thread_local_active_during_context, tests/v1/cudagraph/test_breakable_cudagraph.py::test_nested_capture_raises, tests/v1/cudagraph/test_breakable_cudagraph.py::test_active_state_isolated_across_threads, tests/v1/cudagraph/test_breakable_cudagraph.py::test_capture_with_no_eager_break_records_one_graph, tests/v1/cudagraph/test_breakable_cudagraph.py::test_add_eager_creates_alternating_graph_eager_graph, tests/v1/cudagraph/test_breakable_cudagraph.py::test_capture_replay_matches_eager_simple, tests/v1/cudagraph/test_breakable_cudagraph.py::test_decorator_breaks_when_invoked_inside_capture, tests/v1/cudagraph/test_breakable_cudagraph.py::test_replay_invokes_eager_segments_in_order, tests/v1/cudagraph/test_breakable_cudagraph.py::test_exception_in_body_clears_active, tests/v1/cudagraph/test_breakable_cudagraph.py::test_nested_decorated_op_runs_inline
+[2026-07-13T19:39:51Z]
+[2026-07-13T19:39:51Z] v1/cudagraph/test_breakable_cudagraph.py::test_decorator_passthrough_outside_capture PASSED
+[2026-07-13T19:39:52Z] v1/cudagraph/test_breakable_cudagraph.py::test_current_is_none_when_inactive PASSED
+[2026-07-13T19:39:52Z] v1/cudagraph/test_breakable_cudagraph.py::test_thread_local_active_during_context PASSED
+[2026-07-13T19:39:52Z] v1/cudagraph/test_breakable_cudagraph.py::test_nested_capture_raises PASSED
+[2026-07-13T19:39:52Z] v1/cudagraph/test_breakable_cudagraph.py::test_active_state_isolated_across_threads PASSED
+[2026-07-13T19:39:53Z] v1/cudagraph/test_breakable_cudagraph.py::test_capture_with_no_eager_break_records_one_graph PASSED
+[2026-07-13T19:39:53Z] v1/cudagraph/test_breakable_cudagraph.py::test_add_eager_creates_alternating_graph_eager_graph PASSED
+[2026-07-13T19:39:53Z] v1/cudagraph/test_breakable_cudagraph.py::test_capture_replay_matches_eager_simple PASSED
+[2026-07-13T19:39:54Z] v1/cudagraph/test_breakable_cudagraph.py::test_decorator_breaks_when_invoked_inside_capture PASSED
+[2026-07-13T19:39:54Z] v1/cudagraph/test_breakable_cudagraph.py::test_replay_invokes_eager_segments_in_order PASSED
+[2026-07-13T19:39:54Z] v1/cudagraph/test_breakable_cudagraph.py::test_exception_in_body_clears_active PASSED
+[2026-07-13T19:39:54Z] v1/cudagraph/test_breakable_cudagraph.py::test_nested_decorated_op_runs_inline PASSED
+[2026-07-13T19:39:54Z]
+[2026-07-13T19:39:54Z] =============================== warnings summary ===============================
+[2026-07-13T19:39:54Z] <frozen importlib._bootstrap>:488
+[2026-07-13T19:39:54Z]   <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute
+[2026-07-13T19:39:54Z]
+[2026-07-13T19:39:54Z] <frozen importlib._bootstrap>:488
+[2026-07-13T19:39:54Z]   <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute
+[2026-07-13T19:39:54Z]
+[2026-07-13T19:39:54Z] tests/v1/cudagraph/test_breakable_cudagraph.py: 14 warnings
+[2026-07-13T19:39:54Z]   /usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
+[2026-07-13T19:39:54Z]     warnings.warn(
+[2026-07-13T19:39:54Z]
+[2026-07-13T19:39:54Z] tests/v1/cudagraph/test_breakable_cudagraph.py::test_thread_local_active_during_context
+[2026-07-13T19:39:54Z] tests/v1/cudagraph/test_breakable_cudagraph.py::test_nested_capture_raises
+[2026-07-13T19:39:54Z] tests/v1/cudagraph/test_breakable_cudagraph.py::test_active_state_isolated_across_threads
+[2026-07-13T19:39:54Z] tests/v1/cudagraph/test_breakable_cudagraph.py::test_exception_in_body_clears_active
+[2026-07-13T19:39:54Z]   /usr/local/lib/python3.12/dist-packages/torch/cuda/graphs.py:264: UserWarning: The CUDA Graph is empty. This usually means that the graph was attempted to be captured on wrong device or stream. (Triggered internally at /__w/pytorch/pytorch/aten/src/ATen/cuda/CUDAGraph.cpp:241.)
+[2026-07-13T19:39:54Z]     super().capture_end_pre()
+[2026-07-13T19:39:54Z]
+[2026-07-13T19:39:54Z] -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+[2026-07-13T19:39:54Z] ======================= 12 passed, 20 warnings in 3.97s ========================
+[2026-07-13T19:39:55Z] sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
+^^^ +++
+[2026-07-13T19:39:58Z] 🚨 Error: The command exited with status 1
+^^^ +++
+[2026-07-13T19:39:58Z] user command error: The plugin docker command hook exited with status 1
+~~~ Running global pre-exit hook
+[2026-07-13T19:39:58Z] $ /etc/buildkite-agent/hooks/pre-exit
+~~~ Running plugin docker pre-exit hook
+[2026-07-13T19:39:58Z] $ /var/lib/buildkite-agent/plugins/bk-gpu-1-queue-ci-i-07eb4eb58535ed8af-1/github-com-buildkite-plugins-docker-buildkite-plugin-v5-2-0/hooks/pre-exit

--- a/tools/torchci/tests/fixtures/log_dynamo_regression.txt
+++ b/tools/torchci/tests/fixtures/log_dynamo_regression.txt
@@ -1,0 +1,1109 @@
+
+
+(EngineCore pid=2181) ERROR 06-19 12:57:13 [core.py:1229]         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+(EngineCore pid=2181) ERROR 06-19 12:57:13 [core.py:1229] AttributeError: 'AlwaysHitShapeEnv' object has no attribute 'produce_guards_expression_with_source_info'
+
+(EngineCore pid=2181) Process EngineCore:
+
+(EngineCore pid=2181) Traceback (most recent call last):
+
+(EngineCore pid=2181)   File "/usr/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
+
+(EngineCore pid=2181)     self.run()
+
+(EngineCore pid=2181)   File "/usr/lib/python3.12/multiprocessing/process.py", line 108, in run
+
+(EngineCore pid=2181)     self._target(*self._args, **self._kwargs)
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 1233, in run_engine_core
+
+(EngineCore pid=2181)     raise e
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 1198, in run_engine_core
+
+(EngineCore pid=2181)     engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
+
+(EngineCore pid=2181)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 964, in __init__
+
+(EngineCore pid=2181)     super().__init__(
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 133, in __init__
+
+(EngineCore pid=2181)     kv_cache_config = self._initialize_kv_caches(vllm_config)
+
+(EngineCore pid=2181)                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 283, in _initialize_kv_caches
+
+(EngineCore pid=2181)     available_gpu_memory = self.model_executor.determine_available_memory()
+
+(EngineCore pid=2181)                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/abstract.py", line 147, in determine_available_memory
+
+(EngineCore pid=2181)     return self.collective_rpc("determine_available_memory")
+
+(EngineCore pid=2181)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/uniproc_executor.py", line 92, in collective_rpc
+
+(EngineCore pid=2181)     result = run_method(self.driver_worker, method, args, kwargs)
+
+(EngineCore pid=2181)              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/serial_utils.py", line 510, in run_method
+
+(EngineCore pid=2181)     return func(*args, **kwargs)
+
+(EngineCore pid=2181)            ^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
+
+(EngineCore pid=2181)     return func(*args, **kwargs)
+
+(EngineCore pid=2181)            ^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_worker.py", line 410, in determine_available_memory
+
+(EngineCore pid=2181)     self.model_runner.profile_run()
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_model_runner.py", line 6287, in profile_run
+
+(EngineCore pid=2181)     hidden_states, last_hidden_states = self._dummy_run(
+
+(EngineCore pid=2181)                                         ^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
+
+(EngineCore pid=2181)     return func(*args, **kwargs)
+
+(EngineCore pid=2181)            ^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_model_runner.py", line 5947, in _dummy_run
+
+(EngineCore pid=2181)     outputs = self.model(
+
+(EngineCore pid=2181)               ^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/cuda_graph.py", line 254, in __call__
+
+(EngineCore pid=2181)     return self.runnable(*args, **kwargs)
+
+(EngineCore pid=2181)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1778, in _wrapped_call_impl
+
+(EngineCore pid=2181)     return self._call_impl(*args, **kwargs)
+
+(EngineCore pid=2181)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1789, in _call_impl
+
+(EngineCore pid=2181)     return forward_call(*args, **kwargs)
+
+(EngineCore pid=2181)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/opt.py", line 407, in forward
+
+(EngineCore pid=2181)     hidden_states = self.model(
+
+(EngineCore pid=2181)                     ^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/decorators.py", line 663, in __call__
+
+(EngineCore pid=2181)     self.aot_compiled_fn = self.aot_compile(*args, **kwargs)
+
+(EngineCore pid=2181)                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/wrapper.py", line 169, in aot_compile
+
+(EngineCore pid=2181)     return self._compiled_callable.aot_compile((args, kwargs))
+
+(EngineCore pid=2181)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/eval_frame.py", line 964, in aot_compile
+
+(EngineCore pid=2181)     return aot_compile_fullgraph(
+
+(EngineCore pid=2181)            ^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/aot_compile.py", line 396, in aot_compile_fullgraph
+
+(EngineCore pid=2181)     compiled_fn = backend(
+
+(EngineCore pid=2181)                   ^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/__init__.py", line 2569, in __call__
+
+(EngineCore pid=2181)     return self.compiler_fn(model_, inputs_, **self.kwargs)
+
+(EngineCore pid=2181)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/lib/python3.12/contextlib.py", line 81, in inner
+
+(EngineCore pid=2181)     return func(*args, **kwds)
+
+(EngineCore pid=2181)            ^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/backends.py", line 1214, in __call__
+
+(EngineCore pid=2181)     PiecewiseCompileInterpreter(
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/backends.py", line 723, in run
+
+(EngineCore pid=2181)     return super().run(*args)
+
+(EngineCore pid=2181)            ^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/fx/interpreter.py", line 197, in run
+
+(EngineCore pid=2181)     self.env[node] = self.run_node(node)
+
+(EngineCore pid=2181)                      ^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/fx/interpreter.py", line 294, in run_node
+
+(EngineCore pid=2181)     return getattr(self, n.op)(n.target, args, kwargs)
+
+(EngineCore pid=2181)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/backends.py", line 750, in call_module
+
+(EngineCore pid=2181)     piecewise_backend = PiecewiseBackend(
+
+(EngineCore pid=2181)                         ^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/piecewise_backend.py", line 190, in __init__
+
+(EngineCore pid=2181)     self.compile_all_ranges()
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/piecewise_backend.py", line 266, in compile_all_ranges
+
+(EngineCore pid=2181)     range_entry.runnable = self.vllm_backend.compiler_manager.compile(
+
+(EngineCore pid=2181)                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/backends.py", line 353, in compile
+
+(EngineCore pid=2181)     compiled_graph, handle = self.compiler.compile(
+
+(EngineCore pid=2181)                              ^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/compiler_interface.py", line 637, in compile
+
+(EngineCore pid=2181)     compiled_graph = compile_fx(
+
+(EngineCore pid=2181)                      ^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/compile_fx.py", line 2731, in compile_fx
+
+(EngineCore pid=2181)     return compile_fx(
+
+(EngineCore pid=2181)            ^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/compile_fx.py", line 2790, in compile_fx
+
+(EngineCore pid=2181)     return _maybe_wrap_and_compile_fx_main(
+
+(EngineCore pid=2181)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/compile_fx.py", line 2871, in _maybe_wrap_and_compile_fx_main
+
+(EngineCore pid=2181)     return _compile_fx_main(
+
+(EngineCore pid=2181)            ^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/compile_fx.py", line 3069, in _compile_fx_main
+
+(EngineCore pid=2181)     return dynamo_common.aot_autograd(
+
+(EngineCore pid=2181)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/backends/common.py", line 123, in __call__
+
+(EngineCore pid=2181)     cg = aot_module_simplified(gm, example_inputs, **self.kwargs)
+
+(EngineCore pid=2181)          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/aot_autograd.py", line 1238, in aot_module_simplified
+
+(EngineCore pid=2181)     compiled_fn, _ = aot_stage2_compile(
+
+(EngineCore pid=2181)                      ^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/graph_compile.py", line 364, in aot_stage2_compile
+
+(EngineCore pid=2181)     return aot_stage2_inference(
+
+(EngineCore pid=2181)            ^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/graph_compile.py", line 488, in aot_stage2_inference
+
+(EngineCore pid=2181)     compiled_fw = _aot_stage2b_inference_compile(
+
+(EngineCore pid=2181)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/graph_compile.py", line 415, in _aot_stage2b_inference_compile
+
+(EngineCore pid=2181)     return _aot_stage2b_compile_forward_or_inference(
+
+(EngineCore pid=2181)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/graph_compile.py", line 2800, in _aot_stage2b_compile_forward_or_inference
+
+(EngineCore pid=2181)     compiled_fw_func = compiler(fw_module, adjusted_flat_args)
+
+(EngineCore pid=2181)                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/schemas.py", line 1472, in __call__
+
+(EngineCore pid=2181)     output_code = self.compiler_fn(gm, example_inputs)
+
+(EngineCore pid=2181)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/compile_fx.py", line 2932, in fw_compiler_base
+
+(EngineCore pid=2181)     return compile_fx_forward(
+
+(EngineCore pid=2181)            ^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/compile_fx.py", line 2545, in compile_fx_forward
+
+(EngineCore pid=2181)     result = inner_compile(
+
+(EngineCore pid=2181)              ^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/lib/python3.12/contextlib.py", line 81, in inner
+
+(EngineCore pid=2181)     return func(*args, **kwds)
+
+(EngineCore pid=2181)            ^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/compiler_interface.py", line 518, in hijacked_compile_fx_inner
+
+(EngineCore pid=2181)     output = torch._inductor.compile_fx.compile_fx_inner(*args, **kwargs)
+
+(EngineCore pid=2181)              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/compile_fx.py", line 837, in compile_fx_inner
+
+(EngineCore pid=2181)     return wrap_compiler_debug(_compile_fx_inner, compiler_name="inductor")(
+
+(EngineCore pid=2181)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/repro/after_aot.py", line 317, in debug_wrapper
+
+(EngineCore pid=2181)     inner_compiled_fn = compiler_fn(gm, example_inputs)
+
+(EngineCore pid=2181)                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/compile_fx.py", line 1088, in _compile_fx_inner
+
+(EngineCore pid=2181)     FxGraphCache._save_graph(
+
+(EngineCore pid=2181)   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/codecache.py", line 2180, in _save_graph
+
+(EngineCore pid=2181)     ) = shape_env.produce_guards_expression_with_source_info(
+
+(EngineCore pid=2181)         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(EngineCore pid=2181) AttributeError: 'AlwaysHitShapeEnv' object has no attribute 'produce_guards_expression_with_source_info'
+
+[rank0]:[W619 12:57:14.946296329 ProcessGroupNCCL.cpp:1624] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
+
+(APIServer pid=1913) Traceback (most recent call last):
+
+(APIServer pid=1913)   File "/usr/local/bin/vllm", line 10, in <module>
+
+(APIServer pid=1913)     sys.exit(main())
+
+(APIServer pid=1913)              ^^^^^^
+
+(APIServer pid=1913)   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/cli/main.py", line 95, in main
+
+(APIServer pid=1913)     args.dispatch_function(args)
+
+(APIServer pid=1913)   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/cli/serve.py", line 148, in cmd
+
+(APIServer pid=1913)     uvloop.run(run_server(args))
+
+(APIServer pid=1913)   File "/usr/local/lib/python3.12/dist-packages/uvloop/__init__.py", line 96, in run
+
+(APIServer pid=1913)     return __asyncio.run(
+
+(APIServer pid=1913)            ^^^^^^^^^^^^^^
+
+(APIServer pid=1913)   File "/usr/lib/python3.12/asyncio/runners.py", line 195, in run
+
+(APIServer pid=1913)     return runner.run(main)
+
+(APIServer pid=1913)            ^^^^^^^^^^^^^^^^
+
+(APIServer pid=1913)   File "/usr/lib/python3.12/asyncio/runners.py", line 118, in run
+
+(APIServer pid=1913)     return self._loop.run_until_complete(task)
+
+(APIServer pid=1913)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(APIServer pid=1913)   File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
+
+(APIServer pid=1913)   File "/usr/local/lib/python3.12/dist-packages/uvloop/__init__.py", line 48, in wrapper
+
+(APIServer pid=1913)     return await main
+
+(APIServer pid=1913)            ^^^^^^^^^^
+
+(APIServer pid=1913)   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/api_server.py", line 658, in run_server
+
+(APIServer pid=1913)     await run_server_worker(listen_address, sock, args, **uvicorn_kwargs)
+
+(APIServer pid=1913)   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/api_server.py", line 672, in run_server_worker
+
+(APIServer pid=1913)     async with build_async_engine_client(
+
+(APIServer pid=1913)                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(APIServer pid=1913)   File "/usr/lib/python3.12/contextlib.py", line 210, in __aenter__
+
+(APIServer pid=1913)     return await anext(self.gen)
+
+(APIServer pid=1913)            ^^^^^^^^^^^^^^^^^^^^^
+
+(APIServer pid=1913)   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/api_server.py", line 99, in build_async_engine_client
+
+(APIServer pid=1913)     async with build_async_engine_client_from_engine_args(
+
+(APIServer pid=1913)                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(APIServer pid=1913)   File "/usr/lib/python3.12/contextlib.py", line 210, in __aenter__
+
+(APIServer pid=1913)     return await anext(self.gen)
+
+(APIServer pid=1913)            ^^^^^^^^^^^^^^^^^^^^^
+
+(APIServer pid=1913)   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/api_server.py", line 135, in build_async_engine_client_from_engine_args
+
+(APIServer pid=1913)     async_llm = AsyncLLM.from_vllm_config(
+
+(APIServer pid=1913)                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(APIServer pid=1913)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/async_llm.py", line 217, in from_vllm_config
+
+(APIServer pid=1913)     return cls(
+
+(APIServer pid=1913)            ^^^^
+
+(APIServer pid=1913)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/async_llm.py", line 146, in __init__
+
+(APIServer pid=1913)     self.engine_core = EngineCoreClient.make_async_mp_client(
+
+(APIServer pid=1913)                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(APIServer pid=1913)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core_client.py", line 132, in make_async_mp_client
+
+(APIServer pid=1913)     return AsyncMPClient(*client_args)
+
+(APIServer pid=1913)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+(APIServer pid=1913)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core_client.py", line 963, in __init__
+
+(APIServer pid=1913)     super().__init__(
+
+(APIServer pid=1913)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core_client.py", line 573, in __init__
+
+(APIServer pid=1913)     with launch_core_engines(
+
+(APIServer pid=1913)          ^^^^^^^^^^^^^^^^^^^^
+
+(APIServer pid=1913)   File "/usr/lib/python3.12/contextlib.py", line 144, in __exit__
+
+(APIServer pid=1913)     next(self.gen)
+
+(APIServer pid=1913)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/utils.py", line 1190, in launch_core_engines
+
+(APIServer pid=1913)     wait_for_engine_startup(
+
+(APIServer pid=1913)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/utils.py", line 1249, in wait_for_engine_startup
+
+(APIServer pid=1913)     raise RuntimeError(
+
+(APIServer pid=1913) RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
+
+[RemoteOpenAIServer] Sent SIGTERM to process 1913
+
+[RemoteOpenAIServer] Server 1913 terminated gracefully
+
+FAILED
+
+compile/test_aot_compile.py::test_gpt2_cache_hit INFO 06-19 12:57:29 [api_utils.py:273] non-default args: {'max_model_len': 256, 'disable_log_stats': True, 'compilation_config': {'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': [], 'ir_enable_torch_wrap': None, 'splitting_ops': None, 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': None, 'compile_ranges_endpoints': None, 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': None, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': None, 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': None, 'pass_config': {}, 'max_cudagraph_capture_size': None, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': None, 'static_all_moe_layers': []}, 'model': 'gpt2'}
+
+WARNING 06-19 12:57:29 [envs.py:2005] Unknown vLLM environment variable detected: VLLM_TEST_SPAWN_CHILD
+
+INFO 06-19 12:57:38 [model.py:598] Resolved architecture: GPT2LMHeadModel
+
+INFO 06-19 12:57:39 [model.py:2060] Downcasting torch.float32 to torch.bfloat16.
+
+INFO 06-19 12:57:39 [model.py:1725] Using max model len 256
+
+INFO 06-19 12:57:39 [scheduler.py:252] Chunked prefill is enabled with max_num_batched_tokens=8192.
+
+INFO 06-19 12:57:39 [vllm.py:1009] Asynchronous scheduling is enabled.
+
+INFO 06-19 12:57:39 [kernel.py:274] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
+
+WARNING 06-19 12:57:41 [system_utils.py:157] We must use the `spawn` multiprocessing start method. Overriding VLLM_WORKER_MULTIPROC_METHOD to 'spawn'. See https://docs.vllm.ai/en/latest/usage/troubleshooting.html#python-multiprocessing for more information. Reasons: CUDA is initialized
+
+(EngineCore pid=3125) INFO 06-19 12:57:48 [core.py:114] Initializing a V1 LLM engine (v0.23.1rc1.dev169+g14ee052ee) with config: model='gpt2', speculative_config=None, tokenizer='gpt2', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=256, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=None, quantization_config=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False, jit_monitor_verbose=False), seed=0, served_model_name=gpt2, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'ir_enable_torch_wrap': True, 'splitting_ops': ['vllm::unified_attention_with_output', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::qwen_gdn_attention_core', 'vllm::gdn_attention_core_xpu', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::deepseek_v4_attention', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': [], 'compile_ranges_endpoints': [8192], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_rope_kvcache_cat_mla': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 512, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': False, 'static_all_moe_layers': []}, kernel_config=KernelConfig(ir_op_priority=IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native']), enable_flashinfer_autotune=True, moe_backend='auto', linear_backend='auto')
+
+(EngineCore pid=3125) INFO 06-19 12:57:48 [parallel_state.py:1568] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://172.17.0.2:51079 backend=nccl
+
+(EngineCore pid=3125) INFO 06-19 12:57:48 [parallel_state.py:1903] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A
+
+(EngineCore pid=3125) INFO 06-19 12:57:49 [topk_topp_sampler.py:55] Using FlashInfer for top-p & top-k sampling.
+
+(EngineCore pid=3125) INFO 06-19 12:57:49 [gpu_model_runner.py:5148] Starting to load model gpt2...
+
+(EngineCore pid=3125) INFO 06-19 12:57:49 [cuda.py:436] Using FLASH_ATTN attention backend out of potential backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION'].
+
+(EngineCore pid=3125) INFO 06-19 12:57:49 [flash_attn.py:670] Using FlashAttention version 3
+
+(EngineCore pid=3125) INFO 06-19 12:57:52 [weight_utils.py:574] No model.safetensors.index.json found in remote.
+
+(EngineCore pid=3125) INFO 06-19 12:57:52 [weight_utils.py:849] Filesystem type for checkpoints: NFS. Checkpoint size: 0.51 GiB. Available RAM: 1897.64 GiB.
+
+(EngineCore pid=3125) INFO 06-19 12:57:52 [weight_utils.py:811] Prefetching checkpoint files into page cache started (in background, num_threads=8, block_size=16777216 bytes)
+
+(EngineCore pid=3125)
+Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
+
+(EngineCore pid=3125) INFO 06-19 12:57:52 [weight_utils.py:783] Prefetching checkpoint files: 10% (1/1)
+
+(EngineCore pid=3125) INFO 06-19 12:57:52 [weight_utils.py:806] Prefetching checkpoint files into page cache finished in 0.12s
+
+(EngineCore pid=3125)
+Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  5.46it/s]
+
+(EngineCore pid=3125)
+Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  5.45it/s]
+
+(EngineCore pid=3125)
+
+(EngineCore pid=3125) INFO 06-19 12:57:52 [default_loader.py:430] Loading weights took 0.20 seconds
+
+(EngineCore pid=3125) INFO 06-19 12:57:52 [gpu_model_runner.py:5243] Model loading took 0.24 GiB memory and 2.352527 seconds
+
+(EngineCore pid=3125) INFO 06-19 12:57:54 [backends.py:1089] Using cache directory: /tmp/tmpqrvbt0nz/torch_compile_cache/8cbce09549/rank_0_0/backbone for vLLM's torch.compile
+
+(EngineCore pid=3125) INFO 06-19 12:57:54 [backends.py:1148] Dynamo bytecode transform time: 1.27 s
+
+(EngineCore pid=3125) INFO 06-19 12:57:57 [backends.py:393] Compiling a graph for compile range (1, 8192) takes 2.38 s
+
+(EngineCore pid=3125) INFO 06-19 12:57:58 [backends.py:915] collected artifacts: 13 entries, 3 artifacts, 2962014 bytes total
+
+(EngineCore pid=3125) INFO 06-19 12:57:58 [decorators.py:708] saved AOT compiled function to /tmp/tmpqrvbt0nz/torch_compile_cache/torch_aot_compile/8a780ed0de8084eb85e5f243455c7a5c391a3dddf699cba509306157f21f19c0/rank_0_0/model
+
+(EngineCore pid=3125) INFO 06-19 12:57:58 [monitor.py:53] torch.compile took 4.75 s in total
+
+(EngineCore pid=3125) INFO 06-19 12:57:58 [monitor.py:81] Initial profiling/warmup run took 0.08 s
+
+(EngineCore pid=3125) INFO 06-19 12:58:09 [gpu_model_runner.py:6471] Profiling CUDA graph memory: PIECEWISE=51 (largest=512), FULL=35 (largest=256)
+
+(EngineCore pid=3125) INFO 06-19 12:58:10 [gpu_model_runner.py:6576] Estimated CUDA graph memory: 0.14 GiB total
+
+(EngineCore pid=3125) INFO 06-19 12:58:10 [gpu_worker.py:480] Available KV cache memory: 29.13 GiB
+
+(EngineCore pid=3125) INFO 06-19 12:58:10 [gpu_worker.py:495] CUDA graph memory profiling is enabled (default since v0.21.0). The current --gpu-memory-utilization=0.9200 is equivalent to --gpu-memory-utilization=0.9156 without CUDA graph memory profiling. To maintain the same effective KV cache size as before, increase --gpu-memory-utilization to 0.9244. To disable, set VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0.
+
+(EngineCore pid=3125) INFO 06-19 12:58:10 [kv_cache_utils.py:2078] GPU KV cache size: 848,512 tokens
+
+(EngineCore pid=3125) INFO 06-19 12:58:10 [kv_cache_utils.py:2079] Maximum concurrency for 256 tokens per request: 3314.50x
+
+(EngineCore pid=3125) INFO 06-19 12:58:10 [deep_gemm.py:160] deep_gemm not found in site-packages, trying vendored vllm.third_party.deep_gemm
+
+(EngineCore pid=3125) INFO 06-19 12:58:10 [deep_gemm.py:187] DeepGEMM PDL enabled on vllm.third_party.deep_gemm.
+
+(EngineCore pid=3125) 2026-06-19 12:58:10,909 - INFO - autotuner.py:622 - flashinfer.jit: [Autotuner]: Autotuning process starts ...
+
+(EngineCore pid=3125) 2026-06-19 12:58:10,914 - INFO - autotuner.py:641 - flashinfer.jit: [Autotuner]: Autotuning process ends
+
+(EngineCore pid=3125)
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):   0%|                                                                           | 0/51 [00:00<?, ?it/s]
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  16%|██████████▌                                                        | 8/51 [00:00<00:00, 75.67it/s]
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  31%|████████████████████▋                                             | 16/51 [00:00<00:00, 70.02it/s]
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  49%|████████████████████████████████▎                                 | 25/51 [00:00<00:00, 74.87it/s]
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  65%|██████████████████████████████████████████▋                       | 33/51 [00:00<00:00, 75.42it/s]
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  80%|█████████████████████████████████████████████████████             | 41/51 [00:00<00:00, 74.53it/s]
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  96%|███████████████████████████████████████████████████████████████▍  | 49/51 [00:00<00:00, 71.59it/s]
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|██████████████████████████████████████████████████████████████████| 51/51 [00:00<00:00, 71.93it/s]
+
+(EngineCore pid=3125)
+Capturing CUDA graphs (decode, FULL):   0%|                                                                                              | 0/35 [00:00<?, ?it/s]
+Capturing CUDA graphs (decode, FULL):  26%|██████████████████████                                                                | 9/35 [00:00<00:00, 81.52it/s]
+Capturing CUDA graphs (decode, FULL):  54%|██████████████████████████████████████████████▏                                      | 19/35 [00:00<00:00, 91.21it/s]
+Capturing CUDA graphs (decode, FULL):  86%|████████████████████████████████████████████████████████████████████████▊            | 30/35 [00:00<00:00, 99.05it/s]
+Capturing CUDA graphs (decode, FULL): 100%|█████████████████████████████████████████████████████████████████████████████████████| 35/35 [00:00<00:00, 98.08it/s]
+
+(EngineCore pid=3125) INFO 06-19 12:58:12 [gpu_model_runner.py:6644] Graph capturing finished in 2 secs, took 0.18 GiB
+
+(EngineCore pid=3125) INFO 06-19 12:58:12 [gpu_worker.py:639] CUDA graph pool memory: 0.18 GiB (actual), 0.14 GiB (estimated), difference: 0.04 GiB (20.7%).
+
+(EngineCore pid=3125) INFO 06-19 12:58:12 [jit_monitor.py:60] Kernel JIT monitor activated — Triton JIT compilations during inference will be logged as warnings.
+
+(EngineCore pid=3125) INFO 06-19 12:58:13 [core.py:337] init engine (profile, create kv cache, warmup model) took 20.22 s (compilation: 4.75 s)
+
+(EngineCore pid=3125) WARNING 06-19 12:58:15 [serial_utils.py:79] Allowing insecure serialization using pickle due to VLLM_ALLOW_INSECURE_SERIALIZATION=1
+
+(EngineCore pid=3125) INFO 06-19 12:58:15 [vllm.py:1009] Asynchronous scheduling is enabled.
+
+WARNING 06-19 12:58:15 [serial_utils.py:79] Allowing insecure serialization using pickle due to VLLM_ALLOW_INSECURE_SERIALIZATION=1
+
+(EngineCore pid=3125) INFO 06-19 12:58:15 [kernel.py:274] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
+
+
+Rendering prompts:   0%|                                                                                                                  | 0/1 [00:00<?, ?it/s]
+Rendering prompts: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 41.81it/s]
+
+
+Processed prompts:   0%|                                                              | 0/1 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s](EngineCore pid=3125) WARNING 06-19 12:58:15 [jit_monitor.py:106] Triton kernel JIT compilation during inference: _compute_slot_mapping_kernel. This causes a latency spike; consider extending warmup to cover this shape/config.
+
+
+Processed prompts: 100%|███████████████████████████████████████████████████| 1/1 [00:00<00:00,  6.83it/s, est. speed input: 34.14 toks/s, output: 109.23 toks/s]
+Processed prompts: 100%|███████████████████████████████████████████████████| 1/1 [00:00<00:00,  6.83it/s, est. speed input: 34.14 toks/s, output: 109.23 toks/s]
+Processed prompts: 100%|███████████████████████████████████████████████████| 1/1 [00:00<00:00,  6.81it/s, est. speed input: 34.14 toks/s, output: 109.23 toks/s]
+
+(EngineCore pid=3125) INFO 06-19 12:58:15 [core.py:1212] [shutdown] EngineCore: trigger received signal=SIGTERM
+
+(EngineCore pid=3125) INFO 06-19 12:58:15 [core.py:1331] [shutdown] EngineCore: start mode=abort timeout=0s
+
+(EngineCore pid=3125) INFO 06-19 12:58:15 [core.py:1362] [shutdown] EngineCore: request processing complete; starting resource teardown
+
+(EngineCore pid=3125) INFO 06-19 12:58:15 [core.py:1225] [shutdown] EngineCore: exiting busy loop
+
+INFO 06-19 12:58:18 [api_utils.py:273] non-default args: {'max_model_len': 256, 'disable_log_stats': True, 'compilation_config': {'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': [], 'ir_enable_torch_wrap': None, 'splitting_ops': None, 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': None, 'compile_ranges_endpoints': None, 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': None, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': None, 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': None, 'pass_config': {}, 'max_cudagraph_capture_size': None, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': None, 'static_all_moe_layers': []}, 'model': 'gpt2'}
+
+WARNING 06-19 12:58:18 [envs.py:2005] Unknown vLLM environment variable detected: VLLM_TEST_SPAWN_CHILD
+
+INFO 06-19 12:58:19 [model.py:598] Resolved architecture: GPT2LMHeadModel
+
+INFO 06-19 12:58:20 [model.py:2060] Downcasting torch.float32 to torch.bfloat16.
+
+INFO 06-19 12:58:20 [model.py:1725] Using max model len 256
+
+INFO 06-19 12:58:20 [kernel.py:274] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
+
+(EngineCore pid=3733) INFO 06-19 12:58:27 [core.py:114] Initializing a V1 LLM engine (v0.23.1rc1.dev169+g14ee052ee) with config: model='gpt2', speculative_config=None, tokenizer='gpt2', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=256, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=None, quantization_config=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False, jit_monitor_verbose=False), seed=0, served_model_name=gpt2, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'ir_enable_torch_wrap': True, 'splitting_ops': ['vllm::unified_attention_with_output', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::qwen_gdn_attention_core', 'vllm::gdn_attention_core_xpu', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::deepseek_v4_attention', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': [], 'compile_ranges_endpoints': [8192], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_rope_kvcache_cat_mla': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 512, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': False, 'static_all_moe_layers': []}, kernel_config=KernelConfig(ir_op_priority=IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native']), enable_flashinfer_autotune=True, moe_backend='auto', linear_backend='auto')
+
+(EngineCore pid=3733) INFO 06-19 12:58:27 [parallel_state.py:1568] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://172.17.0.2:54387 backend=nccl
+
+(EngineCore pid=3733) INFO 06-19 12:58:27 [parallel_state.py:1903] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A
+
+(EngineCore pid=3733) INFO 06-19 12:58:28 [topk_topp_sampler.py:55] Using FlashInfer for top-p & top-k sampling.
+
+(EngineCore pid=3733) INFO 06-19 12:58:28 [gpu_model_runner.py:5148] Starting to load model gpt2...
+
+(EngineCore pid=3733) INFO 06-19 12:58:28 [cuda.py:436] Using FLASH_ATTN attention backend out of potential backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION'].
+
+(EngineCore pid=3733) INFO 06-19 12:58:28 [flash_attn.py:670] Using FlashAttention version 3
+
+(EngineCore pid=3733) INFO 06-19 12:58:31 [weight_utils.py:574] No model.safetensors.index.json found in remote.
+
+(EngineCore pid=3733) INFO 06-19 12:58:31 [weight_utils.py:849] Filesystem type for checkpoints: NFS. Checkpoint size: 0.51 GiB. Available RAM: 1897.66 GiB.
+
+(EngineCore pid=3733) INFO 06-19 12:58:31 [weight_utils.py:811] Prefetching checkpoint files into page cache started (in background, num_threads=8, block_size=16777216 bytes)
+
+(EngineCore pid=3733)
+Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
+
+(EngineCore pid=3733) INFO 06-19 12:58:31 [weight_utils.py:783] Prefetching checkpoint files: 10% (1/1)
+
+(EngineCore pid=3733) INFO 06-19 12:58:31 [weight_utils.py:806] Prefetching checkpoint files into page cache finished in 0.13s
+
+(EngineCore pid=3733)
+Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  4.95it/s]
+
+(EngineCore pid=3733)
+Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  4.95it/s]
+
+(EngineCore pid=3733)
+
+(EngineCore pid=3733) INFO 06-19 12:58:31 [default_loader.py:430] Loading weights took 0.22 seconds
+
+(EngineCore pid=3733) INFO 06-19 12:58:31 [gpu_model_runner.py:5243] Model loading took 0.24 GiB memory and 2.381435 seconds
+
+(EngineCore pid=3733) INFO 06-19 12:58:33 [caching.py:335] reconstructed serializable fn from standalone compile artifacts. num_artifacts=3 num_submods=13
+
+(EngineCore pid=3733) INFO 06-19 12:58:33 [decorators.py:311] Directly load AOT compilation from path /tmp/tmpqrvbt0nz/torch_compile_cache/torch_aot_compile/8a780ed0de8084eb85e5f243455c7a5c391a3dddf699cba509306157f21f19c0/rank_0_0/model
+
+(EngineCore pid=3733) INFO 06-19 12:58:33 [monitor.py:53] torch.compile took 0.56 s in total
+
+(EngineCore pid=3733) INFO 06-19 12:58:33 [monitor.py:81] Initial profiling/warmup run took 0.08 s
+
+(EngineCore pid=3733) INFO 06-19 12:58:33 [gpu_model_runner.py:6471] Profiling CUDA graph memory: PIECEWISE=51 (largest=512), FULL=35 (largest=256)
+
+(EngineCore pid=3733) INFO 06-19 12:58:34 [gpu_model_runner.py:6576] Estimated CUDA graph memory: 0.14 GiB total
+
+(EngineCore pid=3733) INFO 06-19 12:58:35 [gpu_worker.py:480] Available KV cache memory: 29.13 GiB
+
+(EngineCore pid=3733) INFO 06-19 12:58:35 [gpu_worker.py:495] CUDA graph memory profiling is enabled (default since v0.21.0). The current --gpu-memory-utilization=0.9200 is equivalent to --gpu-memory-utilization=0.9156 without CUDA graph memory profiling. To maintain the same effective KV cache size as before, increase --gpu-memory-utilization to 0.9244. To disable, set VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0.
+
+(EngineCore pid=3733) INFO 06-19 12:58:35 [kv_cache_utils.py:2078] GPU KV cache size: 848,512 tokens
+
+(EngineCore pid=3733) INFO 06-19 12:58:35 [kv_cache_utils.py:2079] Maximum concurrency for 256 tokens per request: 3314.50x
+
+(EngineCore pid=3733) INFO 06-19 12:58:35 [deep_gemm.py:160] deep_gemm not found in site-packages, trying vendored vllm.third_party.deep_gemm
+
+(EngineCore pid=3733) INFO 06-19 12:58:35 [deep_gemm.py:187] DeepGEMM PDL enabled on vllm.third_party.deep_gemm.
+
+(EngineCore pid=3733) 2026-06-19 12:58:35,181 - INFO - autotuner.py:622 - flashinfer.jit: [Autotuner]: Autotuning process starts ...
+
+(EngineCore pid=3733) 2026-06-19 12:58:35,185 - INFO - autotuner.py:641 - flashinfer.jit: [Autotuner]: Autotuning process ends
+
+(EngineCore pid=3733)
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):   0%|                                                                           | 0/51 [00:00<?, ?it/s]
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  16%|██████████▌                                                        | 8/51 [00:00<00:00, 78.88it/s]
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  31%|████████████████████▋                                             | 16/51 [00:00<00:00, 71.19it/s]
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  49%|████████████████████████████████▎                                 | 25/51 [00:00<00:00, 76.00it/s]
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  65%|██████████████████████████████████████████▋                       | 33/51 [00:00<00:00, 76.72it/s]
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  80%|█████████████████████████████████████████████████████             | 41/51 [00:00<00:00, 75.84it/s]
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  96%|███████████████████████████████████████████████████████████████▍  | 49/51 [00:00<00:00, 72.83it/s]
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|██████████████████████████████████████████████████████████████████| 51/51 [00:00<00:00, 73.06it/s]
+
+(EngineCore pid=3733)
+Capturing CUDA graphs (decode, FULL):   0%|                                                                                              | 0/35 [00:00<?, ?it/s]
+Capturing CUDA graphs (decode, FULL):  26%|██████████████████████                                                                | 9/35 [00:00<00:00, 83.08it/s]
+Capturing CUDA graphs (decode, FULL):  57%|████████████████████████████████████████████████▌                                    | 20/35 [00:00<00:00, 94.10it/s]
+Capturing CUDA graphs (decode, FULL):  91%|████████████████████████████████████████████████████████████████████████████▊       | 32/35 [00:00<00:00, 103.17it/s]
+Capturing CUDA graphs (decode, FULL): 100%|████████████████████████████████████████████████████████████████████████████████████| 35/35 [00:00<00:00, 101.03it/s]
+
+(EngineCore pid=3733) INFO 06-19 12:58:36 [gpu_model_runner.py:6644] Graph capturing finished in 2 secs, took 0.18 GiB
+
+(EngineCore pid=3733) INFO 06-19 12:58:36 [gpu_worker.py:639] CUDA graph pool memory: 0.18 GiB (actual), 0.14 GiB (estimated), difference: 0.04 GiB (20.7%).
+
+(EngineCore pid=3733) INFO 06-19 12:58:36 [jit_monitor.py:60] Kernel JIT monitor activated — Triton JIT compilations during inference will be logged as warnings.
+
+(EngineCore pid=3733) INFO 06-19 12:58:37 [core.py:337] init engine (profile, create kv cache, warmup model) took 5.29 s (compilation: 0.56 s)
+
+(EngineCore pid=3733) WARNING 06-19 12:58:39 [serial_utils.py:79] Allowing insecure serialization using pickle due to VLLM_ALLOW_INSECURE_SERIALIZATION=1
+
+(EngineCore pid=3733) INFO 06-19 12:58:39 [vllm.py:1009] Asynchronous scheduling is enabled.
+
+(EngineCore pid=3733) INFO 06-19 12:58:39 [kernel.py:274] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
+
+
+Rendering prompts:   0%|                                                                                                                  | 0/1 [00:00<?, ?it/s]
+Rendering prompts: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 1344.33it/s]
+
+
+Processed prompts:   0%|                                                              | 0/1 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s](EngineCore pid=3733) WARNING 06-19 12:58:39 [jit_monitor.py:106] Triton kernel JIT compilation during inference: _compute_slot_mapping_kernel. This causes a latency spike; consider extending warmup to cover this shape/config.
+
+
+Processed prompts: 100%|██████████████████████████████████████████████████| 1/1 [00:00<00:00, 22.78it/s, est. speed input: 113.97 toks/s, output: 364.60 toks/s]
+Processed prompts: 100%|██████████████████████████████████████████████████| 1/1 [00:00<00:00, 22.70it/s, est. speed input: 113.97 toks/s, output: 364.60 toks/s]
+
+(EngineCore pid=3733) INFO 06-19 12:58:39 [core.py:1212] [shutdown] EngineCore: trigger received signal=SIGTERM
+
+(EngineCore pid=3733) INFO 06-19 12:58:39 [core.py:1331] [shutdown] EngineCore: start mode=abort timeout=0s
+
+(EngineCore pid=3733) INFO 06-19 12:58:39 [core.py:1362] [shutdown] EngineCore: request processing complete; starting resource teardown
+
+(EngineCore pid=3733) INFO 06-19 12:58:39 [core.py:1225] [shutdown] EngineCore: exiting busy loop
+
+PASSED
+
+compile/test_aot_compile.py::TestStandaloneCompiledArtifacts::test_init PASSED
+
+compile/test_aot_compile.py::TestStandaloneCompiledArtifacts::test_insert_new_artifact PASSED
+
+compile/test_aot_compile.py::TestStandaloneCompiledArtifacts::test_insert_duplicate_artifact PASSED
+
+compile/test_aot_compile.py::TestStandaloneCompiledArtifacts::test_get_artifact PASSED
+
+compile/test_aot_compile.py::TestStandaloneCompiledArtifacts::test_get_nonexistent_artifact PASSED
+
+compile/test_aot_compile.py::TestStandaloneCompiledArtifacts::test_size_bytes PASSED
+
+compile/test_aot_compile.py::TestStandaloneCompiledArtifacts::test_num_artifacts_and_entries PASSED
+
+compile/test_aot_compile.py::TestStandaloneCompiledArtifacts::test_load_all_success PASSED
+
+compile/test_aot_compile.py::TestStandaloneCompiledArtifacts::test_load_all_already_loaded PASSED
+
+compile/test_aot_compile.py::TestStandaloneCompiledArtifacts::test_get_loaded_artifact PASSED
+
+compile/test_aot_compile.py::TestStandaloneCompiledArtifacts::test_getstate_setstate PASSED
+
+compile/test_aot_compile.py::TestStandaloneCompiledArtifacts::test_pickle_roundtrip PASSED
+
+compile/test_aot_compile.py::TestStandaloneCompiledArtifactsIntegration::test_add_pickle_unpickle PASSED
+
+compile/test_aot_compile.py::TestStandaloneCompiledArtifactsIntegration::test_deduplication PASSED
+
+compile/test_aot_compile.py::TestStandaloneCompiledArtifactsIntegration::test_functorch_config SKIPPED (There's no AOT Autograd run with mega artifact)
+
+compile/test_aot_compile.py::test_disable_compile_cache_skips_aot_save INFO 06-19 12:58:55 [kernel.py:274] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
+
+INFO 06-19 12:59:00 [backends.py:1087] vLLM's torch.compile cache is disabled.
+
+INFO 06-19 12:59:00 [backends.py:1148] Dynamo bytecode transform time: 5.06 s
+
+INFO 06-19 12:59:25 [backends.py:393] Compiling a graph for compile range (1, 2048) takes 25.31 s
+
+INFO 06-19 12:59:25 [monitor.py:53] torch.compile took 30.55 s in total
+
+INFO 06-19 12:59:25 [monitor.py:81] Initial profiling/warmup run took 0.00 s
+
+PASSED
+
+compile/test_aot_compile.py::test_disable_compile_cache_skips_aot_load INFO 06-19 12:59:26 [kernel.py:274] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
+
+INFO 06-19 12:59:31 [backends.py:1089] Using cache directory: /tmp/tmp1fblfz9_/torch_compile_cache/6a60afcec8/rank_0_0/backbone for vLLM's torch.compile
+
+INFO 06-19 12:59:31 [backends.py:1148] Dynamo bytecode transform time: 4.64 s
+
+INFO 06-19 12:59:57 [backends.py:393] Compiling a graph for compile range (1, 2048) takes 26.32 s
+
+INFO 06-19 13:00:00 [backends.py:915] collected artifacts: 1 entries, 1 artifacts, 1208682 bytes total
+
+INFO 06-19 13:00:01 [decorators.py:708] saved AOT compiled function to /tmp/tmp1fblfz9_/torch_compile_cache/torch_aot_compile/eec6b546a34017af8023b479aac622f33e38dd6e3a5a638a27fc370610af5e64/rank_0_0/model
+
+INFO 06-19 13:00:01 [monitor.py:53] torch.compile took 34.09 s in total
+
+INFO 06-19 13:00:01 [monitor.py:81] Initial profiling/warmup run took 0.00 s
+
+INFO 06-19 13:00:01 [kernel.py:274] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
+
+INFO 06-19 13:00:05 [backends.py:1148] Dynamo bytecode transform time: 4.60 s
+
+INFO 06-19 13:00:30 [backends.py:393] Compiling a graph for compile range (1, 2048) takes 24.59 s
+
+INFO 06-19 13:00:30 [monitor.py:53] torch.compile took 29.36 s in total
+
+INFO 06-19 13:00:30 [monitor.py:81] Initial profiling/warmup run took 0.00 s
+
+PASSED
+
+compile/test_aot_compile.py::test_aot_counters_on_save_and_load INFO 06-19 13:00:31 [kernel.py:274] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
+
+INFO 06-19 13:00:37 [backends.py:1089] Using cache directory: /tmp/tmp4mg38qcj/torch_compile_cache/6a60afcec8/rank_0_0/backbone for vLLM's torch.compile
+
+INFO 06-19 13:00:37 [backends.py:1148] Dynamo bytecode transform time: 5.65 s
+
+INFO 06-19 13:01:04 [backends.py:393] Compiling a graph for compile range (1, 2048) takes 26.66 s
+
+INFO 06-19 13:01:05 [backends.py:915] collected artifacts: 1 entries, 1 artifacts, 1208682 bytes total
+
+INFO 06-19 13:01:05 [decorators.py:708] saved AOT compiled function to /tmp/tmp4mg38qcj/torch_compile_cache/torch_aot_compile/eec6b546a34017af8023b479aac622f33e38dd6e3a5a638a27fc370610af5e64/rank_0_0/model
+
+INFO 06-19 13:01:05 [monitor.py:53] torch.compile took 34.23 s in total
+
+INFO 06-19 13:01:05 [monitor.py:81] Initial profiling/warmup run took 0.00 s
+
+INFO 06-19 13:01:05 [kernel.py:274] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
+
+INFO 06-19 13:01:05 [caching.py:335] reconstructed serializable fn from standalone compile artifacts. num_artifacts=1 num_submods=1
+
+INFO 06-19 13:01:05 [decorators.py:311] Directly load AOT compilation from path /tmp/tmp4mg38qcj/torch_compile_cache/torch_aot_compile/eec6b546a34017af8023b479aac622f33e38dd6e3a5a638a27fc370610af5e64/rank_0_0/model
+
+INFO 06-19 13:01:05 [monitor.py:53] torch.compile took 0.02 s in total
+
+INFO 06-19 13:01:05 [monitor.py:81] Initial profiling/warmup run took 0.00 s
+
+PASSED
+
+
+
+=========================================================================== FAILURES ===========================================================================
+
+_____________________________________________________________ test_standalone_compile_correctness ______________________________________________________________
+
+
+
+args = (), kwargs = {}, tmp = <tempfile._TemporaryFileWrapper object at 0x7f13eee22540>, tb_file = '/tmp/tmpg1dwqb72.tb'
+
+payload = b'\x80\x05\x95\x93\x00\x00\x00\x00\x00\x00\x00}\x94(\x8c\x06module\x94\x8c\x1etests.compile.test_aot_compile\x94\x8c\x...ne_compile_correctness\x94\x8c\x04args\x94)\x8c\x06kwargs\x94}\x94\x8c\x07tb_file\x94\x8c\x13/tmp/tmpg1dwqb72.tb\x94u.'
+
+child_script = "import sys, importlib, cloudpickle, traceback\ntry:\n    from _pytest.outcomes import Skipped\nexcept ImportError:\n ...aseException:\n    with open(data['tb_file'], 'w') as fp:\n        fp.write(traceback.format_exc())\n    sys.exit(1)\n"
+
+repo_root = '/vllm-workspace'
+
+env = {'BUILDKITE': 'true', 'BUILDKITE_AGENT_ID': '019e4741-91e2-402b-a854-f71d14a714ef', 'BUILDKITE_AGENT_META_DATA_QUEUE': 'h200_35gb', 'BUILDKITE_AGENT_NAME': 'h200-ci-6-10', ...}
+
+result = CompletedProcess(args=['/usr/bin/python3', '-c', "import sys, importlib, cloudpickle, traceback\ntry:\n    from _pytes...   with open(data['tb_file'], 'w') as fp:\n        fp.write(traceback.format_exc())\n    sys.exit(1)\n"], returncode=1)
+
+fp = <_io.TextIOWrapper name='/tmp/tmpg1dwqb72.tb' mode='r' encoding='utf-8'>
+
+tb = 'Traceback (most recent call last):\n  File "<string>", line 12, in <module>\n  File "/vllm-workspace/tests/utils.py",...r_server\n    raise RuntimeError("Server exited unexpectedly.") from None\nRuntimeError: Server exited unexpectedly.\n'
+
+
+
+    @functools.wraps(f)
+
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> None:
+
+        if os.environ.get(_SPAWN_CHILD_ENV) == "1":
+
+            return f(*args, **kwargs)
+
+
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".tb", mode="wb") as tmp:
+
+            tb_file = tmp.name
+
+
+
+        try:
+
+            payload = cloudpickle.dumps(
+
+                {
+
+                    "module": f.__module__,
+
+                    "qualname": f.__qualname__,
+
+                    "args": args,
+
+                    "kwargs": kwargs,
+
+                    "tb_file": tb_file,
+
+                }
+
+            )
+
+
+
+            child_script = (
+
+                "import sys, importlib, cloudpickle, traceback\n"
+
+                "try:\n"
+
+                "    from _pytest.outcomes import Skipped\n"
+
+                "except ImportError:\n"
+
+                "    class Skipped(BaseException): pass\n"
+
+                "data = cloudpickle.loads(sys.stdin.buffer.read())\n"
+
+                "mod = importlib.import_module(data['module'])\n"
+
+                "target = mod\n"
+
+                "for name in data['qualname'].split('.'):\n"
+
+                "    target = getattr(target, name)\n"
+
+                "try:\n"
+
+                "    target(*data['args'], **data['kwargs'])\n"
+
+                "except Skipped:\n"
+
+                "    sys.exit(0)\n"
+
+                "except BaseException:\n"
+
+                "    with open(data['tb_file'], 'w') as fp:\n"
+
+                "        fp.write(traceback.format_exc())\n"
+
+                "    sys.exit(1)\n"
+
+            )
+
+
+
+            repo_root = str(VLLM_PATH.resolve())
+
+            env = os.environ.copy()
+
+            env["PYTHONPATH"] = repo_root + os.pathsep + env.get("PYTHONPATH", "")
+
+            env[_SPAWN_CHILD_ENV] = "1"
+
+
+
+            result = subprocess.run(
+
+                [sys.executable, "-c", child_script],
+
+                input=payload,
+
+                env=env,
+
+            )
+
+
+
+            if result.returncode != 0:
+
+                try:
+
+                    with open(tb_file) as fp:
+
+                        tb = fp.read()
+
+                except OSError:
+
+                    tb = ""
+
+                if not tb:
+
+                    tb = "<no Python traceback; see subprocess output above>"
+
+>               raise RuntimeError(
+
+                    f"Test subprocess '{f.__name__}' failed "
+
+                    f"({_format_subprocess_exit(result.returncode)}):\n{tb}"
+
+                )
+
+E               RuntimeError: Test subprocess 'test_standalone_compile_correctness' failed (exit code 1):
+
+E               Traceback (most recent call last):
+
+E                 File "<string>", line 12, in <module>
+
+E                 File "/vllm-workspace/tests/utils.py", line 1739, in wrapper
+
+E                   return f(*args, **kwargs)
+
+E                          ^^^^^^^^^^^^^^^^^^
+
+E                 File "/vllm-workspace/tests/compile/test_aot_compile.py", line 463, in test_standalone_compile_correctness
+
+E                   compare_two_settings(
+
+E                 File "/vllm-workspace/tests/utils.py", line 1194, in compare_two_settings
+
+E                   compare_all_settings(
+
+E                 File "/vllm-workspace/tests/utils.py", line 1274, in compare_all_settings
+
+E                   with RemoteOpenAIServer(
+
+E                        ^^^^^^^^^^^^^^^^^^^
+
+E                 File "/vllm-workspace/tests/utils.py", line 314, in __init__
+
+E                   self._wait_for_server(url=self.url_for("health"), timeout=max_wait_seconds)
+
+E                 File "/vllm-workspace/tests/utils.py", line 700, in _wait_for_server
+
+E                   raise RuntimeError("Server exited unexpectedly.") from None
+
+E               RuntimeError: Server exited unexpectedly.
+
+
+
+utils.py:1795: RuntimeError
+
+======================================================================= warnings summary =======================================================================
+
+<frozen importlib._bootstrap>:488
+
+  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute
+
+
+
+<frozen importlib._bootstrap>:488
+
+  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute
+
+
+
+../../usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: 14 warnings
+
+  /usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
+
+    warnings.warn(
+
+
+
+../../usr/local/lib/python3.12/dist-packages/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py:2383
+
+  /usr/local/lib/python3.12/dist-packages/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py:2383: DeprecationWarning: tcgen05.OperandMajorMode is deprecated, use cute.nvgpu.OperandMajorMode instead
+
+    a_major_mode: tcgen05.OperandMajorMode,
+
+
+
+../../usr/local/lib/python3.12/dist-packages/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py:2385
+
+  /usr/local/lib/python3.12/dist-packages/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py:2385: DeprecationWarning: tcgen05.OperandMajorMode is deprecated, use cute.nvgpu.OperandMajorMode instead
+
+    b_major_mode: tcgen05.OperandMajorMode,
+
+
+
+../../usr/local/lib/python3.12/dist-packages/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py:99
+
+../../usr/local/lib/python3.12/dist-packages/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py:99
+
+  /usr/local/lib/python3.12/dist-packages/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py:99: DeprecationWarning: tcgen05.OperandMajorMode is deprecated, use cute.nvgpu.OperandMajorMode instead
+
+    from cutlass.cute.nvgpu.tcgen05 import OperandMajorMode
+
+
+
+../../usr/local/lib/python3.12/dist-packages/schemathesis/generation/coverage.py:305
+
+  /usr/local/lib/python3.12/dist-packages/schemathesis/generation/coverage.py:305: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
+
+    ref_error: type[Exception] = jsonschema.RefResolutionError,
+
+
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+
+=================================================================== short test summary info ====================================================================
+
+FAILED compile/test_aot_compile.py::test_standalone_compile_correctness - RuntimeError: Test subprocess 'test_standalone_compile_correctness' failed (exit code 1):
+
+Traceback (most recent call last):
+
+  File "<string>", line 12, in <module>
+
+  File "/vllm-workspace/tests/utils.py", line 1739, in wrapper
+
+    return f(*args, **kwargs)
+
+           ^^^^^^^^^^^^^^^^^^
+
+  File "/vllm-workspace/tests/compile/test_aot_compile.py", line 463, in test_standalone_compile_correctness
+
+    compare_two_settings(
+
+  File "/vllm-workspace/tests/utils.py", line 1194, in compare_two_settings
+
+    compare_all_settings(
+
+  File "/vllm-workspace/tests/utils.py", line 1274, in compare_all_settings
+
+    with RemoteOpenAIServer(
+
+         ^^^^^^^^^^^^^^^^^^^
+
+  File "/vllm-workspace/tests/utils.py", line 314, in __init__
+
+    self._wait_for_server(url=self.url_for("health"), timeout=max_wait_seconds)
+
+  File "/vllm-workspace/tests/utils.py", line 700, in _wait_for_server
+
+    raise RuntimeError("Server exited unexpectedly.") from None
+
+RuntimeError: Server exited unexpectedly.
+
+=============================================== 1 failed, 26 passed, 1 skipped, 21 warnings in 541.92s (0:09:01) ===============================================
+
+sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
+
+/usr/local/lib/python3.12/dist-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.

--- a/tools/torchci/tests/fixtures/log_engine_cuda_init_fail.txt
+++ b/tools/torchci/tests/fixtures/log_engine_cuda_init_fail.txt
@@ -1,0 +1,100 @@
+[2026-07-13T19:39:36Z] 2026-07-13 19:32:43,259	INFO kernel.py:292 -- Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['vllm_c', 'native'], fused_add_rms_norm=['vllm_c', 'native'])
+[2026-07-13T19:39:36Z] 2026-07-13 19:32:43,259	INFO vllm.py:1371 -- Cudagraph is disabled under eager mode
+[2026-07-13T19:39:36Z] =============================== warnings summary ===============================
+[2026-07-13T19:39:36Z] <frozen importlib._bootstrap>:488
+[2026-07-13T19:39:36Z]   <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute
+[2026-07-13T19:39:36Z]
+[2026-07-13T19:39:36Z] <frozen importlib._bootstrap>:488
+[2026-07-13T19:39:36Z]   <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute
+[2026-07-13T19:39:36Z]
+[2026-07-13T19:39:36Z] ../../usr/local/lib/python3.12/dist-packages/pytest_asyncio/plugin.py:977
+[2026-07-13T19:39:36Z] ../../usr/local/lib/python3.12/dist-packages/pytest_asyncio/plugin.py:977
+[2026-07-13T19:39:36Z]   /usr/local/lib/python3.12/dist-packages/pytest_asyncio/plugin.py:977: PytestDeprecationWarning: The "scope" keyword argument to the asyncio marker has been deprecated. Please use the "loop_scope" argument instead.
+[2026-07-13T19:39:36Z]
+[2026-07-13T19:39:36Z]     warnings.warn(PytestDeprecationWarning(_MARKER_SCOPE_KWARG_DEPRECATION_WARNING))
+[2026-07-13T19:39:36Z]
+[2026-07-13T19:39:36Z] ../../usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: 14 warnings
+[2026-07-13T19:39:36Z]   /usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
+[2026-07-13T19:39:36Z]     warnings.warn(
+[2026-07-13T19:39:36Z]
+[2026-07-13T19:39:36Z] v1/engine/test_engine_core_client.py:328
+[2026-07-13T19:39:36Z]   /vllm-workspace/tests/v1/engine/test_engine_core_client.py:328: PytestCollectionWarning: cannot collect test class 'TestMessage' because it has a __init__ constructor (from: tests/v1/engine/test_engine_core_client.py)
+[2026-07-13T19:39:36Z]     @dataclass
+[2026-07-13T19:39:36Z]
+[2026-07-13T19:39:36Z] tests/v1/engine/test_abort_final_step.py: 2 warnings
+[2026-07-13T19:39:36Z] tests/v1/engine/test_async_llm.py: 29 warnings
+[2026-07-13T19:39:36Z] tests/v1/engine/test_engine_core_client.py: 7 warnings
+[2026-07-13T19:39:36Z]   /usr/lib/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=192) is multi-threaded, use of fork() may lead to deadlocks in the child.
+[2026-07-13T19:39:36Z]     self.pid = os.fork()
+[2026-07-13T19:39:36Z]
+[2026-07-13T19:39:36Z] tests/v1/engine/test_engine_core.py: 10 warnings
+[2026-07-13T19:39:36Z] tests/v1/engine/test_engine_core_client.py: 3 warnings
+[2026-07-13T19:39:36Z]   /vllm-workspace/tests/utils.py:1732: DeprecationWarning: This process (pid=192) is multi-threaded, use of fork() may lead to deadlocks in the child.
+[2026-07-13T19:39:36Z]     pid = os.fork()
+[2026-07-13T19:39:36Z]
+[2026-07-13T19:39:36Z] tests/v1/engine/test_llm_engine.py::test_parallel_sampling[False]
+[2026-07-13T19:39:36Z]   /usr/local/lib/python3.12/dist-packages/transformers/models/gpt2/tokenization_gpt2.py:110: DeprecationWarning: Deprecated in 0.9.0: BPE.__init__ will not create from files anymore, try `BPE.from_file` instead
+[2026-07-13T19:39:36Z]     BPE(
+[2026-07-13T19:39:36Z]
+[2026-07-13T19:39:36Z] -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+[2026-07-13T19:39:36Z] =========================== short test summary info ============================
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_abort_final_step.py::test_abort_during_final_step[False] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_abort_final_step.py::test_abort_during_final_step[True] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_load[engine_args0-Hello my name is Robert and-RequestOutputKind.DELTA] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_load[engine_args0-Hello my name is Robert and-RequestOutputKind.FINAL_ONLY] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_load[engine_args1-prompt1-RequestOutputKind.DELTA] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_load[engine_args1-prompt1-RequestOutputKind.FINAL_ONLY] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_abort[engine_args0-Hello my name is Robert and-RequestOutputKind.DELTA] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_abort[engine_args0-Hello my name is Robert and-RequestOutputKind.FINAL_ONLY] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_abort[engine_args1-prompt1-RequestOutputKind.DELTA] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_abort[engine_args1-prompt1-RequestOutputKind.FINAL_ONLY] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_multi_abort[RequestOutputKind.DELTA] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_multi_abort[RequestOutputKind.FINAL_ONLY] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_finished_flag[engine_args0-Hello my name is Robert and-1] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_finished_flag[engine_args0-Hello my name is Robert and-3] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_finished_flag[engine_args1-prompt1-1] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_finished_flag[engine_args1-prompt1-3] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_mid_stream_cancellation[engine_args0-Hello my name is Robert and] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_mid_stream_cancellation[engine_args1-prompt1] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_customize_loggers - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_customize_aggregated_loggers - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_dp_rank_argument - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_header_dp_rank_argument - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_check_health - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_abort_final_output[RequestOutputKind.DELTA] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_abort_final_output[RequestOutputKind.FINAL_ONLY] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_pause_resume_basic - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_pause_abort - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_pause_then_abort_queued_request - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_pause_wait - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_pause_keep_single_request - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_async_llm.py::test_pause_keep_multi_request - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_engine_core.py::test_engine_core - RuntimeError: CUDA driver initialization failed, you might not have a CUDA gpu.
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_engine_core.py::test_engine_core_advanced_sampling - RuntimeError: CUDA driver initialization failed, you might not have a CUDA gpu.
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_engine_core.py::test_engine_core_concurrent_batches - RuntimeError: CUDA driver initialization failed, you might not have a CUDA gpu.
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_engine_core.py::test_engine_core_invalid_request_id_type - RuntimeError: CUDA driver initialization failed, you might not have a CUDA gpu.
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_engine_core.py::test_encoder_instance_zero_kv_cache[False-ec_producer-0.01-False] - RuntimeError: CUDA driver initialization failed, you might not have a CUDA gpu.
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_engine_core.py::test_encoder_instance_zero_kv_cache[False-ec_consumer-0.7-True] - RuntimeError: CUDA driver initialization failed, you might not have a CUDA gpu.
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_engine_core.py::test_encoder_instance_zero_kv_cache[False-ec_consumer-0.7-False] - RuntimeError: CUDA driver initialization failed, you might not have a CUDA gpu.
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_engine_core.py::test_encoder_instance_zero_kv_cache[True-ec_producer-0.01-False] - RuntimeError: CUDA driver initialization failed, you might not have a CUDA gpu.
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_engine_core.py::test_encoder_instance_zero_kv_cache[True-ec_consumer-0.7-True] - RuntimeError: CUDA driver initialization failed, you might not have a CUDA gpu.
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_engine_core.py::test_encoder_instance_zero_kv_cache[True-ec_consumer-0.7-False] - RuntimeError: CUDA driver initialization failed, you might not have a CUDA gpu.
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_engine_core_client.py::test_engine_core_client[True] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_engine_core_client.py::test_engine_core_client[False] - RuntimeError: CUDA driver initialization failed, you might not have a CUDA gpu.
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_engine_core_client.py::test_engine_core_client_asyncio - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_engine_core_client.py::test_engine_core_client_util_method_custom_return - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_engine_core_client.py::test_engine_core_client_util_method_custom_dict_return - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_engine_core_client.py::test_engine_core_client_util_method_nested_structures - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_engine_core_client.py::test_engine_core_client_future_utility_async - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_engine_core_client.py::test_kv_cache_events[True-tcp-meta-llama/Llama-3.2-1B-Instruct-1] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] FAILED v1/engine/test_engine_core_client.py::test_kv_cache_events[True-tcp-google/gemma-3-1b-it-7] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-13T19:39:36Z] ====== 50 failed, 67 passed, 2 skipped, 71 warnings in 707.46s (0:11:47) =======
+[2026-07-13T19:39:38Z] sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
+^^^ +++
+[2026-07-13T19:39:41Z] 🚨 Error: The command exited with status 1
+^^^ +++
+[2026-07-13T19:39:41Z] user command error: The plugin docker command hook exited with status 1
+~~~ Running global pre-exit hook
+[2026-07-13T19:39:41Z] $ /etc/buildkite-agent/hooks/pre-exit
+~~~ Running plugin docker pre-exit hook
+[2026-07-13T19:39:41Z] $ /var/lib/buildkite-agent/plugins/bk-gpu-1-queue-ci-i-073a22352e7910a55-1/github-com-buildkite-plugins-docker-buildkite-plugin-v5-2-0/hooks/pre-exit

--- a/tools/torchci/tests/fixtures/log_multi_root_cause_sentinels.txt
+++ b/tools/torchci/tests/fixtures/log_multi_root_cause_sentinels.txt
@@ -1,0 +1,49 @@
+[2026-07-15T10:04:50Z] =============================== FAILURES ================================
+[2026-07-15T10:05:00Z] _________________________ test_model_loading __________________________
+[2026-07-15T10:05:00Z]
+[2026-07-15T10:05:00Z]     def init_gpu_memory():
+[2026-07-15T10:05:00Z] >       raise ValueError("GPU memory exhausted on device 0")
+[2026-07-15T10:05:00Z] E       ValueError: GPU memory exhausted on device 0
+[2026-07-15T10:05:00Z]
+[2026-07-15T10:05:00Z] utils.py:42: ValueError
+[2026-07-15T10:05:00Z]
+[2026-07-15T10:05:00Z] The above exception was the direct cause of the following exception:
+[2026-07-15T10:05:00Z]
+[2026-07-15T10:05:00Z]     def test_model_loading():
+[2026-07-15T10:05:00Z]         try:
+[2026-07-15T10:05:00Z]             engine = create_engine(config)
+[2026-07-15T10:05:00Z]         except ValueError as exc:
+[2026-07-15T10:05:00Z] >           raise RuntimeError(
+[2026-07-15T10:05:00Z]                 "Engine core initialization failed. See root cause above. "
+[2026-07-15T10:05:00Z]                 "Failed core proc(s): {'EngineCore': 1}"
+[2026-07-15T10:05:00Z]             ) from exc
+[2026-07-15T10:05:00Z] E           RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-15T10:05:00Z]
+[2026-07-15T10:05:00Z] test_engine.py:20: RuntimeError
+[2026-07-15T10:05:00Z] ________________________ test_kernel_dispatch _________________________
+[2026-07-15T10:05:00Z]
+[2026-07-15T10:05:00Z]     def dispatch_kernel(dtype):
+[2026-07-15T10:05:00Z] >       raise TypeError("unsupported dtype bfloat16 for this kernel")
+[2026-07-15T10:05:00Z] E       TypeError: unsupported dtype bfloat16 for this kernel
+[2026-07-15T10:05:00Z]
+[2026-07-15T10:05:00Z] kernels.py:87: TypeError
+[2026-07-15T10:05:00Z]
+[2026-07-15T10:05:00Z] The above exception was the direct cause of the following exception:
+[2026-07-15T10:05:00Z]
+[2026-07-15T10:05:00Z]     def test_kernel_dispatch():
+[2026-07-15T10:05:00Z]         try:
+[2026-07-15T10:05:00Z]             dispatch_kernel(torch.bfloat16)
+[2026-07-15T10:05:00Z]         except TypeError as exc:
+[2026-07-15T10:05:00Z] >           raise RuntimeError(
+[2026-07-15T10:05:00Z]                 "Engine core initialization failed. See root cause above. "
+[2026-07-15T10:05:00Z]                 "Failed core proc(s): {'EngineCore': 1}"
+[2026-07-15T10:05:00Z]             ) from exc
+[2026-07-15T10:05:00Z] E           RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-15T10:05:00Z]
+[2026-07-15T10:05:00Z] test_engine.py:30: RuntimeError
+[2026-07-15T10:05:00Z] =============================== warnings summary ===============================
+[2026-07-15T10:05:00Z] -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+[2026-07-15T10:05:00Z] =========================== short test summary info ============================
+[2026-07-15T10:05:00Z] FAILED test_engine.py::test_model_loading - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-15T10:05:00Z] FAILED test_engine.py::test_kernel_dispatch - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+[2026-07-15T10:05:00Z] ========================= 2 failed, 1 warning in 5.00s =========================

--- a/tools/torchci/tests/fixtures/log_nixl_import_error.txt
+++ b/tools/torchci/tests/fixtures/log_nixl_import_error.txt
@@ -1,0 +1,100 @@
+[2026-07-13T19:28:19Z]
+[2026-07-13T19:28:19Z]         # Exercise the core NIXL bindings used by NixlConnector.
+[2026-07-13T19:28:19Z]         importlib.import_module("nixl._api")
+[2026-07-13T19:28:19Z]         importlib.import_module("nixl._bindings")
+[2026-07-13T19:28:19Z]
+[2026-07-13T19:28:19Z]         # Exercise the NIXL EP extension used by fused MoE expert parallelism.
+[2026-07-13T19:28:19Z] >       nixl_ep = importlib.import_module("nixl_ep")
+[2026-07-13T19:28:19Z]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[2026-07-13T19:28:19Z]
+[2026-07-13T19:28:19Z] v1/kv_connector/nixl_integration/test_nixl_imports.py:64:
+[2026-07-13T19:28:19Z] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+[2026-07-13T19:28:19Z] /usr/lib/python3.12/importlib/__init__.py:90: in import_module
+[2026-07-13T19:28:19Z]     return _bootstrap._gcd_import(name[level:], package, level)
+[2026-07-13T19:28:19Z]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[2026-07-13T19:28:19Z] <frozen importlib._bootstrap>:1387: in _gcd_import
+[2026-07-13T19:28:19Z]     ???
+[2026-07-13T19:28:19Z] <frozen importlib._bootstrap>:1360: in _find_and_load
+[2026-07-13T19:28:19Z]     ???
+[2026-07-13T19:28:19Z] <frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
+[2026-07-13T19:28:19Z]     ???
+[2026-07-13T19:28:19Z] <frozen importlib._bootstrap>:935: in _load_unlocked
+[2026-07-13T19:28:19Z]     ???
+[2026-07-13T19:28:19Z] <frozen importlib._bootstrap_external>:999: in exec_module
+[2026-07-13T19:28:19Z]     ???
+[2026-07-13T19:28:19Z] <frozen importlib._bootstrap>:488: in _call_with_frames_removed
+[2026-07-13T19:28:19Z]     ???
+[2026-07-13T19:28:19Z] /usr/local/lib/python3.12/dist-packages/nixl_ep/__init__.py:56: in <module>
+[2026-07-13T19:28:19Z]     _pkg = sys.modules[_load_ep_module()]
+[2026-07-13T19:28:19Z]                        ^^^^^^^^^^^^^^^^^
+[2026-07-13T19:28:19Z] /usr/local/lib/python3.12/dist-packages/nixl_ep/__init__.py:36: in _load_ep_module
+[2026-07-13T19:28:19Z]     return importlib.import_module(mod_name).__name__
+[2026-07-13T19:28:19Z]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[2026-07-13T19:28:19Z] /usr/lib/python3.12/importlib/__init__.py:90: in import_module
+[2026-07-13T19:28:19Z]     return _bootstrap._gcd_import(name[level:], package, level)
+[2026-07-13T19:28:19Z]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[2026-07-13T19:28:19Z] <frozen importlib._bootstrap>:1387: in _gcd_import
+[2026-07-13T19:28:19Z]     ???
+[2026-07-13T19:28:19Z] <frozen importlib._bootstrap>:1360: in _find_and_load
+[2026-07-13T19:28:19Z]     ???
+[2026-07-13T19:28:19Z] <frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
+[2026-07-13T19:28:19Z]     ???
+[2026-07-13T19:28:19Z] <frozen importlib._bootstrap>:935: in _load_unlocked
+[2026-07-13T19:28:19Z]     ???
+[2026-07-13T19:28:19Z] <frozen importlib._bootstrap_external>:999: in exec_module
+[2026-07-13T19:28:19Z]     ???
+[2026-07-13T19:28:19Z] <frozen importlib._bootstrap>:488: in _call_with_frames_removed
+[2026-07-13T19:28:19Z]     ???
+[2026-07-13T19:28:19Z] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+[2026-07-13T19:28:19Z]
+[2026-07-13T19:28:19Z]     # SPDX-FileCopyrightText: Copyright (c) 2025 DeepSeek
+[2026-07-13T19:28:19Z]     # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+[2026-07-13T19:28:19Z]     #
+[2026-07-13T19:28:19Z]     # This file incorporates material from the DeepSeek project, licensed under the MIT License.
+[2026-07-13T19:28:19Z]     # The modifications made by NVIDIA are licensed under the Apache License, Version 2.0.
+[2026-07-13T19:28:19Z]     #
+[2026-07-13T19:28:19Z]     # SPDX-License-Identifier: MIT AND Apache-2.0
+[2026-07-13T19:28:19Z]     #
+[2026-07-13T19:28:19Z]     # Licensed under the Apache License, Version 2.0 (the "License");
+[2026-07-13T19:28:19Z]     # you may not use this file except in compliance with the License.
+[2026-07-13T19:28:19Z]     # You may obtain a copy of the License at
+[2026-07-13T19:28:19Z]     #
+[2026-07-13T19:28:19Z]     #     http://www.apache.org/licenses/LICENSE-2.0
+[2026-07-13T19:28:19Z]     #
+[2026-07-13T19:28:19Z]     # Unless required by applicable law or agreed to in writing, software
+[2026-07-13T19:28:19Z]     # distributed under the License is distributed on an "AS IS" BASIS,
+[2026-07-13T19:28:19Z]     # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+[2026-07-13T19:28:19Z]     # See the License for the specific language governing permissions and
+[2026-07-13T19:28:19Z]     # limitations under the License.
+[2026-07-13T19:28:19Z]
+[2026-07-13T19:28:19Z]     import torch
+[2026-07-13T19:28:19Z]
+[2026-07-13T19:28:19Z] >   from . import nixl_ep_cpp as _nixl_ep_cpp
+[2026-07-13T19:28:19Z] E   ImportError: /usr/local/lib/python3.12/dist-packages/nixl_ep_cu13/nixl_ep_cpp.cpython-312-x86_64-linux-gnu.so: undefined symbol: _ZN3c104impl3cow23materialize_cow_storageERNS_11StorageImplE
+[2026-07-13T19:28:19Z]
+[2026-07-13T19:28:19Z] /usr/local/lib/python3.12/dist-packages/nixl_ep_cu13/__init__.py:23: ImportError
+[2026-07-13T19:28:19Z] =============================== warnings summary ===============================
+[2026-07-13T19:28:19Z] <frozen importlib._bootstrap>:488
+[2026-07-13T19:28:19Z]   <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute
+[2026-07-13T19:28:19Z]
+[2026-07-13T19:28:19Z] <frozen importlib._bootstrap>:488
+[2026-07-13T19:28:19Z]   <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute
+[2026-07-13T19:28:19Z]
+[2026-07-13T19:28:19Z] tests/v1/kv_connector/nixl_integration/test_nixl_imports.py: 14 warnings
+[2026-07-13T19:28:19Z]   /usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
+[2026-07-13T19:28:19Z]     warnings.warn(
+[2026-07-13T19:28:19Z]
+[2026-07-13T19:28:19Z] -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+[2026-07-13T19:28:19Z] =========================== short test summary info ============================
+[2026-07-13T19:28:19Z] FAILED v1/kv_connector/nixl_integration/test_nixl_imports.py::test_nixl_and_nixl_ep_imports - ImportError: /usr/local/lib/python3.12/dist-packages/nixl_ep_cu13/nixl_ep_cpp.cpython-312-x86_64-linux-gnu.so: undefined symbol: _ZN3c104impl3cow23materialize_cow_storageERNS_11StorageImplE
+[2026-07-13T19:28:19Z] !!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
+[2026-07-13T19:28:19Z] ======================== 1 failed, 16 warnings in 1.43s ========================
+[2026-07-13T19:28:20Z] sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
+^^^ +++
+[2026-07-13T19:28:23Z] 🚨 Error: The command exited with status 1
+^^^ +++
+[2026-07-13T19:28:23Z] user command error: The plugin docker command hook exited with status 1
+~~~ Running global pre-exit hook
+[2026-07-13T19:28:23Z] $ /etc/buildkite-agent/hooks/pre-exit
+~~~ Running plugin docker pre-exit hook
+[2026-07-13T19:28:23Z] $ /var/lib/buildkite-agent/plugins/bk-gpu-4-queue-ci-i-04593d39a3d232af3-1/github-com-buildkite-plugins-docker-buildkite-plugin-v5-2-0/hooks/pre-exit

--- a/tools/torchci/tests/fixtures/raw_log_64854_elastic_ep_scaling.txt
+++ b/tools/torchci/tests/fixtures/raw_log_64854_elastic_ep_scaling.txt
@@ -1,0 +1,5318 @@
+_bk;t=1778140778598~~~ Bootstrapping phases plugin,checkout
+_bk;t=1778140778619~~~ Preparing plugins
+_bk;t=1778140778619~~~ Preparing working directory
+_bk;t=1778140778619[90m# Creating "/workspace/build/buildkite"[0m
+_bk;t=1778140778619[90m$[0m cd /workspace/build/buildkite
+_bk;t=1778140778621[90m$[0m git clone -v -- https://github.com/vllm-project/vllm.git .
+_bk;t=1778140778622Cloning into '.'...
+
+_bk;t=1778140778816POST git-upload-pack (181 bytes)
+
+_bk;t=1778140779003POST git-upload-pack (gzip 23608 to 11070 bytes)
+
+_bk;t=1778140779511remote: Enumerating objects: 208433, done.[K_bk;t=1778140779511
+
+_bk;t=1778140779511remote: Counting objects:   0% (1/184)[K_bk;t=1778140779511
+remote: Counting objects:   1% (2/184)[K_bk;t=1778140779511
+remote: Counting objects:   2% (4/184)[K_bk;t=1778140779511
+remote: Counting objects:   3% (6/184)[K_bk;t=1778140779511
+remote: Counting objects:   4% (8/184)[K_bk;t=1778140779511
+remote: Counting objects:   5% (10/184)[K_bk;t=1778140779511
+remote: Counting objects:   6% (12/184)[K_bk;t=1778140779511
+remote: Counting objects:   7% (13/184)[K_bk;t=1778140779511
+remote: Counting objects:   8% (15/184)[K_bk;t=1778140779511
+remote: Counting objects:   9% (17/184)[K_bk;t=1778140779511
+remote: Counting objects:  10% (19/184)[K_bk;t=1778140779511
+remote: Counting objects:  11% (21/184)[K_bk;t=1778140779511
+remote: Counting objects:  12% (23/184)[K_bk;t=1778140779511
+remote: Counting objects:  13% (24/184)[K_bk;t=1778140779511
+remote: Counting objects:  14% (26/184)[K_bk;t=1778140779511
+remote: Counting objects:  15% (28/184)[K_bk;t=1778140779511
+remote: Counting objects:  16% (30/184)[K_bk;t=1778140779511
+remote: Counting objects:  17% (32/184)[K_bk;t=1778140779511
+remote: Counting objects:  18% (34/184)[K_bk;t=1778140779511
+remote: Counting objects:  19% (35/184)[K_bk;t=1778140779511
+remote: Counting objects:  20% (37/184)[K_bk;t=1778140779511
+remote: Counting objects:  21% (39/184)[K_bk;t=1778140779511
+remote: Counting objects:  22% (41/184)[K_bk;t=1778140779511
+remote: Counting objects:  23% (43/184)[K_bk;t=1778140779511
+remote: Counting objects:  24% (45/184)[K_bk;t=1778140779511
+remote: Counting objects:  25% (46/184)[K_bk;t=1778140779511
+remote: Counting objects:  26% (48/184)[K_bk;t=1778140779511
+remote: Counting objects:  27% (50/184)[K_bk;t=1778140779511
+remote: Counting objects:  28% (52/184)[K_bk;t=1778140779511
+remote: Counting objects:  29% (54/184)[K_bk;t=1778140779511
+remote: Counting objects:  30% (56/184)[K_bk;t=1778140779511
+remote: Counting objects:  31% (58/184)[K_bk;t=1778140779511
+remote: Counting objects:  32% (59/184)[K_bk;t=1778140779511
+remote: Counting objects:  33% (61/184)[K_bk;t=1778140779511
+remote: Counting objects:  34% (63/184)[K_bk;t=1778140779511
+remote: Counting objects:  35% (65/184)[K_bk;t=1778140779511
+remote: Counting objects:  36% (67/184)[K_bk;t=1778140779511
+remote: Counting objects:  37% (69/184)[K_bk;t=1778140779511
+remote: Counting objects:  38% (70/184)[K_bk;t=1778140779511
+remote: Counting objects:  39% (72/184)[K_bk;t=1778140779511
+remote: Counting objects:  40% (74/184)[K_bk;t=1778140779511
+remote: Counting objects:  41% (76/184)[K_bk;t=1778140779511
+remote: Counting objects:  42% (78/184)[K_bk;t=1778140779511
+remote: Counting objects:  43% (80/184)[K_bk;t=1778140779511
+remote: Counting objects:  44% (81/184)[K_bk;t=1778140779511
+remote: Counting objects:  45% (83/184)[K_bk;t=1778140779511
+remote: Counting objects:  46% (85/184)[K_bk;t=1778140779511
+remote: Counting objects:  47% (87/184)[K_bk;t=1778140779511
+remote: Counting objects:  48% (89/184)[K_bk;t=1778140779511
+remote: Counting objects:  49% (91/184)[K_bk;t=1778140779511
+remote: Counting objects:  50% (92/184)[K_bk;t=1778140779511
+remote: Counting objects:  51% (94/184)[K_bk;t=1778140779511
+remote: Counting objects:  52% (96/184)[K_bk;t=1778140779511
+remote: Counting objects:  53% (98/184)[K_bk;t=1778140779511
+remote: Counting objects:  54% (100/184)[K_bk;t=1778140779511
+remote: Counting objects:  55% (102/184)[K_bk;t=1778140779511
+remote: Counting objects:  56% (104/184)[K_bk;t=1778140779511
+remote: Counting objects:  57% (105/184)[K_bk;t=1778140779511
+remote: Counting objects:  58% (107/184)[K_bk;t=1778140779511
+remote: Counting objects:  59% (109/184)[K_bk;t=1778140779511
+remote: Counting objects:  60% (111/184)[K_bk;t=1778140779511
+remote: Counting objects:  61% (113/184)[K_bk;t=1778140779511
+remote: Counting objects:  62% (115/184)[K_bk;t=1778140779511
+remote: Counting objects:  63% (116/184)[K_bk;t=1778140779511
+remote: Counting objects:  64% (118/184)[K_bk;t=1778140779511
+remote: Counting objects:  65% (120/184)[K_bk;t=1778140779511
+remote: Counting objects:  66% (122/184)[K_bk;t=1778140779511
+remote: Counting objects:  67% (124/184)[K_bk;t=1778140779511
+remote: Counting objects:  68% (126/184)[K_bk;t=1778140779511
+remote: Counting objects:  69% (127/184)[K_bk;t=1778140779511
+remote: Counting objects:  70% (129/184)[K_bk;t=1778140779511
+remote: Counting objects:  71% (131/184)[K_bk;t=1778140779511
+remote: Counting objects:  72% (133/184)[K_bk;t=1778140779511
+remote: Counting objects:  73% (135/184)[K_bk;t=1778140779511
+remote: Counting objects:  74% (137/184)[K_bk;t=1778140779511
+remote: Counting objects:  75% (138/184)[K_bk;t=1778140779511
+remote: Counting objects:  76% (140/184)[K_bk;t=1778140779511
+remote: Counting objects:  77% (142/184)[K_bk;t=1778140779511
+remote: Counting objects:  78% (144/184)[K_bk;t=1778140779511
+remote: Counting objects:  79% (146/184)[K_bk;t=1778140779511
+remote: Counting objects:  80% (148/184)[K_bk;t=1778140779511
+remote: Counting objects:  81% (150/184)[K_bk;t=1778140779511
+remote: Counting objects:  82% (151/184)[K_bk;t=1778140779511
+remote: Counting objects:  83% (153/184)[K_bk;t=1778140779511
+remote: Counting objects:  84% (155/184)[K_bk;t=1778140779511
+remote: Counting objects:  85% (157/184)[K_bk;t=1778140779511
+remote: Counting objects:  86% (159/184)[K_bk;t=1778140779511
+remote: Counting objects:  87% (161/184)[K_bk;t=1778140779511
+remote: Counting objects:  88% (162/184)[K_bk;t=1778140779511
+remote: Counting objects:  89% (164/184)[K_bk;t=1778140779511
+remote: Counting objects:  90% (166/184)[K_bk;t=1778140779511
+remote: Counting objects:  91% (168/184)[K_bk;t=1778140779511
+remote: Counting objects:  92% (170/184)[K_bk;t=1778140779511
+remote: Counting objects:  93% (172/184)[K_bk;t=1778140779511
+remote: Counting objects:  94% (173/184)[K_bk;t=1778140779511
+remote: Counting objects:  95% (175/184)[K_bk;t=1778140779511
+remote: Counting objects:  96% (177/184)[K_bk;t=1778140779511
+remote: Counting objects:  97% (179/184)[K_bk;t=1778140779511
+remote: Counting objects:  98% (181/184)[K_bk;t=1778140779511
+remote: Counting objects:  99% (183/184)[K_bk;t=1778140779511
+remote: Counting objects: 100% (184/184)[K_bk;t=1778140779511
+remote: Counting objects: 100% (184/184), done.[K_bk;t=1778140779511
+
+_bk;t=1778140779511remote: Compressing objects:   0% (1/115)[K_bk;t=1778140779511
+remote: Compressing objects:   1% (2/115)[K_bk;t=1778140779511
+remote: Compressing objects:   2% (3/115)[K_bk;t=1778140779511
+remote: Compressing objects:   3% (4/115)[K_bk;t=1778140779543
+remote: Compressing objects:   4% (5/115)[K_bk;t=1778140779543
+remote: Compressing objects:   5% (6/115)[K_bk;t=1778140779543
+remote: Compressing objects:   6% (7/115)[K_bk;t=1778140779543
+remote: Compressing objects:   7% (9/115)[K_bk;t=1778140779543
+remote: Compressing objects:   8% (10/115)[K_bk;t=1778140779543
+remote: Compressing objects:   9% (11/115)[K_bk;t=1778140779543
+remote: Compressing objects:  10% (12/115)[K_bk;t=1778140779543
+remote: Compressing objects:  11% (13/115)[K_bk;t=1778140779543
+remote: Compressing objects:  12% (14/115)[K_bk;t=1778140779543
+remote: Compressing objects:  13% (15/115)[K_bk;t=1778140779543
+remote: Compressing objects:  14% (17/115)[K_bk;t=1778140779543
+remote: Compressing objects:  15% (18/115)[K_bk;t=1778140779543
+remote: Compressing objects:  16% (19/115)[K_bk;t=1778140779543
+remote: Compressing objects:  17% (20/115)[K_bk;t=1778140779543
+remote: Compressing objects:  18% (21/115)[K_bk;t=1778140779543
+remote: Compressing objects:  19% (22/115)[K_bk;t=1778140779543
+remote: Compressing objects:  20% (23/115)[K_bk;t=1778140779543
+remote: Compressing objects:  21% (25/115)[K_bk;t=1778140779543
+remote: Compressing objects:  22% (26/115)[K_bk;t=1778140779543
+remote: Compressing objects:  23% (27/115)[K_bk;t=1778140779543
+remote: Compressing objects:  24% (28/115)[K_bk;t=1778140779543
+remote: Compressing objects:  25% (29/115)[K_bk;t=1778140779543
+remote: Compressing objects:  26% (30/115)[K_bk;t=1778140779543
+remote: Compressing objects:  27% (32/115)[K_bk;t=1778140779543
+remote: Compressing objects:  28% (33/115)[K_bk;t=1778140779543
+remote: Compressing objects:  29% (34/115)[K_bk;t=1778140779543
+remote: Compressing objects:  30% (35/115)[K_bk;t=1778140779543
+remote: Compressing objects:  31% (36/115)[K_bk;t=1778140779543
+remote: Compressing objects:  32% (37/115)[K_bk;t=1778140779543
+remote: Compressing objects:  33% (38/115)[K_bk;t=1778140779543
+remote: Compressing objects:  34% (40/115)[K_bk;t=1778140779543
+remote: Compressing objects:  35% (41/115)[K_bk;t=1778140779543
+remote: Compressing objects:  36% (42/115)[K_bk;t=1778140779543
+remote: Compressing objects:  37% (43/115)[K_bk;t=1778140779543
+remote: Compressing objects:  38% (44/115)[K_bk;t=1778140779543
+remote: Compressing objects:  39% (45/115)[K_bk;t=1778140779543
+remote: Compressing objects:  40% (46/115)[K_bk;t=1778140779543
+remote: Compressing objects:  41% (48/115)[K_bk;t=1778140779543
+remote: Compressing objects:  42% (49/115)[K_bk;t=1778140779543
+remote: Compressing objects:  43% (50/115)[K_bk;t=1778140779543
+remote: Compressing objects:  44% (51/115)[K_bk;t=1778140779543
+remote: Compressing objects:  45% (52/115)[K_bk;t=1778140779543
+remote: Compressing objects:  46% (53/115)[K_bk;t=1778140779543
+remote: Compressing objects:  47% (55/115)[K_bk;t=1778140779543
+remote: Compressing objects:  48% (56/115)[K_bk;t=1778140779543
+remote: Compressing objects:  49% (57/115)[K_bk;t=1778140779543
+remote: Compressing objects:  50% (58/115)[K_bk;t=1778140779543
+remote: Compressing objects:  51% (59/115)[K_bk;t=1778140779543
+remote: Compressing objects:  52% (60/115)[K_bk;t=1778140779543
+remote: Compressing objects:  53% (61/115)[K_bk;t=1778140779543
+remote: Compressing objects:  54% (63/115)[K_bk;t=1778140779543
+remote: Compressing objects:  55% (64/115)[K_bk;t=1778140779543
+remote: Compressing objects:  56% (65/115)[K_bk;t=1778140779543
+remote: Compressing objects:  57% (66/115)[K_bk;t=1778140779543
+remote: Compressing objects:  58% (67/115)[K_bk;t=1778140779543
+remote: Compressing objects:  59% (68/115)[K_bk;t=1778140779543
+remote: Compressing objects:  60% (69/115)[K_bk;t=1778140779543
+remote: Compressing objects:  61% (71/115)[K_bk;t=1778140779543
+remote: Compressing objects:  62% (72/115)[K_bk;t=1778140779543
+remote: Compressing objects:  63% (73/115)[K_bk;t=1778140779543
+remote: Compressing objects:  64% (74/115)[K_bk;t=1778140779543
+remote: Compressing objects:  65% (75/115)[K_bk;t=1778140779543
+remote: Compressing objects:  66% (76/115)[K_bk;t=1778140779543
+remote: Compressing objects:  67% (78/115)[K_bk;t=1778140779543
+remote: Compressing objects:  68% (79/115)[K_bk;t=1778140779543
+remote: Compressing objects:  69% (80/115)[K_bk;t=1778140779543
+remote: Compressing objects:  70% (81/115)[K_bk;t=1778140779543
+remote: Compressing objects:  71% (82/115)[K_bk;t=1778140779543
+remote: Compressing objects:  72% (83/115)[K_bk;t=1778140779543
+remote: Compressing objects:  73% (84/115)[K_bk;t=1778140779543
+remote: Compressing objects:  74% (86/115)[K_bk;t=1778140779543
+remote: Compressing objects:  75% (87/115)[K_bk;t=1778140779543
+remote: Compressing objects:  76% (88/115)[K_bk;t=1778140779543
+remote: Compressing objects:  77% (89/115)[K_bk;t=1778140779543
+remote: Compressing objects:  78% (90/115)[K_bk;t=1778140779543
+remote: Compressing objects:  79% (91/115)[K_bk;t=1778140779543
+remote: Compressing objects:  80% (92/115)[K_bk;t=1778140779543
+remote: Compressing objects:  81% (94/115)[K_bk;t=1778140779543
+remote: Compressing objects:  82% (95/115)[K_bk;t=1778140779543
+remote: Compressing objects:  83% (96/115)[K_bk;t=1778140779543
+remote: Compressing objects:  84% (97/115)[K_bk;t=1778140779543
+remote: Compressing objects:  85% (98/115)[K_bk;t=1778140779543
+remote: Compressing objects:  86% (99/115)[K_bk;t=1778140779543
+remote: Compressing objects:  87% (101/115)[K_bk;t=1778140779543
+remote: Compressing objects:  88% (102/115)[K_bk;t=1778140779543
+remote: Compressing objects:  89% (103/115)[K_bk;t=1778140779543
+remote: Compressing objects:  90% (104/115)[K_bk;t=1778140779543
+remote: Compressing objects:  91% (105/115)[K_bk;t=1778140779543
+remote: Compressing objects:  92% (106/115)[K_bk;t=1778140779543
+remote: Compressing objects:  93% (107/115)[K_bk;t=1778140779543
+remote: Compressing objects:  94% (109/115)[K_bk;t=1778140779543
+remote: Compressing objects:  95% (110/115)[K_bk;t=1778140779543
+remote: Compressing objects:  96% (111/115)[K_bk;t=1778140779543
+remote: Compressing objects:  97% (112/115)[K_bk;t=1778140779543
+remote: Compressing objects:  98% (113/115)[K_bk;t=1778140779543
+remote: Compressing objects:  99% (114/115)[K_bk;t=1778140779543
+remote: Compressing objects: 100% (115/115)[K_bk;t=1778140779543
+remote: Compressing objects: 100% (115/115), done.[K_bk;t=1778140779543
+
+_bk;t=1778140779543Receiving objects:   0% (1/208433)
+Receiving objects:   1% (2085/208433)
+Receiving objects:   2% (4169/208433)
+Receiving objects:   3% (6253/208433)
+Receiving objects:   4% (8338/208433)
+Receiving objects:   5% (10422/208433)
+Receiving objects:   6% (12506/208433), 8.91 MiB | 17.83 MiB/s
+Receiving objects:   7% (14591/208433), 8.91 MiB | 17.83 MiB/s
+Receiving objects:   8% (16675/208433), 8.91 MiB | 17.83 MiB/s
+Receiving objects:   9% (18759/208433), 8.91 MiB | 17.83 MiB/s
+_bk;t=1778140780543Receiving objects:   9% (19828/208433), 8.91 MiB | 17.83 MiB/s
+Receiving objects:  10% (20844/208433), 37.14 MiB | 37.21 MiB/s
+Receiving objects:  11% (22928/208433), 37.14 MiB | 37.21 MiB/s
+Receiving objects:  12% (25012/208433), 37.14 MiB | 37.21 MiB/s
+Receiving objects:  13% (27097/208433), 37.14 MiB | 37.21 MiB/s
+Receiving objects:  14% (29181/208433), 37.14 MiB | 37.21 MiB/s
+Receiving objects:  15% (31265/208433), 53.89 MiB | 35.97 MiB/s
+Receiving objects:  16% (33350/208433), 53.89 MiB | 35.97 MiB/s
+Receiving objects:  17% (35434/208433), 53.89 MiB | 35.97 MiB/s
+Receiving objects:  18% (37518/208433), 53.89 MiB | 35.97 MiB/s
+Receiving objects:  19% (39603/208433), 53.89 MiB | 35.97 MiB/s
+Receiving objects:  20% (41687/208433), 53.89 MiB | 35.97 MiB/s
+Receiving objects:  21% (43771/208433), 53.89 MiB | 35.97 MiB/s
+Receiving objects:  21% (45434/208433), 53.89 MiB | 35.97 MiB/s
+_bk;t=1778140781554Receiving objects:  22% (45856/208433), 72.00 MiB | 36.03 MiB/s
+Receiving objects:  23% (47940/208433), 72.00 MiB | 36.03 MiB/s
+Receiving objects:  24% (50024/208433), 72.00 MiB | 36.03 MiB/s
+Receiving objects:  25% (52109/208433), 72.00 MiB | 36.03 MiB/s
+Receiving objects:  26% (54193/208433), 72.00 MiB | 36.03 MiB/s
+Receiving objects:  27% (56277/208433), 72.00 MiB | 36.03 MiB/s
+Receiving objects:  28% (58362/208433), 72.00 MiB | 36.03 MiB/s
+Receiving objects:  29% (60446/208433), 72.00 MiB | 36.03 MiB/s
+Receiving objects:  30% (62530/208433), 72.00 MiB | 36.03 MiB/s
+Receiving objects:  31% (64615/208433), 91.64 MiB | 36.68 MiB/s
+Receiving objects:  32% (66699/208433), 91.64 MiB | 36.68 MiB/s
+Receiving objects:  33% (68783/208433), 91.64 MiB | 36.68 MiB/s
+Receiving objects:  34% (70868/208433), 91.64 MiB | 36.68 MiB/s
+Receiving objects:  35% (72952/208433), 91.64 MiB | 36.68 MiB/s
+Receiving objects:  36% (75036/208433), 91.64 MiB | 36.68 MiB/s
+Receiving objects:  37% (77121/208433), 91.64 MiB | 36.68 MiB/s
+Receiving objects:  38% (79205/208433), 91.64 MiB | 36.68 MiB/s
+Receiving objects:  38% (80024/208433), 91.64 MiB | 36.68 MiB/s
+_bk;t=1778140782583Receiving objects:  39% (81289/208433), 111.46 MiB | 37.18 MiB/s
+Receiving objects:  40% (83374/208433), 111.46 MiB | 37.18 MiB/s
+Receiving objects:  41% (85458/208433), 111.46 MiB | 37.18 MiB/s
+Receiving objects:  42% (87542/208433), 111.46 MiB | 37.18 MiB/s
+Receiving objects:  43% (89627/208433), 111.46 MiB | 37.18 MiB/s
+Receiving objects:  44% (91711/208433), 111.46 MiB | 37.18 MiB/s
+Receiving objects:  45% (93795/208433), 111.46 MiB | 37.18 MiB/s
+Receiving objects:  46% (95880/208433), 111.46 MiB | 37.18 MiB/s
+Receiving objects:  47% (97964/208433), 133.16 MiB | 38.06 MiB/s
+Receiving objects:  48% (100048/208433), 133.16 MiB | 38.06 MiB/s
+Receiving objects:  49% (102133/208433), 133.16 MiB | 38.06 MiB/s
+Receiving objects:  50% (104217/208433), 133.16 MiB | 38.06 MiB/s
+Receiving objects:  51% (106301/208433), 133.16 MiB | 38.06 MiB/s
+Receiving objects:  52% (108386/208433), 133.16 MiB | 38.06 MiB/s
+Receiving objects:  53% (110470/208433), 133.16 MiB | 38.06 MiB/s
+Receiving objects:  54% (112554/208433), 133.16 MiB | 38.06 MiB/s
+Receiving objects:  55% (114639/208433), 133.16 MiB | 38.06 MiB/s
+Receiving objects:  56% (116723/208433), 133.16 MiB | 38.06 MiB/s
+Receiving objects:  57% (118807/208433), 133.16 MiB | 38.06 MiB/s
+Receiving objects:  58% (120892/208433), 133.16 MiB | 38.06 MiB/s
+Receiving objects:  58% (122126/208433), 133.16 MiB | 38.06 MiB/s
+Receiving objects:  59% (122976/208433), 154.35 MiB | 38.61 MiB/s
+Receiving objects:  60% (125060/208433), 154.35 MiB | 38.61 MiB/s
+Receiving objects:  61% (127145/208433), 154.35 MiB | 38.61 MiB/s
+_bk;t=1778140783599Receiving objects:  62% (129229/208433), 154.35 MiB | 38.61 MiB/s
+Receiving objects:  63% (131313/208433), 154.35 MiB | 38.61 MiB/s
+Receiving objects:  64% (133398/208433), 154.35 MiB | 38.61 MiB/s
+Receiving objects:  65% (135482/208433), 154.35 MiB | 38.61 MiB/s
+Receiving objects:  66% (137566/208433), 154.35 MiB | 38.61 MiB/s
+Receiving objects:  67% (139651/208433), 154.35 MiB | 38.61 MiB/s
+Receiving objects:  68% (141735/208433), 154.35 MiB | 38.61 MiB/s
+Receiving objects:  69% (143819/208433), 154.35 MiB | 38.61 MiB/s
+Receiving objects:  70% (145904/208433), 154.35 MiB | 38.61 MiB/s
+Receiving objects:  71% (147988/208433), 154.35 MiB | 38.61 MiB/s
+Receiving objects:  72% (150072/208433), 154.35 MiB | 38.61 MiB/s
+Receiving objects:  73% (152157/208433), 154.35 MiB | 38.61 MiB/s
+Receiving objects:  74% (154241/208433), 154.35 MiB | 38.61 MiB/s
+Receiving objects:  75% (156325/208433), 154.35 MiB | 38.61 MiB/s
+Receiving objects:  76% (158410/208433), 154.35 MiB | 38.61 MiB/s
+Receiving objects:  77% (160494/208433), 154.35 MiB | 38.61 MiB/s
+Receiving objects:  78% (162578/208433), 154.35 MiB | 38.61 MiB/s
+Receiving objects:  79% (164663/208433), 154.35 MiB | 38.61 MiB/s
+Receiving objects:  80% (166747/208433), 177.26 MiB | 39.42 MiB/s
+Receiving objects:  81% (168831/208433), 177.26 MiB | 39.42 MiB/s
+Receiving objects:  82% (170916/208433), 177.26 MiB | 39.42 MiB/s
+Receiving objects:  83% (173000/208433), 177.26 MiB | 39.42 MiB/s
+Receiving objects:  84% (175084/208433), 177.26 MiB | 39.42 MiB/s
+Receiving objects:  85% (177169/208433), 177.26 MiB | 39.42 MiB/s
+Receiving objects:  86% (179253/208433), 177.26 MiB | 39.42 MiB/s
+Receiving objects:  87% (181337/208433), 177.26 MiB | 39.42 MiB/s
+Receiving objects:  88% (183422/208433), 177.26 MiB | 39.42 MiB/s
+Receiving objects:  89% (185506/208433), 177.26 MiB | 39.42 MiB/s
+Receiving objects:  90% (187590/208433), 177.26 MiB | 39.42 MiB/s
+Receiving objects:  91% (189675/208433), 177.26 MiB | 39.42 MiB/s
+Receiving objects:  92% (191759/208433), 177.26 MiB | 39.42 MiB/s
+Receiving objects:  93% (193843/208433), 177.26 MiB | 39.42 MiB/s
+Receiving objects:  94% (195928/208433), 177.26 MiB | 39.42 MiB/s
+Receiving objects:  95% (198012/208433), 177.26 MiB | 39.42 MiB/s
+Receiving objects:  96% (200096/208433), 177.26 MiB | 39.42 MiB/s
+Receiving objects:  97% (202181/208433), 177.26 MiB | 39.42 MiB/s
+Receiving objects:  98% (204265/208433), 177.26 MiB | 39.42 MiB/s
+Receiving objects:  99% (206349/208433), 177.26 MiB | 39.42 MiB/s
+remote: Total 208433 (delta 117), reused 69 (delta 69), pack-reused 208249 (from 3)[K_bk;t=1778140784383
+
+_bk;t=1778140784386Receiving objects: 100% (208433/208433), 177.26 MiB | 39.42 MiB/s
+Receiving objects: 100% (208433/208433), 192.99 MiB | 39.86 MiB/s, done.
+
+_bk;t=1778140784438Resolving deltas:   0% (0/165414)
+Resolving deltas:   1% (1656/165414)
+Resolving deltas:   2% (3311/165414)
+Resolving deltas:   3% (4963/165414)
+Resolving deltas:   4% (6618/165414)
+Resolving deltas:   5% (8271/165414)
+Resolving deltas:   6% (9925/165414)
+Resolving deltas:   7% (11579/165414)
+Resolving deltas:   8% (13236/165414)
+Resolving deltas:   9% (14889/165414)
+Resolving deltas:  10% (16543/165414)
+Resolving deltas:  11% (18197/165414)
+Resolving deltas:  11% (19069/165414)
+_bk;t=1778140785486Resolving deltas:  12% (19851/165414)
+Resolving deltas:  13% (21504/165414)
+Resolving deltas:  14% (23160/165414)
+Resolving deltas:  15% (24817/165414)
+Resolving deltas:  16% (26467/165414)
+Resolving deltas:  17% (28121/165414)
+Resolving deltas:  18% (29776/165414)
+Resolving deltas:  19% (31429/165414)
+Resolving deltas:  20% (33086/165414)
+Resolving deltas:  21% (34738/165414)
+Resolving deltas:  22% (36398/165414)
+Resolving deltas:  23% (38046/165414)
+Resolving deltas:  24% (39702/165414)
+Resolving deltas:  25% (41356/165414)
+Resolving deltas:  26% (43009/165414)
+Resolving deltas:  26% (43350/165414)
+_bk;t=1778140786503Resolving deltas:  27% (44666/165414)
+Resolving deltas:  28% (46318/165414)
+Resolving deltas:  29% (47976/165414)
+Resolving deltas:  30% (49625/165414)
+Resolving deltas:  31% (51279/165414)
+Resolving deltas:  32% (52934/165414)
+Resolving deltas:  33% (54587/165414)
+Resolving deltas:  34% (56250/165414)
+Resolving deltas:  35% (57896/165414)
+Resolving deltas:  36% (59552/165414)
+Resolving deltas:  37% (61206/165414)
+Resolving deltas:  38% (62858/165414)
+Resolving deltas:  39% (64513/165414)
+Resolving deltas:  40% (66166/165414)
+Resolving deltas:  41% (67821/165414)
+Resolving deltas:  42% (69474/165414)
+Resolving deltas:  43% (71131/165414)
+Resolving deltas:  43% (71925/165414)
+Resolving deltas:  44% (72783/165414)
+Resolving deltas:  45% (74437/165414)
+_bk;t=1778140787550Resolving deltas:  46% (76092/165414)
+Resolving deltas:  47% (77751/165414)
+Resolving deltas:  48% (79399/165414)
+Resolving deltas:  49% (81053/165414)
+Resolving deltas:  50% (82707/165414)
+Resolving deltas:  51% (84362/165414)
+Resolving deltas:  52% (86016/165414)
+Resolving deltas:  53% (87670/165414)
+Resolving deltas:  54% (89324/165414)
+Resolving deltas:  55% (90980/165414)
+Resolving deltas:  56% (92635/165414)
+Resolving deltas:  57% (94286/165414)
+Resolving deltas:  58% (95943/165414)
+Resolving deltas:  59% (97595/165414)
+Resolving deltas:  60% (99249/165414)
+Resolving deltas:  61% (100904/165414)
+Resolving deltas:  62% (102557/165414)
+Resolving deltas:  63% (104211/165414)
+Resolving deltas:  63% (105608/165414)
+Resolving deltas:  64% (105865/165414)
+Resolving deltas:  65% (107520/165414)
+Resolving deltas:  66% (109177/165414)
+Resolving deltas:  67% (110830/165414)
+_bk;t=1778140788569Resolving deltas:  68% (112483/165414)
+Resolving deltas:  69% (114136/165414)
+Resolving deltas:  70% (115790/165414)
+Resolving deltas:  71% (117448/165414)
+Resolving deltas:  72% (119100/165414)
+Resolving deltas:  73% (120755/165414)
+Resolving deltas:  74% (122409/165414)
+Resolving deltas:  75% (124061/165414)
+Resolving deltas:  76% (125715/165414)
+Resolving deltas:  77% (127369/165414)
+Resolving deltas:  78% (129023/165414)
+Resolving deltas:  79% (130679/165414)
+Resolving deltas:  80% (132332/165414)
+Resolving deltas:  81% (133986/165414)
+Resolving deltas:  82% (135640/165414)
+Resolving deltas:  83% (137294/165414)
+Resolving deltas:  84% (138948/165414)
+Resolving deltas:  85% (140605/165414)
+Resolving deltas:  86% (142257/165414)
+Resolving deltas:  87% (143912/165414)
+Resolving deltas:  88% (145565/165414)
+Resolving deltas:  89% (147219/165414)
+Resolving deltas:  90% (148874/165414)
+Resolving deltas:  91% (150529/165414)
+Resolving deltas:  91% (150551/165414)
+Resolving deltas:  92% (152181/165414)
+Resolving deltas:  93% (153836/165414)
+Resolving deltas:  94% (155490/165414)
+Resolving deltas:  95% (157144/165414)
+Resolving deltas:  96% (158800/165414)
+_bk;t=1778140789596Resolving deltas:  97% (160452/165414)
+Resolving deltas:  98% (162107/165414)
+Resolving deltas:  99% (163761/165414)
+Resolving deltas: 100% (165414/165414)
+Resolving deltas: 100% (165414/165414), done.
+
+_bk;t=1778140790675[90m$[0m git clean -ffxdq
+_bk;t=1778140790687[90m$[0m git fetch -v --prune -- origin f596e760c8ed0fbc53db45479c8d460f1a40fd06
+_bk;t=1778140790842POST git-upload-pack (134 bytes)
+
+_bk;t=1778140790906POST git-upload-pack (949 bytes)
+
+_bk;t=1778140790986remote: Enumerating objects: 44, done.[K_bk;t=1778140790986
+
+_bk;t=1778140790986remote: Counting objects:   2% (1/35)[K_bk;t=1778140790986
+remote: Counting objects:   5% (2/35)[K_bk;t=1778140790986
+remote: Counting objects:   8% (3/35)[K_bk;t=1778140790986
+remote: Counting objects:  11% (4/35)[K_bk;t=1778140790986
+remote: Counting objects:  14% (5/35)[K_bk;t=1778140790986
+remote: Counting objects:  17% (6/35)[K_bk;t=1778140790986
+remote: Counting objects:  20% (7/35)[K_bk;t=1778140790986
+remote: Counting objects:  22% (8/35)[K_bk;t=1778140790986
+remote: Counting objects:  25% (9/35)[K_bk;t=1778140790986
+remote: Counting objects:  28% (10/35)[K_bk;t=1778140790986
+remote: Counting objects:  31% (11/35)[K_bk;t=1778140790986
+remote: Counting objects:  34% (12/35)[K_bk;t=1778140790986
+remote: Counting objects:  37% (13/35)[K_bk;t=1778140790986
+remote: Counting objects:  40% (14/35)[K_bk;t=1778140790986
+remote: Counting objects:  42% (15/35)[K_bk;t=1778140790986
+remote: Counting objects:  45% (16/35)[K_bk;t=1778140790986
+remote: Counting objects:  48% (17/35)[K_bk;t=1778140790986
+remote: Counting objects:  51% (18/35)[K_bk;t=1778140790986
+remote: Counting objects:  54% (19/35)[K_bk;t=1778140790986
+remote: Counting objects:  57% (20/35)[K_bk;t=1778140790986
+remote: Counting objects:  60% (21/35)[K_bk;t=1778140790986
+remote: Counting objects:  62% (22/35)[K_bk;t=1778140790986
+remote: Counting objects:  65% (23/35)[K_bk;t=1778140790986
+remote: Counting objects:  68% (24/35)[K_bk;t=1778140790986
+remote: Counting objects:  71% (25/35)[K_bk;t=1778140790986
+remote: Counting objects:  74% (26/35)[K_bk;t=1778140790986
+remote: Counting objects:  77% (27/35)[K_bk;t=1778140790986
+remote: Counting objects:  80% (28/35)[K_bk;t=1778140790986
+remote: Counting objects:  82% (29/35)[K_bk;t=1778140790986
+remote: Counting objects:  85% (30/35)[K_bk;t=1778140790986
+remote: Counting objects:  88% (31/35)[K_bk;t=1778140790986
+remote: Counting objects:  91% (32/35)[K_bk;t=1778140790986
+remote: Counting objects:  94% (33/35)[K_bk;t=1778140790986
+remote: Counting objects:  97% (34/35)[K_bk;t=1778140790986
+remote: Counting objects: 100% (35/35)[K_bk;t=1778140790986
+remote: Counting objects: 100% (35/35), done.[K_bk;t=1778140790986
+
+_bk;t=1778140790986remote: Compressing objects:   7% (1/13)[K_bk;t=1778140790986
+remote: Compressing objects:  15% (2/13)[K_bk;t=1778140790986
+remote: Compressing objects:  23% (3/13)[K_bk;t=1778140790986
+remote: Compressing objects:  30% (4/13)[K_bk;t=1778140790987
+remote: Compressing objects:  38% (5/13)[K_bk;t=1778140790987
+remote: Compressing objects:  46% (6/13)[K_bk;t=1778140790987
+remote: Compressing objects:  53% (7/13)[K_bk;t=1778140790987
+remote: Compressing objects:  61% (8/13)[K_bk;t=1778140790987
+remote: Compressing objects:  69% (9/13)[K_bk;t=1778140790987
+remote: Compressing objects:  76% (10/13)[K_bk;t=1778140790987
+remote: Compressing objects:  84% (11/13)[K_bk;t=1778140790987
+remote: Compressing objects:  92% (12/13)[K_bk;t=1778140790987
+remote: Compressing objects: 100% (13/13)[K_bk;t=1778140790987
+remote: Compressing objects: 100% (13/13), done.[K_bk;t=1778140790987
+
+_bk;t=1778140790997Unpacking objects:   2% (1/44)
+Unpacking objects:   4% (2/44)
+Unpacking objects:   6% (3/44)
+Unpacking objects:   9% (4/44)
+Unpacking objects:  11% (5/44)
+Unpacking objects:  13% (6/44)
+Unpacking objects:  15% (7/44)
+Unpacking objects:  18% (8/44)
+Unpacking objects:  20% (9/44)
+Unpacking objects:  22% (10/44)
+Unpacking objects:  25% (11/44)
+Unpacking objects:  27% (12/44)
+Unpacking objects:  29% (13/44)
+Unpacking objects:  31% (14/44)
+Unpacking objects:  34% (15/44)
+Unpacking objects:  36% (16/44)
+Unpacking objects:  38% (17/44)
+Unpacking objects:  40% (18/44)
+Unpacking objects:  43% (19/44)
+Unpacking objects:  45% (20/44)
+remote: Total 44 (delta 26), reused 22 (delta 22), pack-reused 9 (from 2)[K_bk;t=1778140791023
+
+_bk;t=1778140791023Unpacking objects:  47% (21/44)
+Unpacking objects:  50% (22/44)
+Unpacking objects:  52% (23/44)
+Unpacking objects:  54% (24/44)
+Unpacking objects:  56% (25/44)
+Unpacking objects:  59% (26/44)
+Unpacking objects:  61% (27/44)
+Unpacking objects:  63% (28/44)
+Unpacking objects:  65% (29/44)
+Unpacking objects:  68% (30/44)
+Unpacking objects:  70% (31/44)
+Unpacking objects:  72% (32/44)
+Unpacking objects:  75% (33/44)
+Unpacking objects:  77% (34/44)
+Unpacking objects:  79% (35/44)
+Unpacking objects:  81% (36/44)
+Unpacking objects:  84% (37/44)
+Unpacking objects:  86% (38/44)
+Unpacking objects:  88% (39/44)
+Unpacking objects:  90% (40/44)
+Unpacking objects:  93% (41/44)
+Unpacking objects:  95% (42/44)
+Unpacking objects:  97% (43/44)
+Unpacking objects: 100% (44/44)
+Unpacking objects: 100% (44/44), 31.35 KiB | 867.00 KiB/s, done.
+
+_bk;t=1778140791048From https://github.com/vllm-project/vllm
+
+_bk;t=1778140791048 * branch                f596e760c8ed0fbc53db45479c8d460f1a40fd06 -> FETCH_HEAD
+
+_bk;t=1778140791050[90m$[0m git checkout -f f596e760c8ed0fbc53db45479c8d460f1a40fd06
+_bk;t=1778140791557Note: switching to 'f596e760c8ed0fbc53db45479c8d460f1a40fd06'.
+
+_bk;t=1778140791557
+
+_bk;t=1778140791557You are in 'detached HEAD' state. You can look around, make experimental
+
+_bk;t=1778140791557changes and commit them, and you can discard any commits you make in this
+
+_bk;t=1778140791557state without impacting any branches by switching back to a branch.
+
+_bk;t=1778140791557
+
+_bk;t=1778140791557If you want to create a new branch to retain commits you create, you may
+
+_bk;t=1778140791557do so (now or later) by using -c with the switch command. Example:
+
+_bk;t=1778140791557
+
+_bk;t=1778140791557  git switch -c <new-branch-name>
+
+_bk;t=1778140791557
+
+_bk;t=1778140791557Or undo this operation with:
+
+_bk;t=1778140791557
+
+_bk;t=1778140791557  git switch -
+
+_bk;t=1778140791557
+
+_bk;t=1778140791557Turn off this advice by setting config variable advice.detachedHead to false
+
+_bk;t=1778140791557
+
+_bk;t=1778140791557HEAD is now at f596e760c Fix B200 batch determinism in fused_moe logic
+
+_bk;t=1778140791558[90m# Cleaning again to catch any post-checkout changes[0m
+_bk;t=1778140791558[90m$[0m git clean -ffxdq
+_bk;t=1778140791567[90m# Checking to see if git commit information needs to be sent to Buildkite...[0m
+_bk;t=1778140791567[90m# BUILDKITE_COMMIT is already resolved and meta-data populated, skipping[0m
+_bk;t=1778140792236~~~ Bootstrapping phases plugin,command
+_bk;t=1778140792258~~~ Preparing plugins
+_bk;t=1778140792258[90m$[0m cd /workspace/build/buildkite
+_bk;t=1778140792258~~~ Running commands
+_bk;t=1778140792258[90m$[0m cd /vllm-workspace/tests
+_bk;t=1778140792258echo "--- :nvidia: GPU Info"
+_bk;t=1778140792258(command nvidia-smi || true)
+_bk;t=1778140792258echo "--- :gear: CUDA Coredump Setup"
+_bk;t=1778140792258export CUDA_ENABLE_COREDUMP_ON_EXCEPTION=1 && export CUDA_COREDUMP_SHOW_PROGRESS=1 && export CUDA_COREDUMP_GENERATION_FLAGS="skip_nonrelocated_elf_images,skip_global_memory,skip_shared_memory,skip_local_memory,skip_constbank_memory"
+_bk;t=1778140792258echo "+++ :test_tube: Command (1/1): pytest -v -s distributed/test_elastic_ep.py"
+_bk;t=1778140792258pytest -v -s distributed/test_elastic_ep.py
+_bk;t=1778140792260--- :nvidia: GPU Info
+
+_bk;t=1778140792310Thu May  7 07:59:52 2026
+
+_bk;t=1778140792310+-----------------------------------------------------------------------------------------+
+
+_bk;t=1778140792310| NVIDIA-SMI 580.95.05              Driver Version: 580.95.05      CUDA Version: 13.0     |
+
+_bk;t=1778140792310+-----------------------------------------+------------------------+----------------------+
+
+_bk;t=1778140792310| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+
+_bk;t=1778140792310| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+
+_bk;t=1778140792310|                                         |                        |               MIG M. |
+
+_bk;t=1778140792310|=========================================+========================+======================|
+
+_bk;t=1778140792374|   0  NVIDIA H100 80GB HBM3          On  |   00000000:BF:00.0 Off |                    0 |
+
+_bk;t=1778140792374| N/A   31C    P0             70W /  700W |       0MiB /  81559MiB |      0%      Default |
+
+_bk;t=1778140792374|                                         |                        |             Disabled |
+
+_bk;t=1778140792374+-----------------------------------------+------------------------+----------------------+
+
+_bk;t=1778140792374|   1  NVIDIA H100 80GB HBM3          On  |   00000000:CF:00.0 Off |                    0 |
+
+_bk;t=1778140792374| N/A   38C    P0             72W /  700W |       0MiB /  81559MiB |      0%      Default |
+
+_bk;t=1778140792374|                                         |                        |             Disabled |
+
+_bk;t=1778140792374+-----------------------------------------+------------------------+----------------------+
+
+_bk;t=1778140792374|   2  NVIDIA H100 80GB HBM3          On  |   00000000:DF:00.0 Off |                    0 |
+
+_bk;t=1778140792374| N/A   34C    P0             74W /  700W |       0MiB /  81559MiB |      0%      Default |
+
+_bk;t=1778140792374|                                         |                        |             Disabled |
+
+_bk;t=1778140792374+-----------------------------------------+------------------------+----------------------+
+
+_bk;t=1778140792374|   3  NVIDIA H100 80GB HBM3          On  |   00000000:EF:00.0 Off |                    0 |
+
+_bk;t=1778140792374| N/A   33C    P0             73W /  700W |       0MiB /  81559MiB |      0%      Default |
+
+_bk;t=1778140792374|                                         |                        |             Disabled |
+
+_bk;t=1778140792374+-----------------------------------------+------------------------+----------------------+
+
+_bk;t=1778140792376
+
+_bk;t=1778140792376+-----------------------------------------------------------------------------------------+
+
+_bk;t=1778140792376| Processes:                                                                              |
+
+_bk;t=1778140792376|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+
+_bk;t=1778140792376|        ID   ID                                                               Usage      |
+
+_bk;t=1778140792376|=========================================================================================|
+
+_bk;t=1778140792378|  No running processes found                                                             |
+
+_bk;t=1778140792378+-----------------------------------------------------------------------------------------+
+
+_bk;t=1778140792672--- :gear: CUDA Coredump Setup
+
+_bk;t=1778140792672+++ :test_tube: Command (1/1): pytest -v -s distributed/test_elastic_ep.py
+
+_bk;t=1778140809596/usr/local/lib/python3.12/dist-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
+
+_bk;t=1778140809596The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"
+
+_bk;t=1778140809596
+
+_bk;t=1778140809596  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
+
+_bk;t=1778140809603[1m===================================================================== test session starts ======================================================================[0m
+
+_bk;t=1778140809603platform linux -- Python 3.12.13, pytest-8.3.5, pluggy-1.5.0 -- /usr/bin/python3
+
+_bk;t=1778140809608cachedir: .pytest_cache
+
+_bk;t=1778140809608hypothesis profile 'ci' -> database=None, deadline=None, print_blob=True, derandomize=True, suppress_health_check=[HealthCheck.too_slow]
+
+_bk;t=1778140809608rootdir: /vllm-workspace
+
+_bk;t=1778140809608configfile: pyproject.toml
+
+_bk;t=1778140809608plugins: anyio-4.6.2.post1, timeout-2.3.1, hypothesis-6.131.0, subtests-0.14.1, rerunfailures-14.0, asyncio-0.24.0, buildkite-test-collector-0.1.9, schemathesis-3.39.15, mock-3.14.0, forked-1.6.0, shard-0.1.2, cov-6.3.0
+
+_bk;t=1778140809608asyncio: mode=Mode.STRICT, default_loop_scope=None
+
+_bk;t=1778140809608[1mcollecting ... [0m_bk;t=1778140813762[32mINFO[0m [90m05-07 08:00:13[0m [90m[nixl_utils.py:20][0m Setting UCX_RCACHE_MAX_UNRELEASED to '1024' to avoid a rare memory leak in UCX when using NIXL.
+
+_bk;t=1778140813762[33mWARNING[0m [90m05-07 08:00:13[0m [90m[nixl_utils.py:34][0m NIXL is not available
+
+_bk;t=1778140813762[33mWARNING[0m [90m05-07 08:00:13[0m [90m[nixl_utils.py:44][0m NIXL agent config is not available
+
+_bk;t=1778140814768[1m
+collecting 2 items                                                                                                                                             [0m[1m
+collected 2 items                                                                                                                                              [0m
+
+_bk;t=1778140814768Running 2 items in this shard: tests/distributed/test_elastic_ep.py::test_elastic_ep_scaling, tests/distributed/test_elastic_ep.py::test_elastic_ep_scaling_uneven
+
+_bk;t=1778140814768
+
+_bk;t=1778140814768distributed/test_elastic_ep.py::test_elastic_ep_scaling _bk;t=1778140822985Fork a new process to run a test 439
+
+_bk;t=1778140822986Fork a new process to run a test 0
+
+_bk;t=1778140823552`rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778140823552`rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778140823552`rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778140823621`rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778140823621`rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778140823621`rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778140823622`rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778140823622`rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778140823622`rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778140832091[32mINFO[0m [90m05-07 08:00:32[0m [90m[model.py:563][0m Resolved architecture: DeepseekV2ForCausalLM
+
+_bk;t=1778140832149[32mINFO[0m [90m05-07 08:00:32[0m [90m[model.py:1692][0m Using max model len 4096
+
+_bk;t=1778140832686[RemoteOpenAIServer] GPU memory before server start: 2.01 GB
+
+_bk;t=1778140832687Launching RemoteOpenAIServer with: vllm serve deepseek-ai/DeepSeek-V2-Lite-Chat --trust-remote-code --tensor-parallel-size 1 --gpu-memory-utilization 0.8 --max-model-len 4096 --max-num-seqs 32 --enable-expert-parallel --all2all-backend allgather_reducescatter --enable-elastic-ep --enable-eplb --eplb-config.num_redundant_experts 0 --data-parallel-backend ray --data-parallel-size 2 --api-server-count 1 --port 50109 --seed 0
+
+_bk;t=1778140832687Environment variables: {'BUILDKITE_CANCEL_GRACE_PERIOD': '60', 'BUILDKITE_PULL_REQUEST_LABELS': '', 'NVIDIA_CTK_LIBCUDA_DIR': '/usr/lib/x86_64-linux-gnu', 'BUILDKITE_ADDITIONAL_HOOKS_PATHS': '', 'BUILDKITE_BUILD_CHECKOUT_PATH': '/workspace/build/buildkite', 'BUILDKITE_CONTAINER_ID': '1', 'BUILDKITE_GIT_FETCH_FLAGS': '-v --prune', 'HF_XET_HIGH_PERFORMANCE': '1', 'KUBERNETES_PORT': 'tcp://172.20.0.1:443', 'KUBERNETES_SERVICE_PORT': '443', 'CUDA_COREDUMP_SHOW_PROGRESS': '1', 'BUILDKITE_CONFIG_PATH': '/buildkite/buildkite-agent.cfg', 'BUILDKITE_K8S_SERVICE_ACCOUNT': 'default', 'BUILDKITE_PIPELINE_ID': '018cdabc-d930-49f6-9085-634c4cb582ed', 'BUILDKITE_AGENT_META_DATA_K8S_AGENT_STACK_VERSION': 'v0.38.0', 'BUILDKITE_ARTIFACT_PATHS': '', 'BUILDKITE_BUILD_CREATOR': 'yzong-rh', 'BUILDKITE_GIT_CHECKOUT_FLAGS': '-f', 'BUILDKITE_TRIGGERED_FROM_BUILD_ID': '', 'CI': 'true', 'BUILDKITE_KUBERNETES_EXEC': 'true', 'HOSTNAME': 'buildkite-019e00c4-b131-40db-8b1a-513aa2d204dc-2pwbn', 'VLLM_ENABLE_CUDA_COMPATIBILITY': '0', 'BUILDKITE_AGENT_ENDPOINT': 'https://agent.buildkite.com/v3', 'BUILDKITE_AGENT_ID': '019e0173-0c2b-42b3-b6d4-42db2b5e742d', 'BUILDKITE_K8S_NODE': 'inf-4x8h100-3', 'BUILDKITE_PIPELINE_TEAMS': 'everyone', 'BUILDKITE_PLUGIN_VALIDATION': 'false', 'LD_LIBRARY_PATH': '/usr/local/lib/python3.12/dist-packages/cv2/../../lib64:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64', 'SHLVL': '0', 'BUILDKITE_AGENT_META_DATA_QUEUE': 'mithril-h100-pool', 'BUILDKITE_BUILD_ID': '019e00c3-8f1d-4b76-bbaf-eb4f840ebede', 'BUILDKITE_PIPELINE_DEFAULT_BRANCH': 'main', 'BUILDKITE_STEP_IDENTIFIER': 'elastic-ep-scaling-test', 'BUILDKITE_STRICT_SINGLE_HOOKS': 'false', 'HOME': '/root', 'OLDPWD': '/workspace/build/buildkite', 'BUILDKITE_AGENT_PID': '7', 'BUILDKITE_BUILD_AUTHOR_EMAIL': '', 'BUILDKITE_STEP_KEY': 'elastic-ep-scaling-test', 'BUILDKITE_TRIGGERED_FROM_BUILD_NUMBER': '', 'BUILDKITE_BUILD_CREATOR_TEAMS': 'everyone', 'BUILDKITE_GIT_CLONE_FLAGS': '-v', 'CUDA_COREDUMP_GENERATION_FLAGS': 'skip_nonrelocated_elf_images,skip_global_memory,skip_shared_memory,skip_local_memory,skip_constbank_memory', 'BUILDKITE': 'true', 'BUILDKITE_AGENT_EXPERIMENT': '', 'BUILDKITE_COMPUTE_TYPE': 'self-hosted', 'BUILDKITE_ORGANIZATION_ID': '018b5ec5-c236-4037-ba08-d8a5d29bcdae', 'HF_HOME': '/root/.cache/huggingface', 'BUILDKITE_BUILD_NUMBER': '64854', 'BUILDKITE_BUILD_PATH': '/workspace/build', 'BUILDKITE_GROUP_KEY': '', 'BUILDKITE_AGENT_JOB_API_SOCKET': '/workspace/sockets/container-0/job-api/93-87912.sock', 'BUILDKITE_GROUP_LABEL': 'Expert Parallelism', 'BUILDKITE_PIPELINE_PROVIDER': 'github', 'BUILDKITE_SHELL': '/bin/sh -ec', 'BUILDKITE_TAG': '', 'BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG': '', 'NCCL_CUMEM_HOST_ENABLE': '0', 'BUILDKITE_JOB_ID': '019e00c4-b131-40db-8b1a-513aa2d204dc', 'BUILDKITE_K8S_NAMESPACE': 'buildkite', 'CUDA_VERSION': '13.0.2', 'BUILDKITE_AGENT_DEBUG_HTTP': 'false', 'BUILDKITE_BIN_PATH': '/workspace', 'BUILDKITE_COMMIT': 'f596e760c8ed0fbc53db45479c8d460f1a40fd06', 'BUILDKITE_LOCAL_HOOKS_ENABLED': 'true', 'UV_LINK_MODE': 'copy', 'BUILDKITE_GIT_MIRRORS_PATH': '', 'BUILDKITE_PULL_REQUEST': 'false', 'NVIDIA_REQUIRE_CUDA': 'cuda>=13.0 brand=unknown,driver>=535,driver<536 brand=grid,driver>=535,driver<536 brand=tesla,driver>=535,driver<536 brand=nvidia,driver>=535,driver<536 brand=quadro,driver>=535,driver<536 brand=quadrortx,driver>=535,driver<536 brand=nvidiartx,driver>=535,driver<536 brand=vapps,driver>=535,driver<536 brand=vpc,driver>=535,driver<536 brand=vcs,driver>=535,driver<536 brand=vws,driver>=535,driver<536 brand=cloudgaming,driver>=535,driver<536 brand=unknown,driver>=550,driver<551 brand=grid,driver>=550,driver<551 brand=tesla,driver>=550,driver<551 brand=nvidia,driver>=550,driver<551 brand=quadro,driver>=550,driver<551 brand=quadrortx,driver>=550,driver<551 brand=nvidiartx,driver>=550,driver<551 brand=vapps,driver>=550,driver<551 brand=vpc,driver>=550,driver<551 brand=vcs,driver>=550,driver<551 brand=vws,driver>=550,driver<551 brand=cloudgaming,driver>=550,driver<551 brand=unknown,driver>=565,driver<566 brand=grid,driver>=565,driver<566 brand=tesla,driver>=565,driver<566 brand=nvidia,driver>=565,driver<566 brand=quadro,driver>=565,driver<566 brand=quadrortx,driver>=565,driver<566 brand=nvidiartx,driver>=565,driver<566 brand=vapps,driver>=565,driver<566 brand=vpc,driver>=565,driver<566 brand=vcs,driver>=565,driver<566 brand=vws,driver>=565,driver<566 brand=cloudgaming,driver>=565,driver<566 brand=unknown,driver>=570,driver<571 brand=grid,driver>=570,driver<571 brand=tesla,driver>=570,driver<571 brand=nvidia,driver>=570,driver<571 brand=quadro,driver>=570,driver<571 brand=quadrortx,driver>=570,driver<571 brand=nvidiartx,driver>=570,driver<571 brand=vapps,driver>=570,driver<571 brand=vpc,driver>=570,driver<571 brand=vcs,driver>=570,driver<571 brand=vws,driver>=570,driver<571 brand=cloudgaming,driver>=570,driver<571 brand=unknown,driver>=575,driver<576 brand=grid,driver>=575,driver<576 brand=tesla,driver>=575,driver<576 brand=nvidia,driver>=575,driver<576 brand=quadro,driver>=575,driver<576 brand=quadrortx,driver>=575,driver<576 brand=nvidiartx,driver>=575,driver<576 brand=vapps,driver>=575,driver<576 brand=vpc,driver>=575,driver<576 brand=vcs,driver>=575,driver<576 brand=vws,driver>=575,driver<576 brand=cloudgaming,driver>=575,driver<576', 'NVIDIA_DRIVER_CAPABILITIES': 'compute,utility', 'BUILDKITE_AGENT_JOB_API_TOKEN': '[REDACTED]', 'BUILDKITE_ENV_FILE': '/workspace/job-env-019e00c4-b131-40db-8b1a-513aa2d204dc3507003521', 'UV_HTTP_TIMEOUT': '500', 'TERM': 'xterm-256color', 'BUILDKITE_CONTAINER_COUNT': '2', 'HF_TOKEN': '[REDACTED]', 'KUBERNETES_PORT_443_TCP_ADDR': '172.20.0.1', 'NV_CUDA_CUDART_VERSION': '13.0.96-1', 'BUILDKITE_BUILD_AUTHOR': '', 'BUILDKITE_CLUSTER_NAME': 'CI', 'BUILDKITE_COMMIT_RESOLVED': 'true', 'BUILDKITE_PIPELINE_SLUG': 'ci', 'PATH': '/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/workspace', 'NVARCH': 'x86_64', 'BUILDKITE_AGENT_META_DATA_K8S_SERVICE_ACCOUNT': 'default', 'BUILDKITE_PULL_REQUEST_BASE_BRANCH': '', 'BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS': '50', 'KUBERNETES_PORT_443_TCP_PORT': '443', 'BUILDKITE_RETRY_COUNT': '0', 'BUILDKITE_SOURCE': 'ui', 'KUBERNETES_PORT_443_TCP_PROTO': 'tcp', 'CUDA_ENABLE_COREDUMP_ON_EXCEPTION': '1', 'BUILDKITE_NO_HTTP2': 'false', 'BUILDKITE_REPO': 'https://github.com/vllm-project/vllm.git', 'BUILDKITE_AGENT_META_DATA_K8S_NODE': 'inf-4x8h100-3', 'BUILDKITE_REBUILT_FROM_BUILD_ID': '', 'BUILDKITE_REQUEST_HEADER_BUILDKITE_PIPELINES_SHARD_ID': '002', 'BUILDKITE_GIT_MIRRORS_SKIP_UPDATE': 'false', 'BUILDKITE_PLUGINS': '[]', 'BUILDKITE_SOCKETS_PATH': '/workspace/sockets/container-0', 'DEBIAN_FRONTEND': 'noninteractive', 'BUILDKITE_BOOTSTRAP_PHASES': 'plugin,command', 'BUILDKITE_BRANCH': 'atalman:release_212_tests', 'BUILDKITE_LABEL': 'Elastic EP Scaling Test', 'BUILDKITE_ORGANIZATION_SLUG': 'vllm', 'BUILDKITE_PLUGINS_ENABLED': 'true', 'BUILDKITE_PROJECT_PROVIDER': 'github', 'BUILDKITE_SSH_KEYSCAN': 'true', 'GIT_TERMINAL_PROMPT': '0', 'BUILDKITE_AGENT_DEBUG': 'false', 'BUILDKITE_CLUSTER_ID': '9cecc6b1-94cd-43d1-a256-ab438083f4f5', 'BUILDKITE_GIT_SUBMODULES': 'true', 'HF_HUB_DOWNLOAD_TIMEOUT': '60', 'VLLM_USAGE_SOURCE': 'ci-test', 'BUILDKITE_BUILD_CREATOR_EMAIL': 'yzong@redhat.com', 'BUILDKITE_REBUILT_FROM_BUILD_NUMBER': '', 'BUILDKITE_BUILD_URL': 'https://buildkite.com/vllm/ci/builds/64854', 'BUILDKITE_COMMAND': 'cd /vllm-workspace/tests\necho "--- :nvidia: GPU Info"\n(command nvidia-smi || true)\necho "--- :gear: CUDA Coredump Setup"\nexport CUDA_ENABLE_COREDUMP_ON_EXCEPTION=1 && export CUDA_COREDUMP_SHOW_PROGRESS=1 && export CUDA_COREDUMP_GENERATION_FLAGS="skip_nonrelocated_elf_images,skip_global_memory,skip_shared_memory,skip_local_memory,skip_constbank_memory"\necho "+++ :test_tube: Command (1/1): pytest -v -s distributed/test_elastic_ep.py"\npytest -v -s distributed/test_elastic_ep.py', 'BUILDKITE_HOOKS_PATH': '/workspace/hooks', 'BUILDKITE_COMMAND_EVAL': 'true', 'BUILDKITE_PULL_REQUEST_REPO': '', 'BUILDKITE_TIMEOUT': '600', 'KUBERNETES_PORT_443_TCP': 'tcp://172.20.0.1:443', 'KUBERNETES_SERVICE_PORT_HTTPS': '443', 'BUILDKITE_GIT_CLONE_MIRROR_FLAGS': '-v', 'BUILDKITE_PLUGINS_PATH': '/workspace/plugins', 'BUILDKITE_STEP_ID': '019e00c4-af8c-4a4a-8084-da1a5bbbe97c', 'BUILDKITE_AGENT_META_DATA_K8S_NAMESPACE': 'buildkite', 'BUILDKITE_GIT_CLEAN_FLAGS': '-ffxdq', 'BUILDKITE_PIPELINE_NAME': 'CI', 'BUILDKITE_SCRIPT_PATH': 'cd /vllm-workspace/tests\necho "--- :nvidia: GPU Info"\n(command nvidia-smi || true)\necho "--- :gear: CUDA Coredump Setup"\nexport CUDA_ENABLE_COREDUMP_ON_EXCEPTION=1 && export CUDA_COREDUMP_SHOW_PROGRESS=1 && export CUDA_COREDUMP_GENERATION_FLAGS="skip_nonrelocated_elf_images,skip_global_memory,skip_shared_memory,skip_local_memory,skip_constbank_memory"\necho "+++ :test_tube: Command (1/1): pytest -v -s distributed/test_elastic_ep.py"\npytest -v -s distributed/test_elastic_ep.py', 'KUBERNETES_SERVICE_HOST': '172.20.0.1', 'PWD': '/vllm-workspace/tests', 'UV_INDEX_STRATEGY': 'unsafe-best-match', 'BUILDKITE_GIT_MIRRORS_LOCK_TIMEOUT': '300', 'BUILDKITE_REDACTED_VARS': '*_PASSWORD,*_SECRET,*_TOKEN,*_PRIVATE_KEY,*_ACCESS_KEY,*_SECRET_KEY,*_CONNECTION_STRING', 'BUILDKITE_GROUP_ID': '019e00c4-af8a-4e0d-9c7a-82b528ddc05b', 'BUILDKITE_PROJECT_SLUG': 'vllm/ci', 'BUILDKITE_AGENT_NAME': 'buildkite-019e00c4-b131-40db-8b1a-513aa2d204dc-2pwbn-1', 'BUILDKITE_MESSAGE': 'Retry without `Revert "[Bugfix] Fix RuntimeError: Already borrowed by adding thread-safe Hugging Face fast-tokenizer wrappers"`', 'NVIDIA_VISIBLE_DEVICES': 'void', 'BUILDKITE_AGENT_ACCESS_TOKEN': '[REDACTED]', 'BUILDKITE_AGENT_DISABLE_WARNINGS_FOR': '', 'BUILDKITE_ENV_JSON_FILE': '/workspace/job-env-json-019e00c4-b131-40db-8b1a-513aa2d204dc3222473979', 'BUILDKITE_TRACE_CONTEXT_ENCODING': 'gob', 'LC_CTYPE': 'C.UTF-8', 'PYTEST_VERSION': '8.3.5', 'TORCHINDUCTOR_CACHE_DIR': '/tmp/torchinductor_root', 'KMP_DUPLICATE_LIB_OK': 'True', 'KMP_INIT_AT_FORK': 'FALSE', 'PYTORCH_NVML_BASED_CUDA_CHECK': '1', 'TORCHINDUCTOR_COMPILE_THREADS': '1', 'TRITON_CACHE_AUTOTUNING': '1', 'UCX_RCACHE_MAX_UNRELEASED': '1024', 'PYTEST_CURRENT_TEST': 'tests/distributed/test_elastic_ep.py::test_elastic_ep_scaling (call)', 'RAY_CLIENT_MODE': '0', 'VLLM_WORKER_MULTIPROC_METHOD': 'spawn'}
+
+_bk;t=1778140839111[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:00:39[0m [90m[utils.py:306][0m
+
+
+_bk;t=1778140839111[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:00:39[0m [90m[utils.py:306][0m        [97;1m█     █     █▄   ▄█[0m
+
+
+_bk;t=1778140839111[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:00:39[0m [90m[utils.py:306][0m  [93m▄▄[0m [94m▄█[0m [97;1m█     █     █ ▀▄▀ █[0m  version [97;1m0.20.2rc1.dev96+gf596e760c[0m
+
+
+_bk;t=1778140839111[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:00:39[0m [90m[utils.py:306][0m   [93m█[0m[94m▄█▀[0m [97;1m█     █     █     █[0m  model   [97;1mdeepseek-ai/DeepSeek-V2-Lite-Chat[0m
+
+
+_bk;t=1778140839111[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:00:39[0m [90m[utils.py:306][0m    [94m▀▀[0m  [97;1m▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀[0m
+
+
+_bk;t=1778140839111[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:00:39[0m [90m[utils.py:306][0m
+
+_bk;t=1778140839114[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:00:39[0m [90m[utils.py:240][0m non-default args: {'model_tag': 'deepseek-ai/DeepSeek-V2-Lite-Chat', 'port': 50109, 'model': 'deepseek-ai/DeepSeek-V2-Lite-Chat', 'trust_remote_code': True, 'max_model_len': 4096, 'data_parallel_size': 2, 'data_parallel_backend': 'ray', 'enable_expert_parallel': True, 'enable_elastic_ep': True, 'enable_eplb': True, 'gpu_memory_utilization': 0.8, 'max_num_seqs': 32}
+
+_bk;t=1778140839708[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778140839708[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778140839708[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778140839778[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778140839778[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778140839778[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778140839779[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778140839779[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778140839779[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778140840101[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:00:40[0m [90m[model.py:563][0m Resolved architecture: DeepseekV2ForCausalLM
+
+_bk;t=1778140840101[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:00:40[0m [90m[model.py:1692][0m Using max model len 4096
+
+_bk;t=1778140840102[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:00:40[0m [90m[arg_utils.py:1857][0m Using host IP 192.168.5.77 as ray-based data parallel address
+
+_bk;t=1778140840102[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:00:40[0m [90m[parallel.py:856][0m Using ray distributed inference because data_parallel_backend is ray
+
+_bk;t=1778140840102[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:00:40[0m [90m[scheduler.py:239][0m Chunked prefill is enabled with max_num_batched_tokens=8192.
+
+_bk;t=1778140840107[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:00:40[0m [90m[vllm.py:844][0m Asynchronous scheduling is enabled.
+
+_bk;t=1778140840107[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:00:40[0m [90m[vllm.py:854][0m Disabling NCCL for DP synchronization when using async scheduling.
+
+_bk;t=1778140840107[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:00:40[0m [90m[kernel.py:212][0m Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
+
+_bk;t=1778140841583[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778140841583[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778140841583[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778140841588[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778140841588[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778140841588[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778140841589[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778140841589[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778140841589[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778140841851[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778140841851[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778140841851[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778140849584[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:00:49[0m [90m[utils.py:1040][0m Started DP Coordinator process (PID: 973)
+
+_bk;t=1778140849584[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:00:49[0m [90m[utils.py:1045][0m Starting ray-based data parallel backend
+
+_bk;t=1778140849584[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:00:49[0m [90m[ray_env.py:100][0m Env var prefixes to copy: ['HF_', 'HUGGING_FACE_', 'LMCACHE_', 'NCCL_', 'UCX_', 'VLLM_']
+
+_bk;t=1778140849584[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:00:49[0m [90m[ray_env.py:101][0m Copying the following environment variables to DPMoEEngineCoreActor: ['HF_HOME', 'HF_HUB_DOWNLOAD_TIMEOUT', 'HF_TOKEN', 'HF_XET_HIGH_PERFORMANCE', 'LD_LIBRARY_PATH', 'NCCL_CUMEM_HOST_ENABLE', 'UCX_RCACHE_MAX_UNRELEASED', 'VLLM_ENABLE_CUDA_COMPATIBILITY', 'VLLM_USAGE_SOURCE', 'VLLM_WORKER_MULTIPROC_METHOD']
+
+_bk;t=1778140849584[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:00:49[0m [90m[ray_env.py:111][0m To exclude env vars from copying, add them to /root/.config/vllm/ray_non_carry_over_env_vars.json
+
+_bk;t=1778140852341[0;36m(APIServer pid=707)[0;0m 2026-05-07 08:00:52,340	INFO worker.py:1918 -- Started a local Ray instance. View the dashboard at [1m[32mhttp://127.0.0.1:8265 [39m[22m
+
+_bk;t=1778140853644[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:00:53[0m [90m[utils.py:479][0m Creating placement groups for data parallel
+
+_bk;t=1778140860010[0;36m(APIServer pid=707)[0;0m [36m(pid=11351)[0m W0507 08:00:59.988000 11351 torch/utils/cpp_extension.py:140] No CUDA runtime is found, using CUDA_HOME='/usr/local/cuda'
+
+_bk;t=1778140860433[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11351)[0m INFO 05-07 08:01:00 [ray_utils.py:568] Ray is already initialized. Skipping Ray initialization.
+
+_bk;t=1778140860433[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11351)[0m INFO 05-07 08:01:00 [ray_utils.py:599] Using the existing placement group
+
+_bk;t=1778140860434[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11350)[0m INFO 05-07 08:01:00 [core.py:109] Initializing a V1 LLM engine (v0.20.2rc1.dev96+gf596e760c) with config: model='deepseek-ai/DeepSeek-V2-Lite-Chat', speculative_config=None, tokenizer='deepseek-ai/DeepSeek-V2-Lite-Chat', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=4096, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=2, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=None, quantization_config=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=deepseek-ai/DeepSeek-V2-Lite-Chat, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'ir_enable_torch_wrap': True, 'splitting_ops': ['vllm::unified_attention_with_output', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::gdn_attention_core_xpu', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::deepseek_v4_attention', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': [], 'compile_ranges_endpoints': [8192], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 64, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': False, 'static_all_moe_layers': []}, kernel_config=KernelConfig(ir_op_priority=IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native']), enable_flashinfer_autotune=False, moe_backend='auto')
+
+_bk;t=1778140868028[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m WARNING 05-07 08:01:07 [nixl_utils.py:34] NIXL is not available
+
+_bk;t=1778140868028[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m WARNING 05-07 08:01:07 [nixl_utils.py:44] NIXL agent config is not available
+
+_bk;t=1778140868028[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11350)[0m INFO 05-07 08:01:00 [ray_utils.py:568] Ray is already initialized. Skipping Ray initialization.
+
+_bk;t=1778140868028[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11350)[0m INFO 05-07 08:01:00 [ray_utils.py:599] Using the existing placement group
+
+_bk;t=1778140868348[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m WARNING 05-07 08:01:08 [worker_base.py:292] Missing `shared_worker_lock` argument from executor. This argument is needed for mm_processor_cache_type='shm'.
+
+_bk;t=1778140868980[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker pid=11767) INFO 05-07 08:01:08 [parallel_state.py:1410] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://192.168.5.77:54657 backend=nccl
+
+_bk;t=1778140874919[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker pid=11768) INFO 05-07 08:01:14 [pynccl.py:111] vLLM is using nccl==2.29.7
+
+_bk;t=1778140874919[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m WARNING 05-07 08:01:08 [nixl_utils.py:34] NIXL is not available
+
+_bk;t=1778140874919[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m WARNING 05-07 08:01:08 [nixl_utils.py:44] NIXL agent config is not available
+
+_bk;t=1778140874919[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m WARNING 05-07 08:01:08 [worker_base.py:292] Missing `shared_worker_lock` argument from executor. This argument is needed for mm_processor_cache_type='shm'.
+
+_bk;t=1778140874919[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker pid=11768) INFO 05-07 08:01:09 [parallel_state.py:1410] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://192.168.5.77:58165 backend=nccl
+
+_bk;t=1778140876280[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker pid=11768) INFO 05-07 08:01:16 [cuda_communicator.py:168] Using AgRsAll2AllManager all2all manager.
+
+_bk;t=1778140886689[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker pid=11768) INFO 05-07 08:01:26 [parallel_state.py:1723] rank 0 in world size 2 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank 0, EPLB rank 0
+
+_bk;t=1778140887212[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker pid=11768) INFO 05-07 08:01:27 [topk_topp_sampler.py:45] Using FlashInfer for top-p & top-k sampling.
+
+_bk;t=1778140887320[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:01:27 [gpu_model_runner.py:4842] Starting to load model deepseek-ai/DeepSeek-V2-Lite-Chat...
+
+_bk;t=1778140887739[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:01:27 [cuda.py:368] Using FLASH_ATTN_MLA attention backend out of potential backends: ['FLASH_ATTN_MLA', 'FLASHMLA', 'TRITON_MLA'].
+
+_bk;t=1778140887739[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:01:27 [selector.py:162] Using FLASH_ATTN MLA prefill backend.
+
+_bk;t=1778140887847[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:01:27 [deep_gemm.py:113] DeepGEMM E8M0 enabled on current platform.
+
+_bk;t=1778140887847[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:01:27 [layer.py:408] [EP Rank 0/2] Expert parallelism is enabled. Expert placement strategy: linear. Local/global number of experts: 32/64. Experts local to global index map: 0->0, 1->1, 2->2, 3->3, 4->4, 5->5, 6->6, 7->7, 8->8, 9->9, 10->10, 11->11, 12->12, 13->13, 14->14, 15->15, 16->16, 17->17, 18->18, 19->19, 20->20, 21->21, 22->22, 23->23, 24->24, 25->25, 26->26, 27->27, 28->28, 29->29, 30->30, 31->31.
+
+_bk;t=1778140887847[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:01:27 [unquantized.py:286] Using TRITON Unquantized MoE backend out of potential backends: ['FlashInfer TRTLLM', 'TRITON', 'BATCHED_TRITON', 'FlashInfer CUTLASS'].
+
+_bk;t=1778140888689[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:01:28 [weight_utils.py:904] Filesystem type for checkpoints: VIRTIOFS. Checkpoint size: 29.26 GiB. Available RAM: 1597.55 GiB.
+
+_bk;t=1778140888689[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:01:28 [weight_utils.py:927] Auto-prefetch is disabled because the filesystem (VIRTIOFS) is not a recognized network FS (NFS/Lustre). If you want to force prefetching, start vLLM with --safetensors-load-strategy=prefetch.
+
+_bk;t=1778140888690[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768)
+Loading safetensors checkpoint shards:   0% Completed | 0/4 [00:00<?, ?it/s]
+
+_bk;t=1778140888690[0;36m(APIServer pid=707)[0;0m [36m(pid=11350)[0m W0507 08:01:00.061000 11350 torch/utils/cpp_extension.py:140] No CUDA runtime is found, using CUDA_HOME='/usr/local/cuda'
+
+_bk;t=1778140896095[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767)
+Loading safetensors checkpoint shards:  25% Completed | 1/4 [00:07<00:21,  7.24s/it]
+
+_bk;t=1778140896095[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767)
+Loading safetensors checkpoint shards:   0% Completed | 0/4 [00:00<?, ?it/s]
+
+_bk;t=1778140903393[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768)
+Loading safetensors checkpoint shards:  50% Completed | 2/4 [00:14<00:14,  7.31s/it][32m [repeated 2x across cluster] (Ray deduplicates logs by default. Set RAY_DEDUP_LOGS=0 to disable log deduplication, or see https://docs.ray.io/en/master/ray-observability/user-guides/configure-logging.html#log-deduplication for more options.)[0m
+
+_bk;t=1778140910684[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768)
+Loading safetensors checkpoint shards:  75% Completed | 3/4 [00:22<00:07,  7.32s/it][32m [repeated 2x across cluster][0m
+
+_bk;t=1778140917249[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768)
+
+_bk;t=1778140917249[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768)
+Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:28<00:00,  7.16s/it][32m [repeated 3x across cluster][0m
+
+_bk;t=1778140917249[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767)
+
+_bk;t=1778140917357[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:01:57 [default_loader.py:391] Loading weights took 28.72 seconds
+
+_bk;t=1778140917357[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:01:57 [unquantized.py:343] Using MoEPrepareAndFinalizeNaiveDPEPModular
+
+_bk;t=1778140917357[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:01:57 [gpu_model_runner.py:4920] EPLB is enabled for model deepseek-ai/DeepSeek-V2-Lite-Chat.
+
+_bk;t=1778140917357[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:01:57 [eplb_communicator.py:83] Initialized EPLB communicator: PyNcclEplbCommunicator.
+
+_bk;t=1778140917357[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker pid=11767) INFO 05-07 08:01:26 [parallel_state.py:1723] rank 1 in world size 2 is assigned as DP rank 1, PP rank 0, PCP rank 0, TP rank 0, EP rank 1, EPLB rank 1
+
+_bk;t=1778140917358[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:01:27 [cuda.py:368] Using FLASH_ATTN_MLA attention backend out of potential backends: ['FLASH_ATTN_MLA', 'FLASHMLA', 'TRITON_MLA'].
+
+_bk;t=1778140917358[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:01:27 [selector.py:162] Using FLASH_ATTN MLA prefill backend.
+
+_bk;t=1778140917358[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:01:27 [deep_gemm.py:113] DeepGEMM E8M0 enabled on current platform.
+
+_bk;t=1778140917358[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:01:27 [layer.py:408] [EP Rank 1/2] Expert parallelism is enabled. Expert placement strategy: linear. Local/global number of experts: 32/64. Experts local to global index map: 0->32, 1->33, 2->34, 3->35, 4->36, 5->37, 6->38, 7->39, 8->40, 9->41, 10->42, 11->43, 12->44, 13->45, 14->46, 15->47, 16->48, 17->49, 18->50, 19->51, 20->52, 21->53, 22->54, 23->55, 24->56, 25->57, 26->58, 27->59, 28->60, 29->61, 30->62, 31->63.
+
+_bk;t=1778140917358[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:01:27 [unquantized.py:286] Using TRITON Unquantized MoE backend out of potential backends: ['FlashInfer TRTLLM', 'TRITON', 'BATCHED_TRITON', 'FlashInfer CUTLASS'].
+
+_bk;t=1778140917358[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:01:28 [weight_utils.py:904] Filesystem type for checkpoints: VIRTIOFS. Checkpoint size: 29.26 GiB. Available RAM: 1597.97 GiB.
+
+_bk;t=1778140917358[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:01:28 [weight_utils.py:927] Auto-prefetch is disabled because the filesystem (VIRTIOFS) is not a recognized network FS (NFS/Lustre). If you want to force prefetching, start vLLM with --safetensors-load-strategy=prefetch.
+
+_bk;t=1778140917990[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:01:57 [gpu_model_runner.py:4944] Model loading took 16.57 GiB memory and 29.777644 seconds
+
+_bk;t=1778140918306[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:01:58 [dp_utils.py:28] Using CPU all reduce to synchronize DP padding between ranks.
+
+_bk;t=1778140924258[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:02:04 [backends.py:1089] Using cache directory: /root/.cache/vllm/torch_compile_cache/00679c7f8c/rank_0_0/backbone for vLLM's torch.compile
+
+_bk;t=1778140924258[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:02:04 [backends.py:1148] Dynamo bytecode transform time: 4.89 s
+
+_bk;t=1778140924258[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:01:57 [default_loader.py:391] Loading weights took 28.84 seconds
+
+_bk;t=1778140924258[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:01:57 [unquantized.py:343] Using MoEPrepareAndFinalizeNaiveDPEPModular
+
+_bk;t=1778140924258[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:01:57 [gpu_model_runner.py:4920] EPLB is enabled for model deepseek-ai/DeepSeek-V2-Lite-Chat.
+
+_bk;t=1778140924258[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:01:57 [eplb_communicator.py:83] Initialized EPLB communicator: PyNcclEplbCommunicator.
+
+_bk;t=1778140924258[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:01:58 [gpu_model_runner.py:4944] Model loading took 16.57 GiB memory and 29.901747 seconds
+
+_bk;t=1778140924258[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:01:58 [dp_utils.py:28] Using CPU all reduce to synchronize DP padding between ranks.
+
+_bk;t=1778140934501[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:02:14 [backends.py:393] Compiling a graph for compile range (1, 8192) takes 10.21 s
+
+_bk;t=1778140934501[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:02:04 [backends.py:1089] Using cache directory: /root/.cache/vllm/torch_compile_cache/00679c7f8c/rank_0_1/backbone for vLLM's torch.compile
+
+_bk;t=1778140934501[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:02:04 [backends.py:1148] Dynamo bytecode transform time: 4.89 s
+
+_bk;t=1778140936897[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:02:16 [backends.py:915] collected artifacts: 28 entries, 4 artifacts, 7234811 bytes total
+
+_bk;t=1778140936897[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:02:16 [decorators.py:708] saved AOT compiled function to /root/.cache/vllm/torch_compile_cache/torch_aot_compile/ff9c3316c0705b1d758398a034722258453633687e3684f2c727c0d53a13edce/rank_0_0/model
+
+_bk;t=1778140936897[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:02:16 [monitor.py:53] torch.compile took 17.58 s in total
+
+_bk;t=1778140940330[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) WARNING 05-07 08:02:20 [fused_moe.py:1091] Using default MoE config. Performance might be sub-optimal! Config file not found at /usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/configs/E=32,N=1408,device_name=NVIDIA_H100_80GB_HBM3.json
+
+_bk;t=1778140940330[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:02:14 [backends.py:393] Compiling a graph for compile range (1, 8192) takes 10.26 s
+
+_bk;t=1778140941168[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:02:21 [monitor.py:81] Initial profiling/warmup run took 4.31 s
+
+_bk;t=1778140941168[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:02:21 [eplb_state.py:684] Rearranging experts sync mode (profile)...
+
+_bk;t=1778140941588[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:02:21 [eplb_state.py:787] Rearranged experts  (profile)  in 0.38 s.
+
+_bk;t=1778140941588[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) /usr/local/lib/python3.12/dist-packages/torch/distributed/c10d_logger.py:83: UserWarning: barrier(): using the device under current context. You can specify `device_id` in `init_process_group` to mute this warning.
+
+_bk;t=1778140941588[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768)   return func(*args, **kwargs)
+
+_bk;t=1778140941588[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m [rank0]:[W507 08:02:21.635164157 ProcessGroupNCCL.cpp:5324] Guessing device ID based on global rank. This can cause a hang if rank to GPU mapping is heterogeneous. You can specify device_id in init_process_group()
+
+_bk;t=1778140941588[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767)
+Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:28<00:00,  7.10s/it][32m [repeated 2x across cluster][0m
+
+_bk;t=1778140948553[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:02:28 [gpu_model_runner.py:6048] Profiling CUDA graph memory: PIECEWISE=11 (largest=64), FULL=7 (largest=32)
+
+_bk;t=1778140948553[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:02:16 [backends.py:915] collected artifacts: 28 entries, 4 artifacts, 7234811 bytes total
+
+_bk;t=1778140948553[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:02:16 [decorators.py:708] saved AOT compiled function to /root/.cache/vllm/torch_compile_cache/torch_aot_compile/ff9c3316c0705b1d758398a034722258453633687e3684f2c727c0d53a13edce/rank_0_1/model
+
+_bk;t=1778140948553[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:02:16 [monitor.py:53] torch.compile took 17.69 s in total
+
+_bk;t=1778140948553[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) WARNING 05-07 08:02:20 [fused_moe.py:1091] Using default MoE config. Performance might be sub-optimal! Config file not found at /usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/configs/E=32,N=1408,device_name=NVIDIA_H100_80GB_HBM3.json
+
+_bk;t=1778140948554[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:02:21 [monitor.py:81] Initial profiling/warmup run took 4.20 s
+
+_bk;t=1778140951891[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:02:31 [gpu_model_runner.py:6127] Estimated CUDA graph memory: 0.34 GiB total
+
+_bk;t=1778140952311[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11351)[0m INFO 05-07 08:02:32 [kv_cache_utils.py:1710] GPU KV cache size: 1,493,264 tokens
+
+_bk;t=1778140952311[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11351)[0m INFO 05-07 08:02:32 [kv_cache_utils.py:1711] Maximum concurrency for 4,096 tokens per request: 364.57x
+
+_bk;t=1778140952312[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:02:32 [gpu_worker.py:460] Available KV cache memory: 43.26 GiB
+
+_bk;t=1778140952312[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:02:32 [gpu_worker.py:475] CUDA graph memory profiling is enabled (default since v0.21.0). The current --gpu-memory-utilization=0.8000 is equivalent to --gpu-memory-utilization=0.7957 without CUDA graph memory profiling. To maintain the same effective KV cache size as before, increase --gpu-memory-utilization to 0.8043. To disable, set VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0.
+
+_bk;t=1778140952312[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:02:32 [kernel_warmup.py:44] Skipping FlashInfer autotune because it is disabled.
+
+_bk;t=1778140952737[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768)
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):   0%|          | 0/11 [00:00<?, ?it/s]
+
+_bk;t=1778140952737[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) /usr/local/lib/python3.12/dist-packages/torch/distributed/c10d_logger.py:83: UserWarning: barrier(): using the device under current context. You can specify `device_id` in `init_process_group` to mute this warning.
+
+_bk;t=1778140952737[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767)   return func(*args, **kwargs)
+
+_bk;t=1778140952737[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m [rank0]:[W507 08:02:21.635297024 ProcessGroupNCCL.cpp:5324] Guessing device ID based on global rank. This can cause a hang if rank to GPU mapping is heterogeneous. You can specify device_id in init_process_group()
+
+_bk;t=1778140952851[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):   9%|▉         | 1/11 [00:00<00:01,  6.85it/s]
+
+_bk;t=1778140952963[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  18%|█▊        | 2/11 [00:00<00:01,  6.69it/s]
+
+_bk;t=1778140953712[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  27%|██▋       | 3/11 [00:01<00:03,  2.41it/s]
+
+_bk;t=1778140953929[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  36%|███▋      | 4/11 [00:01<00:02,  3.01it/s]
+
+_bk;t=1778140954042[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  45%|████▌     | 5/11 [00:01<00:01,  3.75it/s]
+
+_bk;t=1778140954256[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  55%|█████▍    | 6/11 [00:01<00:01,  4.38it/s]
+
+_bk;t=1778140954885[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  64%|██████▎   | 7/11 [00:02<00:01,  2.66it/s]
+
+_bk;t=1778140955097[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  73%|███████▎  | 8/11 [00:02<00:00,  3.23it/s]
+
+_bk;t=1778140955309[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  82%|████████▏ | 9/11 [00:02<00:00,  3.52it/s]
+
+_bk;t=1778140955941[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  91%|█████████ | 10/11 [00:03<00:00,  2.48it/s]
+
+_bk;t=1778140957296[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|██████████| 11/11 [00:04<00:00,  1.44it/s]
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|██████████| 11/11 [00:04<00:00,  2.37it/s]
+
+_bk;t=1778140957296[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768)
+Capturing CUDA graphs (decode, FULL):   0%|          | 0/7 [00:00<?, ?it/s]
+
+_bk;t=1778140957507[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m
+Capturing CUDA graphs (decode, FULL):  14%|█▍        | 1/7 [00:00<00:00,  6.44it/s]
+
+_bk;t=1778140957615[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m
+Capturing CUDA graphs (decode, FULL):  29%|██▊       | 2/7 [00:00<00:00,  6.99it/s]
+
+_bk;t=1778140957723[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m
+Capturing CUDA graphs (decode, FULL):  43%|████▎     | 3/7 [00:00<00:00,  7.14it/s]
+
+_bk;t=1778140957935[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m
+Capturing CUDA graphs (decode, FULL):  57%|█████▋    | 4/7 [00:00<00:00,  6.53it/s]
+
+_bk;t=1778140958044[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m
+Capturing CUDA graphs (decode, FULL):  71%|███████▏  | 5/7 [00:00<00:00,  6.80it/s]
+
+_bk;t=1778140958255[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m
+Capturing CUDA graphs (decode, FULL):  86%|████████▌ | 6/7 [00:00<00:00,  6.81it/s]
+
+_bk;t=1778140958364[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m
+Capturing CUDA graphs (decode, FULL): 100%|██████████| 7/7 [00:01<00:00,  7.09it/s]
+Capturing CUDA graphs (decode, FULL): 100%|██████████| 7/7 [00:01<00:00,  6.92it/s]
+
+_bk;t=1778140958785[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:02:38 [gpu_model_runner.py:6218] Graph capturing finished in 6 secs, took 0.30 GiB
+
+_bk;t=1778140958785[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:02:38 [gpu_worker.py:619] CUDA graph pool memory: 0.3 GiB (actual), 0.34 GiB (estimated), difference: 0.04 GiB (14.4%).
+
+_bk;t=1778140958785[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:02:28 [gpu_model_runner.py:6048] Profiling CUDA graph memory: PIECEWISE=11 (largest=64), FULL=7 (largest=32)
+
+_bk;t=1778140958785[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:02:31 [gpu_model_runner.py:6127] Estimated CUDA graph memory: 0.34 GiB total
+
+_bk;t=1778140958785[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11350)[0m INFO 05-07 08:02:32 [kv_cache_utils.py:1710] GPU KV cache size: 1,493,264 tokens
+
+_bk;t=1778140958785[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11350)[0m INFO 05-07 08:02:32 [kv_cache_utils.py:1711] Maximum concurrency for 4,096 tokens per request: 364.57x
+
+_bk;t=1778140958785[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:02:32 [gpu_worker.py:460] Available KV cache memory: 43.26 GiB
+
+_bk;t=1778140958785[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:02:32 [gpu_worker.py:475] CUDA graph memory profiling is enabled (default since v0.21.0). The current --gpu-memory-utilization=0.8000 is equivalent to --gpu-memory-utilization=0.7957 without CUDA graph memory profiling. To maintain the same effective KV cache size as before, increase --gpu-memory-utilization to 0.8043. To disable, set VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0.
+
+_bk;t=1778140958785[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:02:32 [kernel_warmup.py:44] Skipping FlashInfer autotune because it is disabled.
+
+_bk;t=1778140958893[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11351)[0m INFO 05-07 08:02:38 [core.py:299] init engine (profile, create kv cache, warmup model) took 40.45 s (compilation: 17.69 s)
+
+_bk;t=1778140958894[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) INFO 05-07 08:02:38 [jit_monitor.py:54] Kernel JIT monitor activated — Triton JIT compilations during inference will be logged as warnings.
+
+_bk;t=1778140959524[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11350)[0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778140959524[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11350)[0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778140959524[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11350)[0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778140959632[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11350)[0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778140959632[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11350)[0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778140959632[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11350)[0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778140959632[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11350)[0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778140959632[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11350)[0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778140959632[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11350)[0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778140962779[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11350)[0m WARNING 05-07 08:02:42 [nixl_utils.py:34] NIXL is not available
+
+_bk;t=1778140962779[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11350)[0m WARNING 05-07 08:02:42 [nixl_utils.py:44] NIXL agent config is not available
+
+_bk;t=1778140963888[32mINFO[0m [90m05-07 08:02:43[0m [90m[coordinator.py:255][0m All engine subscriptions received by DP coordinator
+
+_bk;t=1778140963901[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:43[0m [90m[api_server.py:613][0m Supported tasks: ['generate']
+
+_bk;t=1778140964252[0;36m(APIServer pid=707)[0;0m [33mWARNING[0m [90m05-07 08:02:44[0m [90m[model.py:1449][0m Default vLLM sampling parameters have been overridden by the model's `generation_config.json`: `{'temperature': 0.3, 'top_p': 0.95}`. If this is not intended, please relaunch vLLM instance with `--generation-config vllm`.
+
+_bk;t=1778140965768[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778140965768[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778140965768[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778140966420[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778140966420[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778140966420[0;36m(APIServer pid=707)[0;0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778140967405[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[hf.py:483][0m Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[api_server.py:617][0m Starting vLLM server on http://0.0.0.0:50109
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:37][0m Available routes are:
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /openapi.json, Methods: HEAD, GET
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /docs, Methods: HEAD, GET
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /docs/oauth2-redirect, Methods: HEAD, GET
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /redoc, Methods: HEAD, GET
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /tokenize, Methods: POST
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /detokenize, Methods: POST
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /load, Methods: GET
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /version, Methods: GET
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /health, Methods: GET
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /metrics, Methods: GET
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /v1/models, Methods: GET
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /ping, Methods: GET
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /ping, Methods: POST
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /invocations, Methods: POST
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /v1/chat/completions, Methods: POST
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /v1/chat/completions/batch, Methods: POST
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /v1/responses, Methods: POST
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /v1/responses/{response_id}, Methods: GET
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /v1/responses/{response_id}/cancel, Methods: POST
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /v1/completions, Methods: POST
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /v1/messages, Methods: POST
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /v1/messages/count_tokens, Methods: POST
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /inference/v1/generate, Methods: POST
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /scale_elastic_ep, Methods: POST
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /is_scaling_elastic_ep, Methods: POST
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /generative_scoring, Methods: POST
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /v1/chat/completions/render, Methods: POST
+
+_bk;t=1778140967589[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:47[0m [90m[launcher.py:46][0m Route: /v1/completions/render, Methods: POST
+
+_bk;t=1778140967668[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     Started server process [[36m707[0m]
+
+_bk;t=1778140967668[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     Waiting for application startup.
+
+_bk;t=1778140968034[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     Application startup complete.
+
+_bk;t=1778140968492[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:56968 - "[1mGET /health HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140968492Downloading from https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/train.jsonl to /tmp/train.jsonl
+
+_bk;t=1778140968939Downloading from https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl to /tmp/test.jsonl
+
+_bk;t=1778140969060Running GSM8K evaluation: 256 questions, 5-shot
+
+_bk;t=1778140969062
+Evaluating:   0%|                                                                                                                       | 0/256 [00:00<?, ?it/s][0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) WARNING 05-07 08:02:49 [jit_monitor.py:103] Triton kernel JIT compilation during inference: _compute_slot_mapping_kernel. This causes a latency spike; consider extending warmup to cover this shape/config.
+
+_bk;t=1778140969341[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:02:38 [gpu_model_runner.py:6218] Graph capturing finished in 7 secs, took 0.30 GiB
+
+_bk;t=1778140969341[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:02:38 [gpu_worker.py:619] CUDA graph pool memory: 0.3 GiB (actual), 0.34 GiB (estimated), difference: 0.04 GiB (14.4%).
+
+_bk;t=1778140969341[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11350)[0m INFO 05-07 08:02:38 [core.py:299] init engine (profile, create kv cache, warmup model) took 40.90 s (compilation: 17.58 s)
+
+_bk;t=1778140969341[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) INFO 05-07 08:02:38 [jit_monitor.py:54] Kernel JIT monitor activated — Triton JIT compilations during inference will be logged as warnings.
+
+_bk;t=1778140969341[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11351)[0m WARNING 05-07 08:02:43 [nixl_utils.py:34] NIXL is not available
+
+_bk;t=1778140969341[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11351)[0m WARNING 05-07 08:02:43 [nixl_utils.py:44] NIXL agent config is not available
+
+_bk;t=1778140969656[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11768)[0m (Worker_DP0_EP0 pid=11768) WARNING 05-07 08:02:49 [jit_monitor.py:103] Triton kernel JIT compilation during inference: fused_moe_kernel. This causes a latency spike; consider extending warmup to cover this shape/config.
+
+_bk;t=1778140972034[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57022 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140972035
+Evaluating:   0%|▍                                                                                                              | 1/256 [00:02<12:38,  2.97s/it][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57080 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140972044[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57338 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140972233[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57448 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140972233
+Evaluating:   2%|█▋                                                                                                             | 4/256 [00:03<02:35,  1.62it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57076 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140972319[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57524 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140972321[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57430 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140973323[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57210 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140973324
+Evaluating:   3%|███▍                                                                                                           | 8/256 [00:04<01:41,  2.45it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57398 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140973398[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57018 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140973408[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57502 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140973582[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57570 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140973582
+Evaluating:   5%|█████▏                                                                                                        | 12/256 [00:04<01:00,  4.03it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57178 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140973768[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57542 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140973768[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57316 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140973768[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57612 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140973768
+Evaluating:   5%|██████                                                                                                        | 14/256 [00:04<00:50,  4.77it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57002 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140974017
+Evaluating:   7%|███████▎                                                                                                      | 17/256 [00:04<00:39,  6.04it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57062 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140974029[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57330 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140974093[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57282 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140974096[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57480 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140974340[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57586 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140974341
+Evaluating:   9%|█████████▍                                                                                                    | 22/256 [00:05<00:28,  8.34it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57452 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140974350[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57596 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140974414[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57122 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140974650[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57254 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140974650
+Evaluating:  10%|███████████▏                                                                                                  | 26/256 [00:05<00:24,  9.49it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57490 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140974660[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57384 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140975382[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57226 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140975383
+Evaluating:  11%|████████████▍                                                                                                 | 29/256 [00:06<00:32,  7.01it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:56986 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140975566[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57428 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140975566[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57354 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140975566[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57412 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140975567
+Evaluating:  12%|█████████████▎                                                                                                | 31/256 [00:06<00:29,  7.56it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57324 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140975747[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57100 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140975748
+Evaluating:  14%|███████████████                                                                                               | 35/256 [00:06<00:22,  9.97it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57048 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140975763[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57194 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140975952[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57466 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140975952[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57690 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140975953
+Evaluating:  15%|████████████████▎                                                                                             | 38/256 [00:06<00:19, 10.96it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57304 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140976169[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57770 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140976169
+Evaluating:  16%|█████████████████▌                                                                                            | 41/256 [00:07<00:18, 11.66it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57058 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140976275[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57188 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140976275
+Evaluating:  17%|██████████████████▍                                                                                           | 43/256 [00:07<00:16, 12.70it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57668 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140976360[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57752 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140976373[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57084 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140976439[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57606 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140976440
+Evaluating:  18%|████████████████████▏                                                                                         | 47/256 [00:07<00:13, 15.53it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57240 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140976528[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57436 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140976673[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57878 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140976674
+Evaluating:  20%|█████████████████████▍                                                                                        | 50/256 [00:07<00:14, 14.64it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57370 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140976933[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57804 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140976933[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57958 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140976933
+Evaluating:  20%|██████████████████████▎                                                                                       | 52/256 [00:07<00:16, 12.25it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57166 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140977030[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57624 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140977042[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57152 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140977043
+Evaluating:  22%|████████████████████████                                                                                      | 56/256 [00:07<00:12, 16.41it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57274 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140977201[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57500 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140977201[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57656 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140977201
+Evaluating:  23%|█████████████████████████▎                                                                                    | 59/256 [00:08<00:11, 17.07it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57942 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140977324[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57568 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140977330[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57156 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140977330
+Evaluating:  24%|██████████████████████████▋                                                                                   | 62/256 [00:08<00:10, 18.53it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57090 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140977530[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57290 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140977594[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57270 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140977595
+Evaluating:  25%|███████████████████████████▉                                                                                  | 65/256 [00:08<00:12, 15.61it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57514 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140977753[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57952 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140977754
+Evaluating:  26%|████████████████████████████▊                                                                                 | 67/256 [00:08<00:12, 14.82it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57640 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140977777[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57910 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140977777[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57930 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140977922[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57136 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140977922
+Evaluating:  28%|██████████████████████████████▌                                                                               | 71/256 [00:08<00:10, 17.34it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:58[0m [90m[loggers.py:271][0m Engine 000: Avg prompt throughput: 402.6 tokens/s, Avg generation throughput: 381.6 tokens/s, Running: 32 reqs, Waiting: 17 reqs, GPU KV cache usage: 0.4%, Prefix cache hit rate: 88.8%
+
+_bk;t=1778140978034[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:02:58[0m [90m[loggers.py:271][0m Engine 001: Avg prompt throughput: 392.7 tokens/s, Avg generation throughput: 382.3 tokens/s, Running: 32 reqs, Waiting: 19 reqs, GPU KV cache usage: 0.4%, Prefix cache hit rate: 88.7%
+
+_bk;t=1778140978103[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57760 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140978189[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57526 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140978190
+Evaluating:  29%|███████████████████████████████▎                                                                              | 73/256 [00:09<00:13, 13.49it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57634 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140978362[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57706 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140978363[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57816 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140978363
+Evaluating:  29%|████████████████████████████████▏                                                                             | 75/256 [00:09<00:13, 12.97it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57904 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140978440[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:56998 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140978440[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57724 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140978624[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57076 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140978625
+Evaluating:  31%|██████████████████████████████████▍                                                                           | 80/256 [00:09<00:11, 15.21it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57080 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140978741[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57914 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140978741[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57022 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140978742
+Evaluating:  32%|███████████████████████████████████▏                                                                          | 82/256 [00:09<00:11, 15.56it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57384 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140978946
+Evaluating:  33%|████████████████████████████████████                                                                          | 84/256 [00:09<00:12, 13.78it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57788 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140978953[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57716 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140978953[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57730 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140979052[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57178 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140979053
+Evaluating:  34%|█████████████████████████████████████▊                                                                        | 88/256 [00:09<00:09, 18.26it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57034 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140979140[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57430 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140979140[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57502 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140979202[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57226 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140979203
+Evaluating:  36%|███████████████████████████████████████▌                                                                      | 92/256 [00:10<00:07, 20.60it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57570 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140979504[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57114 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140979505[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57852 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140979506
+Evaluating:  37%|████████████████████████████████████████▊                                                                     | 95/256 [00:10<00:10, 15.84it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57954 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140979610[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57786 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140979611
+Evaluating:  38%|█████████████████████████████████████████▋                                                                    | 97/256 [00:10<00:09, 16.44it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:56972 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140979857[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57254 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140979858
+Evaluating:  39%|██████████████████████████████████████████▌                                                                   | 99/256 [00:10<00:11, 13.27it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57330 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140980043[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57018 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140980044
+Evaluating:  39%|███████████████████████████████████████████                                                                  | 101/256 [00:10<00:12, 12.54it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57678 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140980141[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57842 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140980144
+Evaluating:  40%|███████████████████████████████████████████▊                                                                 | 103/256 [00:11<00:11, 13.89it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57612 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140980309[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57802 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140980310
+Evaluating:  41%|████████████████████████████████████████████▋                                                                | 105/256 [00:11<00:11, 13.34it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57480 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140980459[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57466 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140980460
+Evaluating:  42%|█████████████████████████████████████████████▌                                                               | 107/256 [00:11<00:11, 13.33it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57100 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140980535[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57888 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140980684[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57454 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140980684[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57274 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140980685
+Evaluating:  43%|██████████████████████████████████████████████▊                                                              | 110/256 [00:11<00:10, 13.33it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57324 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140980926[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57558 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140980929
+Evaluating:  44%|████████████████████████████████████████████████                                                             | 113/256 [00:11<00:10, 13.02it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57524 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140981105[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57606 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140981106
+Evaluating:  45%|████████████████████████████████████████████████▉                                                            | 115/256 [00:12<00:11, 12.48it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57412 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140981324[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57866 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140981326
+Evaluating:  46%|█████████████████████████████████████████████████▊                                                           | 117/256 [00:12<00:12, 11.38it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57828 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140981424[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57764 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140981424[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57770 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140981497[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57338 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140981498
+Evaluating:  47%|███████████████████████████████████████████████████▌                                                         | 121/256 [00:12<00:09, 14.55it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57596 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140981692[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57740 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140981692
+Evaluating:  48%|████████████████████████████████████████████████████▎                                                        | 123/256 [00:12<00:10, 13.27it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57428 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140981938[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57448 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140981938
+Evaluating:  49%|█████████████████████████████████████████████████████▏                                                       | 125/256 [00:12<00:11, 11.46it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57122 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140982018[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57490 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140982019[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57152 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140982193[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57690 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140982193
+Evaluating:  50%|██████████████████████████████████████████████████████▉                                                      | 129/256 [00:13<00:09, 12.90it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57398 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140982202[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57752 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140982351[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57188 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140982351
+Evaluating:  52%|████████████████████████████████████████████████████████▏                                                    | 132/256 [00:13<00:08, 14.32it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57240 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140982369[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57910 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140982546[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57568 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140982546[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57002 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140982547
+Evaluating:  53%|█████████████████████████████████████████████████████████▍                                                   | 135/256 [00:13<00:08, 14.63it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57354 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140982704[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57090 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140982705
+Evaluating:  54%|██████████████████████████████████████████████████████████▊                                                  | 138/256 [00:13<00:07, 15.72it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57084 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140982783[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57586 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140982869[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57526 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140982869
+Evaluating:  55%|████████████████████████████████████████████████████████████                                                 | 141/256 [00:13<00:06, 16.46it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57452 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140983121[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:56998 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140983122
+Evaluating:  56%|████████████████████████████████████████████████████████████▉                                                | 143/256 [00:14<00:08, 13.22it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57370 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140983132[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57816 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140983293[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57034 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140983294
+Evaluating:  57%|██████████████████████████████████████████████████████████████▏                                              | 146/256 [00:14<00:07, 14.35it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57058 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140983465[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57760 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140983465
+Evaluating:  58%|███████████████████████████████████████████████████████████████                                              | 148/256 [00:14<00:07, 13.61it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57958 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140983618[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57156 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140983618
+Evaluating:  59%|███████████████████████████████████████████████████████████████▊                                             | 150/256 [00:14<00:07, 13.47it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57436 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140983689[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57282 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140983700[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57080 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140983763[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57952 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140983764
+Evaluating:  60%|█████████████████████████████████████████████████████████████████▌                                           | 154/256 [00:14<00:05, 17.13it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57166 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140983916[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57254 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140983917
+Evaluating:  61%|██████████████████████████████████████████████████████████████████▍                                          | 156/256 [00:14<00:06, 15.98it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57624 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140984143[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57878 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140984143
+Evaluating:  62%|███████████████████████████████████████████████████████████████████▎                                         | 158/256 [00:15<00:07, 13.32it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57270 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140984292[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57804 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140984292[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57716 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140984292
+Evaluating:  62%|████████████████████████████████████████████████████████████████████▏                                        | 160/256 [00:15<00:07, 13.34it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:56986 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140984442[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57640 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140984442
+Evaluating:  64%|█████████████████████████████████████████████████████████████████████▍                                       | 163/256 [00:15<00:06, 15.17it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57048 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140984520[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57914 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140984531[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57942 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140984738[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57136 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140984739
+Evaluating:  65%|███████████████████████████████████████████████████████████████████████                                      | 167/256 [00:15<00:06, 14.43it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57226 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140984829[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57668 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140984904[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57316 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140984904[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57612 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140984905
+Evaluating:  66%|████████████████████████████████████████████████████████████████████████▍                                    | 170/256 [00:15<00:05, 15.37it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57210 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140984981[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57634 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140984992[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57178 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140985133[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57944 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140985133[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:56972 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140985134
+Evaluating:  68%|██████████████████████████████████████████████████████████████████████████▌                                  | 175/256 [00:16<00:04, 17.55it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57500 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140985337
+Evaluating:  69%|███████████████████████████████████████████████████████████████████████████▎                                 | 177/256 [00:16<00:05, 15.25it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57076 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140985473[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57194 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140985473
+Evaluating:  70%|████████████████████████████████████████████████████████████████████████████▏                                | 179/256 [00:16<00:05, 15.12it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57542 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140985540[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57656 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140985693[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57802 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140985695
+Evaluating:  71%|█████████████████████████████████████████████████████████████████████████████▍                               | 182/256 [00:16<00:05, 14.59it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57304 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140985852[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57724 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140985853
+Evaluating:  72%|██████████████████████████████████████████████████████████████████████████████▎                              | 184/256 [00:16<00:05, 14.07it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57022 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140985941[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57570 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986022[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57690 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986022
+Evaluating:  73%|███████████████████████████████████████████████████████████████████████████████▌                             | 187/256 [00:16<00:04, 15.14it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57062 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986189[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57524 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986190
+Evaluating:  74%|████████████████████████████████████████████████████████████████████████████████▍                            | 189/256 [00:17<00:04, 14.19it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57502 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986284[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57786 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986372[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57606 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986372
+Evaluating:  75%|█████████████████████████████████████████████████████████████████████████████████▊                           | 192/256 [00:17<00:04, 14.88it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57514 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986537[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57114 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986538[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57954 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986538
+Evaluating:  76%|██████████████████████████████████████████████████████████████████████████████████▌                          | 194/256 [00:17<00:04, 14.07it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57730 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986575[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57330 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986604[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57930 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986604[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57904 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986613[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57338 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986632[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57842 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986654[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57018 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986654[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57428 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986655
+Evaluating:  79%|██████████████████████████████████████████████████████████████████████████████████████                       | 202/256 [00:17<00:02, 26.21it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57596 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986670[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57384 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986710[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57466 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986738[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57084 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986796[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57100 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986796
+Evaluating:  81%|████████████████████████████████████████████████████████████████████████████████████████▌                    | 208/256 [00:17<00:01, 30.75it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57430 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986825[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57788 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986862[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57398 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986880[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57740 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986881[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57852 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986881[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57568 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986890[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57888 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986890[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57354 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986890[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57058 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986911[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57240 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986911
+Evaluating:  85%|████████████████████████████████████████████████████████████████████████████████████████████▊                | 218/256 [00:17<00:00, 44.44it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57526 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986939[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57002 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986940[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57274 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986967[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57760 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986967[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57254 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140986986[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57952 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987006[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57448 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987035[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57290 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987035
+Evaluating:  88%|████████████████████████████████████████████████████████████████████████████████████████████████▏            | 226/256 [00:17<00:00, 49.95it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57454 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987090[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57370 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987098[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57034 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987124[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57490 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987133[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57166 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987142[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57156 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987142
+Evaluating:  91%|██████████████████████████████████████████████████████████████████████████████████████████████████▊          | 232/256 [00:18<00:00, 51.52it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57452 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987185[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57764 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987195[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57678 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987230[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57752 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987273[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57706 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987273[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57412 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987274
+Evaluating:  93%|█████████████████████████████████████████████████████████████████████████████████████████████████████▎       | 238/256 [00:18<00:00, 49.61it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57324 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987291[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57188 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987300[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57152 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987326[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57828 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987326[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57586 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987356[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57436 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987356[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57816 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987403[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57480 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987404
+Evaluating:  96%|████████████████████████████████████████████████████████████████████████████████████████████████████████▋    | 246/256 [00:18<00:00, 53.28it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57910 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987440[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57080 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987552[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57282 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987565[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57958 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987641[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57770 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987717[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57090 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987718
+Evaluating:  98%|███████████████████████████████████████████████████████████████████████████████████████████████████████████▎ | 252/256 [00:18<00:00, 35.83it/s][0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57122 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140987971[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:56998 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140988031[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57866 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140988034[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:03:08[0m [90m[loggers.py:271][0m Engine 000: Avg prompt throughput: 444.6 tokens/s, Avg generation throughput: 975.8 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.1%, Prefix cache hit rate: 89.5%
+
+_bk;t=1778140988034[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:03:08[0m [90m[loggers.py:271][0m Engine 001: Avg prompt throughput: 459.8 tokens/s, Avg generation throughput: 966.4 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.1%, Prefix cache hit rate: 89.2%
+
+_bk;t=1778140988054[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     127.0.0.1:57558 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778140988055
+Evaluating: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 256/256 [00:18<00:00, 13.48it/s]
+
+_bk;t=1778140988067[Initial (2 GPUs)] GSM8K accuracy: 0.672 (256 questions)
+
+_bk;t=1778140988152[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11351)[0m INFO 05-07 08:03:08 [core.py:1909] [Elastic EP] Received reconfiguration request and starting scaling up/down
+
+_bk;t=1778140988152[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) WARNING 05-07 08:02:49 [jit_monitor.py:103] Triton kernel JIT compilation during inference: _compute_slot_mapping_kernel. This causes a latency spike; consider extending warmup to cover this shape/config.
+
+_bk;t=1778140988152[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=11767)[0m (Worker_DP1_EP1 pid=11767) WARNING 05-07 08:02:49 [jit_monitor.py:103] Triton kernel JIT compilation during inference: fused_moe_kernel. This causes a latency spike; consider extending warmup to cover this shape/config.
+
+_bk;t=1778140994746[0;36m(APIServer pid=707)[0;0m [36m(pid=18990)[0m W0507 08:03:14.665000 18990 torch/utils/cpp_extension.py:140] No CUDA runtime is found, using CUDA_HOME='/usr/local/cuda'
+
+_bk;t=1778140994746[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11351)[0m `rope_parameters`'s factor field must be a float >= 1, got 40[32m [repeated 5x across cluster][0m
+
+_bk;t=1778140994746[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11351)[0m `rope_parameters`'s beta_fast field must be a float, got 32[32m [repeated 5x across cluster][0m
+
+_bk;t=1778140994746[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11351)[0m `rope_parameters`'s beta_slow field must be a float, got 1[32m [repeated 5x across cluster][0m
+
+_bk;t=1778140995378[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m Exception raised in creation task: The actor died because of an error raised in its creation task, [36mray::DPMoEEngineCoreActor.__init__()[39m (pid=18989, ip=192.168.5.77, actor_id=94d2e246d3e2189cc95683d101000000, repr=<vllm.v1.engine.core.DPMoEEngineCoreActor object at 0x7ba4e40c8800>)
+
+_bk;t=1778140995378[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778140995378[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778140995378[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 2112, in __init__
+
+_bk;t=1778140995378[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m     DPEngineCoreProc.__init__(
+
+_bk;t=1778140995378[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 1660, in __init__
+
+_bk;t=1778140995378[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m     super().__init__(
+
+_bk;t=1778140995378[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 876, in __init__
+
+_bk;t=1778140995378[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m     super().__init__(
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 118, in __init__
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m     self.model_executor = executor_class(vllm_config)
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/ray_executor_v2.py", line 219, in __init__
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m     super().__init__(vllm_config)
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/multiproc_executor.py", line 107, in __init__
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m     super().__init__(vllm_config)
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/abstract.py", line 109, in __init__
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m     self._init_executor()
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/ray_executor_v2.py", line 349, in _init_executor
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m     .remote(
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m      ^^^^^^^
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m   File "/usr/local/lib/python3.12/dist-packages/ray/actor.py", line 1381, in remote
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m     return actor_cls._remote(args=args, kwargs=kwargs, **updated_options)
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m            ^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m   File "/usr/local/lib/python3.12/dist-packages/ray/actor.py", line 1719, in _remote
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m     actor_id = worker.core_worker.create_actor(
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m   File "python/ray/includes/common.pxi", line 77, in ray._raylet.check_status
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m ValueError: Actor with name 'vllm_Worker_1778140840102885309' already exists in the namespace 2491bca0-ed6c-4f6d-a4e4-8694a5798481
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m INFO 05-07 08:03:15 [ray_utils.py:568] Ray is already initialized. Skipping Ray initialization.
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18989)[0m INFO 05-07 08:03:15 [ray_utils.py:599] Using the existing placement group
+
+_bk;t=1778140995379[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11350)[0m INFO 05-07 08:03:08 [core.py:1909] [Elastic EP] Received reconfiguration request and starting scaling up/down
+
+_bk;t=1778141002763[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=19150)[0m WARNING 05-07 08:03:22 [nixl_utils.py:34] NIXL is not available
+
+_bk;t=1778141002763[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=19150)[0m WARNING 05-07 08:03:22 [nixl_utils.py:44] NIXL agent config is not available
+
+_bk;t=1778141002763[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18990)[0m INFO 05-07 08:03:15 [ray_utils.py:568] Ray is already initialized. Skipping Ray initialization.
+
+_bk;t=1778141002763[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=18990)[0m INFO 05-07 08:03:15 [ray_utils.py:599] Using the existing placement group
+
+_bk;t=1778141002976[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=19150)[0m WARNING 05-07 08:03:22 [worker_base.py:292] Missing `shared_worker_lock` argument from executor. This argument is needed for mm_processor_cache_type='shm'.
+
+_bk;t=1778141003395[0;36m(APIServer pid=707)[0;0m [36m(RayWorkerProc pid=19150)[0m (Worker pid=19150) INFO 05-07 08:03:23 [parallel_state.py:1410] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://192.168.5.77:38461 backend=nccl
+
+_bk;t=1778141055405[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11351)[0m INFO 05-07 08:04:15 [shm_broadcast.py:681] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-consuming work (e.g. compilation, weight/kv cache quantization).
+
+_bk;t=1778141115574[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11351)[0m INFO 05-07 08:05:15 [shm_broadcast.py:681] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-consuming work (e.g. compilation, weight/kv cache quantization).[32m [repeated 2x across cluster][0m
+
+_bk;t=1778141175608[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11351)[0m INFO 05-07 08:06:15 [shm_broadcast.py:681] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-consuming work (e.g. compilation, weight/kv cache quantization).[32m [repeated 2x across cluster][0m
+
+_bk;t=1778141235754[0;36m(APIServer pid=707)[0;0m [36m(DPMoEEngineCoreActor pid=11351)[0m INFO 05-07 08:07:15 [shm_broadcast.py:681] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-consuming work (e.g. compilation, weight/kv cache quantization).[32m [repeated 2x across cluster][0m
+
+_bk;t=1778141288109[RemoteOpenAIServer] Sent SIGTERM to process 707
+
+_bk;t=1778141288113[0;36m(APIServer pid=707)[0;0m [31mERROR[0m [90m05-07 08:08:08[0m [90m[api_router.py:84][0m Scale failed: The actor died unexpectedly before finishing this task.
+
+
+_bk;t=1778141288113[0;36m(APIServer pid=707)[0;0m [31mERROR[0m [90m05-07 08:08:08[0m [90m[api_router.py:84][0m 	class_name: DPMoEEngineCoreActor
+
+
+_bk;t=1778141288113[0;36m(APIServer pid=707)[0;0m [31mERROR[0m [90m05-07 08:08:08[0m [90m[api_router.py:84][0m 	actor_id: 94d2e246d3e2189cc95683d101000000
+
+
+_bk;t=1778141288113[0;36m(APIServer pid=707)[0;0m [31mERROR[0m [90m05-07 08:08:08[0m [90m[api_router.py:84][0m 	pid: 18989
+
+
+_bk;t=1778141288114[0;36m(APIServer pid=707)[0;0m [31mERROR[0m [90m05-07 08:08:08[0m [90m[api_router.py:84][0m 	namespace: 2491bca0-ed6c-4f6d-a4e4-8694a5798481
+
+
+_bk;t=1778141288114[0;36m(APIServer pid=707)[0;0m [31mERROR[0m [90m05-07 08:08:08[0m [90m[api_router.py:84][0m 	ip: 192.168.5.77
+
+
+_bk;t=1778141288114[0;36m(APIServer pid=707)[0;0m [31mERROR[0m [90m05-07 08:08:08[0m [90m[api_router.py:84][0m The actor is dead because it was killed by `ray.kill`.
+
+_bk;t=1778141288193[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     Shutting down
+
+_bk;t=1778141288287[0;36m(APIServer pid=707)[0;0m /usr/lib/python3.12/re/__init__.py:177: RuntimeWarning: coroutine 'DPLBAsyncMPClient._eep_wait_for_setup_switch_complete' was never awaited
+
+_bk;t=1778141288287[0;36m(APIServer pid=707)[0;0m   return _compile(pattern, flags).search(string)
+
+_bk;t=1778141288287[0;36m(APIServer pid=707)[0;0m RuntimeWarning: Enable tracemalloc to get the object allocation traceback
+
+_bk;t=1778141288290[0;36m(APIServer pid=707)[0;0m [32mINFO[0m [90m05-07 08:08:08[0m [90m[launcher.py:137][0m Shutting down FastAPI HTTP server.
+
+_bk;t=1778141288290[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     Shutting down
+
+_bk;t=1778141288391[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     Waiting for application shutdown.
+
+_bk;t=1778141288391[0;36m(APIServer pid=707)[0;0m [32mINFO[0m:     Application shutdown complete.
+
+_bk;t=1778141288909[0;36m(APIServer pid=707)[0;0m [0m[36m(DPMoEEngineCoreActor pid=11350)[0m INFO 05-07 08:07:15 [shm_broadcast.py:681] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-consuming work (e.g. compilation, weight/kv cache quantization).
+
+_bk;t=1778141288909[0;36m(APIServer pid=707)[0;0m [36m(pid=18989)[0m W0507 08:03:14.824000 18989 torch/utils/cpp_extension.py:140] No CUDA runtime is found, using CUDA_HOME='/usr/local/cuda'
+
+_bk;t=1778141291030[RemoteOpenAIServer] Server 707 terminated gracefully
+
+_bk;t=1778141291032[RemoteOpenAIServer] 8 process(es) still in pgid 707 after SIGKILL: [1485, 1486, 1487, 1488, 1489, 1490, 1492, 1494]
+
+_bk;t=1778141291579[RemoteOpenAIServer] GPU memory released to 2.01 GB (target: 4.16 GB) in 0.0s
+
+_bk;t=1778141291614[31mFAILED[0m
+
+_bk;t=1778141291971distributed/test_elastic_ep.py::test_elastic_ep_scaling_uneven _bk;t=1778141298271Fork a new process to run a test 19491
+
+_bk;t=1778141298272Fork a new process to run a test 0
+
+_bk;t=1778141298929`rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778141298929`rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778141298929`rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778141299013`rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778141299013`rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778141299013`rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778141299014`rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778141299014`rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778141299014`rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778141299358[32mINFO[0m [90m05-07 08:08:19[0m [90m[model.py:563][0m Resolved architecture: DeepseekV2ForCausalLM
+
+_bk;t=1778141299417[32mINFO[0m [90m05-07 08:08:19[0m [90m[model.py:1692][0m Using max model len 4096
+
+_bk;t=1778141299839[RemoteOpenAIServer] GPU memory before server start: 2.01 GB
+
+_bk;t=1778141299839Launching RemoteOpenAIServer with: vllm serve deepseek-ai/DeepSeek-V2-Lite-Chat --trust-remote-code --tensor-parallel-size 1 --gpu-memory-utilization 0.8 --max-model-len 4096 --max-num-seqs 32 --enable-expert-parallel --all2all-backend allgather_reducescatter --enable-elastic-ep --enable-eplb --eplb-config.num_redundant_experts 0 --data-parallel-backend ray --data-parallel-size 2 --api-server-count 1 --port 58585 --seed 0
+
+_bk;t=1778141299840Environment variables: {'BUILDKITE_CANCEL_GRACE_PERIOD': '60', 'BUILDKITE_PULL_REQUEST_LABELS': '', 'NVIDIA_CTK_LIBCUDA_DIR': '/usr/lib/x86_64-linux-gnu', 'BUILDKITE_ADDITIONAL_HOOKS_PATHS': '', 'BUILDKITE_BUILD_CHECKOUT_PATH': '/workspace/build/buildkite', 'BUILDKITE_CONTAINER_ID': '1', 'BUILDKITE_GIT_FETCH_FLAGS': '-v --prune', 'HF_XET_HIGH_PERFORMANCE': '1', 'KUBERNETES_PORT': 'tcp://172.20.0.1:443', 'KUBERNETES_SERVICE_PORT': '443', 'CUDA_COREDUMP_SHOW_PROGRESS': '1', 'BUILDKITE_CONFIG_PATH': '/buildkite/buildkite-agent.cfg', 'BUILDKITE_K8S_SERVICE_ACCOUNT': 'default', 'BUILDKITE_PIPELINE_ID': '018cdabc-d930-49f6-9085-634c4cb582ed', 'BUILDKITE_AGENT_META_DATA_K8S_AGENT_STACK_VERSION': 'v0.38.0', 'BUILDKITE_ARTIFACT_PATHS': '', 'BUILDKITE_BUILD_CREATOR': 'yzong-rh', 'BUILDKITE_GIT_CHECKOUT_FLAGS': '-f', 'BUILDKITE_TRIGGERED_FROM_BUILD_ID': '', 'CI': 'true', 'BUILDKITE_KUBERNETES_EXEC': 'true', 'HOSTNAME': 'buildkite-019e00c4-b131-40db-8b1a-513aa2d204dc-2pwbn', 'VLLM_ENABLE_CUDA_COMPATIBILITY': '0', 'BUILDKITE_AGENT_ENDPOINT': 'https://agent.buildkite.com/v3', 'BUILDKITE_AGENT_ID': '019e0173-0c2b-42b3-b6d4-42db2b5e742d', 'BUILDKITE_K8S_NODE': 'inf-4x8h100-3', 'BUILDKITE_PIPELINE_TEAMS': 'everyone', 'BUILDKITE_PLUGIN_VALIDATION': 'false', 'LD_LIBRARY_PATH': '/usr/local/lib/python3.12/dist-packages/cv2/../../lib64:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64', 'SHLVL': '0', 'BUILDKITE_AGENT_META_DATA_QUEUE': 'mithril-h100-pool', 'BUILDKITE_BUILD_ID': '019e00c3-8f1d-4b76-bbaf-eb4f840ebede', 'BUILDKITE_PIPELINE_DEFAULT_BRANCH': 'main', 'BUILDKITE_STEP_IDENTIFIER': 'elastic-ep-scaling-test', 'BUILDKITE_STRICT_SINGLE_HOOKS': 'false', 'HOME': '/root', 'OLDPWD': '/workspace/build/buildkite', 'BUILDKITE_AGENT_PID': '7', 'BUILDKITE_BUILD_AUTHOR_EMAIL': '', 'BUILDKITE_STEP_KEY': 'elastic-ep-scaling-test', 'BUILDKITE_TRIGGERED_FROM_BUILD_NUMBER': '', 'BUILDKITE_BUILD_CREATOR_TEAMS': 'everyone', 'BUILDKITE_GIT_CLONE_FLAGS': '-v', 'CUDA_COREDUMP_GENERATION_FLAGS': 'skip_nonrelocated_elf_images,skip_global_memory,skip_shared_memory,skip_local_memory,skip_constbank_memory', 'BUILDKITE': 'true', 'BUILDKITE_AGENT_EXPERIMENT': '', 'BUILDKITE_COMPUTE_TYPE': 'self-hosted', 'BUILDKITE_ORGANIZATION_ID': '018b5ec5-c236-4037-ba08-d8a5d29bcdae', 'HF_HOME': '/root/.cache/huggingface', 'BUILDKITE_BUILD_NUMBER': '64854', 'BUILDKITE_BUILD_PATH': '/workspace/build', 'BUILDKITE_GROUP_KEY': '', 'BUILDKITE_AGENT_JOB_API_SOCKET': '/workspace/sockets/container-0/job-api/93-87912.sock', 'BUILDKITE_GROUP_LABEL': 'Expert Parallelism', 'BUILDKITE_PIPELINE_PROVIDER': 'github', 'BUILDKITE_SHELL': '/bin/sh -ec', 'BUILDKITE_TAG': '', 'BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG': '', 'NCCL_CUMEM_HOST_ENABLE': '0', 'BUILDKITE_JOB_ID': '019e00c4-b131-40db-8b1a-513aa2d204dc', 'BUILDKITE_K8S_NAMESPACE': 'buildkite', 'CUDA_VERSION': '13.0.2', 'BUILDKITE_AGENT_DEBUG_HTTP': 'false', 'BUILDKITE_BIN_PATH': '/workspace', 'BUILDKITE_COMMIT': 'f596e760c8ed0fbc53db45479c8d460f1a40fd06', 'BUILDKITE_LOCAL_HOOKS_ENABLED': 'true', 'UV_LINK_MODE': 'copy', 'BUILDKITE_GIT_MIRRORS_PATH': '', 'BUILDKITE_PULL_REQUEST': 'false', 'NVIDIA_REQUIRE_CUDA': 'cuda>=13.0 brand=unknown,driver>=535,driver<536 brand=grid,driver>=535,driver<536 brand=tesla,driver>=535,driver<536 brand=nvidia,driver>=535,driver<536 brand=quadro,driver>=535,driver<536 brand=quadrortx,driver>=535,driver<536 brand=nvidiartx,driver>=535,driver<536 brand=vapps,driver>=535,driver<536 brand=vpc,driver>=535,driver<536 brand=vcs,driver>=535,driver<536 brand=vws,driver>=535,driver<536 brand=cloudgaming,driver>=535,driver<536 brand=unknown,driver>=550,driver<551 brand=grid,driver>=550,driver<551 brand=tesla,driver>=550,driver<551 brand=nvidia,driver>=550,driver<551 brand=quadro,driver>=550,driver<551 brand=quadrortx,driver>=550,driver<551 brand=nvidiartx,driver>=550,driver<551 brand=vapps,driver>=550,driver<551 brand=vpc,driver>=550,driver<551 brand=vcs,driver>=550,driver<551 brand=vws,driver>=550,driver<551 brand=cloudgaming,driver>=550,driver<551 brand=unknown,driver>=565,driver<566 brand=grid,driver>=565,driver<566 brand=tesla,driver>=565,driver<566 brand=nvidia,driver>=565,driver<566 brand=quadro,driver>=565,driver<566 brand=quadrortx,driver>=565,driver<566 brand=nvidiartx,driver>=565,driver<566 brand=vapps,driver>=565,driver<566 brand=vpc,driver>=565,driver<566 brand=vcs,driver>=565,driver<566 brand=vws,driver>=565,driver<566 brand=cloudgaming,driver>=565,driver<566 brand=unknown,driver>=570,driver<571 brand=grid,driver>=570,driver<571 brand=tesla,driver>=570,driver<571 brand=nvidia,driver>=570,driver<571 brand=quadro,driver>=570,driver<571 brand=quadrortx,driver>=570,driver<571 brand=nvidiartx,driver>=570,driver<571 brand=vapps,driver>=570,driver<571 brand=vpc,driver>=570,driver<571 brand=vcs,driver>=570,driver<571 brand=vws,driver>=570,driver<571 brand=cloudgaming,driver>=570,driver<571 brand=unknown,driver>=575,driver<576 brand=grid,driver>=575,driver<576 brand=tesla,driver>=575,driver<576 brand=nvidia,driver>=575,driver<576 brand=quadro,driver>=575,driver<576 brand=quadrortx,driver>=575,driver<576 brand=nvidiartx,driver>=575,driver<576 brand=vapps,driver>=575,driver<576 brand=vpc,driver>=575,driver<576 brand=vcs,driver>=575,driver<576 brand=vws,driver>=575,driver<576 brand=cloudgaming,driver>=575,driver<576', 'NVIDIA_DRIVER_CAPABILITIES': 'compute,utility', 'BUILDKITE_AGENT_JOB_API_TOKEN': '[REDACTED]', 'BUILDKITE_ENV_FILE': '/workspace/job-env-019e00c4-b131-40db-8b1a-513aa2d204dc3507003521', 'UV_HTTP_TIMEOUT': '500', 'TERM': 'xterm-256color', 'BUILDKITE_CONTAINER_COUNT': '2', 'HF_TOKEN': '[REDACTED]', 'KUBERNETES_PORT_443_TCP_ADDR': '172.20.0.1', 'NV_CUDA_CUDART_VERSION': '13.0.96-1', 'BUILDKITE_BUILD_AUTHOR': '', 'BUILDKITE_CLUSTER_NAME': 'CI', 'BUILDKITE_COMMIT_RESOLVED': 'true', 'BUILDKITE_PIPELINE_SLUG': 'ci', 'PATH': '/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/workspace', 'NVARCH': 'x86_64', 'BUILDKITE_AGENT_META_DATA_K8S_SERVICE_ACCOUNT': 'default', 'BUILDKITE_PULL_REQUEST_BASE_BRANCH': '', 'BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS': '50', 'KUBERNETES_PORT_443_TCP_PORT': '443', 'BUILDKITE_RETRY_COUNT': '0', 'BUILDKITE_SOURCE': 'ui', 'KUBERNETES_PORT_443_TCP_PROTO': 'tcp', 'CUDA_ENABLE_COREDUMP_ON_EXCEPTION': '1', 'BUILDKITE_NO_HTTP2': 'false', 'BUILDKITE_REPO': 'https://github.com/vllm-project/vllm.git', 'BUILDKITE_AGENT_META_DATA_K8S_NODE': 'inf-4x8h100-3', 'BUILDKITE_REBUILT_FROM_BUILD_ID': '', 'BUILDKITE_REQUEST_HEADER_BUILDKITE_PIPELINES_SHARD_ID': '002', 'BUILDKITE_GIT_MIRRORS_SKIP_UPDATE': 'false', 'BUILDKITE_PLUGINS': '[]', 'BUILDKITE_SOCKETS_PATH': '/workspace/sockets/container-0', 'DEBIAN_FRONTEND': 'noninteractive', 'BUILDKITE_BOOTSTRAP_PHASES': 'plugin,command', 'BUILDKITE_BRANCH': 'atalman:release_212_tests', 'BUILDKITE_LABEL': 'Elastic EP Scaling Test', 'BUILDKITE_ORGANIZATION_SLUG': 'vllm', 'BUILDKITE_PLUGINS_ENABLED': 'true', 'BUILDKITE_PROJECT_PROVIDER': 'github', 'BUILDKITE_SSH_KEYSCAN': 'true', 'GIT_TERMINAL_PROMPT': '0', 'BUILDKITE_AGENT_DEBUG': 'false', 'BUILDKITE_CLUSTER_ID': '9cecc6b1-94cd-43d1-a256-ab438083f4f5', 'BUILDKITE_GIT_SUBMODULES': 'true', 'HF_HUB_DOWNLOAD_TIMEOUT': '60', 'VLLM_USAGE_SOURCE': 'ci-test', 'BUILDKITE_BUILD_CREATOR_EMAIL': 'yzong@redhat.com', 'BUILDKITE_REBUILT_FROM_BUILD_NUMBER': '', 'BUILDKITE_BUILD_URL': 'https://buildkite.com/vllm/ci/builds/64854', 'BUILDKITE_COMMAND': 'cd /vllm-workspace/tests\necho "--- :nvidia: GPU Info"\n(command nvidia-smi || true)\necho "--- :gear: CUDA Coredump Setup"\nexport CUDA_ENABLE_COREDUMP_ON_EXCEPTION=1 && export CUDA_COREDUMP_SHOW_PROGRESS=1 && export CUDA_COREDUMP_GENERATION_FLAGS="skip_nonrelocated_elf_images,skip_global_memory,skip_shared_memory,skip_local_memory,skip_constbank_memory"\necho "+++ :test_tube: Command (1/1): pytest -v -s distributed/test_elastic_ep.py"\npytest -v -s distributed/test_elastic_ep.py', 'BUILDKITE_HOOKS_PATH': '/workspace/hooks', 'BUILDKITE_COMMAND_EVAL': 'true', 'BUILDKITE_PULL_REQUEST_REPO': '', 'BUILDKITE_TIMEOUT': '600', 'KUBERNETES_PORT_443_TCP': 'tcp://172.20.0.1:443', 'KUBERNETES_SERVICE_PORT_HTTPS': '443', 'BUILDKITE_GIT_CLONE_MIRROR_FLAGS': '-v', 'BUILDKITE_PLUGINS_PATH': '/workspace/plugins', 'BUILDKITE_STEP_ID': '019e00c4-af8c-4a4a-8084-da1a5bbbe97c', 'BUILDKITE_AGENT_META_DATA_K8S_NAMESPACE': 'buildkite', 'BUILDKITE_GIT_CLEAN_FLAGS': '-ffxdq', 'BUILDKITE_PIPELINE_NAME': 'CI', 'BUILDKITE_SCRIPT_PATH': 'cd /vllm-workspace/tests\necho "--- :nvidia: GPU Info"\n(command nvidia-smi || true)\necho "--- :gear: CUDA Coredump Setup"\nexport CUDA_ENABLE_COREDUMP_ON_EXCEPTION=1 && export CUDA_COREDUMP_SHOW_PROGRESS=1 && export CUDA_COREDUMP_GENERATION_FLAGS="skip_nonrelocated_elf_images,skip_global_memory,skip_shared_memory,skip_local_memory,skip_constbank_memory"\necho "+++ :test_tube: Command (1/1): pytest -v -s distributed/test_elastic_ep.py"\npytest -v -s distributed/test_elastic_ep.py', 'KUBERNETES_SERVICE_HOST': '172.20.0.1', 'PWD': '/vllm-workspace/tests', 'UV_INDEX_STRATEGY': 'unsafe-best-match', 'BUILDKITE_GIT_MIRRORS_LOCK_TIMEOUT': '300', 'BUILDKITE_REDACTED_VARS': '*_PASSWORD,*_SECRET,*_TOKEN,*_PRIVATE_KEY,*_ACCESS_KEY,*_SECRET_KEY,*_CONNECTION_STRING', 'BUILDKITE_GROUP_ID': '019e00c4-af8a-4e0d-9c7a-82b528ddc05b', 'BUILDKITE_PROJECT_SLUG': 'vllm/ci', 'BUILDKITE_AGENT_NAME': 'buildkite-019e00c4-b131-40db-8b1a-513aa2d204dc-2pwbn-1', 'BUILDKITE_MESSAGE': 'Retry without `Revert "[Bugfix] Fix RuntimeError: Already borrowed by adding thread-safe Hugging Face fast-tokenizer wrappers"`', 'NVIDIA_VISIBLE_DEVICES': 'void', 'BUILDKITE_AGENT_ACCESS_TOKEN': '[REDACTED]', 'BUILDKITE_AGENT_DISABLE_WARNINGS_FOR': '', 'BUILDKITE_ENV_JSON_FILE': '/workspace/job-env-json-019e00c4-b131-40db-8b1a-513aa2d204dc3222473979', 'BUILDKITE_TRACE_CONTEXT_ENCODING': 'gob', 'LC_CTYPE': 'C.UTF-8', 'PYTEST_VERSION': '8.3.5', 'TORCHINDUCTOR_CACHE_DIR': '/tmp/torchinductor_root', 'KMP_DUPLICATE_LIB_OK': 'True', 'KMP_INIT_AT_FORK': 'FALSE', 'PYTORCH_NVML_BASED_CUDA_CHECK': '1', 'TORCHINDUCTOR_COMPILE_THREADS': '1', 'TRITON_CACHE_AUTOTUNING': '1', 'UCX_RCACHE_MAX_UNRELEASED': '1024', 'PYTEST_CURRENT_TEST': 'tests/distributed/test_elastic_ep.py::test_elastic_ep_scaling_uneven (call)', 'RAY_CLIENT_MODE': '0', 'VLLM_WORKER_MULTIPROC_METHOD': 'spawn'}
+
+_bk;t=1778141306158[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:08:26[0m [90m[utils.py:306][0m
+
+
+_bk;t=1778141306158[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:08:26[0m [90m[utils.py:306][0m        [97;1m█     █     █▄   ▄█[0m
+
+
+_bk;t=1778141306158[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:08:26[0m [90m[utils.py:306][0m  [93m▄▄[0m [94m▄█[0m [97;1m█     █     █ ▀▄▀ █[0m  version [97;1m0.20.2rc1.dev96+gf596e760c[0m
+
+
+_bk;t=1778141306158[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:08:26[0m [90m[utils.py:306][0m   [93m█[0m[94m▄█▀[0m [97;1m█     █     █     █[0m  model   [97;1mdeepseek-ai/DeepSeek-V2-Lite-Chat[0m
+
+
+_bk;t=1778141306158[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:08:26[0m [90m[utils.py:306][0m    [94m▀▀[0m  [97;1m▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀[0m
+
+
+_bk;t=1778141306158[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:08:26[0m [90m[utils.py:306][0m
+
+_bk;t=1778141306161[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:08:26[0m [90m[utils.py:240][0m non-default args: {'model_tag': 'deepseek-ai/DeepSeek-V2-Lite-Chat', 'port': 58585, 'model': 'deepseek-ai/DeepSeek-V2-Lite-Chat', 'trust_remote_code': True, 'max_model_len': 4096, 'data_parallel_size': 2, 'data_parallel_backend': 'ray', 'enable_expert_parallel': True, 'enable_elastic_ep': True, 'enable_eplb': True, 'gpu_memory_utilization': 0.8, 'max_num_seqs': 32}
+
+_bk;t=1778141306754[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778141306754[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778141306754[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778141306824[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778141306824[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778141306824[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778141306825[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778141306825[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778141306825[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778141307142[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:08:27[0m [90m[model.py:563][0m Resolved architecture: DeepseekV2ForCausalLM
+
+_bk;t=1778141307143[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:08:27[0m [90m[model.py:1692][0m Using max model len 4096
+
+_bk;t=1778141307143[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:08:27[0m [90m[arg_utils.py:1857][0m Using host IP 192.168.5.77 as ray-based data parallel address
+
+_bk;t=1778141307144[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:08:27[0m [90m[parallel.py:856][0m Using ray distributed inference because data_parallel_backend is ray
+
+_bk;t=1778141307144[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:08:27[0m [90m[scheduler.py:239][0m Chunked prefill is enabled with max_num_batched_tokens=8192.
+
+_bk;t=1778141307145[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:08:27[0m [90m[vllm.py:844][0m Asynchronous scheduling is enabled.
+
+_bk;t=1778141307145[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:08:27[0m [90m[vllm.py:854][0m Disabling NCCL for DP synchronization when using async scheduling.
+
+_bk;t=1778141307146[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:08:27[0m [90m[kernel.py:212][0m Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
+
+_bk;t=1778141308524[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778141308524[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778141308524[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778141308530[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778141308530[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778141308530[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778141308531[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778141308531[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778141308531[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778141308799[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778141308799[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778141308799[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778141316151[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:08:36[0m [90m[utils.py:1040][0m Started DP Coordinator process (PID: 19768)
+
+_bk;t=1778141316151[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:08:36[0m [90m[utils.py:1045][0m Starting ray-based data parallel backend
+
+_bk;t=1778141316152[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:08:36[0m [90m[ray_env.py:100][0m Env var prefixes to copy: ['HF_', 'HUGGING_FACE_', 'LMCACHE_', 'NCCL_', 'UCX_', 'VLLM_']
+
+_bk;t=1778141316152[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:08:36[0m [90m[ray_env.py:101][0m Copying the following environment variables to DPMoEEngineCoreActor: ['HF_HOME', 'HF_HUB_DOWNLOAD_TIMEOUT', 'HF_TOKEN', 'HF_XET_HIGH_PERFORMANCE', 'LD_LIBRARY_PATH', 'NCCL_CUMEM_HOST_ENABLE', 'UCX_RCACHE_MAX_UNRELEASED', 'VLLM_ENABLE_CUDA_COMPATIBILITY', 'VLLM_USAGE_SOURCE', 'VLLM_WORKER_MULTIPROC_METHOD']
+
+_bk;t=1778141316152[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:08:36[0m [90m[ray_env.py:111][0m To exclude env vars from copying, add them to /root/.config/vllm/ray_non_carry_over_env_vars.json
+
+_bk;t=1778141318583[0;36m(APIServer pid=19502)[0;0m 2026-05-07 08:08:38,583	INFO worker.py:1918 -- Started a local Ray instance. View the dashboard at [1m[32mhttp://127.0.0.1:8265 [39m[22m
+
+_bk;t=1778141319712[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:08:39[0m [90m[utils.py:479][0m Creating placement groups for data parallel
+
+_bk;t=1778141326116[0;36m(APIServer pid=19502)[0;0m [36m(pid=30139)[0m W0507 08:08:46.073000 30139 torch/utils/cpp_extension.py:140] No CUDA runtime is found, using CUDA_HOME='/usr/local/cuda'
+
+_bk;t=1778141326432[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m INFO 05-07 08:08:46 [ray_utils.py:568] Ray is already initialized. Skipping Ray initialization.
+
+_bk;t=1778141326432[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m INFO 05-07 08:08:46 [ray_utils.py:599] Using the existing placement group
+
+_bk;t=1778141326432[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m INFO 05-07 08:08:46 [core.py:109] Initializing a V1 LLM engine (v0.20.2rc1.dev96+gf596e760c) with config: model='deepseek-ai/DeepSeek-V2-Lite-Chat', speculative_config=None, tokenizer='deepseek-ai/DeepSeek-V2-Lite-Chat', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=4096, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=2, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=None, quantization_config=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=deepseek-ai/DeepSeek-V2-Lite-Chat, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'ir_enable_torch_wrap': True, 'splitting_ops': ['vllm::unified_attention_with_output', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::gdn_attention_core_xpu', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::deepseek_v4_attention', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': [], 'compile_ranges_endpoints': [8192], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 64, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': False, 'static_all_moe_layers': []}, kernel_config=KernelConfig(ir_op_priority=IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native']), enable_flashinfer_autotune=False, moe_backend='auto')
+
+_bk;t=1778141334018[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m WARNING 05-07 08:08:53 [nixl_utils.py:34] NIXL is not available
+
+_bk;t=1778141334018[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m WARNING 05-07 08:08:53 [nixl_utils.py:44] NIXL agent config is not available
+
+_bk;t=1778141334018[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m INFO 05-07 08:08:46 [ray_utils.py:568] Ray is already initialized. Skipping Ray initialization.
+
+_bk;t=1778141334018[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m INFO 05-07 08:08:46 [ray_utils.py:599] Using the existing placement group
+
+_bk;t=1778141334333[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m WARNING 05-07 08:08:54 [worker_base.py:292] Missing `shared_worker_lock` argument from executor. This argument is needed for mm_processor_cache_type='shm'.
+
+_bk;t=1778141334649[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker pid=30561) INFO 05-07 08:08:54 [parallel_state.py:1410] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://192.168.5.77:47755 backend=nccl
+
+_bk;t=1778141335383[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker pid=30561) INFO 05-07 08:08:55 [pynccl.py:111] vLLM is using nccl==2.29.7
+
+_bk;t=1778141336838[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker pid=30561) INFO 05-07 08:08:56 [cuda_communicator.py:168] Using AgRsAll2AllManager all2all manager.
+
+_bk;t=1778141337154[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker pid=30561) INFO 05-07 08:08:57 [parallel_state.py:1723] rank 0 in world size 2 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank 0, EPLB rank 0
+
+_bk;t=1778141337680[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker pid=30561) INFO 05-07 08:08:57 [topk_topp_sampler.py:45] Using FlashInfer for top-p & top-k sampling.
+
+_bk;t=1778141337788[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:08:57 [gpu_model_runner.py:4842] Starting to load model deepseek-ai/DeepSeek-V2-Lite-Chat...
+
+_bk;t=1778141337999[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:08:57 [cuda.py:368] Using FLASH_ATTN_MLA attention backend out of potential backends: ['FLASH_ATTN_MLA', 'FLASHMLA', 'TRITON_MLA'].
+
+_bk;t=1778141337999[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:08:57 [selector.py:162] Using FLASH_ATTN MLA prefill backend.
+
+_bk;t=1778141337999[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:08:57 [deep_gemm.py:113] DeepGEMM E8M0 enabled on current platform.
+
+_bk;t=1778141337999[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:08:57 [layer.py:408] [EP Rank 1/2] Expert parallelism is enabled. Expert placement strategy: linear. Local/global number of experts: 32/64. Experts local to global index map: 0->32, 1->33, 2->34, 3->35, 4->36, 5->37, 6->38, 7->39, 8->40, 9->41, 10->42, 11->43, 12->44, 13->45, 14->46, 15->47, 16->48, 17->49, 18->50, 19->51, 20->52, 21->53, 22->54, 23->55, 24->56, 25->57, 26->58, 27->59, 28->60, 29->61, 30->62, 31->63.
+
+_bk;t=1778141338000[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:08:57 [unquantized.py:286] Using TRITON Unquantized MoE backend out of potential backends: ['FlashInfer TRTLLM', 'TRITON', 'BATCHED_TRITON', 'FlashInfer CUTLASS'].
+
+_bk;t=1778141338737[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562)
+Loading safetensors checkpoint shards:   0% Completed | 0/4 [00:00<?, ?it/s]
+
+_bk;t=1778141338737[0;36m(APIServer pid=19502)[0;0m [36m(pid=30140)[0m W0507 08:08:46.081000 30140 torch/utils/cpp_extension.py:140] No CUDA runtime is found, using CUDA_HOME='/usr/local/cuda'
+
+_bk;t=1778141338738[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:08:58 [weight_utils.py:904] Filesystem type for checkpoints: VIRTIOFS. Checkpoint size: 29.26 GiB. Available RAM: 1599.66 GiB.
+
+_bk;t=1778141338738[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:08:58 [weight_utils.py:927] Auto-prefetch is disabled because the filesystem (VIRTIOFS) is not a recognized network FS (NFS/Lustre). If you want to force prefetching, start vLLM with --safetensors-load-strategy=prefetch.
+
+_bk;t=1778141340297[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m WARNING 05-07 08:08:54 [nixl_utils.py:34] NIXL is not available
+
+_bk;t=1778141340297[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m WARNING 05-07 08:08:54 [nixl_utils.py:44] NIXL agent config is not available
+
+_bk;t=1778141340297[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m WARNING 05-07 08:08:54 [worker_base.py:292] Missing `shared_worker_lock` argument from executor. This argument is needed for mm_processor_cache_type='shm'.
+
+_bk;t=1778141340297[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker pid=30562) INFO 05-07 08:08:54 [parallel_state.py:1410] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://192.168.5.77:56773 backend=nccl
+
+_bk;t=1778141346122[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562)
+Loading safetensors checkpoint shards:  25% Completed | 1/4 [00:07<00:21,  7.32s/it]
+
+_bk;t=1778141346122[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561)
+Loading safetensors checkpoint shards:   0% Completed | 0/4 [00:00<?, ?it/s]
+
+_bk;t=1778141353195[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561)
+Loading safetensors checkpoint shards:  50% Completed | 2/4 [00:12<00:13,  6.57s/it][32m [repeated 2x across cluster] (Ray deduplicates logs by default. Set RAY_DEDUP_LOGS=0 to disable log deduplication, or see https://docs.ray.io/en/master/ray-observability/user-guides/configure-logging.html#log-deduplication for more options.)[0m
+
+_bk;t=1778141360361[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562)
+Loading safetensors checkpoint shards:  75% Completed | 3/4 [00:21<00:07,  7.16s/it][32m [repeated 2x across cluster][0m
+
+_bk;t=1778141365036[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562)
+
+_bk;t=1778141365036[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561)
+
+_bk;t=1778141365144[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:09:25 [default_loader.py:391] Loading weights took 24.93 seconds
+
+_bk;t=1778141365144[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:09:25 [unquantized.py:343] Using MoEPrepareAndFinalizeNaiveDPEPModular
+
+_bk;t=1778141365144[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:09:25 [gpu_model_runner.py:4920] EPLB is enabled for model deepseek-ai/DeepSeek-V2-Lite-Chat.
+
+_bk;t=1778141365144[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker pid=30562) INFO 05-07 08:08:57 [parallel_state.py:1723] rank 1 in world size 2 is assigned as DP rank 1, PP rank 0, PCP rank 0, TP rank 0, EP rank 1, EPLB rank 1
+
+_bk;t=1778141365144[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:08:58 [cuda.py:368] Using FLASH_ATTN_MLA attention backend out of potential backends: ['FLASH_ATTN_MLA', 'FLASHMLA', 'TRITON_MLA'].
+
+_bk;t=1778141365144[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:08:58 [selector.py:162] Using FLASH_ATTN MLA prefill backend.
+
+_bk;t=1778141365144[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:08:58 [deep_gemm.py:113] DeepGEMM E8M0 enabled on current platform.
+
+_bk;t=1778141365144[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:08:58 [layer.py:408] [EP Rank 0/2] Expert parallelism is enabled. Expert placement strategy: linear. Local/global number of experts: 32/64. Experts local to global index map: 0->0, 1->1, 2->2, 3->3, 4->4, 5->5, 6->6, 7->7, 8->8, 9->9, 10->10, 11->11, 12->12, 13->13, 14->14, 15->15, 16->16, 17->17, 18->18, 19->19, 20->20, 21->21, 22->22, 23->23, 24->24, 25->25, 26->26, 27->27, 28->28, 29->29, 30->30, 31->31.
+
+_bk;t=1778141365144[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:08:58 [unquantized.py:286] Using TRITON Unquantized MoE backend out of potential backends: ['FlashInfer TRTLLM', 'TRITON', 'BATCHED_TRITON', 'FlashInfer CUTLASS'].
+
+_bk;t=1778141365144[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:09:00 [weight_utils.py:904] Filesystem type for checkpoints: VIRTIOFS. Checkpoint size: 29.26 GiB. Available RAM: 1599.64 GiB.
+
+_bk;t=1778141365144[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:09:00 [weight_utils.py:927] Auto-prefetch is disabled because the filesystem (VIRTIOFS) is not a recognized network FS (NFS/Lustre). If you want to force prefetching, start vLLM with --safetensors-load-strategy=prefetch.
+
+_bk;t=1778141365148[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:09:25 [eplb_communicator.py:83] Initialized EPLB communicator: PyNcclEplbCommunicator.
+
+_bk;t=1778141366093[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:09:26 [gpu_model_runner.py:4944] Model loading took 16.57 GiB memory and 27.012554 seconds
+
+_bk;t=1778141366412[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:09:26 [dp_utils.py:28] Using CPU all reduce to synchronize DP padding between ranks.
+
+_bk;t=1778141371712[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:09:31 [backends.py:1089] Using cache directory: /root/.cache/vllm/torch_compile_cache/f7669d7dc6/rank_0_0/backbone for vLLM's torch.compile
+
+_bk;t=1778141371712[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:09:31 [backends.py:1148] Dynamo bytecode transform time: 4.64 s
+
+_bk;t=1778141371712[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:09:25 [default_loader.py:391] Loading weights took 26.73 seconds
+
+_bk;t=1778141371712[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:09:25 [unquantized.py:343] Using MoEPrepareAndFinalizeNaiveDPEPModular
+
+_bk;t=1778141371713[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:09:25 [gpu_model_runner.py:4920] EPLB is enabled for model deepseek-ai/DeepSeek-V2-Lite-Chat.
+
+_bk;t=1778141371713[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:09:25 [eplb_communicator.py:83] Initialized EPLB communicator: PyNcclEplbCommunicator.
+
+_bk;t=1778141371713[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:09:26 [gpu_model_runner.py:4944] Model loading took 16.57 GiB memory and 27.705253 seconds
+
+_bk;t=1778141371713[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:09:26 [dp_utils.py:28] Using CPU all reduce to synchronize DP padding between ranks.
+
+_bk;t=1778141381264[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:09:41 [backends.py:393] Compiling a graph for compile range (1, 8192) takes 9.50 s
+
+_bk;t=1778141381264[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:09:31 [backends.py:1089] Using cache directory: /root/.cache/vllm/torch_compile_cache/f7669d7dc6/rank_0_1/backbone for vLLM's torch.compile
+
+_bk;t=1778141381264[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:09:31 [backends.py:1148] Dynamo bytecode transform time: 4.62 s
+
+_bk;t=1778141383657[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:09:43 [backends.py:915] collected artifacts: 28 entries, 4 artifacts, 7235011 bytes total
+
+_bk;t=1778141383658[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:09:43 [decorators.py:708] saved AOT compiled function to /root/.cache/vllm/torch_compile_cache/torch_aot_compile/ae438e94b4ced1d45cfd8aeb086ac875cd1db6612e1897df2477982a8310b915/rank_0_1/model
+
+_bk;t=1778141383658[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:09:43 [monitor.py:53] torch.compile took 16.60 s in total
+
+_bk;t=1778141387087[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) WARNING 05-07 08:09:47 [fused_moe.py:1091] Using default MoE config. Performance might be sub-optimal! Config file not found at /usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/configs/E=32,N=1408,device_name=NVIDIA_H100_80GB_HBM3.json
+
+_bk;t=1778141387087[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:09:41 [backends.py:393] Compiling a graph for compile range (1, 8192) takes 9.48 s
+
+_bk;t=1778141388029[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:09:47 [monitor.py:81] Initial profiling/warmup run took 4.28 s
+
+_bk;t=1778141388029[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:09:47 [eplb_state.py:684] Rearranging experts sync mode (profile)...
+
+_bk;t=1778141388344[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) /usr/local/lib/python3.12/dist-packages/torch/distributed/c10d_logger.py:83: UserWarning: barrier(): using the device under current context. You can specify `device_id` in `init_process_group` to mute this warning.
+
+_bk;t=1778141388344[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562)   return func(*args, **kwargs)
+
+_bk;t=1778141388344[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m [rank0]:[W507 08:09:48.395981808 ProcessGroupNCCL.cpp:5324] Guessing device ID based on global rank. This can cause a hang if rank to GPU mapping is heterogeneous. You can specify device_id in init_process_group()
+
+_bk;t=1778141388344[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561)
+Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:24<00:00,  6.20s/it][32m [repeated 5x across cluster][0m
+
+_bk;t=1778141388345[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:09:48 [eplb_state.py:787] Rearranged experts  (profile)  in 0.36 s.
+
+_bk;t=1778141395403[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:09:55 [gpu_model_runner.py:6048] Profiling CUDA graph memory: PIECEWISE=11 (largest=64), FULL=7 (largest=32)
+
+_bk;t=1778141395403[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:09:43 [backends.py:915] collected artifacts: 28 entries, 4 artifacts, 7235011 bytes total
+
+_bk;t=1778141395403[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:09:43 [decorators.py:708] saved AOT compiled function to /root/.cache/vllm/torch_compile_cache/torch_aot_compile/ae438e94b4ced1d45cfd8aeb086ac875cd1db6612e1897df2477982a8310b915/rank_0_0/model
+
+_bk;t=1778141395403[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:09:43 [monitor.py:53] torch.compile took 16.64 s in total
+
+_bk;t=1778141395403[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) WARNING 05-07 08:09:47 [fused_moe.py:1091] Using default MoE config. Performance might be sub-optimal! Config file not found at /usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/configs/E=32,N=1408,device_name=NVIDIA_H100_80GB_HBM3.json
+
+_bk;t=1778141395403[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:09:47 [monitor.py:81] Initial profiling/warmup run took 4.32 s
+
+_bk;t=1778141398522[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:09:58 [gpu_model_runner.py:6127] Estimated CUDA graph memory: 0.34 GiB total
+
+_bk;t=1778141398838[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m INFO 05-07 08:09:58 [kv_cache_utils.py:1710] GPU KV cache size: 1,493,264 tokens
+
+_bk;t=1778141398838[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m INFO 05-07 08:09:58 [kv_cache_utils.py:1711] Maximum concurrency for 4,096 tokens per request: 364.57x
+
+_bk;t=1778141398839[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:09:58 [gpu_worker.py:460] Available KV cache memory: 43.26 GiB
+
+_bk;t=1778141398839[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:09:58 [gpu_worker.py:475] CUDA graph memory profiling is enabled (default since v0.21.0). The current --gpu-memory-utilization=0.8000 is equivalent to --gpu-memory-utilization=0.7957 without CUDA graph memory profiling. To maintain the same effective KV cache size as before, increase --gpu-memory-utilization to 0.8043. To disable, set VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0.
+
+_bk;t=1778141398839[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:09:58 [kernel_warmup.py:44] Skipping FlashInfer autotune because it is disabled.
+
+_bk;t=1778141399258[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561)
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):   0%|          | 0/11 [00:00<?, ?it/s]
+
+_bk;t=1778141399258[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) /usr/local/lib/python3.12/dist-packages/torch/distributed/c10d_logger.py:83: UserWarning: barrier(): using the device under current context. You can specify `device_id` in `init_process_group` to mute this warning.
+
+_bk;t=1778141399258[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561)   return func(*args, **kwargs)
+
+_bk;t=1778141399258[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m [rank0]:[W507 08:09:48.396099630 ProcessGroupNCCL.cpp:5324] Guessing device ID based on global rank. This can cause a hang if rank to GPU mapping is heterogeneous. You can specify device_id in init_process_group()
+
+_bk;t=1778141399470[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):   9%|▉         | 1/11 [00:00<00:01,  6.48it/s]
+
+_bk;t=1778141399577[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  18%|█▊        | 2/11 [00:00<00:01,  6.75it/s]
+
+_bk;t=1778141400307[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  27%|██▋       | 3/11 [00:01<00:03,  2.45it/s]
+
+_bk;t=1778141400415[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  36%|███▋      | 4/11 [00:01<00:02,  3.26it/s]
+
+_bk;t=1778141400626[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  45%|████▌     | 5/11 [00:01<00:01,  4.02it/s]
+
+_bk;t=1778141400734[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  55%|█████▍    | 6/11 [00:01<00:01,  4.63it/s]
+
+_bk;t=1778141401464[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  64%|██████▎   | 7/11 [00:02<00:01,  2.74it/s]
+
+_bk;t=1778141401572[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  73%|███████▎  | 8/11 [00:02<00:00,  3.31it/s]
+
+_bk;t=1778141401783[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  82%|████████▏ | 9/11 [00:02<00:00,  3.58it/s]
+
+_bk;t=1778141402517[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  91%|█████████ | 10/11 [00:03<00:00,  2.52it/s]
+
+_bk;t=1778141403869[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|██████████| 11/11 [00:04<00:00,  1.42it/s]
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|██████████| 11/11 [00:04<00:00,  2.39it/s]
+
+_bk;t=1778141403869[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561)
+Capturing CUDA graphs (decode, FULL):   0%|          | 0/7 [00:00<?, ?it/s]
+
+_bk;t=1778141403977[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (decode, FULL):  14%|█▍        | 1/7 [00:00<00:00,  7.38it/s]
+
+_bk;t=1778141404188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (decode, FULL):  29%|██▊       | 2/7 [00:00<00:00,  7.49it/s]
+
+_bk;t=1778141404296[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (decode, FULL):  43%|████▎     | 3/7 [00:00<00:00,  7.42it/s]
+
+_bk;t=1778141404404[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (decode, FULL):  57%|█████▋    | 4/7 [00:00<00:00,  7.48it/s]
+
+_bk;t=1778141404512[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (decode, FULL):  71%|███████▏  | 5/7 [00:00<00:00,  7.57it/s]
+
+_bk;t=1778141404619[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (decode, FULL):  86%|████████▌ | 6/7 [00:00<00:00,  7.60it/s]
+
+_bk;t=1778141404831[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (decode, FULL): 100%|██████████| 7/7 [00:00<00:00,  7.62it/s]
+Capturing CUDA graphs (decode, FULL): 100%|██████████| 7/7 [00:00<00:00,  7.55it/s]
+
+_bk;t=1778141405249[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:10:05 [gpu_model_runner.py:6218] Graph capturing finished in 6 secs, took 0.30 GiB
+
+_bk;t=1778141405249[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:10:05 [gpu_worker.py:619] CUDA graph pool memory: 0.3 GiB (actual), 0.34 GiB (estimated), difference: 0.04 GiB (14.4%).
+
+_bk;t=1778141405249[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:09:55 [gpu_model_runner.py:6048] Profiling CUDA graph memory: PIECEWISE=11 (largest=64), FULL=7 (largest=32)
+
+_bk;t=1778141405249[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:09:58 [gpu_model_runner.py:6127] Estimated CUDA graph memory: 0.34 GiB total
+
+_bk;t=1778141405249[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m INFO 05-07 08:09:58 [kv_cache_utils.py:1710] GPU KV cache size: 1,493,264 tokens
+
+_bk;t=1778141405250[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m INFO 05-07 08:09:58 [kv_cache_utils.py:1711] Maximum concurrency for 4,096 tokens per request: 364.57x
+
+_bk;t=1778141405250[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:09:58 [gpu_worker.py:460] Available KV cache memory: 43.26 GiB
+
+_bk;t=1778141405250[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:09:58 [gpu_worker.py:475] CUDA graph memory profiling is enabled (default since v0.21.0). The current --gpu-memory-utilization=0.8000 is equivalent to --gpu-memory-utilization=0.7957 without CUDA graph memory profiling. To maintain the same effective KV cache size as before, increase --gpu-memory-utilization to 0.8043. To disable, set VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0.
+
+_bk;t=1778141405250[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:09:58 [kernel_warmup.py:44] Skipping FlashInfer autotune because it is disabled.
+
+_bk;t=1778141405358[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m INFO 05-07 08:10:05 [core.py:299] init engine (profile, create kv cache, warmup model) took 39.09 s (compilation: 16.60 s)
+
+_bk;t=1778141405358[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:10:05 [jit_monitor.py:54] Kernel JIT monitor activated — Triton JIT compilations during inference will be logged as warnings.
+
+_bk;t=1778141405881[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778141405881[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778141405881[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778141408493[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m WARNING 05-07 08:10:08 [nixl_utils.py:34] NIXL is not available
+
+_bk;t=1778141408493[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m WARNING 05-07 08:10:08 [nixl_utils.py:44] NIXL agent config is not available
+
+_bk;t=1778141408918[32mINFO[0m [90m05-07 08:10:08[0m [90m[coordinator.py:255][0m All engine subscriptions received by DP coordinator
+
+_bk;t=1778141408932[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:08[0m [90m[api_server.py:613][0m Supported tasks: ['generate']
+
+_bk;t=1778141409144[0;36m(APIServer pid=19502)[0;0m [33mWARNING[0m [90m05-07 08:10:09[0m [90m[model.py:1449][0m Default vLLM sampling parameters have been overridden by the model's `generation_config.json`: `{'temperature': 0.3, 'top_p': 0.95}`. If this is not intended, please relaunch vLLM instance with `--generation-config vllm`.
+
+_bk;t=1778141410257[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778141410257[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778141410257[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778141410553[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778141410553[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778141410554[0;36m(APIServer pid=19502)[0;0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778141411523[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[hf.py:483][0m Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
+
+_bk;t=1778141411712[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[api_server.py:617][0m Starting vLLM server on http://0.0.0.0:58585
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:37][0m Available routes are:
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /openapi.json, Methods: HEAD, GET
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /docs, Methods: HEAD, GET
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /docs/oauth2-redirect, Methods: HEAD, GET
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /redoc, Methods: HEAD, GET
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /tokenize, Methods: POST
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /detokenize, Methods: POST
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /load, Methods: GET
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /version, Methods: GET
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /health, Methods: GET
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /metrics, Methods: GET
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /v1/models, Methods: GET
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /ping, Methods: GET
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /ping, Methods: POST
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /invocations, Methods: POST
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /v1/chat/completions, Methods: POST
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /v1/chat/completions/batch, Methods: POST
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /v1/responses, Methods: POST
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /v1/responses/{response_id}, Methods: GET
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /v1/responses/{response_id}/cancel, Methods: POST
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /v1/completions, Methods: POST
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /v1/messages, Methods: POST
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /v1/messages/count_tokens, Methods: POST
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /inference/v1/generate, Methods: POST
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /scale_elastic_ep, Methods: POST
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /is_scaling_elastic_ep, Methods: POST
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /generative_scoring, Methods: POST
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /v1/chat/completions/render, Methods: POST
+
+_bk;t=1778141411713[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:11[0m [90m[launcher.py:46][0m Route: /v1/completions/render, Methods: POST
+
+_bk;t=1778141411731[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     Started server process [[36m19502[0m]
+
+_bk;t=1778141411731[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     Waiting for application startup.
+
+_bk;t=1778141412048[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     Application startup complete.
+
+_bk;t=1778141412061[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56056 - "[1mGET /health HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141412094Running GSM8K evaluation: 256 questions, 5-shot
+
+_bk;t=1778141412096
+Evaluating:   0%|                                                                                                                       | 0/256 [00:00<?, ?it/s][0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) WARNING 05-07 08:10:12 [jit_monitor.py:103] Triton kernel JIT compilation during inference: _compute_slot_mapping_kernel. This causes a latency spike; consider extending warmup to cover this shape/config.
+
+_bk;t=1778141412449[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:10:05 [gpu_model_runner.py:6218] Graph capturing finished in 6 secs, took 0.30 GiB
+
+_bk;t=1778141412449[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:10:05 [gpu_worker.py:619] CUDA graph pool memory: 0.3 GiB (actual), 0.34 GiB (estimated), difference: 0.04 GiB (14.4%).
+
+_bk;t=1778141412449[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m INFO 05-07 08:10:05 [core.py:299] init engine (profile, create kv cache, warmup model) took 39.23 s (compilation: 16.64 s)
+
+_bk;t=1778141412449[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:10:05 [jit_monitor.py:54] Kernel JIT monitor activated — Triton JIT compilations during inference will be logged as warnings.
+
+_bk;t=1778141412764[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) WARNING 05-07 08:10:12 [jit_monitor.py:103] Triton kernel JIT compilation during inference: fused_moe_kernel. This causes a latency spike; consider extending warmup to cover this shape/config.
+
+_bk;t=1778141414349[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56138 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141414349[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56340 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141414350
+Evaluating:   0%|▍                                                                                                              | 1/256 [00:02<09:34,  2.25s/it][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56122 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141414461
+Evaluating:   1%|█▎                                                                                                             | 3/256 [00:02<02:38,  1.60it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56612 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141414470[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56432 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141415414[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56224 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141415414[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56076 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141415415
+Evaluating:   2%|██▌                                                                                                            | 6/256 [00:03<01:49,  2.29it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56468 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141415633[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56242 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141415634
+Evaluating:   4%|███▉                                                                                                           | 9/256 [00:03<01:05,  3.75it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56382 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141415643[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56640 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141415653[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56218 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141415865[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56332 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141415866
+Evaluating:   5%|█████▌                                                                                                        | 13/256 [00:03<00:40,  5.93it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56644 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141416026[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56086 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141416027
+Evaluating:   6%|██████▍                                                                                                       | 15/256 [00:03<00:35,  6.83it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56114 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141416039[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56264 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141416099[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56130 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141416179[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56072 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141416179
+Evaluating:   7%|████████▏                                                                                                     | 19/256 [00:04<00:23,  9.89it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56544 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141416347[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56168 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141416348
+Evaluating:   8%|█████████                                                                                                     | 21/256 [00:04<00:22, 10.28it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56416 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141417008[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56314 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141417009
+Evaluating:   9%|█████████▉                                                                                                    | 23/256 [00:04<00:36,  6.46it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56462 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141417018[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56512 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141417157[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56542 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141417158
+Evaluating:  10%|███████████▏                                                                                                  | 26/256 [00:05<00:27,  8.44it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56408 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141417249[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56094 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141417259[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56350 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141417259[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56484 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141417259[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56594 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141417260
+Evaluating:  11%|████████████▍                                                                                                 | 29/256 [00:05<00:20, 11.05it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56398 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141417493[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56206 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141417494
+Evaluating:  13%|██████████████▏                                                                                               | 33/256 [00:05<00:17, 12.80it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56220 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141417572[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56150 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141417574[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56448 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141417801[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56556 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141417801
+Evaluating:  14%|███████████████▉                                                                                              | 37/256 [00:05<00:17, 12.87it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56376 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141417887[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56772 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141417973[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56290 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141417973
+Evaluating:  16%|█████████████████▏                                                                                            | 40/256 [00:05<00:15, 13.88it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56100 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141418066[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56690 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141418076[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56364 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141418076
+Evaluating:  17%|██████████████████▍                                                                                           | 43/256 [00:05<00:13, 16.29it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56192 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141418220[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56306 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141418230[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56728 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141418230
+Evaluating:  18%|███████████████████▊                                                                                          | 46/256 [00:06<00:12, 17.10it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56460 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141418453[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56664 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141418455[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56496 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141418455
+Evaluating:  19%|█████████████████████                                                                                         | 49/256 [00:06<00:13, 15.80it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56944 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141418553[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56240 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141418701[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56526 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141418702
+Evaluating:  20%|██████████████████████▎                                                                                       | 52/256 [00:06<00:14, 14.52it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56930 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141418771[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56238 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141418773[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56250 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141418841[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56674 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141418842
+Evaluating:  22%|████████████████████████                                                                                      | 56/256 [00:06<00:11, 17.64it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56580 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141419126[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56198 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141419136[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56280 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141419136[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56162 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141419136[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56680 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141419137
+Evaluating:  23%|█████████████████████████▎                                                                                    | 59/256 [00:07<00:13, 14.64it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56322 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141419199[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56608 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141419354[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56816 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141419354[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56902 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141419355
+Evaluating:  25%|███████████████████████████▌                                                                                  | 64/256 [00:07<00:11, 17.11it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56178 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141419509
+Evaluating:  26%|████████████████████████████▎                                                                                 | 66/256 [00:07<00:11, 16.16it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56564 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141419606[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56706 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141419628[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56748 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141419629
+Evaluating:  27%|█████████████████████████████▋                                                                                | 69/256 [00:07<00:10, 17.96it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56218 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141419869[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56624 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141419869
+Evaluating:  28%|██████████████████████████████▌                                                                               | 71/256 [00:07<00:12, 14.41it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56712 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141419889[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56740 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141419961[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56138 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141420102[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56636 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141420102
+Evaluating:  29%|████████████████████████████████▏                                                                             | 75/256 [00:08<00:11, 15.34it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56700 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141420282[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56264 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141420282
+Evaluating:  30%|█████████████████████████████████                                                                             | 77/256 [00:08<00:12, 14.19it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56122 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141420294[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56592 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141420447[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56828 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141420447[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56842 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141420447
+Evaluating:  31%|██████████████████████████████████▍                                                                           | 80/256 [00:08<00:11, 15.24it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56908 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141420556[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56432 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141420556
+Evaluating:  32%|███████████████████████████████████▋                                                                          | 83/256 [00:08<00:09, 17.68it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56652 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141420778[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56868 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141420778
+Evaluating:  33%|████████████████████████████████████▌                                                                         | 85/256 [00:08<00:11, 14.51it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56784 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141420939[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56798 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141420939
+Evaluating:  34%|█████████████████████████████████████▍                                                                        | 87/256 [00:08<00:12, 13.92it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56142 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141421078[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56958 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141421079
+Evaluating:  35%|██████████████████████████████████████▏                                                                       | 89/256 [00:08<00:11, 14.04it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56408 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141421148[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56072 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141421150[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56182 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141421224[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56076 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141421224
+Evaluating:  36%|███████████████████████████████████████▉                                                                      | 93/256 [00:09<00:09, 17.72it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56094 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141421396[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56484 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141421397
+Evaluating:  37%|████████████████████████████████████████▊                                                                     | 95/256 [00:09<00:10, 15.79it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56942 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141421406[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56640 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141421536[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56688 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141421537
+Evaluating:  38%|██████████████████████████████████████████                                                                    | 98/256 [00:09<00:09, 17.30it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56912 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141421712[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56894 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141421712[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56852 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141421712
+Evaluating:  39%|██████████████████████████████████████████▌                                                                  | 100/256 [00:09<00:10, 15.38it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56704 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141421781[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56206 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141421984[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56910 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141421985
+Evaluating:  41%|████████████████████████████████████████████▎                                                                | 104/256 [00:09<00:10, 15.09it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:22[0m [90m[loggers.py:271][0m Engine 000: Avg prompt throughput: 505.0 tokens/s, Avg generation throughput: 597.8 tokens/s, Running: 32 reqs, Waiting: 19 reqs, GPU KV cache usage: 0.4%, Prefix cache hit rate: 89.2%
+
+_bk;t=1778141422048[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:10:22[0m [90m[loggers.py:271][0m Engine 001: Avg prompt throughput: 510.7 tokens/s, Avg generation throughput: 597.5 tokens/s, Running: 32 reqs, Waiting: 16 reqs, GPU KV cache usage: 0.4%, Prefix cache hit rate: 89.4%
+
+_bk;t=1778141422074[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56880 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141422084[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56548 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141422084[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56612 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141422085
+Evaluating:  41%|█████████████████████████████████████████████▏                                                               | 106/256 [00:09<00:09, 15.97it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56644 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141422295[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56130 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141422295[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56512 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141422295
+Evaluating:  43%|██████████████████████████████████████████████▍                                                              | 109/256 [00:10<00:09, 15.36it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56968 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141422305[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56572 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141422366[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56416 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141422512[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56772 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141422512
+Evaluating:  45%|████████████████████████████████████████████████▌                                                            | 114/256 [00:10<00:07, 17.98it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56542 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141422653[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56594 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141422654
+Evaluating:  45%|█████████████████████████████████████████████████▍                                                           | 116/256 [00:10<00:08, 17.06it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56376 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141422775[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56364 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141422775
+Evaluating:  46%|██████████████████████████████████████████████████▏                                                          | 118/256 [00:10<00:08, 16.92it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56168 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141422917[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56114 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141422917[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56448 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141422917
+Evaluating:  47%|███████████████████████████████████████████████████                                                          | 120/256 [00:10<00:08, 16.14it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56496 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141423062[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56240 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141423063
+Evaluating:  48%|████████████████████████████████████████████████████▎                                                        | 123/256 [00:10<00:07, 17.43it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56728 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141423268[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56840 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141423268[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56322 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141423269
+Evaluating:  49%|█████████████████████████████████████████████████████▏                                                       | 125/256 [00:11<00:08, 14.58it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56192 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141423520[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56382 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141423521
+Evaluating:  50%|██████████████████████████████████████████████████████▌                                                      | 128/256 [00:11<00:09, 13.54it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56556 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141423533[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56086 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141423533[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56150 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141423682[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56764 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141423683
+Evaluating:  52%|████████████████████████████████████████████████████████▏                                                    | 132/256 [00:11<00:07, 16.49it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56544 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141423766[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56680 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141423962[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56350 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141423963
+Evaluating:  53%|█████████████████████████████████████████████████████████▍                                                   | 135/256 [00:11<00:08, 14.21it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56306 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141424044[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56468 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141424125[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56460 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141424125
+Evaluating:  54%|██████████████████████████████████████████████████████████▊                                                  | 138/256 [00:12<00:07, 15.25it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56814 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141424214[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56690 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141424406[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56250 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141424407
+Evaluating:  55%|████████████████████████████████████████████████████████████                                                 | 141/256 [00:12<00:08, 13.52it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56242 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141424479[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56290 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141424578[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56264 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141424579
+Evaluating:  56%|█████████████████████████████████████████████████████████████▎                                               | 144/256 [00:12<00:07, 14.49it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56100 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141424650[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56828 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141424792[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56314 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141424793
+Evaluating:  57%|██████████████████████████████████████████████████████████████▌                                              | 147/256 [00:12<00:07, 14.34it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56748 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141424913[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56398 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141424913[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56580 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141424914
+Evaluating:  58%|███████████████████████████████████████████████████████████████▍                                             | 149/256 [00:12<00:07, 14.77it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56072 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141425054
+Evaluating:  59%|████████████████████████████████████████████████████████████████▎                                            | 151/256 [00:12<00:07, 14.66it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56238 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141425145[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56798 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141425319[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56842 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141425319
+Evaluating:  60%|█████████████████████████████████████████████████████████████████▌                                           | 154/256 [00:13<00:07, 13.31it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56930 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141425499[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56564 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141425500
+Evaluating:  61%|██████████████████████████████████████████████████████████████████▍                                          | 156/256 [00:13<00:07, 12.69it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56664 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141425572[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56138 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141425676[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56198 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141425676
+Evaluating:  62%|███████████████████████████████████████████████████████████████████▋                                         | 159/256 [00:13<00:06, 13.90it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56712 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141425826[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56868 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141425827
+Evaluating:  63%|████████████████████████████████████████████████████████████████████▌                                        | 161/256 [00:13<00:06, 13.74it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56280 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141425898[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56924 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141425909[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56526 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141425983[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56674 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141425983[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56224 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141425983
+Evaluating:  64%|██████████████████████████████████████████████████████████████████████▎                                      | 165/256 [00:13<00:05, 16.98it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56706 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141426145
+Evaluating:  65%|███████████████████████████████████████████████████████████████████████                                      | 167/256 [00:14<00:05, 15.67it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56612 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141426224[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56958 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141426356[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56340 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141426357
+Evaluating:  66%|████████████████████████████████████████████████████████████████████████▍                                    | 170/256 [00:14<00:05, 15.13it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56484 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141426530[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56548 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141426530
+Evaluating:  67%|█████████████████████████████████████████████████████████████████████████▏                                   | 172/256 [00:14<00:05, 14.08it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56122 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141426669[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56218 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141426670
+Evaluating:  68%|██████████████████████████████████████████████████████████████████████████                                   | 174/256 [00:14<00:05, 14.15it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56740 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141426671[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56704 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141426691[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56162 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141426751[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56220 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141426763[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56142 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141426763[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56332 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141426828[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56880 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141426829
+Evaluating:  71%|█████████████████████████████████████████████████████████████████████████████                                | 181/256 [00:14<00:03, 22.81it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56816 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141426986[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56968 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427057[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56908 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427058
+Evaluating:  72%|██████████████████████████████████████████████████████████████████████████████▎                              | 184/256 [00:14<00:03, 19.17it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56608 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427209[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56572 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427282[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56624 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427282
+Evaluating:  73%|███████████████████████████████████████████████████████████████████████████████▌                             | 187/256 [00:15<00:04, 17.19it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56416 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427367[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56636 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427376[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56408 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427376[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56894 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427508[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56240 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427508
+Evaluating:  75%|█████████████████████████████████████████████████████████████████████████████████▊                           | 192/256 [00:15<00:03, 18.81it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56592 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427520[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56594 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427595[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56942 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427623[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56178 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427623
+Evaluating:  77%|███████████████████████████████████████████████████████████████████████████████████▍                         | 196/256 [00:15<00:02, 21.90it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56852 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427718[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56556 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427728[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56688 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427728
+Evaluating:  78%|████████████████████████████████████████████████████████████████████████████████████▋                        | 199/256 [00:15<00:02, 23.26it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56772 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427756[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56784 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427766[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56462 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427785[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56496 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427804[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56512 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427804[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56306 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427823[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56150 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427832[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56094 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427832
+Evaluating:  81%|████████████████████████████████████████████████████████████████████████████████████████▏                    | 207/256 [00:15<00:01, 35.17it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56944 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427920[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56912 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427920[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56640 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427959[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56206 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427996[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56468 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427996[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56828 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141427996
+Evaluating:  83%|██████████████████████████████████████████████████████████████████████████████████████████▎                  | 212/256 [00:15<00:01, 33.61it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56652 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428023[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56690 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428079[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56130 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428098[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56644 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428098
+Evaluating:  85%|████████████████████████████████████████████████████████████████████████████████████████████▍                | 217/256 [00:16<00:01, 37.16it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56432 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428126[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56544 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428172[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56114 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428181[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56290 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428191[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56238 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428191[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56902 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428191[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56376 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428200[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56322 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428200
+Evaluating:  88%|███████████████████████████████████████████████████████████████████████████████████████████████▊             | 225/256 [00:16<00:00, 47.30it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56182 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428221[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56382 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428241[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56242 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428250[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56100 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428258[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56072 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428268[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56086 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428268[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56842 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428338[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56168 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428339
+Evaluating:  91%|███████████████████████████████████████████████████████████████████████████████████████████████████▏         | 233/256 [00:16<00:00, 50.67it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56364 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428391[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56680 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428408[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56448 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428435[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56840 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428435[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56580 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428511[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56250 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428511[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56076 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428511[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56814 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428512
+Evaluating:  93%|█████████████████████████████████████████████████████████████████████████████████████████████████████▊       | 239/256 [00:16<00:00, 44.80it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56930 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428559[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56314 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428608[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56700 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428608[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56910 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428616[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56798 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428616
+Evaluating:  96%|████████████████████████████████████████████████████████████████████████████████████████████████████████▋    | 246/256 [00:16<00:00, 50.19it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56564 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428664[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56398 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428774[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56460 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428862[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56350 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428883[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56764 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428985[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56728 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141428985
+Evaluating:  98%|███████████████████████████████████████████████████████████████████████████████████████████████████████████▎ | 252/256 [00:16<00:00, 31.59it/s][0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56748 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141429233[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56542 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141429343[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56264 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141429343[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:56192 - "[1mPOST /v1/completions HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141429344
+Evaluating: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 256/256 [00:17<00:00, 14.84it/s]
+
+_bk;t=1778141429351[Initial (2 GPUs)] GSM8K accuracy: 0.660 (256 questions)
+
+_bk;t=1778141429472[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m INFO 05-07 08:10:29 [core.py:1909] [Elastic EP] Received reconfiguration request and starting scaling up/down
+
+_bk;t=1778141429472[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m WARNING 05-07 08:10:08 [nixl_utils.py:34] NIXL is not available
+
+_bk;t=1778141429472[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m WARNING 05-07 08:10:08 [nixl_utils.py:44] NIXL agent config is not available
+
+_bk;t=1778141429472[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) WARNING 05-07 08:10:12 [jit_monitor.py:103] Triton kernel JIT compilation during inference: _compute_slot_mapping_kernel. This causes a latency spike; consider extending warmup to cover this shape/config.
+
+_bk;t=1778141429472[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) WARNING 05-07 08:10:12 [jit_monitor.py:103] Triton kernel JIT compilation during inference: fused_moe_kernel. This causes a latency spike; consider extending warmup to cover this shape/config.
+
+_bk;t=1778141435703[0;36m(APIServer pid=19502)[0;0m [36m(pid=37762)[0m W0507 08:10:35.669000 37762 torch/utils/cpp_extension.py:140] No CUDA runtime is found, using CUDA_HOME='/usr/local/cuda'
+
+_bk;t=1778141435703[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m `rope_parameters`'s factor field must be a float >= 1, got 40[32m [repeated 7x across cluster][0m
+
+_bk;t=1778141435703[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m `rope_parameters`'s beta_fast field must be a float, got 32[32m [repeated 7x across cluster][0m
+
+_bk;t=1778141435703[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m `rope_parameters`'s beta_slow field must be a float, got 1[32m [repeated 7x across cluster][0m
+
+_bk;t=1778141436226[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m INFO 05-07 08:10:36 [ray_utils.py:568] Ray is already initialized. Skipping Ray initialization.
+
+_bk;t=1778141436226[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m INFO 05-07 08:10:36 [ray_utils.py:599] Using the existing placement group
+
+_bk;t=1778141436226[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m INFO 05-07 08:10:29 [core.py:1909] [Elastic EP] Received reconfiguration request and starting scaling up/down
+
+_bk;t=1778141443706[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m WARNING 05-07 08:10:43 [nixl_utils.py:34] NIXL is not available
+
+_bk;t=1778141443706[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m WARNING 05-07 08:10:43 [nixl_utils.py:44] NIXL agent config is not available
+
+_bk;t=1778141444022[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m WARNING 05-07 08:10:43 [worker_base.py:292] Missing `shared_worker_lock` argument from executor. This argument is needed for mm_processor_cache_type='shm'.
+
+_bk;t=1778141444337[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker pid=37847) INFO 05-07 08:10:44 [parallel_state.py:1410] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://192.168.5.77:48497 backend=nccl
+
+_bk;t=1778141446622[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m INFO 05-07 08:10:46 [elastic_state.py:474] [Elastic EP] Created standby communication groups
+
+_bk;t=1778141446622[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m INFO 05-07 08:10:46 [elastic_state.py:493] [Elastic EP] Broadcasted expert mapping to new workers
+
+_bk;t=1778141446623[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:10:46 [elastic_execute.py:155] [Elastic EP] EPLB disabled during elastic scaling transition
+
+_bk;t=1778141446623[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker pid=37847) INFO 05-07 08:10:46 [parallel_state.py:1723] rank 2 in world size 3 is assigned as DP rank 2, PP rank 0, PCP rank 0, TP rank 0, EP rank 2, EPLB rank 2
+
+_bk;t=1778141447354[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) INFO 05-07 08:10:47 [cuda.py:368] Using FLASH_ATTN_MLA attention backend out of potential backends: ['FLASH_ATTN_MLA', 'FLASHMLA', 'TRITON_MLA'].
+
+_bk;t=1778141447354[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) INFO 05-07 08:10:47 [selector.py:162] Using FLASH_ATTN MLA prefill backend.
+
+_bk;t=1778141447462[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) INFO 05-07 08:10:47 [deep_gemm.py:113] DeepGEMM E8M0 enabled on current platform.
+
+_bk;t=1778141447462[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) INFO 05-07 08:10:47 [layer.py:408] [EP Rank 2/3] Expert parallelism is enabled. Expert placement strategy: linear. Local/global number of experts: 32/96. Experts local to global index map: 0->64, 1->65, 2->66, 3->67, 4->68, 5->69, 6->70, 7->71, 8->72, 9->73, 10->74, 11->75, 12->76, 13->77, 14->78, 15->79, 16->80, 17->81, 18->82, 19->83, 20->84, 21->85, 22->86, 23->87, 24->88, 25->89, 26->90, 27->91, 28->92, 29->93, 30->94, 31->95.
+
+_bk;t=1778141447462[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) INFO 05-07 08:10:47 [unquantized.py:286] Using TRITON Unquantized MoE backend out of potential backends: ['FlashInfer TRTLLM', 'TRITON', 'BATCHED_TRITON', 'FlashInfer CUTLASS'].
+
+_bk;t=1778141447777[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) INFO 05-07 08:10:47 [unquantized.py:343] Using MoEPrepareAndFinalizeNaiveDPEPModular
+
+_bk;t=1778141448195[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) INFO 05-07 08:10:48 [gpu_model_runner.py:4944] Model loading took 16.04 GiB memory and 0.501982 seconds
+
+_bk;t=1778141448195[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) INFO 05-07 08:10:48 [eplb_communicator.py:83] Initialized EPLB communicator: PyNcclEplbCommunicator.
+
+_bk;t=1778141448407[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m INFO 05-07 08:10:48 [elastic_state.py:485] [Elastic EP] Transferred weights to new workers
+
+_bk;t=1778141448407[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m INFO 05-07 08:10:48 [elastic_state.py:503] [Elastic EP] Synced KV cache memory size to new workers
+
+_bk;t=1778141448407[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m INFO 05-07 08:10:48 [kv_cache_utils.py:1710] GPU KV cache size: 1,493,264 tokens
+
+_bk;t=1778141448407[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m INFO 05-07 08:10:48 [kv_cache_utils.py:1711] Maximum concurrency for 4,096 tokens per request: 364.57x
+
+_bk;t=1778141448408[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) INFO 05-07 08:10:48 [kernel_warmup.py:44] Skipping FlashInfer autotune because it is disabled.
+
+_bk;t=1778141448723[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) INFO 05-07 08:10:48 [dp_utils.py:28] Using CPU all reduce to synchronize DP padding between ranks.
+
+_bk;t=1778141450599[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561)
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):   0%|          | 0/11 [00:00<?, ?it/s]
+
+_bk;t=1778141454860[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:10:54 [backends.py:1089] Using cache directory: /root/.cache/vllm/torch_compile_cache/f5db4e218d/rank_0_0/backbone for vLLM's torch.compile
+
+_bk;t=1778141454860[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:10:54 [backends.py:1148] Dynamo bytecode transform time: 4.20 s
+
+_bk;t=1778141454860[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:10:50 [eplb_communicator.py:83] Initialized EPLB communicator: PyNcclEplbCommunicator.[32m [repeated 2x across cluster][0m
+
+_bk;t=1778141454860[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:10:50 [kernel_warmup.py:44] Skipping FlashInfer autotune because it is disabled.[32m [repeated 2x across cluster][0m
+
+_bk;t=1778141459956[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:10:59 [backends.py:393] Compiling a graph for compile range (1, 8192) takes 5.03 s
+
+_bk;t=1778141459956[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) INFO 05-07 08:10:55 [backends.py:1089] Using cache directory: /root/.cache/vllm/torch_compile_cache/d32225ffb2/rank_0_2/backbone for vLLM's torch.compile[32m [repeated 2x across cluster][0m
+
+_bk;t=1778141459956[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) INFO 05-07 08:10:55 [backends.py:1148] Dynamo bytecode transform time: 4.27 s[32m [repeated 2x across cluster][0m
+
+_bk;t=1778141462139[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:11:02 [backends.py:915] collected artifacts: 28 entries, 4 artifacts, 6254461 bytes total
+
+_bk;t=1778141462139[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:11:02 [decorators.py:708] saved AOT compiled function to /root/.cache/vllm/torch_compile_cache/torch_aot_compile/549ed8f241e47316286746ab67aff86356de9bc99ffa9c47bf64605c4ebe8bc8/rank_0_0/model
+
+_bk;t=1778141462139[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:11:02 [monitor.py:53] torch.compile took 11.54 s in total
+
+_bk;t=1778141466304[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) INFO 05-07 08:11:03 [backends.py:393] Compiling a graph for compile range (1, 8192) takes 8.13 s[32m [repeated 2x across cluster][0m
+
+_bk;t=1778141469014[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) WARNING 05-07 08:11:08 [fused_moe.py:1091] Using default MoE config. Performance might be sub-optimal! Config file not found at /usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/configs/E=32,N=1408,device_name=NVIDIA_H100_80GB_HBM3.json
+
+_bk;t=1778141469014[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) INFO 05-07 08:11:06 [backends.py:915] collected artifacts: 28 entries, 4 artifacts, 5824200 bytes total[32m [repeated 2x across cluster][0m
+
+_bk;t=1778141469014[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) INFO 05-07 08:11:06 [decorators.py:708] saved AOT compiled function to /root/.cache/vllm/torch_compile_cache/torch_aot_compile/558bf2cdc1bb4261d8c924ec3d228cc3e849decbfc86fc02810a19443b281549/rank_0_2/model[32m [repeated 2x across cluster][0m
+
+_bk;t=1778141469014[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) INFO 05-07 08:11:06 [monitor.py:53] torch.compile took 15.21 s in total[32m [repeated 2x across cluster][0m
+
+_bk;t=1778141469641[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:11:09 [monitor.py:81] Initial profiling/warmup run took 7.43 s
+
+_bk;t=1778141470272[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):   9%|▉         | 1/11 [00:19<03:16, 19.69s/it]
+
+_bk;t=1778141472247[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  18%|█▊        | 2/11 [00:21<01:23,  9.27s/it]
+
+_bk;t=1778141472463[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  27%|██▋       | 3/11 [00:21<00:41,  5.14s/it]
+
+_bk;t=1778141473504[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  36%|███▋      | 4/11 [00:22<00:24,  3.49s/it]
+
+_bk;t=1778141474234[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  45%|████▌     | 5/11 [00:23<00:15,  2.51s/it]
+
+_bk;t=1778141474446[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  55%|█████▍    | 6/11 [00:23<00:08,  1.72s/it]
+
+_bk;t=1778141475176[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  64%|██████▎   | 7/11 [00:24<00:05,  1.39s/it]
+
+_bk;t=1778141475803[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  73%|███████▎  | 8/11 [00:25<00:03,  1.16s/it]
+
+_bk;t=1778141476533[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  82%|████████▏ | 9/11 [00:25<00:02,  1.03s/it]
+
+_bk;t=1778141476745[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  91%|█████████ | 10/11 [00:26<00:00,  1.32it/s]
+
+_bk;t=1778141478102[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|██████████| 11/11 [00:27<00:00,  1.06it/s]
+Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|██████████| 11/11 [00:27<00:00,  2.50s/it]
+
+_bk;t=1778141478102[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561)
+Capturing CUDA graphs (decode, FULL):   0%|          | 0/7 [00:00<?, ?it/s]
+
+_bk;t=1778141478210[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (decode, FULL):  14%|█▍        | 1/7 [00:00<00:00,  6.01it/s]
+
+_bk;t=1778141478422[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (decode, FULL):  29%|██▊       | 2/7 [00:00<00:00,  6.71it/s]
+
+_bk;t=1778141478529[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (decode, FULL):  43%|████▎     | 3/7 [00:00<00:00,  6.95it/s]
+
+_bk;t=1778141478637[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (decode, FULL):  57%|█████▋    | 4/7 [00:00<00:00,  6.96it/s]
+
+_bk;t=1778141478745[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (decode, FULL):  71%|███████▏  | 5/7 [00:00<00:00,  7.12it/s]
+
+_bk;t=1778141478957[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (decode, FULL):  86%|████████▌ | 6/7 [00:00<00:00,  7.21it/s]
+
+_bk;t=1778141479064[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m
+Capturing CUDA graphs (decode, FULL): 100%|██████████| 7/7 [00:00<00:00,  7.24it/s]
+Capturing CUDA graphs (decode, FULL): 100%|██████████| 7/7 [00:00<00:00,  7.06it/s]
+
+_bk;t=1778141479588[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) INFO 05-07 08:11:19 [gpu_model_runner.py:6218] Graph capturing finished in 31 secs, took 0.47 GiB
+
+_bk;t=1778141479588[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) INFO 05-07 08:11:10 [monitor.py:81] Initial profiling/warmup run took 3.85 s[32m [repeated 2x across cluster][0m
+
+_bk;t=1778141479695[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:11:19 [gpu_worker.py:619] CUDA graph pool memory: 0.11 GiB (actual), 0.34 GiB (estimated), difference: 0.23 GiB (201.7%).
+
+_bk;t=1778141486341[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m INFO 05-07 08:11:26 [core.py:299] init engine (profile, create kv cache, warmup model) took 37.92 s (compilation: 15.21 s)
+
+_bk;t=1778141486341[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:11:19 [gpu_model_runner.py:6218] Graph capturing finished in 29 secs, took 0.11 GiB[32m [repeated 2x across cluster][0m
+
+_bk;t=1778141486341[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30562)[0m (Worker_DP1_EP1 pid=30562) INFO 05-07 08:11:19 [gpu_worker.py:619] CUDA graph pool memory: 0.11 GiB (actual), 0.34 GiB (estimated), difference: 0.23 GiB (201.7%).
+
+_bk;t=1778141486341[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) INFO 05-07 08:11:26 [jit_monitor.py:54] Kernel JIT monitor activated — Triton JIT compilations during inference will be logged as warnings.
+
+_bk;t=1778141486864[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778141486864[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778141486864[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778141486972[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778141486972[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778141486972[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778141486972[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778141486972[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778141486972[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778141487287[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m `rope_parameters`'s factor field must be a float >= 1, got 40
+
+_bk;t=1778141487287[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m `rope_parameters`'s beta_fast field must be a float, got 32
+
+_bk;t=1778141487287[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m `rope_parameters`'s beta_slow field must be a float, got 1
+
+_bk;t=1778141489469[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m WARNING 05-07 08:11:29 [nixl_utils.py:34] NIXL is not available
+
+_bk;t=1778141489469[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m WARNING 05-07 08:11:29 [nixl_utils.py:44] NIXL agent config is not available
+
+_bk;t=1778141489764[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:11:29[0m [90m[core_client.py:1588][0m [Elastic EP] Successfully started new engines
+
+_bk;t=1778141489766[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:11:29[0m [90m[core_client.py:1630][0m [Elastic EP] Scale up completed, new data parallel size: 3
+
+_bk;t=1778141489766[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     127.0.0.1:39888 - "[1mPOST /scale_elastic_ep HTTP/1.1[0m" [32m200 OK[0m
+
+_bk;t=1778141489766[32mINFO[0m [90m05-07 08:11:29[0m [90m[coordinator.py:334][0m DPCoordinator scaled up from 2 to 3 engines
+
+_bk;t=1778141489784[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m INFO 05-07 08:11:29 [elastic_state.py:535] [Elastic EP] Switched to new setup
+
+_bk;t=1778141489893[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:11:29 [elastic_execute.py:459] [Elastic EP] Starting expert resharding...
+
+_bk;t=1778141489893[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:11:29 [eplb_state.py:684] Rearranging experts sync mode ...
+
+_bk;t=1778141490830[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m INFO 05-07 08:11:30 [elastic_state.py:543] [Elastic EP] EPLB reshuffle completed
+
+_bk;t=1778141490831[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:11:30 [eplb_state.py:787] Rearranged experts   in 0.96 s.
+
+_bk;t=1778141490831[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:11:30 [elastic_execute.py:481] [Elastic EP] Expert resharding completed
+
+_bk;t=1778141490831[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=30561)[0m (Worker_DP0_EP0 pid=30561) INFO 05-07 08:11:30 [elastic_execute.py:155] [Elastic EP] EPLB re-enabled after elastic scaling transition
+
+_bk;t=1778141499797Running GSM8K evaluation: 256 questions, 5-shot
+
+_bk;t=1778141499797
+Evaluating:   0%|                                                                                                                       | 0/256 [00:00<?, ?it/s][0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [dump_input.py:72] Dumping input data for V1 LLM engine (v0.20.2rc1.dev96+gf596e760c) with config: model='deepseek-ai/DeepSeek-V2-Lite-Chat', speculative_config=None, tokenizer='deepseek-ai/DeepSeek-V2-Lite-Chat', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=4096, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=3, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=None, quantization_config=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=deepseek-ai/DeepSeek-V2-Lite-Chat, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'ir_enable_torch_wrap': True, 'splitting_ops': ['vllm::unified_attention_with_output', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::gdn_attention_core_xpu', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::deepseek_v4_attention', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': [], 'compile_ranges_endpoints': [8192], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 64, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': False, 'static_all_moe_layers': []}, kernel_config=KernelConfig(ir_op_priority=IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native']), enable_flashinfer_autotune=False, moe_backend='auto'),
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [dump_input.py:79] Dumping scheduler output for model execution: SchedulerOutput(scheduled_new_reqs=[NewRequestData(req_id=cmpl-bd6be70a2a87874b-0-a8f02a5f,prompt_token_ids_len=773,prefill_token_ids_len=None,mm_features=[],sampling_params=SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=0, min_p=0.0, seed=42, stop=['Question', 'Assistant:', '<|separator|>'], stop_token_ids=[], bad_words=[], thinking_token_budget=None, include_stop_str_in_output=False, ignore_eos=False, max_tokens=256, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, structured_outputs=None, extra_args=None),block_ids=([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49],),num_computed_tokens=0,lora_request=None,prompt_embeds_shape=None), NewRequestData(req_id=cmpl-bf18c0f18332136c-0-a8e50a2d,prompt_token_ids_len=748,prefill_token_ids_len=None,mm_features=[],sampling_params=SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=0, min_p=0.0, seed=42, stop=['Question', 'Assistant:', '<|separator|>'], stop_token_ids=[], bad_words=[], thinking_token_budget=None, include_stop_str_in_output=False, ignore_eos=False, max_tokens=256, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, structured_outputs=None, extra_args=None),block_ids=([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 50, 51, 52, 53, 54],),num_computed_tokens=672,lora_request=None,prompt_embeds_shape=None)], scheduled_cached_reqs=CachedRequestData(req_ids=[],resumed_req_ids=set(),new_token_ids_lens=[],all_token_ids_lens={},new_block_ids=[],num_computed_tokens=[],num_output_tokens=[]), num_scheduled_tokens={cmpl-bf18c0f18332136c-0-a8e50a2d: 76, cmpl-bd6be70a2a87874b-0-a8f02a5f: 773}, total_num_scheduled_tokens=849, scheduled_spec_decode_tokens={}, scheduled_encoder_inputs={}, num_common_prefix_blocks=[42], finished_req_ids=[], free_encoder_mm_hashes=[], preempted_req_ids=[], has_structured_output_requests=false, pending_structured_output_tokens=false, num_invalid_spec_tokens=null, kv_connector_metadata=null, ec_connector_metadata=null, new_block_ids_to_zero=null)
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [dump_input.py:81] Dumping scheduler stats: SchedulerStats(num_running_reqs=5, num_waiting_reqs=0, num_skipped_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.000750042859592015, prefix_cache_stats=PrefixCacheStats(reset=False, requests=5, queries=3767, hits=2688, preempted_requests=0, preempted_queries=0, preempted_hits=0), connector_prefix_cache_stats=None, kv_cache_eviction_events=[], spec_decoding_stats=None, kv_connector_stats=None, waiting_lora_adapters={}, running_lora_adapters={}, cudagraph_stats=None, perf_stats=None)
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088] EngineCore encountered a fatal error.
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088] Traceback (most recent call last):
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 2083, in run
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]     self.run_busy_loop()  # type: ignore[attr-defined]
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]     ^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/ray/util/tracing/tracing_helper.py", line 461, in _resume_span
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]     return method(self, *_args, **_kwargs)
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 1806, in run_busy_loop
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]     executed = self._process_engine_step()
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/ray/util/tracing/tracing_helper.py", line 461, in _resume_span
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]     return method(self, *_args, **_kwargs)
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 1209, in _process_engine_step
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]     outputs, model_executed = self.step_fn()
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]                               ^^^^^^^^^^^^^^
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/ray/util/tracing/tracing_helper.py", line 461, in _resume_span
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]     return method(self, *_args, **_kwargs)
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 525, in step_with_batch_queue
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]     exec_model_fut.result()
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/multiproc_executor.py", line 90, in result
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]     return super().result()
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]            ^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 449, in result
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]     return self.__get_result()
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]            ^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]     raise self._exception
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/multiproc_executor.py", line 94, in _wait_for_response
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]     response = self.aggregate(self.get_response())
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]                               ^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/multiproc_executor.py", line 390, in get_response
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088]     raise RuntimeError(
+
+_bk;t=1778141500078[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=37762)[0m ERROR 05-07 08:11:40 [core.py:2088] RuntimeError: Worker failed with error 'Workspace is locked but allocation from 'modular_kernel.py:1095:_allocate_buffers' requires 49.49 MB, current size is 10.69 MB. Workspace growth is not allowed after locking.', please check the stack trace above for the root cause
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) WARNING 05-07 08:11:39 [jit_monitor.py:103] Triton kernel JIT compilation during inference: _compute_slot_mapping_kernel. This causes a latency spike; consider extending warmup to cover this shape/config.
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962] WorkerProc hit an exception.
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/multiproc_executor.py", line 957, in worker_busy_loop
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     output = func(*args, **kwargs)
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]              ^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/worker_base.py", line 337, in execute_model
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.worker.execute_model(scheduler_output)
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return func(*args, **kwargs)
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_worker.py", line 841, in execute_model
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     output = self.model_runner.execute_model(
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return func(*args, **kwargs)
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_model_runner.py", line 4114, in execute_model
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     model_output = self._model_forward(
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_model_runner.py", line 3587, in _model_forward
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.model(
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/cuda_graph.py", line 254, in __call__
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.runnable(*args, **kwargs)
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1778, in _wrapped_call_impl
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self._call_impl(*args, **kwargs)
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1789, in _call_impl
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return forward_call(*args, **kwargs)
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/deepseek_v2.py", line 1460, in forward
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     hidden_states = self.model(
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                     ^^^^^^^^^^^
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/decorators.py", line 520, in __call__
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.aot_compiled_fn(self, *args, **kwargs)
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/aot_compile.py", line 240, in __call__
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.fn(*args, **kwargs)
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/deepseek_v2.py", line 1258, in forward
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     def forward(
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/caching.py", line 217, in __call__
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.optimized_call(*args, **kwargs)
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "<string>", line 249, in execution_fn
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/cuda_graph.py", line 254, in __call__
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.runnable(*args, **kwargs)
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/piecewise_backend.py", line 380, in __call__
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return range_entry.runnable(*args)
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/standalone_compile.py", line 313, in __call__
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.inner_fn(*args)
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/aot_compile_types.py", line 211, in __call__
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.compiled_fn(*args, **kwargs)
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/eval_frame.py", line 1298, in _fn
+
+_bk;t=1778141500080[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return fn(*args, **kwargs)
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/aot_autograd.py", line 1273, in forward
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return compiled_fn(full_args)
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 777, in runtime_wrapper
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     all_outs = compiled_invoker.run(args, on_before_call=exit_prologue)
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return call_func_at_runtime_with_args(
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/utils.py", line 126, in call_func_at_runtime_with_args
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     out = normalize_as_list(f(args))
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                             ^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 2384, in __call__
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.compiled_fn(*args, **kwargs)
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 850, in wrapper
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return compiled_fn(runtime_args)
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 1055, in inner_fn
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     outs = compiled_fn(args)
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/output_code.py", line 725, in __call__
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.current_callable(inputs)
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/root/.cache/vllm/torch_compile_cache/torch_aot_compile/558bf2cdc1bb4261d8c924ec3d228cc3e849decbfc86fc02810a19443b281549/inductor_cache/25/c25qcojflilobdu57zkz3juxmncjg3fkgbywhm4xoathy2y54mg3.py", line 954, in call
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     buf5 = torch.ops.vllm.moe_forward_shared.default(buf2, buf3, buf4, None, arg5_1)
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_ops.py", line 871, in __call__
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self._op(*args, **kwargs)
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/runner/moe_runner.py", line 125, in _moe_forward_shared
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return layer.runner._forward_impl(
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/runner/moe_runner.py", line 722, in _forward_impl
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     shared_output, hidden_states = self._apply_quant_method(
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                                    ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/runner/moe_runner.py", line 470, in _apply_quant_method
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     fused_out = self._quant_method.apply(
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py", line 281, in apply
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.forward(
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/custom_op.py", line 136, in forward
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self._forward_method(*args, **kwargs)
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py", line 298, in forward_native
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.moe_kernel.apply(
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1614, in apply
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.impl.apply(
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1392, in apply
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     fused_out = self._fused_experts(
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1232, in _fused_experts
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     workspace13, workspace2, fused_out = self._allocate_buffers(
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                                          ^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1095, in _allocate_buffers
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     common_workspace, workspace2 = current_workspace_manager().get_simultaneous(
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/workspace.py", line 110, in get_simultaneous
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     current_workspace = self._ensure_workspace_size(total_bytes)
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/workspace.py", line 157, in _ensure_workspace_size
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     raise AssertionError(
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962] AssertionError: Workspace is locked but allocation from 'modular_kernel.py:1095:_allocate_buffers' requires 49.49 MB, current size is 10.69 MB. Workspace growth is not allowed after locking.
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/multiproc_executor.py", line 957, in worker_busy_loop
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     output = func(*args, **kwargs)
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]              ^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/worker_base.py", line 337, in execute_model
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.worker.execute_model(scheduler_output)
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return func(*args, **kwargs)
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_worker.py", line 841, in execute_model
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     output = self.model_runner.execute_model(
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return func(*args, **kwargs)
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_model_runner.py", line 4114, in execute_model
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     model_output = self._model_forward(
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_model_runner.py", line 3587, in _model_forward
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.model(
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/cuda_graph.py", line 254, in __call__
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.runnable(*args, **kwargs)
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1778, in _wrapped_call_impl
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self._call_impl(*args, **kwargs)
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1789, in _call_impl
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return forward_call(*args, **kwargs)
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/deepseek_v2.py", line 1460, in forward
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     hidden_states = self.model(
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                     ^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/decorators.py", line 520, in __call__
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.aot_compiled_fn(self, *args, **kwargs)
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/aot_compile.py", line 240, in __call__
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.fn(*args, **kwargs)
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/deepseek_v2.py", line 1258, in forward
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     def forward(
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/caching.py", line 217, in __call__
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.optimized_call(*args, **kwargs)
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "<string>", line 249, in execution_fn
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/cuda_graph.py", line 254, in __call__
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.runnable(*args, **kwargs)
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/piecewise_backend.py", line 380, in __call__
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return range_entry.runnable(*args)
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/standalone_compile.py", line 313, in __call__
+
+_bk;t=1778141500081[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.inner_fn(*args)
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/aot_compile_types.py", line 211, in __call__
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.compiled_fn(*args, **kwargs)
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/eval_frame.py", line 1298, in _fn
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return fn(*args, **kwargs)
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/aot_autograd.py", line 1273, in forward
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return compiled_fn(full_args)
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 777, in runtime_wrapper
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     all_outs = compiled_invoker.run(args, on_before_call=exit_prologue)
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return call_func_at_runtime_with_args(
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/utils.py", line 126, in call_func_at_runtime_with_args
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     out = normalize_as_list(f(args))
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                             ^^^^^^^
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 2384, in __call__
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.compiled_fn(*args, **kwargs)
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 850, in wrapper
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return compiled_fn(runtime_args)
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 1055, in inner_fn
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     outs = compiled_fn(args)
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/output_code.py", line 725, in __call__
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.current_callable(inputs)
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/root/.cache/vllm/torch_compile_cache/torch_aot_compile/558bf2cdc1bb4261d8c924ec3d228cc3e849decbfc86fc02810a19443b281549/inductor_cache/25/c25qcojflilobdu57zkz3juxmncjg3fkgbywhm4xoathy2y54mg3.py", line 954, in call
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     buf5 = torch.ops.vllm.moe_forward_shared.default(buf2, buf3, buf4, None, arg5_1)
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_ops.py", line 871, in __call__
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self._op(*args, **kwargs)
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/runner/moe_runner.py", line 125, in _moe_forward_shared
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return layer.runner._forward_impl(
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/runner/moe_runner.py", line 722, in _forward_impl
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     shared_output, hidden_states = self._apply_quant_method(
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                                    ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/runner/moe_runner.py", line 470, in _apply_quant_method
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     fused_out = self._quant_method.apply(
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py", line 281, in apply
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.forward(
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/custom_op.py", line 136, in forward
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self._forward_method(*args, **kwargs)
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py", line 298, in forward_native
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.moe_kernel.apply(
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1614, in apply
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.impl.apply(
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1392, in apply
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     fused_out = self._fused_experts(
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1232, in _fused_experts
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     workspace13, workspace2, fused_out = self._allocate_buffers(
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                                          ^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1095, in _allocate_buffers
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     common_workspace, workspace2 = current_workspace_manager().get_simultaneous(
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/workspace.py", line 110, in get_simultaneous
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     current_workspace = self._ensure_workspace_size(total_bytes)
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/workspace.py", line 157, in _ensure_workspace_size
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     raise AssertionError(
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962] AssertionError: Workspace is locked but allocation from 'modular_kernel.py:1095:_allocate_buffers' requires 49.49 MB, current size is 10.69 MB. Workspace growth is not allowed after locking.
+
+_bk;t=1778141500082[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]
+
+_bk;t=1778141500187[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962] WorkerProc hit an exception.
+
+_bk;t=1778141500187[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/multiproc_executor.py", line 957, in worker_busy_loop
+
+_bk;t=1778141500187[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     output = func(*args, **kwargs)
+
+_bk;t=1778141500187[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]              ^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500187[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/worker_base.py", line 337, in execute_model
+
+_bk;t=1778141500187[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.worker.execute_model(scheduler_output)
+
+_bk;t=1778141500187[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500187[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
+
+_bk;t=1778141500187[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return func(*args, **kwargs)
+
+_bk;t=1778141500187[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500187[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_worker.py", line 841, in execute_model
+
+_bk;t=1778141500187[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     output = self.model_runner.execute_model(
+
+_bk;t=1778141500187[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500187[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
+
+_bk;t=1778141500187[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return func(*args, **kwargs)
+
+_bk;t=1778141500187[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500187[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_model_runner.py", line 4114, in execute_model
+
+_bk;t=1778141500187[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     model_output = self._model_forward(
+
+_bk;t=1778141500187[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_model_runner.py", line 3587, in _model_forward
+
+_bk;t=1778141500187[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.model(
+
+_bk;t=1778141500187[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^
+
+_bk;t=1778141500187[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/cuda_graph.py", line 254, in __call__
+
+_bk;t=1778141500187[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.runnable(*args, **kwargs)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1778, in _wrapped_call_impl
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self._call_impl(*args, **kwargs)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1789, in _call_impl
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return forward_call(*args, **kwargs)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/deepseek_v2.py", line 1460, in forward
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     hidden_states = self.model(
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                     ^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/decorators.py", line 520, in __call__
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.aot_compiled_fn(self, *args, **kwargs)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/aot_compile.py", line 240, in __call__
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.fn(*args, **kwargs)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/deepseek_v2.py", line 1258, in forward
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     def forward(
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/caching.py", line 217, in __call__
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.optimized_call(*args, **kwargs)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "<string>", line 249, in execution_fn
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/cuda_graph.py", line 254, in __call__
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.runnable(*args, **kwargs)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/piecewise_backend.py", line 380, in __call__
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return range_entry.runnable(*args)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/standalone_compile.py", line 313, in __call__
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.inner_fn(*args)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/aot_compile_types.py", line 211, in __call__
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.compiled_fn(*args, **kwargs)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/eval_frame.py", line 1298, in _fn
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return fn(*args, **kwargs)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/aot_autograd.py", line 1273, in forward
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return compiled_fn(full_args)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 777, in runtime_wrapper
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     all_outs = compiled_invoker.run(args, on_before_call=exit_prologue)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return call_func_at_runtime_with_args(
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/utils.py", line 126, in call_func_at_runtime_with_args
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     out = normalize_as_list(f(args))
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                             ^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 2384, in __call__
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.compiled_fn(*args, **kwargs)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 850, in wrapper
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return compiled_fn(runtime_args)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 1055, in inner_fn
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     outs = compiled_fn(args)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/output_code.py", line 725, in __call__
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.current_callable(inputs)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/root/.cache/vllm/torch_compile_cache/torch_aot_compile/558bf2cdc1bb4261d8c924ec3d228cc3e849decbfc86fc02810a19443b281549/inductor_cache/25/c25qcojflilobdu57zkz3juxmncjg3fkgbywhm4xoathy2y54mg3.py", line 954, in call
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     buf5 = torch.ops.vllm.moe_forward_shared.default(buf2, buf3, buf4, None, arg5_1)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_ops.py", line 871, in __call__
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self._op(*args, **kwargs)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/runner/moe_runner.py", line 125, in _moe_forward_shared
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return layer.runner._forward_impl(
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/runner/moe_runner.py", line 722, in _forward_impl
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     shared_output, hidden_states = self._apply_quant_method(
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                                    ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/runner/moe_runner.py", line 470, in _apply_quant_method
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     fused_out = self._quant_method.apply(
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py", line 281, in apply
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.forward(
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/custom_op.py", line 136, in forward
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self._forward_method(*args, **kwargs)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py", line 298, in forward_native
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.moe_kernel.apply(
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1614, in apply
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.impl.apply(
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1392, in apply
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     fused_out = self._fused_experts(
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1232, in _fused_experts
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     workspace13, workspace2, fused_out = self._allocate_buffers(
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                                          ^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1095, in _allocate_buffers
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     common_workspace, workspace2 = current_workspace_manager().get_simultaneous(
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/workspace.py", line 110, in get_simultaneous
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     current_workspace = self._ensure_workspace_size(total_bytes)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/workspace.py", line 157, in _ensure_workspace_size
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     raise AssertionError(
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962] AssertionError: Workspace is locked but allocation from 'modular_kernel.py:1095:_allocate_buffers' requires 20.71 MB, current size is 10.69 MB. Workspace growth is not allowed after locking.
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/multiproc_executor.py", line 957, in worker_busy_loop
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     output = func(*args, **kwargs)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]              ^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/worker_base.py", line 337, in execute_model
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.worker.execute_model(scheduler_output)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return func(*args, **kwargs)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_worker.py", line 841, in execute_model
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     output = self.model_runner.execute_model(
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return func(*args, **kwargs)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_model_runner.py", line 4114, in execute_model
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     model_output = self._model_forward(
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_model_runner.py", line 3587, in _model_forward
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.model(
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/cuda_graph.py", line 254, in __call__
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.runnable(*args, **kwargs)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1778, in _wrapped_call_impl
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self._call_impl(*args, **kwargs)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1789, in _call_impl
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return forward_call(*args, **kwargs)
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/deepseek_v2.py", line 1460, in forward
+
+_bk;t=1778141500188[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     hidden_states = self.model(
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                     ^^^^^^^^^^^
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/decorators.py", line 520, in __call__
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.aot_compiled_fn(self, *args, **kwargs)
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/aot_compile.py", line 240, in __call__
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.fn(*args, **kwargs)
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/deepseek_v2.py", line 1258, in forward
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     def forward(
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/caching.py", line 217, in __call__
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.optimized_call(*args, **kwargs)
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "<string>", line 249, in execution_fn
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/cuda_graph.py", line 254, in __call__
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.runnable(*args, **kwargs)
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/piecewise_backend.py", line 380, in __call__
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return range_entry.runnable(*args)
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/standalone_compile.py", line 313, in __call__
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.inner_fn(*args)
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/aot_compile_types.py", line 211, in __call__
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.compiled_fn(*args, **kwargs)
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/eval_frame.py", line 1298, in _fn
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return fn(*args, **kwargs)
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/aot_autograd.py", line 1273, in forward
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return compiled_fn(full_args)
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 777, in runtime_wrapper
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     all_outs = compiled_invoker.run(args, on_before_call=exit_prologue)
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return call_func_at_runtime_with_args(
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/utils.py", line 126, in call_func_at_runtime_with_args
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     out = normalize_as_list(f(args))
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                             ^^^^^^^
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 2384, in __call__
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.compiled_fn(*args, **kwargs)
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 850, in wrapper
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return compiled_fn(runtime_args)
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 1055, in inner_fn
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     outs = compiled_fn(args)
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/output_code.py", line 725, in __call__
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.current_callable(inputs)
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/root/.cache/vllm/torch_compile_cache/torch_aot_compile/558bf2cdc1bb4261d8c924ec3d228cc3e849decbfc86fc02810a19443b281549/inductor_cache/25/c25qcojflilobdu57zkz3juxmncjg3fkgbywhm4xoathy2y54mg3.py", line 954, in call
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     buf5 = torch.ops.vllm.moe_forward_shared.default(buf2, buf3, buf4, None, arg5_1)
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_ops.py", line 871, in __call__
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self._op(*args, **kwargs)
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/runner/moe_runner.py", line 125, in _moe_forward_shared
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return layer.runner._forward_impl(
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/runner/moe_runner.py", line 722, in _forward_impl
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     shared_output, hidden_states = self._apply_quant_method(
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                                    ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/runner/moe_runner.py", line 470, in _apply_quant_method
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     fused_out = self._quant_method.apply(
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py", line 281, in apply
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.forward(
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/custom_op.py", line 136, in forward
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self._forward_method(*args, **kwargs)
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py", line 298, in forward_native
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.moe_kernel.apply(
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1614, in apply
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     return self.impl.apply(
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1392, in apply
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     fused_out = self._fused_experts(
+
+_bk;t=1778141500189[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1232, in _fused_experts
+
+_bk;t=1778141500190[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     workspace13, workspace2, fused_out = self._allocate_buffers(
+
+_bk;t=1778141500190[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                                          ^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500190[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1095, in _allocate_buffers
+
+_bk;t=1778141500190[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     common_workspace, workspace2 = current_workspace_manager().get_simultaneous(
+
+_bk;t=1778141500190[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500190[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/workspace.py", line 110, in get_simultaneous
+
+_bk;t=1778141500190[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     current_workspace = self._ensure_workspace_size(total_bytes)
+
+_bk;t=1778141500190[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141500190[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/workspace.py", line 157, in _ensure_workspace_size
+
+_bk;t=1778141500190[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]     raise AssertionError(
+
+_bk;t=1778141500190[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962] AssertionError: Workspace is locked but allocation from 'modular_kernel.py:1095:_allocate_buffers' requires 20.71 MB, current size is 10.69 MB. Workspace growth is not allowed after locking.
+
+_bk;t=1778141500190[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]
+
+_bk;t=1778141503221[0;36m(APIServer pid=19502)[0;0m Exception in thread MPClientEngineMonitor:
+
+_bk;t=1778141503221[0;36m(APIServer pid=19502)[0;0m Traceback (most recent call last):
+
+_bk;t=1778141503221[0;36m(APIServer pid=19502)[0;0m   File "/usr/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
+
+_bk;t=1778141503221[0;36m(APIServer pid=19502)[0;0m     self.run()
+
+_bk;t=1778141503221[0;36m(APIServer pid=19502)[0;0m   File "/usr/lib/python3.12/threading.py", line 1012, in run
+
+_bk;t=1778141503221[0;36m(APIServer pid=19502)[0;0m     self._target(*self._args, **self._kwargs)
+
+_bk;t=1778141503221[0;36m(APIServer pid=19502)[0;0m   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core_client.py", line 653, in monitor_engine_cores
+
+_bk;t=1778141503221[0;36m(APIServer pid=19502)[0;0m     engine_manager.monitor_engine_liveness()
+
+_bk;t=1778141503221[0;36m(APIServer pid=19502)[0;0m   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/utils.py", line 926, in monitor_engine_liveness
+
+_bk;t=1778141503221[0;36m(APIServer pid=19502)[0;0m     ray.get(actor_ref)
+
+_bk;t=1778141503221[0;36m(APIServer pid=19502)[0;0m   File "/usr/local/lib/python3.12/dist-packages/ray/_private/auto_init_hook.py", line 22, in auto_init_wrapper
+
+_bk;t=1778141503221[0;36m(APIServer pid=19502)[0;0m     return fn(*args, **kwargs)
+
+_bk;t=1778141503221[0;36m(APIServer pid=19502)[0;0m            ^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141503221[0;36m(APIServer pid=19502)[0;0m   File "/usr/local/lib/python3.12/dist-packages/ray/_private/client_mode_hook.py", line 104, in wrapper
+
+_bk;t=1778141503221[0;36m(APIServer pid=19502)[0;0m     return func(*args, **kwargs)
+
+_bk;t=1778141503221[0;36m(APIServer pid=19502)[0;0m            ^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141503221[0;36m(APIServer pid=19502)[0;0m   File "/usr/local/lib/python3.12/dist-packages/ray/_private/worker.py", line 2858, in get
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m     values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m   File "/usr/local/lib/python3.12/dist-packages/ray/_private/worker.py", line 958, in get_objects
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m     raise value.as_instanceof_cause()
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m ray.exceptions.RayTaskError(RuntimeError): [36mray::DPMoEEngineCoreActor.run()[39m (pid=37762, ip=192.168.5.77, actor_id=da0f17d764ad2a835576558301000000, repr=<vllm.v1.engine.core.DPMoEEngineCoreActor object at 0x738843a5cc50>)
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 2083, in run
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m     self.run_busy_loop()  # type: ignore[attr-defined]
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m     ^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 1806, in run_busy_loop
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m     executed = self._process_engine_step()
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 1209, in _process_engine_step
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m     outputs, model_executed = self.step_fn()
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m                               ^^^^^^^^^^^^^^
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 525, in step_with_batch_queue
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m     exec_model_fut.result()
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/multiproc_executor.py", line 90, in result
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m     return super().result()
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m            ^^^^^^^^^^^^^^^^
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 449, in result
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m     return self.__get_result()
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m            ^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m     raise self._exception
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/multiproc_executor.py", line 94, in _wait_for_response
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m     response = self.aggregate(self.get_response())
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m                               ^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/multiproc_executor.py", line 390, in get_response
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m     raise RuntimeError(
+
+_bk;t=1778141503222[0;36m(APIServer pid=19502)[0;0m RuntimeError: Worker failed with error 'Workspace is locked but allocation from 'modular_kernel.py:1095:_allocate_buffers' requires 49.49 MB, current size is 10.69 MB. Workspace growth is not allowed after locking.', please check the stack trace above for the root cause
+
+_bk;t=1778141561241[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m INFO 05-07 08:12:41 [shm_broadcast.py:681] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-consuming work (e.g. compilation, weight/kv cache quantization).
+
+_bk;t=1778141561241[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962] Traceback (most recent call last):[32m [repeated 4x across cluster][0m
+
+_bk;t=1778141561241[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 523, in run[32m [repeated 4x across cluster][0m
+
+_bk;t=1778141561241[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]                 ^^^^^^^^^^^^^^^^^^^^[32m [repeated 12x across cluster][0m
+
+_bk;t=1778141561241[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[32m [repeated 4x across cluster][0m
+
+_bk;t=1778141561241[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^[32m [repeated 8x across cluster][0m
+
+_bk;t=1778141561241[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^[32m [repeated 4x across cluster][0m
+
+_bk;t=1778141561241[0;36m(APIServer pid=19502)[0;0m [36m(RayWorkerProc pid=37847)[0m (Worker_DP2_EP2 pid=37847) ERROR 05-07 08:11:40 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^[32m [repeated 4x across cluster][0m
+
+_bk;t=1778141621358[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m INFO 05-07 08:13:41 [shm_broadcast.py:681] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-consuming work (e.g. compilation, weight/kv cache quantization).[32m [repeated 2x across cluster][0m
+
+_bk;t=1778141681369[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m INFO 05-07 08:14:41 [shm_broadcast.py:681] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-consuming work (e.g. compilation, weight/kv cache quantization).[32m [repeated 2x across cluster][0m
+
+_bk;t=1778141741506[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m INFO 05-07 08:15:41 [shm_broadcast.py:681] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-consuming work (e.g. compilation, weight/kv cache quantization).[32m [repeated 2x across cluster][0m
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [dump_input.py:72] Dumping input data for V1 LLM engine (v0.20.2rc1.dev96+gf596e760c) with config: model='deepseek-ai/DeepSeek-V2-Lite-Chat', speculative_config=None, tokenizer='deepseek-ai/DeepSeek-V2-Lite-Chat', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=4096, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=3, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=None, quantization_config=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=deepseek-ai/DeepSeek-V2-Lite-Chat, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'ir_enable_torch_wrap': True, 'splitting_ops': ['vllm::unified_attention_with_output', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::gdn_attention_core_xpu', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::deepseek_v4_attention', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': [], 'compile_ranges_endpoints': [8192], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 64, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': False, 'static_all_moe_layers': []}, kernel_config=KernelConfig(ir_op_priority=IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native']), enable_flashinfer_autotune=False, moe_backend='auto'),
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [dump_input.py:79] Dumping scheduler output for model execution: SchedulerOutput(scheduled_new_reqs=[NewRequestData(req_id=cmpl-a108e10c49c1e97c-0-8cedb0d8,prompt_token_ids_len=759,prefill_token_ids_len=None,mm_features=[],sampling_params=SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=0, min_p=0.0, seed=42, stop=['Question', 'Assistant:', '<|separator|>'], stop_token_ids=[], bad_words=[], thinking_token_budget=None, include_stop_str_in_output=False, ignore_eos=False, max_tokens=256, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, structured_outputs=None, extra_args=None),block_ids=([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 62, 63, 64, 65, 66, 1634],),num_computed_tokens=752,lora_request=None,prompt_embeds_shape=None), NewRequestData(req_id=cmpl-a3e61eab735a9b07-0-95566cc5,prompt_token_ids_len=749,prefill_token_ids_len=None,mm_features=[],sampling_params=SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=0, min_p=0.0, seed=42, stop=['Question', 'Assistant:', '<|separator|>'], stop_token_ids=[], bad_words=[], thinking_token_budget=None, include_stop_str_in_output=False, ignore_eos=False, max_tokens=256, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, structured_outputs=None, extra_args=None),block_ids=([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 48, 49, 50, 51, 1635],),num_computed_tokens=736,lora_request=None,prompt_embeds_shape=None)], scheduled_cached_reqs=CachedRequestData(req_ids=[],resumed_req_ids=set(),new_token_ids_lens=[],all_token_ids_lens={},new_block_ids=[],num_computed_tokens=[],num_output_tokens=[]), num_scheduled_tokens={cmpl-a3e61eab735a9b07-0-95566cc5: 13, cmpl-a108e10c49c1e97c-0-8cedb0d8: 7}, total_num_scheduled_tokens=20, scheduled_spec_decode_tokens={}, scheduled_encoder_inputs={}, num_common_prefix_blocks=[42], finished_req_ids=[], free_encoder_mm_hashes=[], preempted_req_ids=[], has_structured_output_requests=false, pending_structured_output_tokens=false, num_invalid_spec_tokens=null, kv_connector_metadata=null, ec_connector_metadata=null, new_block_ids_to_zero=null)
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [dump_input.py:81] Dumping scheduler stats: SchedulerStats(num_running_reqs=5, num_waiting_reqs=0, num_skipped_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0007393279615978132, prefix_cache_stats=PrefixCacheStats(reset=False, requests=5, queries=3746, hits=3664, preempted_requests=0, preempted_queries=0, preempted_hits=0), connector_prefix_cache_stats=None, kv_cache_eviction_events=[], spec_decoding_stats=None, kv_connector_stats=None, waiting_lora_adapters={}, running_lora_adapters={}, cudagraph_stats=None, perf_stats=None)
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088] EngineCore encountered a fatal error.
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088] Traceback (most recent call last):
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/multiproc_executor.py", line 386, in get_response
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]     status, result = mq.dequeue(timeout=dequeue_timeout)
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/distributed/device_communicators/shm_broadcast.py", line 755, in dequeue
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]     with self.acquire_read(timeout, indefinite) as buf:
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/lib/python3.12/contextlib.py", line 137, in __enter__
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]     return next(self.gen)
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]            ^^^^^^^^^^^^^^
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/distributed/device_communicators/shm_broadcast.py", line 674, in acquire_read
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]     self._spin_condition.wait(timeout_ms=read_timeout.timeout_ms())
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]                                          ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/distributed/device_communicators/shm_broadcast.py", line 631, in timeout_ms
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]     raise TimeoutError
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088] TimeoutError
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088] The above exception was the direct cause of the following exception:
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088] Traceback (most recent call last):
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 2083, in run
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]     self.run_busy_loop()  # type: ignore[attr-defined]
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]     ^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/ray/util/tracing/tracing_helper.py", line 461, in _resume_span
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]     return method(self, *_args, **_kwargs)
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 1806, in run_busy_loop
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]     executed = self._process_engine_step()
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/ray/util/tracing/tracing_helper.py", line 461, in _resume_span
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]     return method(self, *_args, **_kwargs)
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 1209, in _process_engine_step
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]     outputs, model_executed = self.step_fn()
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]                               ^^^^^^^^^^^^^^
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/ray/util/tracing/tracing_helper.py", line 461, in _resume_span
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]     return method(self, *_args, **_kwargs)
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 521, in step_with_batch_queue
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]     model_output = future.result()
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]                    ^^^^^^^^^^^^^^^
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/multiproc_executor.py", line 90, in result
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]     return super().result()
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]            ^^^^^^^^^^^^^^^^
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 449, in result
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]     return self.__get_result()
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]            ^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]     raise self._exception
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/multiproc_executor.py", line 94, in _wait_for_response
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]     response = self.aggregate(self.get_response())
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]                               ^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/multiproc_executor.py", line 388, in get_response
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088]     raise TimeoutError(f"RPC call to {method} timed out.") from e
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30140)[0m ERROR 05-07 08:16:39 [core.py:2088] TimeoutError: RPC call to sample_tokens timed out.
+
+_bk;t=1778141800039[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m INFO 05-07 08:15:41 [shm_broadcast.py:681] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-consuming work (e.g. compilation, weight/kv cache quantization).
+
+_bk;t=1778141800040[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [dump_input.py:79] Dumping scheduler output for model execution: SchedulerOutput(scheduled_new_reqs=[NewRequestData(req_id=cmpl-afdf33db879db668-0-85ecc875,prompt_token_ids_len=715,prefill_token_ids_len=None,mm_features=[],sampling_params=SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=0, min_p=0.0, seed=42, stop=['Question', 'Assistant:', '<|separator|>'], stop_token_ids=[], bad_words=[], thinking_token_budget=None, include_stop_str_in_output=False, ignore_eos=False, max_tokens=256, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, structured_outputs=None, extra_args=None),block_ids=([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 59, 60, 1638],),num_computed_tokens=704,lora_request=None,prompt_embeds_shape=None)], scheduled_cached_reqs=CachedRequestData(req_ids=[],resumed_req_ids=set(),new_token_ids_lens=[],all_token_ids_lens={},new_block_ids=[],num_computed_tokens=[],num_output_tokens=[]), num_scheduled_tokens={cmpl-afdf33db879db668-0-85ecc875: 11}, total_num_scheduled_tokens=11, scheduled_spec_decode_tokens={}, scheduled_encoder_inputs={}, num_common_prefix_blocks=[45], finished_req_ids=[], free_encoder_mm_hashes=[], preempted_req_ids=[], has_structured_output_requests=false, pending_structured_output_tokens=false, num_invalid_spec_tokens=null, kv_connector_metadata=null, ec_connector_metadata=null, new_block_ids_to_zero=null)
+
+_bk;t=1778142099956Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099957Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099958Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099959Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099960Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099961Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099962Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099963Error calling vLLM API:
+
+_bk;t=1778142099964Error calling vLLM API:
+
+_bk;t=1778142099964Error calling vLLM API:
+
+_bk;t=1778142099964Error calling vLLM API:
+
+_bk;t=1778142099964Error calling vLLM API:
+
+_bk;t=1778142099964Error calling vLLM API:
+
+_bk;t=1778142099966
+Evaluating:   0%|▍                                                                                                          | 1/256 [10:00<42:30:42, 600.17s/it]
+Evaluating: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 256/256 [10:00<00:00,  2.34s/it]
+
+_bk;t=1778142099969[After scale up (3 GPUs)] GSM8K accuracy: 0.000 (256 questions)
+
+_bk;t=1778142099969[RemoteOpenAIServer] Sent SIGTERM to process 19502
+
+_bk;t=1778142100012[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     Shutting down
+
+_bk;t=1778142100113[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m [90m05-07 08:21:40[0m [90m[launcher.py:137][0m Shutting down FastAPI HTTP server.
+
+_bk;t=1778142100113[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     Shutting down
+
+_bk;t=1778142100214[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     Waiting for application shutdown.
+
+_bk;t=1778142100214[0;36m(APIServer pid=19502)[0;0m [32mINFO[0m:     Application shutdown complete.
+
+_bk;t=1778142100733[0;36m(APIServer pid=19502)[0;0m [0m[36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [dump_input.py:72] Dumping input data for V1 LLM engine (v0.20.2rc1.dev96+gf596e760c) with config: model='deepseek-ai/DeepSeek-V2-Lite-Chat', speculative_config=None, tokenizer='deepseek-ai/DeepSeek-V2-Lite-Chat', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=4096, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=3, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=None, quantization_config=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=deepseek-ai/DeepSeek-V2-Lite-Chat, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'ir_enable_torch_wrap': True, 'splitting_ops': ['vllm::unified_attention_with_output', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::gdn_attention_core_xpu', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::deepseek_v4_attention', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': [], 'compile_ranges_endpoints': [8192], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 64, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': False, 'static_all_moe_layers': []}, kernel_config=KernelConfig(ir_op_priority=IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native']), enable_flashinfer_autotune=False, moe_backend='auto'),
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [dump_input.py:81] Dumping scheduler stats: SchedulerStats(num_running_reqs=3, num_waiting_reqs=0, num_skipped_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0005786044916852306, prefix_cache_stats=PrefixCacheStats(reset=False, requests=3, queries=2182, hits=2096, preempted_requests=0, preempted_queries=0, preempted_hits=0), connector_prefix_cache_stats=None, kv_cache_eviction_events=[], spec_decoding_stats=None, kv_connector_stats=None, waiting_lora_adapters={}, running_lora_adapters={}, cudagraph_stats=None, perf_stats=None)
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088] EngineCore encountered a fatal error.
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088] Traceback (most recent call last):[32m [repeated 2x across cluster][0m
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/multiproc_executor.py", line 388, in get_response[32m [repeated 2x across cluster][0m
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]     status, result = mq.dequeue(timeout=dequeue_timeout)
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/distributed/device_communicators/shm_broadcast.py", line 755, in dequeue
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]     with self.acquire_read(timeout, indefinite) as buf:
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/lib/python3.12/contextlib.py", line 137, in __enter__
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]     return next(self.gen)
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]                               ^^^^^^^^^^^^^^[32m [repeated 2x across cluster][0m
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/distributed/device_communicators/shm_broadcast.py", line 674, in acquire_read
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]     self._spin_condition.wait(timeout_ms=read_timeout.timeout_ms())
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]                                          ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/distributed/device_communicators/shm_broadcast.py", line 631, in timeout_ms
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]     raise TimeoutError
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088] TimeoutError
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088] [32m [repeated 2x across cluster][0m
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088] The above exception was the direct cause of the following exception:
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 2083, in run
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]     self.run_busy_loop()  # type: ignore[attr-defined]
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]     ^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/ray/util/tracing/tracing_helper.py", line 461, in _resume_span[32m [repeated 3x across cluster][0m
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]     return method(self, *_args, **_kwargs)[32m [repeated 3x across cluster][0m
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[32m [repeated 3x across cluster][0m
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 1806, in run_busy_loop
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]     executed = self._process_engine_step()
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 1209, in _process_engine_step
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]     outputs, model_executed = self.step_fn()
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 521, in step_with_batch_queue
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]     model_output = future.result()
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]                    ^^^^^^^^^^^^^^^
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 449, in result[32m [repeated 2x across cluster][0m
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]     return super().result()
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]            ^^^^^^^^^^^^^^^^
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]     return self.__get_result()
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]                               ^^^^^^^^^^^^^^^^^^^[32m [repeated 2x across cluster][0m
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]     raise self._exception
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/multiproc_executor.py", line 94, in _wait_for_response
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]     response = self.aggregate(self.get_response())
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088]     raise TimeoutError(f"RPC call to {method} timed out.") from e
+
+_bk;t=1778142100734[0;36m(APIServer pid=19502)[0;0m [36m(DPMoEEngineCoreActor pid=30139)[0m ERROR 05-07 08:16:39 [core.py:2088] TimeoutError: RPC call to sample_tokens timed out.
+
+_bk;t=1778142103612[RemoteOpenAIServer] Server 19502 terminated gracefully
+
+_bk;t=1778142103614[RemoteOpenAIServer] 5 process(es) still in pgid 19502 after SIGKILL: [20280, 20282, 20284, 20286, 20289]
+
+_bk;t=1778142104162[RemoteOpenAIServer] GPU memory released to 2.01 GB (target: 4.16 GB) in 0.0s
+
+_bk;t=1778142104197[31mFAILED[0m
+
+_bk;t=1778142104557
+
+_bk;t=1778142104557=========================================================================== FAILURES ===========================================================================
+
+_bk;t=1778142104557[31m[1m___________________________________________________________________ test_elastic_ep_scaling ____________________________________________________________________[0m
+
+_bk;t=1778142104557
+
+_bk;t=1778142104590>   [0m[94massert[39;49;00m _send_scale_command(server, [94m4[39;49;00m)[90m[39;49;00m
+
+_bk;t=1778142104590[1m[31mE   assert False[0m
+
+_bk;t=1778142104590[1m[31mE    +  where False = _send_scale_command(<tests.utils.RemoteOpenAIServer object at 0x763f4fb72570>, 4)[0m
+
+_bk;t=1778142104590
+
+_bk;t=1778142104590[1m[31mdistributed/test_elastic_ep.py[0m:98: AssertionError
+
+_bk;t=1778142104590[31m[1m________________________________________________________________ test_elastic_ep_scaling_uneven ________________________________________________________________[0m
+
+_bk;t=1778142104590
+
+_bk;t=1778142104590>   [0mscale_up_accuracy = _run_gsm8k_eval(server, [33m"[39;49;00m[33mAfter scale up (3 GPUs)[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
+
+_bk;t=1778142104590
+
+_bk;t=1778142104590[1m[31mdistributed/test_elastic_ep.py[0m:175:
+
+_bk;t=1778142104590_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+_bk;t=1778142104590
+
+_bk;t=1778142104590>   [0m[94massert[39;49;00m accuracy >= EXPECTED_ACCURACY, ([90m[39;49;00m
+
+_bk;t=1778142104590        [33mf[39;49;00m[33m"[39;49;00m[33m[[39;49;00m[33m{[39;49;00mstage[33m}[39;49;00m[33m] GSM8K accuracy [39;49;00m[33m{[39;49;00maccuracy[33m:[39;49;00m[33m.3f[39;49;00m[33m}[39;49;00m[33m is below [39;49;00m[33m"[39;49;00m[90m[39;49;00m
+
+_bk;t=1778142104590        [33mf[39;49;00m[33m"[39;49;00m[33mexpected threshold [39;49;00m[33m{[39;49;00mEXPECTED_ACCURACY[33m}[39;49;00m[33m"[39;49;00m[90m[39;49;00m
+
+_bk;t=1778142104590    )[90m[39;49;00m
+
+_bk;t=1778142104590[1m[31mE   AssertionError: [After scale up (3 GPUs)] GSM8K accuracy 0.000 is below expected threshold 0.58[0m
+
+_bk;t=1778142104590[1m[31mE   assert np.float64(0.0) >= 0.58[0m
+
+_bk;t=1778142104590
+
+_bk;t=1778142104591[1m[31mdistributed/test_elastic_ep.py[0m:55: AssertionError
+
+_bk;t=1778142104591[33m======================================================================= warnings summary =======================================================================[0m
+
+_bk;t=1778142104591<frozen importlib._bootstrap>:488
+
+_bk;t=1778142104591  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute
+
+_bk;t=1778142104591
+
+_bk;t=1778142104591<frozen importlib._bootstrap>:488
+
+_bk;t=1778142104591  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute
+
+_bk;t=1778142104591
+
+_bk;t=1778142104592../../usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: 14 warnings
+
+_bk;t=1778142104592  /usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
+
+_bk;t=1778142104592    warnings.warn(
+
+_bk;t=1778142104592
+
+_bk;t=1778142104592../../usr/local/lib/python3.12/dist-packages/schemathesis/generation/coverage.py:305
+
+_bk;t=1778142104592  /usr/local/lib/python3.12/dist-packages/schemathesis/generation/coverage.py:305: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
+
+_bk;t=1778142104592    ref_error: type[Exception] = jsonschema.RefResolutionError,
+
+_bk;t=1778142104592
+
+_bk;t=1778142104592tests/distributed/test_elastic_ep.py::test_elastic_ep_scaling
+
+_bk;t=1778142104592tests/distributed/test_elastic_ep.py::test_elastic_ep_scaling_uneven
+
+_bk;t=1778142104592  /vllm-workspace/tests/utils.py:1427: DeprecationWarning: This process (pid=111) is multi-threaded, use of fork() may lead to deadlocks in the child.
+
+_bk;t=1778142104592    pid = os.fork()
+
+_bk;t=1778142104592
+
+_bk;t=1778142104592-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+
+_bk;t=1778142104593[36m[1m=================================================================== short test summary info ====================================================================[0m
+
+_bk;t=1778142104593[31mFAILED[0m distributed/test_elastic_ep.py::[1mtest_elastic_ep_scaling[0m - assert False
+
+_bk;t=1778142104593 +  where False = _send_scale_command(<tests.utils.RemoteOpenAIServer object at 0x763f4fb72570>, 4)
+
+_bk;t=1778142104593[31mFAILED[0m distributed/test_elastic_ep.py::[1mtest_elastic_ep_scaling_uneven[0m - AssertionError: [After scale up (3 GPUs)] GSM8K accuracy 0.000 is below expected threshold 0.58
+
+_bk;t=1778142104593assert np.float64(0.0) >= 0.58
+
+_bk;t=1778142104593[31m========================================================= [31m[1m2 failed[0m, [33m19 warnings[0m[31m in 1294.99s (0:21:34)[0m[31m ==========================================================[0m
+
+_bk;t=1778142104881sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
+
+_bk;t=1778142106168^^^ +++
+_bk;t=1778142106168[31m🚨 Error: The command exited with status 1[0m
+_bk;t=1778142106168^^^ +++
+_bk;t=1778142106168user command error: exit status 1

--- a/tools/torchci/tests/fixtures/raw_log_snippet.bin
+++ b/tools/torchci/tests/fixtures/raw_log_snippet.bin
@@ -1,0 +1,12 @@
+648
+_bk;t=1783974785648-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+_bk;t=1783974785649[36m[1m=================================================================== short test summary info ====================================================================[0m
+_bk;t=1783974785649[31mFAILED[0m quantization/test_cutlass_w4a16.py::[1mtest_w4a16_machete_e2e[nm-testing/tinyllama-oneshot-w4a16-channel-v2][0m - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+_bk;t=1783974785649[31mFAILED[0m quantization/test_cutlass_w4a16.py::[1mtest_w4a16_machete_e2e[nm-testing/TinyLlama-1.1B-Chat-v1.0-W4A16-G128-Asym-Updated-ActOrder][0m - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+_bk;t=1783974785649[31mFAILED[0m quantization/test_cutlass_w4a16.py::[1mtest_w4a16_machete_bfloat16_deterministic[0m - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore': 1}
+_bk;t=1783974785649[31m========================================================== [31m[1m3 failed[0m, [32m8 passed[0m, [33m19 warnings[0m[31m in 21.94s[0m[31m ===========================================================[0m
+_bk;t=1783974786533sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
+_bk;t=1783974787899^^^ +++
+_bk;t=1783974787899[31m🚨 Error: The command exited with status 1[0m
+_bk;t=1783974787899^^^ +++
+_bk;t=1783974787899user command error: exit status 1

--- a/tools/torchci/tests/test_vllm_log_parser.py
+++ b/tools/torchci/tests/test_vllm_log_parser.py
@@ -276,7 +276,9 @@ class TestErrorLinesParsing(unittest.TestCase):
         parsed_log = parse_log(log)
         pytest_result = parsed_log.pytest_results[0]
         self.assertEqual(len(pytest_result.test_failures), 1)
-        self.assertEqual(pytest_result.test_failures[0].test_id, "tests/test_x.py::test_y")
+        self.assertEqual(
+            pytest_result.test_failures[0].test_id, "tests/test_x.py::test_y"
+        )
 
 
 class TestExpectedFailureCount(unittest.TestCase):
@@ -362,14 +364,18 @@ class TestMultipleSessionsGrouping(unittest.TestCase):
 
         session_one = parsed_log.pytest_results[0]
         self.assertEqual(len(session_one.test_failures), 1)
-        self.assertEqual(session_one.test_failures[0].test_id, "tests/test_a.py::test_one")
+        self.assertEqual(
+            session_one.test_failures[0].test_id, "tests/test_a.py::test_one"
+        )
         self.assertEqual(session_one.test_failures[0].exception_class, "ValueError")
         self.assertIn("bad", session_one.test_failures[0].exception_chain)
         self.assertEqual(session_one.expected_test_failure_count, 1)
 
         session_two = parsed_log.pytest_results[1]
         self.assertEqual(len(session_two.test_failures), 2)
-        self.assertEqual(session_two.test_failures[0].test_id, "tests/test_b.py::test_two")
+        self.assertEqual(
+            session_two.test_failures[0].test_id, "tests/test_b.py::test_two"
+        )
         self.assertEqual(session_two.test_failures[0].exception_class, "TypeError")
         self.assertIn("wrong", session_two.test_failures[0].exception_chain)
         self.assertEqual(
@@ -410,7 +416,9 @@ class TestMultipleSessionsGrouping(unittest.TestCase):
 
         session_one = parsed_log.pytest_results[0]
         self.assertEqual(len(session_one.test_failures), 1)
-        self.assertEqual(session_one.test_failures[0].test_id, "tests/test_a.py::test_one")
+        self.assertEqual(
+            session_one.test_failures[0].test_id, "tests/test_a.py::test_one"
+        )
 
         session_two = parsed_log.pytest_results[1]
         self.assertEqual(len(session_two.test_failures), 0)
@@ -463,6 +471,7 @@ class TestMultipleSessionsGrouping(unittest.TestCase):
             if pytest_result.test_failures:
                 failing_session = pytest_result
         self.assertIsNotNone(failing_session)
+        assert failing_session is not None
         self.assertEqual(len(failing_session.test_failures), 2)
         self.assertEqual(failing_session.expected_test_failure_count, 2)
         self.assertIn("2 failed", failing_session.pytest_summary)
@@ -496,6 +505,7 @@ class TestMultipleSessionsGrouping(unittest.TestCase):
             if pytest_result.test_failures:
                 failing_session = pytest_result
         self.assertIsNotNone(failing_session)
+        assert failing_session is not None
         self.assertEqual(len(failing_session.test_failures), 2)
         self.assertEqual(failing_session.expected_test_failure_count, 2)
 
@@ -510,7 +520,9 @@ class TestMultipleSessionsGrouping(unittest.TestCase):
         self.assertIn("RuntimeError: Engine core initialization failed", body)
 
         kernel_dispatch = failing_session.test_failures[1]
-        self.assertEqual(kernel_dispatch.test_id, "test_engine.py::test_kernel_dispatch")
+        self.assertEqual(
+            kernel_dispatch.test_id, "test_engine.py::test_kernel_dispatch"
+        )
         self.assertEqual(kernel_dispatch.exception_class, "RuntimeError")
         self.assertIn(
             "Engine core initialization failed", kernel_dispatch.exception_chain
@@ -628,7 +640,8 @@ class TestCustomRunnerSummaryIgnored(unittest.TestCase):
         self.assertEqual(session.expected_test_failure_count, 1)
         self.assertEqual(len(session.test_failures), 1)
         self.assertEqual(
-            session.test_failures[0].test_id, "tests/test_moe.py::test_moe_layer[param-3]"
+            session.test_failures[0].test_id,
+            "tests/test_moe.py::test_moe_layer[param-3]",
         )
 
     def test_multiple_custom_summaries_before_real(self) -> None:

--- a/tools/torchci/tests/test_vllm_log_parser.py
+++ b/tools/torchci/tests/test_vllm_log_parser.py
@@ -1,0 +1,867 @@
+"""Tests for clean_logs against real Buildkite log fixtures.
+
+Log fixtures are tails (~100 lines) from real Buildkite job logs.
+raw_log_snippet.bin has ANSI + BKT markers for strip testing.
+"""
+
+import unittest
+from pathlib import Path
+
+from torchci.vllm_log_parser import parse_log, strip_markers
+
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def read_fixture_text(name: str) -> str:
+    return (FIXTURES_DIR / name).read_text()
+
+
+def read_fixture_bytes(name: str) -> bytes:
+    return (FIXTURES_DIR / name).read_bytes()
+
+
+class TestStripMarkers(unittest.TestCase):
+    """ANSI escape and BKT timestamp marker removal."""
+
+    def test_strips_ansi_escapes(self) -> None:
+        raw = "\x1b[31mFAILED\x1b[0m test_foo"
+        self.assertEqual(strip_markers(raw), "FAILED test_foo")
+
+    def test_strips_bkt_timestamps(self) -> None:
+        raw = "\x1b_bk;t=1720000000\x07some log line"
+        self.assertEqual(strip_markers(raw), "some log line")
+
+    def test_strips_both(self) -> None:
+        raw = "\x1b_bk;t=123\x07\x1b[1m\x1b[31mERROR\x1b[0m oops"
+        self.assertEqual(strip_markers(raw), "ERROR oops")
+
+    def test_passthrough_clean_text(self) -> None:
+        clean = "FAILED tests/test_foo.py::test_bar - AssertionError"
+        self.assertEqual(strip_markers(clean), clean)
+
+    def test_strips_group_marker_with_ansi(self) -> None:
+        raw = "\x1b_bk;t=1778129393332\x07+++ \x1b[33m:test_tube:\x1b[0m Command (1/1): bash run-test.sh\r"
+        cleaned = strip_markers(raw)
+        self.assertTrue(cleaned.startswith("+++ "))
+        self.assertIn(":test_tube:", cleaned)
+        self.assertNotIn("\x1b", cleaned)
+
+    def test_strips_osc_image_and_hyperlink(self) -> None:
+        raw = (
+            "before"
+            "\x1b]1338;url=http://example.com/img.gif;alt=screenshot\x07"
+            "middle"
+            "\x1b]1339;url=https://google.com;content=Google\x07"
+            "after"
+        )
+        self.assertEqual(strip_markers(raw), "beforemiddleafter")
+
+    def test_strips_progress_bar_with_erase_to_eol(self) -> None:
+        raw = (
+            "\x1b_bk;t=100\x07remote: Counting objects:   0% (1/163)\x1b[K"
+            "\x1b_bk;t=100\x07\rremote: Counting objects:   1% (2/163)\x1b[K"
+            "\x1b_bk;t=100\x07\rremote: Counting objects: 100% (163/163)\x1b[K"
+            "\x1b_bk;t=100\x07\r\r"
+        )
+        cleaned = strip_markers(raw)
+        self.assertNotIn("\x1b", cleaned)
+        self.assertNotIn("\x07", cleaned)
+        self.assertIn("remote: Counting objects", cleaned)
+
+    def test_strips_cursor_movement_codes(self) -> None:
+        raw = "\x1b_bk;t=123\x07\x1b[?25h\x1b[1A\x1b[0G\x1b[?25l[+] Building 0.2s (1/2)  docker:default"
+        cleaned = strip_markers(raw)
+        self.assertNotIn("\x1b", cleaned)
+        self.assertIn("[+] Building 0.2s (1/2)", cleaned)
+
+    def test_strips_cursor_only_line(self) -> None:
+        raw = "\x1b_bk;t=123\x07\x1b[1A\x1b[1B\x1b[0G\x1b[?25l\r\r"
+        cleaned = strip_markers(raw)
+        self.assertNotIn("\x1b", cleaned)
+        self.assertEqual(cleaned.strip("\r"), "")
+
+    def test_real_raw_snippet(self) -> None:
+        raw_log_snippet = read_fixture_bytes("raw_log_snippet.bin")
+        text = raw_log_snippet.decode("utf-8", errors="replace")
+        cleaned = strip_markers(text)
+        self.assertNotIn("\x1b", cleaned)
+        self.assertTrue("FAILED" in cleaned or "failed" in cleaned)
+
+
+class TestCleanLog(unittest.TestCase):
+    """Full log cleaning: strip + extract structured fields."""
+
+    def test_nixl_import_per_test_cause(self) -> None:
+        log_nixl_import = read_fixture_text("log_nixl_import_error.txt")
+        parsed_log = parse_log(log_nixl_import)
+        all_failures = []
+        for pytest_result in parsed_log.pytest_results:
+            for failure in pytest_result.test_failures:
+                all_failures.append(failure)
+        self.assertEqual(len(all_failures), 1)
+        self.assertEqual(all_failures[0].exception_class, "ImportError")
+        self.assertIn("nixl_ep_cpp", all_failures[0].exception_chain)
+
+    def test_nixl_import_summary(self) -> None:
+        log_nixl_import = read_fixture_text("log_nixl_import_error.txt")
+        parsed_log = parse_log(log_nixl_import)
+        found_summary = False
+        for pytest_result in parsed_log.pytest_results:
+            if "1 failed" in pytest_result.pytest_summary:
+                found_summary = True
+        self.assertTrue(found_summary)
+
+    def test_engine_many_failures(self) -> None:
+        log_engine_cuda_fail = read_fixture_text("log_engine_cuda_init_fail.txt")
+        parsed_log = parse_log(log_engine_cuda_fail)
+        found_summary = False
+        for pytest_result in parsed_log.pytest_results:
+            if "50 failed" in pytest_result.pytest_summary:
+                found_summary = True
+        self.assertTrue(found_summary)
+
+    def test_engine_per_test_causes(self) -> None:
+        log_engine_cuda_fail = read_fixture_text("log_engine_cuda_init_fail.txt")
+        parsed_log = parse_log(log_engine_cuda_fail)
+        all_failures = []
+        for pytest_result in parsed_log.pytest_results:
+            for failure in pytest_result.test_failures:
+                all_failures.append(failure)
+        self.assertEqual(len(all_failures), 50)
+        for failure in all_failures:
+            self.assertTrue(failure.exception_class)
+
+    def test_engine_sentinel_and_direct_failures(self) -> None:
+        """Engine tail: some tests have CUDA driver error directly, sentinels
+        are identified by their exception_chain."""
+        log_engine_cuda_fail = read_fixture_text("log_engine_cuda_init_fail.txt")
+        parsed_log = parse_log(log_engine_cuda_fail)
+        direct_cuda_count = 0
+        sentinel_count = 0
+        for pytest_result in parsed_log.pytest_results:
+            for failure in pytest_result.test_failures:
+                if "CUDA driver initialization failed" in failure.exception_chain:
+                    direct_cuda_count += 1
+                elif "See root cause above" in failure.exception_chain:
+                    sentinel_count += 1
+        self.assertGreater(direct_cuda_count, 0)
+        self.assertGreater(sentinel_count, 0)
+
+    def test_dynamo_regression_chain_scoped_to_section(self) -> None:
+        """Chain is a single raw section body from the FAILURES block,
+        scoped to this test — includes the subprocess wrapper's inner
+        traceback but not the EngineCore process output."""
+        log_dynamo_regression = read_fixture_text("log_dynamo_regression.txt")
+        parsed_log = parse_log(log_dynamo_regression)
+        failure = parsed_log.pytest_results[0].test_failures[0]
+        self.assertEqual(failure.exception_class, "RuntimeError")
+        self.assertIn("Test subprocess", failure.exception_chain)
+        self.assertIn("RuntimeError", failure.exception_chain)
+        self.assertIn("Server exited unexpectedly", failure.exception_chain)
+
+
+class TestExpandedExceptionSuffixes(unittest.TestCase):
+    """Exception classes beyond Error/Exception/Failure."""
+
+    def test_system_exit(self) -> None:
+        log = "FAILED tests/test_runner.py::test_spawn - SystemExit: 1\n= 1 failed in 5.00s ="
+        parsed_log = parse_log(log)
+        failure = parsed_log.pytest_results[0].test_failures[0]
+        self.assertEqual(failure.exception_class, "SystemExit")
+        self.assertIn("1", failure.exception_chain)
+
+    def test_keyboard_interrupt(self) -> None:
+        log = "FAILED tests/test_server.py::test_startup - KeyboardInterrupt: \n= 1 failed in 30.00s ="
+        parsed_log = parse_log(log)
+        failure = parsed_log.pytest_results[0].test_failures[0]
+        self.assertEqual(failure.exception_class, "KeyboardInterrupt")
+
+    def test_exception_group(self) -> None:
+        log = (
+            "FAILED tests/test_async.py::test_gather - ExceptionGroup: multiple errors (2 sub-exceptions)\n"
+            "= 1 failed in 2.00s ="
+        )
+        parsed_log = parse_log(log)
+        failure = parsed_log.pytest_results[0].test_failures[0]
+        self.assertEqual(failure.exception_class, "ExceptionGroup")
+
+    def test_warning_as_error(self) -> None:
+        log = (
+            "FAILED tests/test_compat.py::test_legacy - DeprecationWarning: function X is deprecated\n"
+            "= 1 failed in 1.00s ="
+        )
+        parsed_log = parse_log(log)
+        failure = parsed_log.pytest_results[0].test_failures[0]
+        self.assertEqual(failure.exception_class, "DeprecationWarning")
+
+    def test_stop_iteration(self) -> None:
+        log = "FAILED tests/test_gen.py::test_iter - StopIteration: \n= 1 failed in 0.50s ="
+        parsed_log = parse_log(log)
+        failure = parsed_log.pytest_results[0].test_failures[0]
+        self.assertEqual(failure.exception_class, "StopIteration")
+
+    def test_dotted_torch_exception(self) -> None:
+        log = (
+            "FAILED tests/test_gpu.py::test_alloc - torch.cuda.OutOfMemoryError: CUDA out of memory\n"
+            "= 1 failed in 10.00s ="
+        )
+        parsed_log = parse_log(log)
+        failure = parsed_log.pytest_results[0].test_failures[0]
+        self.assertEqual(failure.exception_class, "torch.cuda.OutOfMemoryError")
+
+    def test_body_keyboard_interrupt_in_chain(self) -> None:
+        log = (
+            "E   KeyboardInterrupt: timeout\n"
+            "FAILED tests/test_server.py::test_hang - RuntimeError: "
+            "Engine core initialization failed. See root cause above.\n"
+            "= 1 failed in 60.00s ="
+        )
+        parsed_log = parse_log(log)
+        failure = parsed_log.pytest_results[0].test_failures[0]
+        self.assertIn("KeyboardInterrupt: timeout", failure.exception_chain)
+
+    def test_body_exception_group_in_chain(self) -> None:
+        log = (
+            "E   BaseExceptionGroup: errors (3 sub-exceptions)\n"
+            "FAILED tests/test_tasks.py::test_concurrent - RuntimeError: "
+            "Engine core initialization failed. See root cause above.\n"
+            "= 1 failed in 5.00s ="
+        )
+        parsed_log = parse_log(log)
+        failure = parsed_log.pytest_results[0].test_failures[0]
+        self.assertIn(
+            "BaseExceptionGroup: errors (3 sub-exceptions)", failure.exception_chain
+        )
+
+
+class TestErrorLinesParsing(unittest.TestCase):
+    """ERROR lines from setup/teardown/collection failures."""
+
+    def test_error_with_exception(self) -> None:
+        log = "ERROR tests/test_foo.py - SyntaxError: invalid syntax\n= 1 error in 0.50s ="
+        parsed_log = parse_log(log)
+        failure = parsed_log.pytest_results[0].test_failures[0]
+        self.assertEqual(failure.test_id, "tests/test_foo.py")
+        self.assertEqual(failure.exception_class, "SyntaxError")
+
+    def test_error_with_nodeid(self) -> None:
+        log = "ERROR tests/test_db.py::test_query - ConnectionRefusedError: [Errno 111]\n= 1 error in 1.00s ="
+        parsed_log = parse_log(log)
+        failure = parsed_log.pytest_results[0].test_failures[0]
+        self.assertEqual(failure.test_id, "tests/test_db.py::test_query")
+        self.assertEqual(failure.exception_class, "ConnectionRefusedError")
+
+    def test_error_and_failed_together(self) -> None:
+        log = (
+            "ERROR tests/conftest.py - ImportError: No module named 'foo'\n"
+            "FAILED tests/test_bar.py::test_baz - ValueError: bad\n"
+            "= 1 failed, 1 error in 2.00s ="
+        )
+        parsed_log = parse_log(log)
+        pytest_result = parsed_log.pytest_results[0]
+        self.assertEqual(len(pytest_result.test_failures), 2)
+        by_id = {failure.test_id: failure for failure in pytest_result.test_failures}
+        self.assertEqual(by_id["tests/conftest.py"].exception_class, "ImportError")
+        self.assertEqual(
+            by_id["tests/test_bar.py::test_baz"].exception_class, "ValueError"
+        )
+
+    def test_error_does_not_match_log_noise(self) -> None:
+        log = (
+            "(EngineCore pid=2181) ERROR 06-19 12:57:13 [core.py:1229] something broke\n"
+            "FAILED tests/test_x.py::test_y - RuntimeError: fail\n"
+            "= 1 failed in 5.00s ="
+        )
+        parsed_log = parse_log(log)
+        pytest_result = parsed_log.pytest_results[0]
+        self.assertEqual(len(pytest_result.test_failures), 1)
+        self.assertEqual(pytest_result.test_failures[0].test_id, "tests/test_x.py::test_y")
+
+
+class TestExpectedFailureCount(unittest.TestCase):
+    """Validate extracted count against pytest summary line."""
+
+    def test_count_from_failed_only(self) -> None:
+        log = (
+            "FAILED tests/test_a.py::test_one - ValueError: bad\n"
+            "FAILED tests/test_a.py::test_two - TypeError: wrong\n"
+            "= 2 failed in 1.00s ="
+        )
+        parsed_log = parse_log(log)
+        pytest_result = parsed_log.pytest_results[0]
+        self.assertEqual(pytest_result.expected_test_failure_count, 2)
+        self.assertEqual(len(pytest_result.test_failures), 2)
+
+    def test_count_from_failed_and_passed(self) -> None:
+        log = "FAILED tests/test_a.py::test_one - ValueError: bad\n= 1 failed, 5 passed in 2.00s ="
+        parsed_log = parse_log(log)
+        self.assertEqual(parsed_log.pytest_results[0].expected_test_failure_count, 1)
+
+    def test_count_from_errors_only(self) -> None:
+        log = "ERROR tests/conftest.py - SyntaxError: invalid syntax\n= 1 error in 0.50s ="
+        parsed_log = parse_log(log)
+        self.assertEqual(parsed_log.pytest_results[0].expected_test_failure_count, 1)
+
+    def test_count_from_failed_and_errors(self) -> None:
+        log = (
+            "ERROR tests/conftest.py - ImportError: no module\n"
+            "FAILED tests/test_a.py::test_one - ValueError: bad\n"
+            "= 1 failed, 1 error in 2.00s ="
+        )
+        parsed_log = parse_log(log)
+        pytest_result = parsed_log.pytest_results[0]
+        self.assertEqual(pytest_result.expected_test_failure_count, 2)
+        self.assertEqual(len(pytest_result.test_failures), 2)
+
+    def test_none_when_no_summary(self) -> None:
+        log = "some random log output\n"
+        parsed_log = parse_log(log)
+        self.assertEqual(len(parsed_log.pytest_results), 0)
+
+    def test_mismatch_raises(self) -> None:
+        log = (
+            "FAILED tests/test_a.py::test_one - ValueError: bad\n= 3 failed in 1.00s ="
+        )
+        with self.assertRaises(AssertionError):
+            parse_log(log)
+
+    def test_real_fixture_counts_match(self) -> None:
+        log_cuda_init_fail = read_fixture_text("log_cudagraph_cuda_init_fail.txt")
+        parsed_log = parse_log(log_cuda_init_fail)
+        for pytest_result in parsed_log.pytest_results:
+            if pytest_result.test_failures:
+                self.assertEqual(
+                    pytest_result.expected_test_failure_count,
+                    len(pytest_result.test_failures),
+                )
+
+    def test_real_engine_counts_match(self) -> None:
+        log_engine_cuda_fail = read_fixture_text("log_engine_cuda_init_fail.txt")
+        parsed_log = parse_log(log_engine_cuda_fail)
+        total_failures = 0
+        for pytest_result in parsed_log.pytest_results:
+            total_failures += len(pytest_result.test_failures)
+        self.assertEqual(total_failures, 50)
+
+
+class TestMultipleSessionsGrouping(unittest.TestCase):
+    """Multiple pytest sessions within a single Buildkite job log."""
+
+    def test_two_sessions_grouped_separately(self) -> None:
+        log = (
+            "FAILED tests/test_a.py::test_one - ValueError: bad\n"
+            "= 1 failed, 2 passed in 5.00s =\n"
+            "+++ Command (2/2): pytest tests/test_b.py\n"
+            "FAILED tests/test_b.py::test_two - TypeError: wrong\n"
+            "FAILED tests/test_b.py::test_three - KeyError: missing\n"
+            "= 2 failed in 3.00s ="
+        )
+        parsed_log = parse_log(log)
+        self.assertEqual(len(parsed_log.pytest_results), 2)
+
+        session_one = parsed_log.pytest_results[0]
+        self.assertEqual(len(session_one.test_failures), 1)
+        self.assertEqual(session_one.test_failures[0].test_id, "tests/test_a.py::test_one")
+        self.assertEqual(session_one.test_failures[0].exception_class, "ValueError")
+        self.assertIn("bad", session_one.test_failures[0].exception_chain)
+        self.assertEqual(session_one.expected_test_failure_count, 1)
+
+        session_two = parsed_log.pytest_results[1]
+        self.assertEqual(len(session_two.test_failures), 2)
+        self.assertEqual(session_two.test_failures[0].test_id, "tests/test_b.py::test_two")
+        self.assertEqual(session_two.test_failures[0].exception_class, "TypeError")
+        self.assertIn("wrong", session_two.test_failures[0].exception_chain)
+        self.assertEqual(
+            session_two.test_failures[1].test_id, "tests/test_b.py::test_three"
+        )
+        self.assertEqual(session_two.test_failures[1].exception_class, "KeyError")
+        self.assertIn("missing", session_two.test_failures[1].exception_chain)
+        self.assertEqual(session_two.expected_test_failure_count, 2)
+
+    def test_passing_session_produces_empty_result(self) -> None:
+        log = (
+            "= 5 passed in 1.00s =\n"
+            "+++ Command (2/2): pytest tests/test_b.py\n"
+            "FAILED tests/test_b.py::test_one - RuntimeError: boom\n"
+            "= 1 failed in 2.00s ="
+        )
+        parsed_log = parse_log(log)
+        self.assertEqual(len(parsed_log.pytest_results), 2)
+
+        session_one = parsed_log.pytest_results[0]
+        self.assertEqual(len(session_one.test_failures), 0)
+        self.assertEqual(session_one.expected_test_failure_count, 0)
+        self.assertIn("5 passed", session_one.pytest_summary)
+
+        session_two = parsed_log.pytest_results[1]
+        self.assertEqual(len(session_two.test_failures), 1)
+        self.assertEqual(session_two.expected_test_failure_count, 1)
+
+    def test_failing_then_passing_session(self) -> None:
+        log = (
+            "FAILED tests/test_a.py::test_one - ValueError: bad\n"
+            "= 1 failed, 2 passed in 5.00s =\n"
+            "+++ Command (2/2): pytest tests/test_b.py\n"
+            "= 12 passed in 3.00s ="
+        )
+        parsed_log = parse_log(log)
+        self.assertEqual(len(parsed_log.pytest_results), 2)
+
+        session_one = parsed_log.pytest_results[0]
+        self.assertEqual(len(session_one.test_failures), 1)
+        self.assertEqual(session_one.test_failures[0].test_id, "tests/test_a.py::test_one")
+
+        session_two = parsed_log.pytest_results[1]
+        self.assertEqual(len(session_two.test_failures), 0)
+        self.assertEqual(session_two.expected_test_failure_count, 0)
+
+    def test_real_cudagraph_end_to_end(self) -> None:
+        """Full end-to-end: cudagraph fixture has 2 sessions, 4 failures."""
+        log_cuda_init_fail = read_fixture_text("log_cudagraph_cuda_init_fail.txt")
+        parsed_log = parse_log(log_cuda_init_fail)
+        self.assertEqual(len(parsed_log.pytest_results), 2)
+
+        failing_session = parsed_log.pytest_results[0]
+        self.assertEqual(len(failing_session.test_failures), 4)
+        self.assertEqual(failing_session.expected_test_failure_count, 4)
+        self.assertIn("4 failed", failing_session.pytest_summary)
+
+        sentinel_one = failing_session.test_failures[0]
+        self.assertEqual(
+            sentinel_one.test_id,
+            "v1/cudagraph/test_cudagraph_mode.py::test_backend_and_cudagraph_mode_combo[FA2-FULL-True]",
+        )
+        self.assertEqual(sentinel_one.exception_class, "RuntimeError")
+        self.assertIn("Engine core initialization failed", sentinel_one.exception_chain)
+        chain_text = sentinel_one.exception_chain
+        self.assertIn("ValueError", chain_text)
+        self.assertIn("Memory of devices", chain_text)
+
+        direct_one = failing_session.test_failures[2]
+        self.assertEqual(
+            direct_one.test_id,
+            "v1/cudagraph/test_cudagraph_mode.py::test_cudagraph_compilation_combo[FA2-FULL-3-True]",
+        )
+        self.assertEqual(direct_one.exception_class, "ValueError")
+        self.assertIn("Memory of devices", direct_one.exception_chain)
+
+        passing_session = parsed_log.pytest_results[1]
+        self.assertEqual(len(passing_session.test_failures), 0)
+        self.assertEqual(passing_session.expected_test_failure_count, 0)
+        self.assertIn("12 passed", passing_session.pytest_summary)
+
+    def test_real_elastic_ep_end_to_end(self) -> None:
+        """Full end-to-end: elastic EP has 2 failures with distinct assertions."""
+        raw_log_64854_elastic_ep = read_fixture_text(
+            "raw_log_64854_elastic_ep_scaling.txt"
+        )
+        parsed_log = parse_log(raw_log_64854_elastic_ep)
+
+        failing_session = None
+        for pytest_result in parsed_log.pytest_results:
+            if pytest_result.test_failures:
+                failing_session = pytest_result
+        self.assertIsNotNone(failing_session)
+        self.assertEqual(len(failing_session.test_failures), 2)
+        self.assertEqual(failing_session.expected_test_failure_count, 2)
+        self.assertIn("2 failed", failing_session.pytest_summary)
+
+        scaling_failure = failing_session.test_failures[0]
+        self.assertEqual(
+            scaling_failure.test_id,
+            "distributed/test_elastic_ep.py::test_elastic_ep_scaling",
+        )
+        self.assertEqual(scaling_failure.exception_class, "AssertionError")
+        self.assertIn("assert False", scaling_failure.exception_chain)
+
+        uneven_failure = failing_session.test_failures[1]
+        self.assertEqual(
+            uneven_failure.test_id,
+            "distributed/test_elastic_ep.py::test_elastic_ep_scaling_uneven",
+        )
+        self.assertEqual(uneven_failure.exception_class, "AssertionError")
+        self.assertIn("assert False", uneven_failure.exception_chain)
+
+    def test_multi_root_cause_sentinels_end_to_end(self) -> None:
+        """Two sentinel tests with different root causes — each chain is
+        a single raw section body containing the full traceback."""
+        log_multi_root_cause_sentinels = read_fixture_text(
+            "log_multi_root_cause_sentinels.txt"
+        )
+        parsed_log = parse_log(log_multi_root_cause_sentinels)
+
+        failing_session = None
+        for pytest_result in parsed_log.pytest_results:
+            if pytest_result.test_failures:
+                failing_session = pytest_result
+        self.assertIsNotNone(failing_session)
+        self.assertEqual(len(failing_session.test_failures), 2)
+        self.assertEqual(failing_session.expected_test_failure_count, 2)
+
+        model_loading = failing_session.test_failures[0]
+        self.assertEqual(model_loading.test_id, "test_engine.py::test_model_loading")
+        self.assertEqual(model_loading.exception_class, "RuntimeError")
+        self.assertIn(
+            "Engine core initialization failed", model_loading.exception_chain
+        )
+        body = model_loading.exception_chain
+        self.assertIn("ValueError: GPU memory exhausted on device 0", body)
+        self.assertIn("RuntimeError: Engine core initialization failed", body)
+
+        kernel_dispatch = failing_session.test_failures[1]
+        self.assertEqual(kernel_dispatch.test_id, "test_engine.py::test_kernel_dispatch")
+        self.assertEqual(kernel_dispatch.exception_class, "RuntimeError")
+        self.assertIn(
+            "Engine core initialization failed", kernel_dispatch.exception_chain
+        )
+        body = kernel_dispatch.exception_chain
+        self.assertIn("TypeError: unsupported dtype bfloat16 for this kernel", body)
+        self.assertIn("RuntimeError: Engine core initialization failed", body)
+
+    def test_orphan_failures_no_summary(self) -> None:
+        """Truncated log: FAILED lines but no summary (timeout kill)."""
+        log = (
+            "FAILED tests/test_a.py::test_one - ValueError: bad\n"
+            "FAILED tests/test_a.py::test_two - TypeError: wrong\n"
+        )
+        parsed_log = parse_log(log)
+        self.assertEqual(len(parsed_log.pytest_results), 1)
+
+        orphan_result = parsed_log.pytest_results[0]
+        self.assertIsNone(orphan_result.expected_test_failure_count)
+        self.assertEqual(len(orphan_result.test_failures), 2)
+
+
+class TestInfraTagging(unittest.TestCase):
+    """Infrastructure failures are tagged (test_is_infra), not filtered out."""
+
+    def _only_failure(self, parsed_log):
+        failures = [
+            failure
+            for pytest_result in parsed_log.pytest_results
+            for failure in pytest_result.test_failures
+        ]
+        self.assertEqual(len(failures), 1)
+        return failures[0]
+
+    def test_nvidia_container_cli_tagged(self) -> None:
+        log = (
+            "FAILED tests/test_a.py::test_one - RuntimeError: nvidia-container-cli: initialization error\n"
+            "= 1 failed in 1.00s ="
+        )
+        self.assertTrue(self._only_failure(parse_log(log)).test_is_infra)
+
+    def test_oom_killed_tagged(self) -> None:
+        log = "FAILED tests/test_a.py::test_one - RuntimeError: exit status 137\n= 1 failed in 1.00s ="
+        self.assertTrue(self._only_failure(parse_log(log)).test_is_infra)
+
+    def test_gpu_memory_tagged(self) -> None:
+        log = (
+            "FAILED tests/test_a.py::test_one - ValueError: Free memory on device "
+            "cuda:0 (1.2/80.0 GiB) on startup is less than desired\n"
+            "= 1 failed in 1.00s ="
+        )
+        self.assertTrue(self._only_failure(parse_log(log)).test_is_infra)
+
+    def test_connection_refused_tagged(self) -> None:
+        log = "FAILED tests/test_a.py::test_one - ConnectionRefusedError: Connection refused\n= 1 failed in 1.00s ="
+        self.assertTrue(self._only_failure(parse_log(log)).test_is_infra)
+
+    def test_no_space_tagged(self) -> None:
+        log = "FAILED tests/test_a.py::test_one - OSError: no space left on device\n= 1 failed in 1.00s ="
+        self.assertTrue(self._only_failure(parse_log(log)).test_is_infra)
+
+    def test_docker_pull_tagged(self) -> None:
+        log = "FAILED tests/test_a.py::test_one - RuntimeError: docker pull failed\n= 1 failed in 1.00s ="
+        self.assertTrue(self._only_failure(parse_log(log)).test_is_infra)
+
+    def test_regular_error_not_tagged(self) -> None:
+        log = "FAILED tests/test_a.py::test_one - ValueError: invalid literal\n= 1 failed in 1.00s ="
+        failure = self._only_failure(parse_log(log))
+        self.assertEqual(failure.test_id, "tests/test_a.py::test_one")
+        self.assertFalse(failure.test_is_infra)
+
+    def test_infra_and_real_tests_tagged_independently(self) -> None:
+        log = (
+            "=================================== FAILURES ===================================\n"
+            "____________________________ test_one _____________________________\n"
+            "    def test_one():\n"
+            ">       run()\n"
+            "E   RuntimeError: exit status 137\n"
+            "tests/test_a.py:10: RuntimeError\n"
+            "____________________________ test_two _____________________________\n"
+            "    def test_two():\n"
+            ">       run()\n"
+            "E   ValueError: bad value\n"
+            "tests/test_b.py:20: ValueError\n"
+            "=========================== short test summary info ============================\n"
+            "FAILED tests/test_a.py::test_one - RuntimeError: exit status 137\n"
+            "FAILED tests/test_b.py::test_two - ValueError: bad value\n"
+            "= 2 failed in 1.00s ="
+        )
+        by_id = {
+            failure.test_id: failure
+            for pytest_result in parse_log(log).pytest_results
+            for failure in pytest_result.test_failures
+        }
+        self.assertTrue(by_id["tests/test_a.py::test_one"].test_is_infra)
+        self.assertFalse(by_id["tests/test_b.py::test_two"].test_is_infra)
+
+
+class TestCustomRunnerSummaryIgnored(unittest.TestCase):
+    """Non-pytest summary lines must not be treated as pytest summaries."""
+
+    def test_subtest_runner_summary_ignored(self) -> None:
+        log = (
+            "subtest: [param-1] PASSED\n"
+            "subtest: [param-2] PASSED\n"
+            "============= 1 failed, 31 passed of 32 total tests =============\n"
+            "============= Failed subtests =============\n"
+            "[param-3]\n"
+            "FAILED tests/test_moe.py::test_moe_layer[param-3] - AssertionError: Tensor-likes are not close!\n"
+            "= 1 failed, 31 passed, 297 skipped in 632.60s (0:10:32) =\n"
+        )
+        parsed_log = parse_log(log)
+        self.assertEqual(len(parsed_log.pytest_results), 1)
+        session = parsed_log.pytest_results[0]
+        self.assertEqual(session.expected_test_failure_count, 1)
+        self.assertEqual(len(session.test_failures), 1)
+        self.assertEqual(
+            session.test_failures[0].test_id, "tests/test_moe.py::test_moe_layer[param-3]"
+        )
+
+    def test_multiple_custom_summaries_before_real(self) -> None:
+        log = (
+            "============= 1 failed, 31 passed of 32 total tests =============\n"
+            "============= 1 failed, 31 passed of 32 total tests =============\n"
+            "FAILED tests/test_a.py::test_one - ValueError: bad\n"
+            "= 1 failed, 220 passed, 297 skipped, 21 warnings in 632.60s (0:10:32) =\n"
+        )
+        parsed_log = parse_log(log)
+        self.assertEqual(len(parsed_log.pytest_results), 1)
+        self.assertEqual(parsed_log.pytest_results[0].expected_test_failure_count, 1)
+
+
+class TestSectionBodyCapture(unittest.TestCase):
+    """Raw section body capture from the FAILURES block."""
+
+    def test_section_body_contains_full_traceback(self) -> None:
+        log = (
+            "=================================== FAILURES ===================================\n"
+            "____________________________ test_moe_forward _____________________________\n"
+            "\n"
+            "    def test_moe_forward():\n"
+            ">       run_moe()\n"
+            "\n"
+            "E   AssertionError: expected size 3072==2880, stride 1==1 at dim=0\n"
+            "E   Error in op: torch.ops.vllm.moe_forward.default\n"
+            "E   This error most often comes from a incorrect fake (aka meta) kernel for a custom op.\n"
+            "\n"
+            "tests/test_moe.py:42: AssertionError\n"
+            "=========================== short test summary info ============================\n"
+            "FAILED tests/test_moe.py::test_moe_forward - AssertionError: "
+            "expected size 3072==2880, stride 1==1 at dim=0\n"
+            "= 1 failed in 5.00s ="
+        )
+        parsed_log = parse_log(log)
+        failure = parsed_log.pytest_results[0].test_failures[0]
+        self.assertIn(
+            "Error in op: torch.ops.vllm.moe_forward.default", failure.exception_chain
+        )
+        self.assertIn("This error most often comes from", failure.exception_chain)
+        self.assertIn("expected size 3072==2880", failure.exception_chain)
+
+    def test_bare_assert_backfills_class_from_file_ref(self) -> None:
+        """Bare FAILED line + section body with no EXCEPTION_RE match
+        backfills exception_class from the file reference line."""
+        log = (
+            "=================================== FAILURES ===================================\n"
+            "_________________ test_check_padding _________________\n"
+            "\n"
+            "    def test_check_padding():\n"
+            "        layer = make_layer(4096, 96)\n"
+            ">       assert check_supports(layer, 32, allow_padding=True)\n"
+            "E       assert False\n"
+            "E        +  where False = check_supports(..., 32, allow_padding=True)\n"
+            "\n"
+            "tests/test_padding.py:42: AssertionError\n"
+            "=========================== short test summary info ============================\n"
+            "FAILED tests/test_padding.py::test_check_padding\n"
+            "= 1 failed in 5.00s ="
+        )
+        parsed_log = parse_log(log)
+        failure = parsed_log.pytest_results[0].test_failures[0]
+        self.assertEqual(failure.exception_class, "AssertionError")
+        self.assertIn("assert False", failure.exception_chain)
+
+    def test_no_section_body_uses_fallback(self) -> None:
+        """Without FAILURES section headers, chain falls back to body exceptions."""
+        log = (
+            "E   ValueError: bad value\n"
+            "INFO 06-19 12:57:13 [core.py:1229] some log line\n"
+            "FAILED tests/test_a.py::test_one - ValueError: bad value\n"
+            "= 1 failed in 5.00s ="
+        )
+        parsed_log = parse_log(log)
+        failure = parsed_log.pytest_results[0].test_failures[0]
+        self.assertNotIn("some log line", failure.exception_chain)
+
+
+class TestNonPytestFallback(unittest.TestCase):
+    def test_non_pytest_log_produces_error_excerpt(self) -> None:
+        log = "Step 1: Building wheel...\nerror: command 'gcc' failed with exit code 1\nBuild failed.\n"
+        parsed_log = parse_log(log)
+        self.assertEqual(parsed_log.pytest_results, [])
+        self.assertIn("error: command 'gcc' failed", parsed_log.error_excerpt)
+
+    def test_segfault_log_produces_error_excerpt(self) -> None:
+        log = "importing torch...\nSegmentation fault (core dumped)\n"
+        parsed_log = parse_log(log)
+        self.assertEqual(parsed_log.pytest_results, [])
+        self.assertIn("Segmentation fault", parsed_log.error_excerpt)
+
+    def test_pytest_log_has_empty_error_excerpt(self) -> None:
+        log = (
+            "FAILED tests/test_a.py::test_one - ValueError: bad\n= 1 failed in 1.00s ="
+        )
+        parsed_log = parse_log(log)
+        self.assertEqual(len(parsed_log.pytest_results), 1)
+        self.assertEqual(parsed_log.error_excerpt, "")
+
+    def test_empty_log_has_empty_error_excerpt(self) -> None:
+        parsed_log = parse_log("")
+        self.assertEqual(parsed_log.pytest_results, [])
+        self.assertEqual(parsed_log.error_excerpt, "")
+
+    def test_error_excerpt_strips_ansi_markers(self) -> None:
+        log = "\x1b[31mFatal Python error\x1b[0m: Segmentation fault\n"
+        parsed_log = parse_log(log)
+        self.assertEqual(parsed_log.pytest_results, [])
+        self.assertNotIn("\x1b", parsed_log.error_excerpt)
+        self.assertIn("Fatal Python error", parsed_log.error_excerpt)
+
+
+class TestNonPytestInfraTagging(unittest.TestCase):
+    """Infra failures on the non-pytest (prior-failure) path keep their
+    excerpt and are tagged job_is_infra instead of being dropped."""
+
+    def test_non_pytest_nvidia_container_cli_tagged(self) -> None:
+        log = "nvidia-container-cli: initialization error\nBuild failed.\n"
+        parsed_log = parse_log(log)
+        self.assertEqual(parsed_log.pytest_results, [])
+        self.assertIn("nvidia-container-cli", parsed_log.error_excerpt)
+        self.assertTrue(parsed_log.job_is_infra)
+
+    def test_non_pytest_oom_killed_tagged(self) -> None:
+        log = "Downloading wheel...\nexit status 137\n"
+        parsed_log = parse_log(log)
+        self.assertEqual(parsed_log.pytest_results, [])
+        self.assertIn("exit status 137", parsed_log.error_excerpt)
+        self.assertTrue(parsed_log.job_is_infra)
+
+    def test_non_pytest_connection_refused_tagged(self) -> None:
+        log = "importing torch...\nConnection refused\n"
+        parsed_log = parse_log(log)
+        self.assertEqual(parsed_log.pytest_results, [])
+        self.assertIn("Connection refused", parsed_log.error_excerpt)
+        self.assertTrue(parsed_log.job_is_infra)
+
+    def test_non_pytest_regular_error_not_tagged(self) -> None:
+        log = "error: command 'gcc' failed with exit code 1\nBuild failed.\n"
+        parsed_log = parse_log(log)
+        self.assertEqual(parsed_log.pytest_results, [])
+        self.assertIn("gcc", parsed_log.error_excerpt)
+        self.assertFalse(parsed_log.job_is_infra)
+
+
+class TestTransientInfraSignatures(unittest.TestCase):
+    """Retryable transient-infra signatures from the triage skill are tagged."""
+
+    def _only_failure(self, log: str):
+        parsed_log = parse_log(log)
+        failures = [
+            failure
+            for pytest_result in parsed_log.pytest_results
+            for failure in pytest_result.test_failures
+        ]
+        self.assertEqual(len(failures), 1)
+        return failures[0]
+
+    def test_cuda_driver_init_failed_tagged(self) -> None:
+        log = (
+            "FAILED tests/test_a.py::test_one - RuntimeError: CUDA driver initialization failed, "
+            "you might not have a CUDA gpu.\n"
+            "= 1 failed in 1.00s ="
+        )
+        self.assertTrue(self._only_failure(log).test_is_infra)
+
+    def test_engine_core_init_wrapper_with_cuda_root_cause_tagged(self) -> None:
+        log = (
+            "=================================== FAILURES ===================================\n"
+            "____________________________ test_engine _____________________________\n"
+            "    def test_engine():\n"
+            ">       run()\n"
+            "E   RuntimeError: CUDA driver initialization failed, you might not have a CUDA gpu.\n"
+            "E   RuntimeError: Engine core initialization failed. See root cause above.\n"
+            "tests/test_a.py:10: RuntimeError\n"
+            "=========================== short test summary info ============================\n"
+            "FAILED tests/test_a.py::test_engine - RuntimeError: "
+            "Engine core initialization failed. See root cause above.\n"
+            "= 1 failed in 1.00s ="
+        )
+        self.assertTrue(self._only_failure(log).test_is_infra)
+
+    def test_exit_status_125_tagged(self) -> None:
+        parsed_log = parse_log(
+            "Error: The command exited with status 125\nBuild failed.\n"
+        )
+        self.assertTrue(parsed_log.job_is_infra)
+
+    def test_docker_setup_hook_tagged(self) -> None:
+        parsed_log = parse_log("docker command hook exited with status 1\n")
+        self.assertTrue(parsed_log.job_is_infra)
+
+    def test_ecr_toomanyrequests_tagged(self) -> None:
+        parsed_log = parse_log(
+            "Error response from daemon: toomanyrequests: Rate exceeded\n"
+        )
+        self.assertTrue(parsed_log.job_is_infra)
+
+    def test_ecr_data_limit_exceeded_tagged(self) -> None:
+        parsed_log = parse_log("denied: Data limit exceeded\n")
+        self.assertTrue(parsed_log.job_is_infra)
+
+    def test_manifest_unknown_tagged(self) -> None:
+        log = (
+            "+ docker pull 12345.dkr.ecr.us-east-1.amazonaws.com/pytorch:abc123\n"
+            "Error response from daemon: manifest for pytorch:abc123 not found: manifest unknown\n"
+        )
+        self.assertTrue(parse_log(log).job_is_infra)
+
+    def test_not_found_manifest_tagged(self) -> None:
+        self.assertTrue(
+            parse_log(
+                "failed to resolve reference: not found: manifest unknown\n"
+            ).job_is_infra
+        )
+
+
+class TestNonInfraNotTagged(unittest.TestCase):
+    """Signatures with no infra pattern stay untagged (job_is_infra False)."""
+
+    def test_module_not_found_torch_not_tagged(self) -> None:
+        parsed_log = parse_log(
+            "ModuleNotFoundError: No module named 'torch'\nBuild failed.\n"
+        )
+        self.assertFalse(parsed_log.job_is_infra)
+
+    def test_undefined_symbol_not_tagged(self) -> None:
+        parsed_log = parse_log(
+            "ImportError: /lib/libtorch.so: undefined symbol: _ZN3c10\n"
+        )
+        self.assertFalse(parsed_log.job_is_infra)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/torchci/tests/test_vllm_log_parser.py
+++ b/tools/torchci/tests/test_vllm_log_parser.py
@@ -1,4 +1,4 @@
-"""Tests for clean_logs against real Buildkite log fixtures.
+"""Tests for parse_log/strip_markers against real Buildkite log fixtures.
 
 Log fixtures are tails (~100 lines) from real Buildkite job logs.
 raw_log_snippet.bin has ANSI + BKT markers for strip testing.
@@ -100,7 +100,7 @@ class TestCleanLog(unittest.TestCase):
             for failure in pytest_result.test_failures:
                 all_failures.append(failure)
         self.assertEqual(len(all_failures), 1)
-        self.assertEqual(all_failures[0].exception_class, "ImportError")
+        self.assertEqual(all_failures[0].pytest_exception_class, "ImportError")
         self.assertIn("nixl_ep_cpp", all_failures[0].exception_chain)
 
     def test_nixl_import_summary(self) -> None:
@@ -130,7 +130,7 @@ class TestCleanLog(unittest.TestCase):
                 all_failures.append(failure)
         self.assertEqual(len(all_failures), 50)
         for failure in all_failures:
-            self.assertTrue(failure.exception_class)
+            self.assertTrue(failure.pytest_exception_class)
 
     def test_engine_sentinel_and_direct_failures(self) -> None:
         """Engine tail: some tests have CUDA driver error directly, sentinels
@@ -155,7 +155,7 @@ class TestCleanLog(unittest.TestCase):
         log_dynamo_regression = read_fixture_text("log_dynamo_regression.txt")
         parsed_log = parse_log(log_dynamo_regression)
         failure = parsed_log.pytest_results[0].test_failures[0]
-        self.assertEqual(failure.exception_class, "RuntimeError")
+        self.assertEqual(failure.pytest_exception_class, "RuntimeError")
         self.assertIn("Test subprocess", failure.exception_chain)
         self.assertIn("RuntimeError", failure.exception_chain)
         self.assertIn("Server exited unexpectedly", failure.exception_chain)
@@ -168,14 +168,14 @@ class TestExpandedExceptionSuffixes(unittest.TestCase):
         log = "FAILED tests/test_runner.py::test_spawn - SystemExit: 1\n= 1 failed in 5.00s ="
         parsed_log = parse_log(log)
         failure = parsed_log.pytest_results[0].test_failures[0]
-        self.assertEqual(failure.exception_class, "SystemExit")
+        self.assertEqual(failure.pytest_exception_class, "SystemExit")
         self.assertIn("1", failure.exception_chain)
 
     def test_keyboard_interrupt(self) -> None:
         log = "FAILED tests/test_server.py::test_startup - KeyboardInterrupt: \n= 1 failed in 30.00s ="
         parsed_log = parse_log(log)
         failure = parsed_log.pytest_results[0].test_failures[0]
-        self.assertEqual(failure.exception_class, "KeyboardInterrupt")
+        self.assertEqual(failure.pytest_exception_class, "KeyboardInterrupt")
 
     def test_exception_group(self) -> None:
         log = (
@@ -184,7 +184,7 @@ class TestExpandedExceptionSuffixes(unittest.TestCase):
         )
         parsed_log = parse_log(log)
         failure = parsed_log.pytest_results[0].test_failures[0]
-        self.assertEqual(failure.exception_class, "ExceptionGroup")
+        self.assertEqual(failure.pytest_exception_class, "ExceptionGroup")
 
     def test_warning_as_error(self) -> None:
         log = (
@@ -193,13 +193,13 @@ class TestExpandedExceptionSuffixes(unittest.TestCase):
         )
         parsed_log = parse_log(log)
         failure = parsed_log.pytest_results[0].test_failures[0]
-        self.assertEqual(failure.exception_class, "DeprecationWarning")
+        self.assertEqual(failure.pytest_exception_class, "DeprecationWarning")
 
     def test_stop_iteration(self) -> None:
         log = "FAILED tests/test_gen.py::test_iter - StopIteration: \n= 1 failed in 0.50s ="
         parsed_log = parse_log(log)
         failure = parsed_log.pytest_results[0].test_failures[0]
-        self.assertEqual(failure.exception_class, "StopIteration")
+        self.assertEqual(failure.pytest_exception_class, "StopIteration")
 
     def test_dotted_torch_exception(self) -> None:
         log = (
@@ -208,31 +208,7 @@ class TestExpandedExceptionSuffixes(unittest.TestCase):
         )
         parsed_log = parse_log(log)
         failure = parsed_log.pytest_results[0].test_failures[0]
-        self.assertEqual(failure.exception_class, "torch.cuda.OutOfMemoryError")
-
-    def test_body_keyboard_interrupt_in_chain(self) -> None:
-        log = (
-            "E   KeyboardInterrupt: timeout\n"
-            "FAILED tests/test_server.py::test_hang - RuntimeError: "
-            "Engine core initialization failed. See root cause above.\n"
-            "= 1 failed in 60.00s ="
-        )
-        parsed_log = parse_log(log)
-        failure = parsed_log.pytest_results[0].test_failures[0]
-        self.assertIn("KeyboardInterrupt: timeout", failure.exception_chain)
-
-    def test_body_exception_group_in_chain(self) -> None:
-        log = (
-            "E   BaseExceptionGroup: errors (3 sub-exceptions)\n"
-            "FAILED tests/test_tasks.py::test_concurrent - RuntimeError: "
-            "Engine core initialization failed. See root cause above.\n"
-            "= 1 failed in 5.00s ="
-        )
-        parsed_log = parse_log(log)
-        failure = parsed_log.pytest_results[0].test_failures[0]
-        self.assertIn(
-            "BaseExceptionGroup: errors (3 sub-exceptions)", failure.exception_chain
-        )
+        self.assertEqual(failure.pytest_exception_class, "torch.cuda.OutOfMemoryError")
 
 
 class TestErrorLinesParsing(unittest.TestCase):
@@ -243,14 +219,14 @@ class TestErrorLinesParsing(unittest.TestCase):
         parsed_log = parse_log(log)
         failure = parsed_log.pytest_results[0].test_failures[0]
         self.assertEqual(failure.test_id, "tests/test_foo.py")
-        self.assertEqual(failure.exception_class, "SyntaxError")
+        self.assertEqual(failure.pytest_exception_class, "SyntaxError")
 
     def test_error_with_nodeid(self) -> None:
         log = "ERROR tests/test_db.py::test_query - ConnectionRefusedError: [Errno 111]\n= 1 error in 1.00s ="
         parsed_log = parse_log(log)
         failure = parsed_log.pytest_results[0].test_failures[0]
         self.assertEqual(failure.test_id, "tests/test_db.py::test_query")
-        self.assertEqual(failure.exception_class, "ConnectionRefusedError")
+        self.assertEqual(failure.pytest_exception_class, "ConnectionRefusedError")
 
     def test_error_and_failed_together(self) -> None:
         log = (
@@ -262,9 +238,11 @@ class TestErrorLinesParsing(unittest.TestCase):
         pytest_result = parsed_log.pytest_results[0]
         self.assertEqual(len(pytest_result.test_failures), 2)
         by_id = {failure.test_id: failure for failure in pytest_result.test_failures}
-        self.assertEqual(by_id["tests/conftest.py"].exception_class, "ImportError")
         self.assertEqual(
-            by_id["tests/test_bar.py::test_baz"].exception_class, "ValueError"
+            by_id["tests/conftest.py"].pytest_exception_class, "ImportError"
+        )
+        self.assertEqual(
+            by_id["tests/test_bar.py::test_baz"].pytest_exception_class, "ValueError"
         )
 
     def test_error_does_not_match_log_noise(self) -> None:
@@ -321,12 +299,35 @@ class TestExpectedFailureCount(unittest.TestCase):
         parsed_log = parse_log(log)
         self.assertEqual(len(parsed_log.pytest_results), 0)
 
-    def test_mismatch_raises(self) -> None:
+    def test_mismatch_does_not_raise_and_records_counts(self) -> None:
+        # A summary count that disagrees with the parsed failures must not raise:
+        # both counts stay readable (expected_test_failure_count vs the actual
+        # test_failures length) so a consumer can detect the mismatch itself.
         log = (
             "FAILED tests/test_a.py::test_one - ValueError: bad\n= 3 failed in 1.00s ="
         )
-        with self.assertRaises(AssertionError):
-            parse_log(log)
+        parsed_log = parse_log(log)
+        pytest_result = parsed_log.pytest_results[0]
+        self.assertEqual(pytest_result.expected_test_failure_count, 3)
+        self.assertEqual(len(pytest_result.test_failures), 1)
+
+    def test_mismatch_does_not_discard_later_sessions(self) -> None:
+        # A mismatched session must degrade to itself, not lose a well-formed
+        # session that follows it in the same log.
+        log = (
+            "FAILED tests/test_a.py::test_one - ValueError: bad\n"
+            "= 3 failed in 1.00s =\n"
+            "FAILED tests/test_b.py::test_two - TypeError: wrong\n"
+            "= 1 failed in 2.00s ="
+        )
+        parsed_log = parse_log(log)
+        self.assertEqual(len(parsed_log.pytest_results), 2)
+        good_session = parsed_log.pytest_results[1]
+        self.assertEqual(good_session.expected_test_failure_count, 1)
+        self.assertEqual(len(good_session.test_failures), 1)
+        self.assertEqual(
+            good_session.test_failures[0].test_id, "tests/test_b.py::test_two"
+        )
 
     def test_real_fixture_counts_match(self) -> None:
         log_cuda_init_fail = read_fixture_text("log_cudagraph_cuda_init_fail.txt")
@@ -367,7 +368,9 @@ class TestMultipleSessionsGrouping(unittest.TestCase):
         self.assertEqual(
             session_one.test_failures[0].test_id, "tests/test_a.py::test_one"
         )
-        self.assertEqual(session_one.test_failures[0].exception_class, "ValueError")
+        self.assertEqual(
+            session_one.test_failures[0].pytest_exception_class, "ValueError"
+        )
         self.assertIn("bad", session_one.test_failures[0].exception_chain)
         self.assertEqual(session_one.expected_test_failure_count, 1)
 
@@ -376,12 +379,16 @@ class TestMultipleSessionsGrouping(unittest.TestCase):
         self.assertEqual(
             session_two.test_failures[0].test_id, "tests/test_b.py::test_two"
         )
-        self.assertEqual(session_two.test_failures[0].exception_class, "TypeError")
+        self.assertEqual(
+            session_two.test_failures[0].pytest_exception_class, "TypeError"
+        )
         self.assertIn("wrong", session_two.test_failures[0].exception_chain)
         self.assertEqual(
             session_two.test_failures[1].test_id, "tests/test_b.py::test_three"
         )
-        self.assertEqual(session_two.test_failures[1].exception_class, "KeyError")
+        self.assertEqual(
+            session_two.test_failures[1].pytest_exception_class, "KeyError"
+        )
         self.assertIn("missing", session_two.test_failures[1].exception_chain)
         self.assertEqual(session_two.expected_test_failure_count, 2)
 
@@ -440,18 +447,18 @@ class TestMultipleSessionsGrouping(unittest.TestCase):
             sentinel_one.test_id,
             "v1/cudagraph/test_cudagraph_mode.py::test_backend_and_cudagraph_mode_combo[FA2-FULL-True]",
         )
-        self.assertEqual(sentinel_one.exception_class, "RuntimeError")
+        self.assertEqual(sentinel_one.pytest_exception_class, "RuntimeError")
         self.assertIn("Engine core initialization failed", sentinel_one.exception_chain)
-        chain_text = sentinel_one.exception_chain
-        self.assertIn("ValueError", chain_text)
-        self.assertIn("Memory of devices", chain_text)
+        # The chain is scoped to this test's own section: the real root cause
+        # (a ValueError in another test's failure) is not merged in here.
+        self.assertNotIn("Memory of devices", sentinel_one.exception_chain)
 
         direct_one = failing_session.test_failures[2]
         self.assertEqual(
             direct_one.test_id,
             "v1/cudagraph/test_cudagraph_mode.py::test_cudagraph_compilation_combo[FA2-FULL-3-True]",
         )
-        self.assertEqual(direct_one.exception_class, "ValueError")
+        self.assertEqual(direct_one.pytest_exception_class, "ValueError")
         self.assertIn("Memory of devices", direct_one.exception_chain)
 
         passing_session = parsed_log.pytest_results[1]
@@ -481,7 +488,7 @@ class TestMultipleSessionsGrouping(unittest.TestCase):
             scaling_failure.test_id,
             "distributed/test_elastic_ep.py::test_elastic_ep_scaling",
         )
-        self.assertEqual(scaling_failure.exception_class, "AssertionError")
+        self.assertEqual(scaling_failure.pytest_exception_class, "AssertionError")
         self.assertIn("assert False", scaling_failure.exception_chain)
 
         uneven_failure = failing_session.test_failures[1]
@@ -489,8 +496,12 @@ class TestMultipleSessionsGrouping(unittest.TestCase):
             uneven_failure.test_id,
             "distributed/test_elastic_ep.py::test_elastic_ep_scaling_uneven",
         )
-        self.assertEqual(uneven_failure.exception_class, "AssertionError")
-        self.assertIn("assert False", uneven_failure.exception_chain)
+        self.assertEqual(uneven_failure.pytest_exception_class, "AssertionError")
+        self.assertIn(
+            "GSM8K accuracy 0.000 is below expected threshold",
+            uneven_failure.exception_chain,
+        )
+        self.assertNotIn("assert False", uneven_failure.exception_chain)
 
     def test_multi_root_cause_sentinels_end_to_end(self) -> None:
         """Two sentinel tests with different root causes — each chain is
@@ -511,7 +522,7 @@ class TestMultipleSessionsGrouping(unittest.TestCase):
 
         model_loading = failing_session.test_failures[0]
         self.assertEqual(model_loading.test_id, "test_engine.py::test_model_loading")
-        self.assertEqual(model_loading.exception_class, "RuntimeError")
+        self.assertEqual(model_loading.pytest_exception_class, "RuntimeError")
         self.assertIn(
             "Engine core initialization failed", model_loading.exception_chain
         )
@@ -523,7 +534,7 @@ class TestMultipleSessionsGrouping(unittest.TestCase):
         self.assertEqual(
             kernel_dispatch.test_id, "test_engine.py::test_kernel_dispatch"
         )
-        self.assertEqual(kernel_dispatch.exception_class, "RuntimeError")
+        self.assertEqual(kernel_dispatch.pytest_exception_class, "RuntimeError")
         self.assertIn(
             "Engine core initialization failed", kernel_dispatch.exception_chain
         )
@@ -685,9 +696,10 @@ class TestSectionBodyCapture(unittest.TestCase):
         self.assertIn("This error most often comes from", failure.exception_chain)
         self.assertIn("expected size 3072==2880", failure.exception_chain)
 
-    def test_bare_assert_backfills_class_from_file_ref(self) -> None:
-        """Bare FAILED line + section body with no EXCEPTION_RE match
-        backfills exception_class from the file reference line."""
+    def test_bare_failed_line_leaves_class_empty(self) -> None:
+        """A bare FAILED line (no class on pytest's summary line) leaves
+        pytest_exception_class empty -- the class is not inferred from the
+        section footer -- while exception_chain still carries the traceback."""
         log = (
             "=================================== FAILURES ===================================\n"
             "_________________ test_check_padding _________________\n"
@@ -705,8 +717,9 @@ class TestSectionBodyCapture(unittest.TestCase):
         )
         parsed_log = parse_log(log)
         failure = parsed_log.pytest_results[0].test_failures[0]
-        self.assertEqual(failure.exception_class, "AssertionError")
+        self.assertEqual(failure.pytest_exception_class, "")
         self.assertIn("assert False", failure.exception_chain)
+        self.assertIn("AssertionError", failure.exception_chain)
 
     def test_no_section_body_uses_fallback(self) -> None:
         """Without FAILURES section headers, chain falls back to body exceptions."""

--- a/tools/torchci/vllm_log_parser.py
+++ b/tools/torchci/vllm_log_parser.py
@@ -1,0 +1,314 @@
+"""Parse vLLM Buildkite job logs into structured failure signatures.
+
+Vendored from the vllm-pytorch-ci-triage package (clean_logs + the dataclasses it
+needs). Strips ANSI escape codes and BKT timestamp markers, then extracts per-test
+signatures: test id, exception class/message, and the raw section body from pytest's
+FAILURES block. Extraction is position-independent -- a failure far from the end of
+a huge log is still captured.
+"""
+
+import re
+from dataclasses import dataclass, field
+
+
+@dataclass
+class FailedTest:
+    """A single failed test with its exception signature."""
+
+    test_id: str
+    exception_class: str = ""
+    exception_chain: str = ""
+    test_is_infra: bool = False
+
+
+@dataclass
+class PytestResult:
+    """One pytest session's output within a Buildkite job log."""
+
+    test_failures: list[FailedTest] = field(default_factory=list)
+    pytest_summary: str = ""
+    expected_test_failure_count: int | None = None
+
+
+@dataclass
+class ParsedLog:
+    """Parsed log output from a Buildkite job.
+
+    Either pytest_results is populated (pytest failures) or error_excerpt holds the
+    whole cleaned log (a build/crash before pytest ran).
+    """
+
+    pytest_results: list[PytestResult] = field(default_factory=list)
+    error_excerpt: str = ""
+    job_is_infra: bool = False
+
+
+TIMESTAMP_RE = re.compile(r"^\[[\d\-T:Z]+\]\s*")
+FAILED_TEST_RE = re.compile(r"^(?:FAILED|ERROR)\s+(\S+/\S*\.py\S*)")
+PYTEST_SUMMARY_RE = re.compile(
+    r"=+\s+.*\d+\s+(?:failed|error|passed|skipped|warning|deselected).*\bin\s+\d.*=+"
+)
+SUMMARY_FAILED_COUNT_RE = re.compile(r"(\d+)\s+failed")
+SUMMARY_ERROR_COUNT_RE = re.compile(r"(\d+)\s+error")
+TEST_SECTION_HEADER_RE = re.compile(r"_{1,}\s+(.+?)\s+_{1,}")
+
+_EXC_SUFFIX = r"(?:Error|Exception|Failure|Failed|Exit|Interrupt|Group|Iteration)"
+_EXC_SUFFIX_FULL = (
+    r"(?:Error|Exception|Failure|Failed|Warning|Exit|Interrupt|Group|Iteration)"
+)
+EXCEPTION_RE = re.compile(
+    r"(?:^|\s)(?:E\s+)?(\w+(?:\.\w+)*" + _EXC_SUFFIX + r")"
+    r":\s*(.*)"
+)
+FAILED_INLINE_EXC_RE = re.compile(
+    r"(?:FAILED|ERROR)\s+(.+?)\s+-\s+(\w+(?:\.\w+)*" + _EXC_SUFFIX_FULL + r")"
+    r":\s*(.*)"
+)
+FAILED_INLINE_ASSERT_RE = re.compile(r"(?:FAILED|ERROR)\s+(.+?)\s+-\s+(assert\s+.*)")
+
+FILE_REF_EXC_RE = re.compile(r"^\S+:\d+: (\w+(?:\.\w+)*)$", re.MULTILINE)
+INFRA_PATTERNS = [
+    re.compile(r"nvidia-container-cli", re.IGNORECASE),
+    re.compile(r"CUDA driver initialization failed", re.IGNORECASE),
+    re.compile(r"exit status 137"),
+    re.compile(r"exit(?:ed with)? status 125", re.IGNORECASE),
+    re.compile(r"Free memory on device cuda:\d+.*less than desired"),
+    re.compile(r"docker.*pull", re.IGNORECASE),
+    re.compile(r"command hook exited with status", re.IGNORECASE),
+    re.compile(r"toomanyrequests", re.IGNORECASE),
+    re.compile(r"Data limit exceeded", re.IGNORECASE),
+    re.compile(r"Connection refused", re.IGNORECASE),
+    re.compile(r"no space left on device", re.IGNORECASE),
+    re.compile(r"manifest unknown", re.IGNORECASE),
+    re.compile(r"not found: manifest", re.IGNORECASE),
+]
+
+
+def strip_markers(text: str) -> str:
+    """Remove escape sequences from raw Buildkite log text.
+
+    Filters:
+        - ANSI CSI sequences (\\x1b[...): colors, cursor movement, erase-to-EOL
+        - BKT timestamp markers (\\x1b_bk;t=<ms>\\x07)
+        - OSC sequences (\\x1b]...\\x07): inline images (1338), hyperlinks (1339)
+    """
+    ansi_regex = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
+    osc_regex = re.compile(r"\x1b[\]_][^\x07]*\x07")
+    return osc_regex.sub("", ansi_regex.sub("", text))
+
+
+def parse_log(text: str) -> ParsedLog:
+    """Clean a raw log and extract structured failure information.
+
+    Args:
+        text: Raw log text from Buildkite.
+
+    Returns:
+        Parsed log with extracted failure signatures.
+    """
+    cleaned = strip_markers(text)
+    lines = cleaned.splitlines()
+
+    extraction = _extract_pytest_failures(lines)
+
+    if not extraction.pytest_results:
+        return ParsedLog(error_excerpt=cleaned, job_is_infra=_matches_infra(cleaned))
+
+    for pytest_result in extraction.pytest_results:
+        for failure in pytest_result.test_failures:
+            had_inline = bool(failure.exception_class)
+            inline_message = extraction.inline_messages.get(id(failure), "")
+
+            section_body = _get_section_body(failure.test_id, extraction.section_bodies)
+
+            if not failure.exception_class:
+                raw = _get_raw_section_exceptions(
+                    failure.test_id, extraction.section_exceptions
+                )
+                if raw:
+                    failure.exception_class = raw[0][0]
+                elif section_body:
+                    matches = FILE_REF_EXC_RE.findall(section_body)
+                    if matches:
+                        failure.exception_class = matches[-1]
+                elif extraction.body_exceptions:
+                    failure.exception_class = extraction.body_exceptions[0][0]
+            if section_body is not None:
+                failure.exception_chain = section_body
+            elif failure.exception_class:
+                inline = f"{failure.exception_class}: {inline_message}"
+                all_body = [f"{c}: {m}" for c, m, _ in extraction.body_exceptions]
+                parts = (
+                    [inline] + all_body
+                    if had_inline and all_body
+                    else (all_body if all_body else [inline])
+                )
+                failure.exception_chain = "\n".join(parts)
+        for failure in pytest_result.test_failures:
+            failure.test_is_infra = _matches_infra(failure.exception_chain)
+
+    return ParsedLog(pytest_results=extraction.pytest_results)
+
+
+def _get_section_body(
+    test_id: str,
+    section_bodies: dict[str, str],
+) -> str | None:
+    for section_name, body in section_bodies.items():
+        if section_name in test_id:
+            return body
+    return None
+
+
+def _get_raw_section_exceptions(
+    test_id: str,
+    section_exceptions: dict[str, list[tuple[str, str, int]]],
+) -> list[tuple[str, str, int]] | None:
+    for section_name, exceptions in section_exceptions.items():
+        if section_name in test_id:
+            return exceptions
+    return None
+
+
+class _ExtractionResult:
+    """Internal container for extraction output."""
+
+    def __init__(self) -> None:
+        self.pytest_results: list[PytestResult] = []
+        self.body_exceptions: list[tuple[str, str, int]] = []
+        self.section_exceptions: dict[str, list[tuple[str, str, int]]] = {}
+        self.section_bodies: dict[str, str] = {}
+        self.inline_messages: dict[int, str] = {}
+
+
+def _extract_pytest_failures(lines: list[str]) -> _ExtractionResult:
+    """Scan lines, extract pytest sessions, body exceptions, and section bodies."""
+    result = _ExtractionResult()
+    current_failures: list[FailedTest] = []
+    current_section: str = ""
+    section_start: int = -1
+
+    for line_index, line in enumerate(lines):
+        stripped = TIMESTAMP_RE.sub("", line).strip()
+
+        section_match = TEST_SECTION_HEADER_RE.search(stripped)
+        if section_match:
+            name = section_match.group(1).strip()
+            if re.search(r"[a-zA-Z0-9]", name):
+                _save_section_body(
+                    result, current_section, section_start, line_index, lines
+                )
+                current_section = name
+                section_start = line_index + 1
+                continue
+
+        if _is_equals_boundary(stripped):
+            _save_section_body(
+                result, current_section, section_start, line_index, lines
+            )
+            current_section = ""
+            section_start = -1
+
+        inline_exc_match = FAILED_INLINE_EXC_RE.search(stripped)
+        if inline_exc_match:
+            failed_test = FailedTest(
+                test_id=inline_exc_match.group(1),
+                exception_class=inline_exc_match.group(2),
+            )
+            result.inline_messages[id(failed_test)] = inline_exc_match.group(3).strip()
+            current_failures.append(failed_test)
+        else:
+            assert_match = FAILED_INLINE_ASSERT_RE.search(stripped)
+            if assert_match:
+                failed_test = FailedTest(
+                    test_id=assert_match.group(1),
+                    exception_class="AssertionError",
+                )
+                result.inline_messages[id(failed_test)] = assert_match.group(2).strip()
+                current_failures.append(failed_test)
+            else:
+                bare_failed_match = FAILED_TEST_RE.search(stripped)
+                if bare_failed_match:
+                    failed_test = FailedTest(
+                        test_id=bare_failed_match.group(1),
+                    )
+                    current_failures.append(failed_test)
+
+            exception_match = EXCEPTION_RE.search(stripped)
+            if exception_match:
+                exc_class = exception_match.group(1)
+                exc_message = exception_match.group(2).strip()
+
+                result.body_exceptions.append((exc_class, exc_message, line_index))
+
+                if current_section:
+                    if current_section not in result.section_exceptions:
+                        result.section_exceptions[current_section] = []
+                    result.section_exceptions[current_section].append(
+                        (exc_class, exc_message, line_index)
+                    )
+
+        if PYTEST_SUMMARY_RE.search(stripped):
+            expected_count = _parse_summary_count(line.strip())
+            assert expected_count == len(current_failures)
+            result.pytest_results.append(
+                PytestResult(
+                    test_failures=current_failures,
+                    pytest_summary=line.strip(),
+                    expected_test_failure_count=expected_count,
+                )
+            )
+            current_failures = []
+            current_section = ""
+            section_start = -1
+
+    if current_failures:
+        result.pytest_results.append(
+            PytestResult(
+                test_failures=current_failures,
+                expected_test_failure_count=None,
+            )
+        )
+
+    return result
+
+
+def _is_equals_boundary(stripped: str) -> bool:
+    return len(stripped) > 20 and stripped.startswith("=") and stripped.endswith("=")
+
+
+def _save_section_body(
+    result: _ExtractionResult,
+    section_name: str,
+    start: int,
+    end: int,
+    lines: list[str],
+) -> None:
+    if not section_name or start < 0:
+        return
+    body_lines = []
+    for i in range(start, end):
+        cleaned = TIMESTAMP_RE.sub("", lines[i]).rstrip()
+        body_lines.append(cleaned)
+    body = "\n".join(body_lines).strip()
+    if body:
+        result.section_bodies[section_name] = body
+
+
+def _matches_infra(text: str) -> bool:
+    """
+    Return True for a confirmed transient (retryable) infra signature.
+    """
+
+    return any(pattern.search(text) for pattern in INFRA_PATTERNS)
+
+
+def _parse_summary_count(summary: str) -> int:
+    count = 0
+    failed_match = SUMMARY_FAILED_COUNT_RE.search(summary)
+    if failed_match:
+        count += int(failed_match.group(1))
+    error_match = SUMMARY_ERROR_COUNT_RE.search(summary)
+    if error_match:
+        count += int(error_match.group(1))
+    return count

--- a/tools/torchci/vllm_log_parser.py
+++ b/tools/torchci/vllm_log_parser.py
@@ -1,10 +1,10 @@
 """Parse vLLM Buildkite job logs into structured failure signatures.
 
-Vendored from the vllm-pytorch-ci-triage package (clean_logs + the dataclasses it
-needs). Strips ANSI escape codes and BKT timestamp markers, then extracts per-test
-signatures: test id, exception class/message, and the raw section body from pytest's
-FAILURES block. Extraction is position-independent -- a failure far from the end of
-a huge log is still captured.
+Vendored from the vllm-pytorch-ci-triage package (parse_log/strip_markers + the
+dataclasses they need). Strips ANSI escape codes and BKT timestamp markers, then
+extracts per-test signatures: test id, exception class/message, and the raw section
+body from pytest's FAILURES block. Extraction is position-independent -- a failure
+far from the end of a huge log is still captured.
 """
 
 import re
@@ -16,8 +16,11 @@ class FailedTest:
     """A single failed test with its exception signature."""
 
     test_id: str
-    exception_class: str = ""
-    exception_chain: str = ""
+    pytest_exception_class: str = (
+        ""  # The exception class pytest named on its inline FAILED/ERROR summary line.
+    )
+    exception_chain: str = ""  # This test's own FAILURES section body
+    inline_message: str = ""
     test_is_infra: bool = False
 
 
@@ -52,21 +55,16 @@ SUMMARY_FAILED_COUNT_RE = re.compile(r"(\d+)\s+failed")
 SUMMARY_ERROR_COUNT_RE = re.compile(r"(\d+)\s+error")
 TEST_SECTION_HEADER_RE = re.compile(r"_{1,}\s+(.+?)\s+_{1,}")
 
-_EXC_SUFFIX = r"(?:Error|Exception|Failure|Failed|Exit|Interrupt|Group|Iteration)"
-_EXC_SUFFIX_FULL = (
-    r"(?:Error|Exception|Failure|Failed|Warning|Exit|Interrupt|Group|Iteration)"
-)
-EXCEPTION_RE = re.compile(
-    r"(?:^|\s)(?:E\s+)?(\w+(?:\.\w+)*" + _EXC_SUFFIX + r")"
-    r":\s*(.*)"
-)
+# The inline path trusts pytest: the text after " - " on a FAILED/ERROR line is
+# ExceptionInfo.exconly() output -- "{ExcClass}: {message}". The message is
+# optional: exconly() emits a bare class name when the exception has no message.
 FAILED_INLINE_EXC_RE = re.compile(
-    r"(?:FAILED|ERROR)\s+(.+?)\s+-\s+(\w+(?:\.\w+)*" + _EXC_SUFFIX_FULL + r")"
-    r":\s*(.*)"
+    r"(?:FAILED|ERROR)\s+(.+?)\s+-\s+"
+    r"([A-Za-z_][\w.]*(?:::[\w.]+)*)"
+    r"(?::\s*(.*))?"
 )
 FAILED_INLINE_ASSERT_RE = re.compile(r"(?:FAILED|ERROR)\s+(.+?)\s+-\s+(assert\s+.*)")
 
-FILE_REF_EXC_RE = re.compile(r"^\S+:\d+: (\w+(?:\.\w+)*)$", re.MULTILINE)
 INFRA_PATTERNS = [
     re.compile(r"nvidia-container-cli", re.IGNORECASE),
     re.compile(r"CUDA driver initialization failed", re.IGNORECASE),
@@ -116,58 +114,56 @@ def parse_log(text: str) -> ParsedLog:
 
     for pytest_result in extraction.pytest_results:
         for failure in pytest_result.test_failures:
-            had_inline = bool(failure.exception_class)
-            inline_message = extraction.inline_messages.get(id(failure), "")
-
+            # Both fields hold only what pytest scoped to this specific test:
+            #   - pytest_exception_class: the class pytest named on the inline
+            #     FAILED/ERROR summary line (set at construction); empty otherwise.
+            #   - exception_chain: this test's own FAILURES section body.
             section_body = _get_section_body(failure.test_id, extraction.section_bodies)
-
-            if not failure.exception_class:
-                raw = _get_raw_section_exceptions(
-                    failure.test_id, extraction.section_exceptions
-                )
-                if raw:
-                    failure.exception_class = raw[0][0]
-                elif section_body:
-                    matches = FILE_REF_EXC_RE.findall(section_body)
-                    if matches:
-                        failure.exception_class = matches[-1]
-                elif extraction.body_exceptions:
-                    failure.exception_class = extraction.body_exceptions[0][0]
             if section_body is not None:
                 failure.exception_chain = section_body
-            elif failure.exception_class:
-                inline = f"{failure.exception_class}: {inline_message}"
-                all_body = [f"{c}: {m}" for c, m, _ in extraction.body_exceptions]
-                parts = (
-                    [inline] + all_body
-                    if had_inline and all_body
-                    else (all_body if all_body else [inline])
+            elif failure.pytest_exception_class:
+                failure.exception_chain = (
+                    f"{failure.pytest_exception_class}: {failure.inline_message}"
                 )
-                failure.exception_chain = "\n".join(parts)
         for failure in pytest_result.test_failures:
             failure.test_is_infra = _matches_infra(failure.exception_chain)
 
     return ParsedLog(pytest_results=extraction.pytest_results)
 
 
+def _normalize_test_id(test_id: str) -> str:
+    """Reduce a test id to the node pytest names its FAILURES section by.
+
+    ``distributed/test_elastic_ep.py::test_scaling_uneven`` -> ``test_scaling_uneven``
+    ``suite.py::TestClass::test_method`` -> ``TestClass.test_method`` (pytest joins the
+    class and method with a dot in the section header).
+    """
+    _, separator, node = test_id.partition(".py::")
+    node = node if separator else test_id
+    return node.replace("::", ".")
+
+
+def _match_section_name(test_id: str, section_names: list[str]) -> str | None:
+    """Resolve which FAILURES section belongs to a test id.
+
+    Both the section header and the ``FAILED`` line come from the same pytest run, so
+    the header names the test's node exactly. Matching exactly (not by substring) keeps
+    a test whose name prefixes another's (``test_scaling`` vs ``test_scaling_uneven``)
+    from stealing its section.
+    """
+    node = _normalize_test_id(test_id)
+    for section_name in section_names:
+        if section_name == node:
+            return section_name
+    return None
+
+
 def _get_section_body(
     test_id: str,
     section_bodies: dict[str, str],
 ) -> str | None:
-    for section_name, body in section_bodies.items():
-        if section_name in test_id:
-            return body
-    return None
-
-
-def _get_raw_section_exceptions(
-    test_id: str,
-    section_exceptions: dict[str, list[tuple[str, str, int]]],
-) -> list[tuple[str, str, int]] | None:
-    for section_name, exceptions in section_exceptions.items():
-        if section_name in test_id:
-            return exceptions
-    return None
+    section_name = _match_section_name(test_id, list(section_bodies))
+    return section_bodies[section_name] if section_name is not None else None
 
 
 class _ExtractionResult:
@@ -175,14 +171,11 @@ class _ExtractionResult:
 
     def __init__(self) -> None:
         self.pytest_results: list[PytestResult] = []
-        self.body_exceptions: list[tuple[str, str, int]] = []
-        self.section_exceptions: dict[str, list[tuple[str, str, int]]] = {}
         self.section_bodies: dict[str, str] = {}
-        self.inline_messages: dict[int, str] = {}
 
 
 def _extract_pytest_failures(lines: list[str]) -> _ExtractionResult:
-    """Scan lines, extract pytest sessions, body exceptions, and section bodies."""
+    """Scan lines, extract pytest sessions and per-test FAILURES section bodies."""
     result = _ExtractionResult()
     current_failures: list[FailedTest] = []
     current_section: str = ""
@@ -209,48 +202,37 @@ def _extract_pytest_failures(lines: list[str]) -> _ExtractionResult:
             current_section = ""
             section_start = -1
 
-        inline_exc_match = FAILED_INLINE_EXC_RE.search(stripped)
+        # Assert first: the permissive inline regex would otherwise capture
+        # "assert" as the class from a rewritten-assertion "- assert x == y" line.
+        assert_match = FAILED_INLINE_ASSERT_RE.search(stripped)
+        inline_exc_match = (
+            None if assert_match else FAILED_INLINE_EXC_RE.search(stripped)
+        )
         if inline_exc_match:
             failed_test = FailedTest(
                 test_id=inline_exc_match.group(1),
-                exception_class=inline_exc_match.group(2),
+                pytest_exception_class=inline_exc_match.group(2),
+                inline_message=(inline_exc_match.group(3) or "").strip(),
             )
-            result.inline_messages[id(failed_test)] = inline_exc_match.group(3).strip()
+            current_failures.append(failed_test)
+        elif assert_match:
+            failed_test = FailedTest(
+                test_id=assert_match.group(1),
+                pytest_exception_class="AssertionError",
+                inline_message=assert_match.group(2).strip(),
+            )
             current_failures.append(failed_test)
         else:
-            assert_match = FAILED_INLINE_ASSERT_RE.search(stripped)
-            if assert_match:
+            bare_failed_match = FAILED_TEST_RE.search(stripped)
+            if bare_failed_match:
                 failed_test = FailedTest(
-                    test_id=assert_match.group(1),
-                    exception_class="AssertionError",
+                    test_id=bare_failed_match.group(1),
                 )
-                result.inline_messages[id(failed_test)] = assert_match.group(2).strip()
                 current_failures.append(failed_test)
-            else:
-                bare_failed_match = FAILED_TEST_RE.search(stripped)
-                if bare_failed_match:
-                    failed_test = FailedTest(
-                        test_id=bare_failed_match.group(1),
-                    )
-                    current_failures.append(failed_test)
-
-            exception_match = EXCEPTION_RE.search(stripped)
-            if exception_match:
-                exc_class = exception_match.group(1)
-                exc_message = exception_match.group(2).strip()
-
-                result.body_exceptions.append((exc_class, exc_message, line_index))
-
-                if current_section:
-                    if current_section not in result.section_exceptions:
-                        result.section_exceptions[current_section] = []
-                    result.section_exceptions[current_section].append(
-                        (exc_class, exc_message, line_index)
-                    )
 
         if PYTEST_SUMMARY_RE.search(stripped):
+            # Record the summary's count.
             expected_count = _parse_summary_count(line.strip())
-            assert expected_count == len(current_failures)
             result.pytest_results.append(
                 PytestResult(
                     test_failures=current_failures,

--- a/tools/torchci/vllm_torch_nightly_triage.py
+++ b/tools/torchci/vllm_torch_nightly_triage.py
@@ -34,6 +34,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from torchci.clickhouse import get_clickhouse_client
 
+from torchci.vllm_log_parser import parse_log, strip_markers
+
 
 VLLM_REPO = "https://github.com/vllm-project/vllm.git"
 PIPELINE = "CI"
@@ -289,17 +291,64 @@ def render(
     return "\n".join(out)
 
 
-_ANSI = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
-_BK_TIMESTAMP = re.compile(r"\x1b_bk;[^\x07]*\x07")
+def _render_cluster_artifact(
+    body: str, cluster_key: str, representative: Dict, tail_lines: int
+) -> str:
+    """Serialize one cluster's representative log for the root-cause agent.
 
-
-def clean_log(text: str) -> str:
-    """Strip Buildkite timestamp markers and ANSI colour codes.
-
-    Raw Buildkite logs interleave ``\\x1b_bk;t=...\\x07`` markers with ANSI escapes;
-    left in place they make the logs nearly unreadable and waste a lot of tokens.
+    parse_log extracts per-test signatures (test id, exception class, the raw
+    traceback body) from anywhere in the log, so a failure far from the end of a
+    huge log is still captured. When there are no pytest failures -- a build/crash
+    before pytest ran, an empty parse, or the parser raising on its own invariant --
+    fall back to the raw tail this script has always emitted.
     """
-    return _BK_TIMESTAMP.sub("", _ANSI.sub("", text))
+    header = (
+        f"# cluster: {cluster_key}\n"
+        f"# job: {representative['name']}\n"
+        f"# url: {representative['url']}\n"
+        f"# state: {representative['state']} exit_status: {representative['exit_status']}\n"
+    )
+
+    parse_error = ""
+    parsed = None
+    try:
+        parsed = parse_log(body)
+    except Exception as exc:  # parser asserts an invariant; never abort the run
+        parse_error = str(exc)
+
+    test_failures = (
+        [
+            failure
+            for result in parsed.pytest_results
+            for failure in result.test_failures
+        ]
+        if parsed
+        else []
+    )
+
+    if test_failures:
+        sections = [header, f"# parsed {len(test_failures)} failing test(s)\n"]
+        for failure in test_failures:
+            sections.append(f"## {failure.test_id}")
+            sections.append(f"exception_class: {failure.exception_class}")
+            sections.append(f"test_is_infra: {failure.test_is_infra}")
+            sections.append("")
+            sections.append(failure.exception_chain)
+            sections.append("")
+        return "\n".join(sections)
+
+    cleaned_lines = strip_markers(body).splitlines()
+    job_is_infra = parsed.job_is_infra if parsed else False
+    fallback_notes = (
+        "# parse_fallback: true (raw tail; scan upward for the real error)\n"
+    )
+    if parse_error:
+        fallback_notes += f"# parse_error: {parse_error}\n"
+    fallback_notes += (
+        f"# job_is_infra: {job_is_infra}\n"
+        f"# showing last {tail_lines} of {len(cleaned_lines)} lines\n\n"
+    )
+    return header + fallback_notes + "\n".join(cleaned_lines[-tail_lines:])
 
 
 def fetch_cluster_logs(
@@ -353,14 +402,11 @@ def fetch_cluster_logs(
             print(f"skip {key}: {exc}", file=sys.stderr)
             continue
 
-        lines = clean_log(body).splitlines()
+        artifact = _render_cluster_artifact(body, key, rep, tail_lines)
         safe = re.sub(r"[^A-Za-z0-9._-]+", "_", key)[:80]
         dest = pathlib_dir / f"{safe}.log"
         with open(dest, "w") as f:
-            f.write(f"# cluster: {key}\n# job: {rep['name']}\n# url: {rep['url']}\n")
-            f.write(f"# state: {rep['state']} exit_status: {rep['exit_status']}\n")
-            f.write(f"# showing last {tail_lines} of {len(lines)} lines\n\n")
-            f.write("\n".join(lines[-tail_lines:]))
+            f.write(artifact)
         written.append(str(dest))
     return written
 

--- a/tools/torchci/vllm_torch_nightly_triage.py
+++ b/tools/torchci/vllm_torch_nightly_triage.py
@@ -33,7 +33,6 @@ from collections import defaultdict
 from typing import Any, Dict, List, Optional, Tuple
 
 from torchci.clickhouse import get_clickhouse_client
-
 from torchci.vllm_log_parser import parse_log, strip_markers
 
 

--- a/tools/torchci/vllm_torch_nightly_triage.py
+++ b/tools/torchci/vllm_torch_nightly_triage.py
@@ -329,7 +329,7 @@ def _render_cluster_artifact(
         sections = [header, f"# parsed {len(test_failures)} failing test(s)\n"]
         for failure in test_failures:
             sections.append(f"## {failure.test_id}")
-            sections.append(f"exception_class: {failure.exception_class}")
+            sections.append(f"pytest_exception_class: {failure.pytest_exception_class}")
             sections.append(f"test_is_infra: {failure.test_is_infra}")
             sections.append("")
             sections.append(failure.exception_chain)


### PR DESCRIPTION
I added a parser per pytest, I found this got a lot better signal and reduced a signifcant portion of the gotchas.  It looked like torchci was the natural integration point as opposed to a separate package, so I moved it there.

I have some end to end testing for parser, but if we want to cut down on lines of code in the PR we can remove the fixture(s). 

The schema of the parsed logs is detailed in the skill, but I think a basic example speaks for itself:
```json
[
  {
    "job_name": "V1 attention (B200)",
    "job_id": "019fd73d-f567-48ff-b05b-9e526fd89eb0",
    "exit_status": 1,
    "web_url": "https://buildkite.com/vllm/ci/builds/82682#019fd73d-f567-48ff-b05b-9e526fd89eb0",
    "build_number": 82682,
    "state": "failed",
    "log": {
      "pytest_results": [
        {
          "test_failures": [
            {
              "test_id": "v1/attention/test_attention_backends.py::test_causal_backend_correctness[auto-1-meta-llama/Meta-Llama-3-8B-medium_decode]",
              "exception_class": "cutlass.base_dsl.common.DSLUserCodeError",
              "exception_chain": "writing this for what can be a very long full error message (what pytest showed for the test)",
              "test_is_infra": false,
              "main_exception_chains": []
            },
            {
              "test_id": "example/test.py::test_example",
              "exception_class": "ExampleError",
              "exception_chain": "Example error message",
              "test_is_infra": false,
              "main_exception_chains": []
            }
          ]
        }
      ],
      "error_excerpt": "",
      "job_is_infra": false
    }
  }
]
```