### PR TITLE
[hud] Distinguish stale queued rows from real queue signal in metrics

### DIFF
--- a/torchci/clickhouse_queries/queued_jobs_by_label/query.sql
+++ b/torchci/clickhouse_queries/queued_jobs_by_label/query.sql
@@ -23,6 +23,7 @@ WITH possible_queued_jobs as (
 ec2_queued_jobs AS (
     SELECT
         DATE_DIFF('second', job.created_at, CURRENT_TIMESTAMP()) AS queue_s,
+        job.created_at AS created_at,
         CONCAT(workflow.name, ' / ', job.name) AS name,
         job.html_url,
         IF(
@@ -56,6 +57,7 @@ ec2_queued_jobs AS (
 arc_queued_jobs AS (
     SELECT
         DATE_DIFF('second', job.created_at, CURRENT_TIMESTAMP()) AS queue_s,
+        job.created_at AS created_at,
         CONCAT(workflow.name, ' / ', job.name) AS name,
         job.html_url,
         IF(LENGTH(job.labels) > 1, job.labels [ 2 ], job.labels [ 1 ]) AS machine_type
@@ -85,17 +87,49 @@ arc_queued_jobs AS (
              AND LENGTH(job.steps) <= 2
              AND job.created_at > (CURRENT_TIMESTAMP() - INTERVAL 10 MINUTE))
         )
+),
+--- Last time a runner of each machine type actually picked up work.
+--- Not filtered by repository: these runner pools are shared across the org,
+--- so any repo's job starting proves the pool was serving that label.
+last_started_by_label AS (
+    SELECT
+        IF(LENGTH(labels) > 1, labels [ 2 ], labels [ 1 ]) AS machine_type,
+        MAX(started_at) AS last_started_at
+    FROM default.workflow_job
+    WHERE
+        started_at > (CURRENT_TIMESTAMP() - INTERVAL 1 DAY)
+        AND status != 'queued'
+        AND LENGTH(labels) > 0
+    GROUP BY machine_type
+),
+--- A queued row is stale when the pool for its label has already started a job
+--- that was created later than this one. Dispatch within a label is roughly
+--- FIFO, so being overtaken means this row was orphaned (typically a dropped
+--- terminating webhook), not that capacity is unavailable. When a pool is
+--- genuinely starved nothing newer starts, so real backlogs stay unflagged.
+classified_jobs AS (
+    SELECT
+        q.queue_s AS queue_s,
+        q.machine_type AS machine_type,
+        l.last_started_at > q.created_at AS is_stale
+    FROM (
+        SELECT queue_s, created_at, machine_type FROM ec2_queued_jobs
+        UNION ALL
+        SELECT queue_s, created_at, machine_type FROM arc_queued_jobs
+    ) AS q
+    LEFT JOIN last_started_by_label AS l ON l.machine_type = q.machine_type
 )
 SELECT
     COUNT(*) AS count,
+    --- Unchanged: max over all rows. Kept under the historical name so the
+    --- persisted queue_times_historical column and its consumers still work.
     MAX(queue_s) AS avg_queue_s,
+    --- Same statistic with stale rows removed: the queue signal to trust.
+    MAX(IF(is_stale, 0, queue_s)) AS active_queue_s,
+    countIf(is_stale) AS stale_count,
     machine_type,
     CURRENT_TIMESTAMP() AS time
-FROM (
-    SELECT queue_s, machine_type FROM ec2_queued_jobs
-    UNION ALL
-    SELECT queue_s, machine_type FROM arc_queued_jobs
-)
+FROM classified_jobs
 GROUP BY
     machine_type
 ORDER BY

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -864,7 +864,9 @@ export default function Page() {
             columns={[
               { field: "count", headerName: "Count", flex: 1 },
               {
-                field: "avg_queue_s",
+                // Excludes rows the query flagged as stale, so an orphaned
+                // record cannot colour a machine type red on its own.
+                field: "active_queue_s",
                 headerName: "Queue time",
                 flex: 1,
                 valueFormatter: (params: number) => durationDisplay(params),
@@ -875,13 +877,28 @@ export default function Page() {
                   return "";
                 },
               },
+              {
+                // MAX over every queued row, stale ones included. Named
+                // avg_queue_s for historical reasons; it has never been a mean.
+                field: "avg_queue_s",
+                headerName: "Oldest queued",
+                flex: 1,
+                valueFormatter: (params: number) => durationDisplay(params),
+              },
+              {
+                field: "stale_count",
+                headerName: "Stale",
+                flex: 1,
+                description:
+                  "Queued rows the pool has already overtaken - almost always a dropped webhook rather than real queueing.",
+              },
               { field: "machine_type", headerName: "Machine Type", flex: 4 },
             ]}
             dataGridProps={{
               getRowId: (el: any) => el.machine_type,
               initialState: {
                 sorting: {
-                  sortModel: [{ field: "avg_queue_s", sort: "desc" }],
+                  sortModel: [{ field: "active_queue_s", sort: "desc" }],
                 },
               },
               onRowClick: (params: any) => {


### PR DESCRIPTION
## Problem

The "Queue time" column on the metrics page is `MAX(queue_s)`, despite the column being named `avg_queue_s` — `queue_times_historical/query.sql` already carries a `/* misnomer, this is the max queue time, not the avg queue time */` comment about this.

Because it is a max, **a single orphaned queued row sets the displayed queue time for an entire machine type**, and keeps it there. Nothing bounds the age of a queued ARC row, so an orphan drifts upward until it falls out of the query's `INTERVAL 1 WEEK` candidate window. A machine type can therefore show multi-day "queue time" while the pool is running normally.

Concretely, `mt-l-x86aavx2-29-113-a10g` (the ARC replacement for `linux.g5.4xlarge.nvidia.gpu`, ~596 concurrent / 695 peak) can display a multi-day queue while comfortably serving traffic.

## Approach

Rather than an age cutoff, this asks a question the data can answer: **has the pool for this label already started a job that was created later than this one?**

```sql
last_started_by_label AS (
    SELECT
        IF(LENGTH(labels) > 1, labels [ 2 ], labels [ 1 ]) AS machine_type,
        MAX(started_at) AS last_started_at
    FROM default.workflow_job
    WHERE started_at > (CURRENT_TIMESTAMP() - INTERVAL 1 DAY)
      AND status != 'queued'
      AND LENGTH(labels) > 0
    GROUP BY machine_type
)
```

Dispatch within a label is roughly FIFO, so being overtaken means the row was orphaned — typically a dropped terminating webhook — not that capacity is unavailable.

The property that makes this safe: **when a pool is genuinely starved, nothing newer starts, so a real backlog is never flagged stale.** An age threshold could not make that distinction and would risk hiding an outage.

## Changes

`torchci/clickhouse_queries/queued_jobs_by_label/query.sql`
- adds `active_queue_s` — the same max with stale rows excluded
- adds `stale_count`
- leaves `avg_queue_s` unchanged in meaning. It is a persisted column on `queue_times_historical`, written by `aws/lambda/clickhouse-replicator-s3` and read by `tools/torchci/queue_alert.py` and `aws/lambda/ci-queue-pct`. This change is purely additive; nothing downstream breaks.

`torchci/pages/metrics.tsx`
- "Queue time" now reads `active_queue_s` and carries the red/yellow thresholds, so an orphan can no longer colour a machine type red
- the previous value remains visible as "Oldest queued"
- adds a "Stale" count column
- default sort moves to `active_queue_s`

## Testing

**Not yet run against ClickHouse — this is why the PR is a draft.** Before merge it needs a real run of `queued_jobs_by_label` plus a torchci build to confirm the new columns render.

Reviewers may want to sanity check:
- a machine type currently showing a large queue time, to see whether it resolves to `stale_count > 0` with a small `active_queue_s`
- a machine type under genuine load, to confirm `active_queue_s` still tracks `avg_queue_s` (nothing incorrectly suppressed)

Behaviour on a label absent from `last_started_by_label`: the `LEFT JOIN` yields epoch, so `is_stale` is false. Unknown labels count as real queueing, which is the conservative direction.

## Follow-ups, deliberately not in this PR

- `tools/torchci/queue_alert.py` still alerts on the stale-inclusive `avg_queue_s`, so an orphan can page oncall. Changing that alters paging behaviour and should have the owners' sign-off in its own PR.
- Renaming `avg_queue_s` to something truthful is a schema migration across the persisted table, the replicator lambda, and three consumers. Out of scope here.

---

🤖 Drafted with assistance from Claude Code; reviewed by @atalman before opening.