### PR TITLE
torchci: let preview deployments use their own GitHub App

### DIFF
--- a/torchci/.env.example
+++ b/torchci/.env.example
@@ -2,9 +2,16 @@
 # these keys can be found on Keeper.
 
 # GitHub App credentials for probot. Only needed if testing bot stuff locally.
+# PRIVATE_KEY is the base64 of the whole .pem file, not the PEM text.
 PRIVATE_KEY=
 APP_ID=
 WEBHOOK_SECRET=
+
+# Preview deployments (VERCEL_ENV=preview) use their own GitHub App so they
+# cannot act as the production bot. Set these on the Preview environment only;
+# they fall back to APP_ID/PRIVATE_KEY when unset.
+PREVIEW_PRIVATE_KEY=
+PREVIEW_APP_ID=
 
 # AWS Access key for Dynamo/S3. Only needed if testing lambda stuff locally.
 OUR_AWS_ACCESS_KEY_ID=

--- a/torchci/lib/github.ts
+++ b/torchci/lib/github.ts
@@ -2,17 +2,39 @@ import { createAppAuth } from "@octokit/auth-app";
 import { App, Octokit } from "octokit";
 import { CommitData } from "./types";
 
+// Preview deployments authenticate as their own GitHub App, so a preview can
+// never act as the production bot. Falls back to the production pair when the
+// preview one is not configured, to keep existing previews working.
+function getAppCredentials(): { appId: string; privateKey: string } {
+  const isPreview = process.env.VERCEL_ENV === "preview";
+  const appId = (isPreview && process.env.PREVIEW_APP_ID) || process.env.APP_ID;
+  const encodedPrivateKey =
+    (isPreview && process.env.PREVIEW_PRIVATE_KEY) || process.env.PRIVATE_KEY;
+
+  if (!appId || !encodedPrivateKey) {
+    const names = isPreview
+      ? "PREVIEW_APP_ID and PREVIEW_PRIVATE_KEY"
+      : "APP_ID and PRIVATE_KEY";
+    throw new Error(`Missing GitHub App credentials: ${names} are not set.`);
+  }
+
+  // Both variables hold the base64 of the whole .pem file, not the PEM text.
+  return {
+    appId,
+    privateKey: Buffer.from(encodedPrivateKey, "base64").toString(),
+  };
+}
+
 // Retrieve an Octokit instance authenticated as PyTorchBot's installation on
 // the given repo.
 export async function getOctokit(
   owner: string,
   repo: string
 ): Promise<Octokit> {
-  let privateKey = process.env.PRIVATE_KEY as string;
-  privateKey = Buffer.from(privateKey, "base64").toString();
+  const { appId, privateKey } = getAppCredentials();
 
   const app = new App({
-    appId: process.env.APP_ID!,
+    appId,
     privateKey,
   });
 
@@ -32,7 +54,7 @@ export async function getOctokit(
   return new Octokit({
     authStrategy: createAppAuth,
     auth: {
-      appId: process.env.APP_ID,
+      appId,
       privateKey,
       installationId: installation.data.id,
     },


### PR DESCRIPTION
`getOctokit()` reads `APP_ID` and `PRIVATE_KEY` directly, so a preview deployment can only authenticate as the production PyTorchBot app. Giving previews that pair hands every branch deployment the bot's write access — Dr.CI comment posting (`pages/api/drci/drci.ts`), flaky-test issue creation (`pages/api/flaky-tests/disable.ts`) and `workflow_dispatch` on pytorch/pytorch (`pages/api/github/dispatch/...`).

Adds `PREVIEW_APP_ID` and `PREVIEW_PRIVATE_KEY`, preferred when `VERCEL_ENV === "preview"`. This follows the convention already in `pages/api/auth/[...nextauth].ts`, which gates `PREVIEW_USER`/`PREVIEW_PASS` on the same variable. A separate app can then be scoped read-only — Metadata, Contents, Pull requests, Issues — which is everything the HUD read path needs (`repos.listCommits` in `lib/fetchHud.ts`), so previews render but cannot write.

Falls back to `APP_ID`/`PRIVATE_KEY` when the preview pair is absent, so nothing changes for existing deployments until the new variables are set on the Preview environment. Tightening that to a hard requirement is a one-line change once every preview has them.

Also replaces a silent failure. With the variable unset, `Buffer.from(undefined, "base64")` threw:

```
TypeError: The "string" argument must be of type string or an instance of Buffer. Received undefined
```

which gives no hint which variable is missing — and `/api/hud/...` surfaces it verbatim via `res.status(500).json({ error: error.message })`. It now names the pair it expected.

### Deploying

Both variables hold the **base64 of the whole `.pem`**, not the PEM text — same convention as the existing `PRIVATE_KEY`, now documented in `.env.example`:

```bash
base64 -w0 pytorch-hud-preview.private-key.pem
```

Set both on the **Preview** environment only, then redeploy — Vercel binds env vars at deploy time. The app also has to be installed on the repos HUD renders, or `getOctokit` throws `Failed to get installation for repo ...`.

### Test plan

Exercised the selection logic directly for all four cases:

| `VERCEL_ENV` | vars present | result |
| --- | --- | --- |
| `production` | `APP_ID`, `PRIVATE_KEY` | uses production pair |
| `preview` | both pairs | uses `PREVIEW_*` |
| `preview` | production pair only | falls back to it |
| `preview` | neither | `Missing GitHub App credentials: PREVIEW_APP_ID and PREVIEW_PRIVATE_KEY are not set.` |

All changed lines are within prettier's 80-column width and imports are untouched, so the organize-imports plugin is unaffected. I could not run the repo's pinned prettier locally (npm installs are blocked in my environment), so CI's `prettier --check` is the real gate here.