### PR TITLE
Add Inductor kernel benchmark dashboard

### DIFF
--- a/torchci/components/benchmark_v3/configs/configurations.tsx
+++ b/torchci/components/benchmark_v3/configs/configurations.tsx
@@ -20,6 +20,10 @@ import {
   BenchmarkPageType,
 } from "./config_book_types";
 import {
+  BETTER_BENCHMARK_ID,
+  BetterBenchmarkDashboardConfig,
+} from "./teams/compilers/inductor_kernel_benchmark_config";
+import {
   PYTORCH_GPTFAST_BENCHMARK_ID,
   PytorchGptFastBenchmarkDashboardConfig,
 } from "./teams/gptfast/config";
@@ -45,6 +49,9 @@ export const REPORT_ID_TO_BENCHMARK_ID_MAPPING: Record<string, string> = {
 };
 
 export const PREDEFINED_BENCHMARK_CONFIG: BenchmarkConfigMap = {
+  [BETTER_BENCHMARK_ID]: {
+    [BenchmarkPageType.DashboardPage]: BetterBenchmarkDashboardConfig,
+  },
   [COMPILTER_BENCHMARK_NAME]: {
     [BenchmarkPageType.DashboardPage]: CompilerDashboardBenchmarkUIConfig,
   },
@@ -78,6 +85,11 @@ export const PREDEFINED_BENCHMARK_CONFIG: BenchmarkConfigMap = {
 };
 
 export const BENCHMARK_ID_MAPPING: Record<string, BenchmarkIdMappingItem> = {
+  [BETTER_BENCHMARK_ID]: {
+    id: BETTER_BENCHMARK_ID,
+    repoName: "pytorch/pytorch",
+    benchmarkName: "inductor-kernel-benchmark",
+  },
   [COMPILTER_BENCHMARK_NAME]: {
     id: COMPILTER_BENCHMARK_NAME,
     repoName: "pytorch/pytorch",
@@ -222,6 +234,13 @@ export const BENCHMARK_CATEGORIES: BenchmarkCategoryGroup[] = [
             href: "/benchmark/llms?repoName=pytorch%2Fpytorch&benchmarkName=PyTorch+operator+microbenchmark",
           },
         ],
+      },
+      {
+        name: "Better Benchmark",
+        route: `/benchmark/v3/dashboard/${BETTER_BENCHMARK_ID}`,
+        info: "Powered by [better-benchmark](https://github.com/eellison/better-benchmark), which extracts and deduplicates fused kernel regions from real model compilations, and the [PyTorch B200 workflow](https://github.com/pytorch/pytorch/blob/main/.github/workflows/better-benchmark-b200.yml).",
+        description:
+          "Nightly B200 measurements of TorchInductor kernels across retained model shapes, including latency and gap to memory-bandwidth SOL.",
       },
       {
         name: "Triton Benchmark",

--- a/torchci/components/benchmark_v3/configs/teams/compilers/inductor_kernel_benchmark_config.ts
+++ b/torchci/components/benchmark_v3/configs/teams/compilers/inductor_kernel_benchmark_config.ts
@@ -1,0 +1,83 @@
+import {
+  BenchmarkUIConfig,
+  SubSectionRenderConfig,
+  UIRenderConfig,
+} from "../../config_book_types";
+import { BenchmarkComparisonPolicyConfig } from "../../helpers/RegressionPolicy";
+import {
+  DEFAULT_DASHBOARD_BENCHMARK_INITIAL,
+  defaultDashboardBenchmarkUIConfig,
+} from "../defaults/default_dashboard_config";
+
+export const BETTER_BENCHMARK_ID = "better_benchmark";
+
+const LOWER_IS_BETTER_POLICY: BenchmarkComparisonPolicyConfig = {
+  target: "latency_us",
+  type: "ratio",
+  ratioPolicy: {
+    badRatio: 1.05,
+    goodRatio: 0.95,
+    direction: "down",
+  },
+};
+
+const COMPARISON_POLICY = {
+  latency_us: LOWER_IS_BETTER_POLICY,
+  gap_vs_sol: {
+    ...LOWER_IS_BETTER_POLICY,
+    target: "gap_vs_sol",
+  },
+};
+
+function withComparisonPolicy(render: UIRenderConfig): UIRenderConfig {
+  if (render.type !== "AutoBenchmarkTimeSeriesTable") {
+    return render;
+  }
+  return {
+    ...render,
+    config: {
+      ...render.config,
+      comparisonPolicy: COMPARISON_POLICY,
+    },
+  };
+}
+
+const defaultDataRender = defaultDashboardBenchmarkUIConfig.dataRender;
+
+export const BetterBenchmarkDashboardConfig: BenchmarkUIConfig = {
+  ...defaultDashboardBenchmarkUIConfig,
+  benchmarkId: BETTER_BENCHMARK_ID,
+  apiId: BETTER_BENCHMARK_ID,
+  title: "Better Benchmark",
+  type: "dashboard",
+  dataBinding: {
+    ...defaultDashboardBenchmarkUIConfig.dataBinding,
+    initial: {
+      ...DEFAULT_DASHBOARD_BENCHMARK_INITIAL,
+      benchmarkId: BETTER_BENCHMARK_ID,
+      filters: {
+        device: "cuda",
+        arch: "NVIDIA B200",
+        deviceName: "cuda||NVIDIA B200",
+      },
+    },
+  },
+  dataRender: {
+    ...defaultDataRender,
+    renders: (defaultDataRender.renders ?? []).map(withComparisonPolicy),
+    subSectionRenders: Object.fromEntries(
+      (
+        Object.entries(defaultDataRender.subSectionRenders ?? {}) as [
+          string,
+          SubSectionRenderConfig
+        ][]
+      ).map(([name, section]) => [
+        name,
+        {
+          ...section,
+          renders: section.renders.map(withComparisonPolicy),
+        },
+      ])
+    ),
+  },
+};


### PR DESCRIPTION
Adds a PyTorch Inductor kernel benchmark dashboard backed by results from better-benchmark.

- Registers pytorch_inductor_kernel_benchmark.
- Maps it to inductor-kernel-benchmark records from pytorch/pytorch.
- Adds lower-is-better comparison policies for latency_us and gap_vs_sol.
- Defaults to CUDA on NVIDIA B200.
- Adds the dashboard to the PyTorch benchmark catalog.

the benchmark CI was validated in [pytorch/pytorch#192659](https://github.com/pytorch/pytorch/pull/192659) [B200 run](https://github.com/pytorch/pytorch/actions/runs/31334635356) generated and uploaded 3,454 records for 1,727 kernels.