### PR TITLE
Default test-infra-ref to "main" in reusable job workflows

### DIFF
--- a/.github/workflows/_binary_upload.yml
+++ b/.github/workflows/_binary_upload.yml
@@ -17,7 +17,7 @@ on:
         type: string
       test-infra-ref:
         description: "Test infra reference to use"
-        default: ""
+        default: "main"
         type: string
       build-matrix:
         description: "Build matrix to utilize"

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -17,7 +17,7 @@ on:
         type: string
       test-infra-ref:
         description: "Test infra reference to use"
-        default: ""
+        default: "main"
         type: string
       build-matrix:
         description: "Build matrix to utilize"

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -17,7 +17,7 @@ on:
         type: string
       test-infra-ref:
         description: "Test infra reference to use"
-        default: ""
+        default: "main"
         type: string
       build-matrix:
         description: "Build matrix to utilize"

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -17,7 +17,7 @@ on:
         type: string
       test-infra-ref:
         description: "Test infra reference to use"
-        default: ""
+        default: "main"
         type: string
       build-matrix:
         description: "Build matrix to utilize"

--- a/.github/workflows/linux_job.yml
+++ b/.github/workflows/linux_job.yml
@@ -56,7 +56,7 @@ on:
         type: string
       test-infra-ref:
         description: "Test infra reference to use"
-        default: ""
+        default: "main"
         type: string
       docker-image:
         description: Identifies the Docker image by name.

--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -69,7 +69,7 @@ on:
         type: string
       test-infra-ref:
         description: "Test infra reference to use"
-        default: ""
+        default: "main"
         type: string
       use-custom-docker-registry:
         description: "Use the custom ECR registry. Applies only if build.sh exists in docker-build-dir."

--- a/.github/workflows/linux_job_v3.yml
+++ b/.github/workflows/linux_job_v3.yml
@@ -70,7 +70,7 @@ on:
         type: string
       test-infra-ref:
         description: "Test infra reference to use"
-        default: ""
+        default: "main"
         type: string
       use-custom-docker-registry:
         description: "[Ignored on OSDC] Kept for compatibility with linux_job_v2.yml."

--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -56,7 +56,7 @@ on:
         type: string
       test-infra-ref:
         description: "Test infra reference to use"
-        default: ""
+        default: "main"
         type: string
       job-name:
         description: "Name for the job, which is displayed in the GitHub UI"

--- a/.github/workflows/mobile_job.yml
+++ b/.github/workflows/mobile_job.yml
@@ -47,7 +47,7 @@ on:
         type: string
       test-infra-ref:
         description: Test infra reference to use
-        default: ''
+        default: "main"
         type: string
 
       # iOS-specific inputs

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -56,7 +56,7 @@ on:
         type: string
       test-infra-ref:
         description: "Test infra reference to use"
-        default: ""
+        default: "main"
         type: string
       job-name:
         description: "Name for the job, which is displayed in the GitHub UI"

--- a/release/cut-release-branch.sh
+++ b/release/cut-release-branch.sh
@@ -40,9 +40,11 @@ function update_test_infra_branch() {
       if [[ "$OSTYPE" == "darwin"* ]]; then
         sed -i '' -e s#@main#@"${TEST_INFRA_BRANCH}"# $i;
         sed -i '' -e s#test-infra-ref:[[:space:]]main#"test-infra-ref: ${TEST_INFRA_BRANCH}"# $i;
+        sed -i '' -e "/^[[:space:]]*test-infra-ref:[[:space:]]*\$/,/type:/ s#default: \"main\"#default: \"${TEST_INFRA_BRANCH}\"#" $i;
       else
         sed -i -e s#@main#@"${TEST_INFRA_BRANCH}"# $i;
         sed -i -e s#test-infra-ref:[[:space:]]main#"test-infra-ref: ${TEST_INFRA_BRANCH}"# $i;
+        sed -i -e "/^[[:space:]]*test-infra-ref:[[:space:]]*\$/,/type:/ s#default: \"main\"#default: \"${TEST_INFRA_BRANCH}\"#" $i;
       fi
     done
 }


### PR DESCRIPTION
The reusable `*_job*` / `build_wheels_*` / `_binary_upload` workflows default `test-infra-ref` to `""` and pass it to `actions/checkout` as `ref:`. An empty `ref` makes checkout do a "Determining the default branch" REST call per job, which under large fan-out exhausts the org GitHub App installation rate limit — the cause of the `Checkout repository (pytorch/test-infra@)` failures in [pytorch-gha-infra#1375](https://github.com/meta-pytorch/pytorch-gha-infra/issues/1375).

Default it to `"main"` instead. `main` is what an empty ref already resolves to, so no checkout behavior changes — checkout just skips the default-branch lookup, dropping that call from the quota path for consumers that don't pin their own ref.

Mitigation, not a full fix: it doesn't bound the fan-out or the separate runner-registration quota (see #1375), and explicit `test-infra-ref: ''` callers still override it. Draft for infra owners to confirm on CI.

Authored with assistance from Claude Code.