### PR TITLE
Aggregate autorevert restart runs like any other run in the HUD (partial revert of #6954)

### DIFF
--- a/torchci/clickhouse_queries/commit_jobs_query/query.sql
+++ b/torchci/clickhouse_queries/commit_jobs_query/query.sql
@@ -37,7 +37,33 @@ WITH job AS (
         job.torchci_classification_kg.'context' as context,
         job.runner_name AS runner_name,
         workflow.head_commit. 'author'.'email' AS authorEmail,
-        job.run_attempt AS run_attempt
+        job.run_attempt AS run_attempt,
+        -- Origin of the run, so the workflow picker can say what it is offering instead of a bare
+        -- numeric id. Same multiIf as hud_query's run_origin on purpose: one run must not read two
+        -- different ways on the grid and on this page. A plain push stays NULL -- it is the
+        -- overwhelming majority and the default reading.
+        multiIf(
+            workflow.event = 'workflow_dispatch'
+            AND workflow.head_branch LIKE 'trunk/%',
+            'autorevert',
+            job.run_attempt > 1,
+            'retry',
+            workflow.event = 'push',
+            NULL,
+            workflow.event
+        ) AS run_origin,
+        -- Who ORIGINALLY dispatched an autorevert restart. This query already joins workflow_run
+        -- for the run-level event, branch, head_sha and name, and workflow_run.actor is invariant
+        -- across re-run attempts -- so the row FINAL selects is sufficient here. hud_query starts
+        -- from workflow_job and additionally needs the latest triggering_actor and run_attempt,
+        -- which is why it pays for a separate grouped workflow_run lookup; FINAL would NOT be
+        -- sufficient for those. NULL for anything that is not a restart.
+        if(
+            workflow.event = 'workflow_dispatch'
+            AND workflow.head_branch LIKE 'trunk/%',
+            nullIf(workflow.actor. 'login', ''),
+            NULL
+        ) AS restart_actor_login
     FROM
         workflow_job job final
         INNER JOIN workflow_run workflow final ON workflow.id = job.run_id
@@ -96,7 +122,27 @@ WITH job AS (
         [ ] as context,
         '' AS runner_name,
         workflow.head_commit.author.email AS authorEmail,
-        workflow.run_attempt as run_attempt
+        workflow.run_attempt as run_attempt,
+        -- Same two columns as the branch above, because a UNION ALL needs matching shapes. These
+        -- rows carry workflow_id = 0, which fetchCommit normalizes to null and getWorkflowIdsByName
+        -- then filters out, so a startup-failure pseudo-row never reaches the picker -- they are
+        -- projected for the union, not for the dropdown.
+        multiIf(
+            workflow.event = 'workflow_dispatch'
+            AND workflow.head_branch LIKE 'trunk/%',
+            'autorevert',
+            workflow.run_attempt > 1,
+            'retry',
+            workflow.event = 'push',
+            NULL,
+            workflow.event
+        ) AS run_origin,
+        if(
+            workflow.event = 'workflow_dispatch'
+            AND workflow.head_branch LIKE 'trunk/%',
+            nullIf(workflow.actor. 'login', ''),
+            NULL
+        ) AS restart_actor_login
     FROM
         workflow_run workflow final
     WHERE
@@ -136,7 +182,9 @@ SELECT
     runner_name AS runnerName,
     authorEmail,
     time,
-    run_attempt AS runAttempt
+    run_attempt AS runAttempt,
+    run_origin AS runOrigin,
+    restart_actor_login AS restartDispatchedBy
 FROM
     job
 ORDER BY

--- a/torchci/clickhouse_queries/commit_jobs_query/query.sql
+++ b/torchci/clickhouse_queries/commit_jobs_query/query.sql
@@ -51,19 +51,7 @@ WITH job AS (
             workflow.event = 'push',
             NULL,
             workflow.event
-        ) AS run_origin,
-        -- Who ORIGINALLY dispatched an autorevert restart. This query already joins workflow_run
-        -- for the run-level event, branch, head_sha and name, and workflow_run.actor is invariant
-        -- across re-run attempts -- so the row FINAL selects is sufficient here. hud_query starts
-        -- from workflow_job and additionally needs the latest triggering_actor and run_attempt,
-        -- which is why it pays for a separate grouped workflow_run lookup; FINAL would NOT be
-        -- sufficient for those. NULL for anything that is not a restart.
-        if(
-            workflow.event = 'workflow_dispatch'
-            AND workflow.head_branch LIKE 'trunk/%',
-            nullIf(workflow.actor. 'login', ''),
-            NULL
-        ) AS restart_actor_login
+        ) AS run_origin
     FROM
         workflow_job job final
         INNER JOIN workflow_run workflow final ON workflow.id = job.run_id
@@ -123,9 +111,9 @@ WITH job AS (
         '' AS runner_name,
         workflow.head_commit.author.email AS authorEmail,
         workflow.run_attempt as run_attempt,
-        -- Same two columns as the branch above, because a UNION ALL needs matching shapes. These
-        -- rows carry workflow_id = 0, which fetchCommit normalizes to null and getWorkflowIdsByName
-        -- then filters out, so a startup-failure pseudo-row never reaches the picker -- they are
+        -- Same column as the branch above, because a UNION ALL needs matching shapes. These rows
+        -- carry workflow_id = 0, which fetchCommit normalizes to null and getWorkflowIdsByName then
+        -- filters out, so a startup-failure pseudo-row never reaches the picker -- this is
         -- projected for the union, not for the dropdown.
         multiIf(
             workflow.event = 'workflow_dispatch'
@@ -136,13 +124,7 @@ WITH job AS (
             workflow.event = 'push',
             NULL,
             workflow.event
-        ) AS run_origin,
-        if(
-            workflow.event = 'workflow_dispatch'
-            AND workflow.head_branch LIKE 'trunk/%',
-            nullIf(workflow.actor. 'login', ''),
-            NULL
-        ) AS restart_actor_login
+        ) AS run_origin
     FROM
         workflow_run workflow final
     WHERE
@@ -183,8 +165,7 @@ SELECT
     authorEmail,
     time,
     run_attempt AS runAttempt,
-    run_origin AS runOrigin,
-    restart_actor_login AS restartDispatchedBy
+    run_origin AS runOrigin
 FROM
     job
 ORDER BY

--- a/torchci/clickhouse_queries/commit_jobs_query/query.sql
+++ b/torchci/clickhouse_queries/commit_jobs_query/query.sql
@@ -46,6 +46,7 @@ WITH job AS (
         AND job.name != 'generate-test-matrix'
         AND workflow.event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
         AND workflow.event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
+        AND NOT (workflow.event = 'workflow_dispatch' AND workflow.head_branch LIKE 'trunk/%' AND job.conclusion_kg != 'success') -- Autorevert restart jobs count only when they PASSED (see hud_query); fetchCommit dedups by newest id with no flaky marker at all, so a non-success restart row would silently replace the natural conclusion
         AND workflow.id in (select id from materialized_views.workflow_run_by_head_sha where head_sha = {sha: String})
         AND (
             {workflowId: Int64} = 0
@@ -93,6 +94,7 @@ WITH job AS (
     WHERE
         workflow.event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
         AND workflow.event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
+        AND NOT (workflow.event = 'workflow_dispatch' AND workflow.head_branch LIKE 'trunk/%' AND workflow.conclusion != 'success') -- Autorevert restart runs count only when they PASSED. This branch maps a still-queued run to 'failure', so admitting a restart here would put a red "Workflow Startup Failure / trunk" box on the commit page for the whole queue window
         AND workflow.id in (select id from materialized_views.workflow_run_by_head_sha where head_sha = {sha: String})
         AND (
             {workflowId: Int64} = 0

--- a/torchci/clickhouse_queries/commit_jobs_query/query.sql
+++ b/torchci/clickhouse_queries/commit_jobs_query/query.sql
@@ -46,7 +46,6 @@ WITH job AS (
         AND job.name != 'generate-test-matrix'
         AND workflow.event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
         AND workflow.event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
-        AND NOT (workflow.event = 'workflow_dispatch' AND workflow.head_branch LIKE 'trunk/%') -- Filter out restart jobs
         AND workflow.id in (select id from materialized_views.workflow_run_by_head_sha where head_sha = {sha: String})
         AND (
             {workflowId: Int64} = 0
@@ -94,7 +93,6 @@ WITH job AS (
     WHERE
         workflow.event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
         AND workflow.event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
-        AND NOT (workflow.event = 'workflow_dispatch' AND workflow.head_branch LIKE 'trunk/%') -- Filter out restart jobs
         AND workflow.id in (select id from materialized_views.workflow_run_by_head_sha where head_sha = {sha: String})
         AND (
             {workflowId: Int64} = 0

--- a/torchci/clickhouse_queries/commit_jobs_query/query.sql
+++ b/torchci/clickhouse_queries/commit_jobs_query/query.sql
@@ -46,7 +46,15 @@ WITH job AS (
         AND job.name != 'generate-test-matrix'
         AND workflow.event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
         AND workflow.event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
-        AND NOT (workflow.event = 'workflow_dispatch' AND workflow.head_branch LIKE 'trunk/%' AND job.conclusion_kg != 'success') -- Autorevert restart jobs count only when they PASSED (see hud_query); fetchCommit dedups by newest id with no flaky marker at all, so a non-success restart row would silently replace the natural conclusion
+        -- KNOWN DIVERGENCE FROM hud_query, deliberate. hud_query no longer filters restarts by
+        -- conclusion at all: it admits every run and lets mergeCellRuns decide the cell
+        -- issuer-agnostically, so a restart that failed makes a passing cell render flaky instead of
+        -- vanishing. This surface cannot do that yet -- fetchCommit dedups by newest id and has no
+        -- flaky marker to render, so admitting a non-success restart here would silently REPLACE the
+        -- natural conclusion rather than combine with it. Until the commit page can express a flaky
+        -- result, the success-only filter stays, and the grid and the commit page will disagree about
+        -- a commit whose restart failed.
+        AND NOT (workflow.event = 'workflow_dispatch' AND workflow.head_branch LIKE 'trunk/%' AND job.conclusion_kg != 'success')
         AND workflow.id in (select id from materialized_views.workflow_run_by_head_sha where head_sha = {sha: String})
         AND (
             {workflowId: Int64} = 0

--- a/torchci/clickhouse_queries/hud_query/query.sql
+++ b/torchci/clickhouse_queries/hud_query/query.sql
@@ -33,6 +33,7 @@ WITH job AS (
         )  -- Should be filtered out by the workflow_event filters, but workflow_event takes some time to populate
         AND job.workflow_event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
         AND job.workflow_event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
+        AND NOT (job.workflow_event = 'workflow_dispatch' AND job.head_branch LIKE 'trunk/%' AND job.conclusion_kg != 'success') -- Autorevert restart jobs count only when they PASSED: fetchHud's failedPreviousRun can label a success that failed before ("F", flaky), but has no way to label a restart that failed, is still running, or was skipped by the dispatch filter
         AND job.id in (select id from materialized_views.workflow_job_by_head_sha where head_sha in {shas: Array(String)})
         AND job.repository_full_name = {repo: String}
         AND job.workflow_name != 'Upload test stats while running' -- Continuously running cron job that cancels itself to avoid running concurrently

--- a/torchci/clickhouse_queries/hud_query/query.sql
+++ b/torchci/clickhouse_queries/hud_query/query.sql
@@ -18,10 +18,56 @@ WITH job AS (
         job.torchci_classification_kg.'line' as line,
         job.torchci_classification_kg.'captures' as captures,
         job.torchci_classification_kg.'line_num' as line_num,
-        annotation.annotation as annotation
+        annotation.annotation as annotation,
+        -- Provenance for the rows the restart clause below now admits: mark a job that came from
+        -- an autorevert restart run, so the tooltip can say so instead of leaving an unexplained
+        -- green cell for a job the commit never naturally ran.
+        -- NULL rather than '' on purpose: fetchHud strips nulls before shipping the grid, so this
+        -- costs nothing on the ordinary jobs that are the vast majority of rows.
+        if(
+            job.workflow_event = 'workflow_dispatch'
+            AND job.head_branch LIKE 'trunk/%',
+            'autorevert',
+            NULL
+        ) AS restart_source,
+        tupleElement(restart_run.latest, 1) as restart_actor_login,
+        tupleElement(restart_run.latest, 2) as restart_triggering_actor_login,
+        tupleElement(restart_run.latest, 3) as restart_run_attempt
     FROM
         workflow_job job final
         LEFT JOIN job_annotation annotation final ON job.id = annotation.jobID
+        -- workflow_job carries no actor column, so the dispatching identity has to come from
+        -- workflow_run. Scoped to restart runs for the requested shas only, and keyed through the
+        -- same materialized view commit_jobs_query uses so this is a primary-key lookup instead of
+        -- a scan on head_sha (which is not in workflow_run's sorting key).
+        -- GROUP BY + argMax rather than FINAL: workflow_run is a ReplacingMergeTree with no version
+        -- column, and FINAL on it measured ~5.6s against ~0.7s for this shape on the same input.
+        -- run_attempt is monotonic per run, so argMax also expresses what we actually want here --
+        -- the latest attempt -- which FINAL alone does not guarantee.
+        LEFT JOIN (
+            SELECT
+                id,
+                -- ONE argMax over a tuple rather than three separate ones: independent argMax calls
+                -- may resolve their tie differently and report an actor from one physical row with a
+                -- triggering actor from another. Ordering by run_attempt takes the latest attempt.
+                argMax(
+                    (actor.'login', triggering_actor.'login', run_attempt),
+                    run_attempt
+                ) AS latest
+            FROM workflow_run
+            WHERE
+                id in (
+                    select id from materialized_views.workflow_run_by_head_sha
+                    where head_sha in {shas: Array(String)}
+                )
+                -- That materialized view is keyed on head_sha ALONE (its only columns are id and
+                -- head_sha), so it can return a run id belonging to a different repo that shares the
+                -- sha -- a fork, most obviously. Constrain the repo here, since the MV cannot.
+                AND repository.'full_name' = {repo: String}
+                AND event = 'workflow_dispatch'
+                AND head_branch LIKE 'trunk/%'
+            GROUP BY id
+        ) restart_run ON restart_run.id = job.run_id
     WHERE
         job.name != 'ciflow_should_run'
         AND job.name != 'generate-test-matrix'
@@ -61,6 +107,33 @@ SELECT
     if(line = '', [ ], [ line ]) AS failureLines,
     if(line_num = 0, [ ], [ line_num ]) AS failureLineNumbers,
     captures as failureCaptures,
-    annotation as failureAnnotation
+    annotation as failureAnnotation,
+    restart_source as restartSource,
+    -- Every provenance field below is gated on restart_source, so none can ever appear on a job the
+    -- badge does not also mark. The two sides are derived independently -- the badge from
+    -- workflow_job, the identity from workflow_run -- and nothing guarantees they agree under
+    -- ingestion lag. The reverse case (badge present, identity missing) stays possible and renders
+    -- fine, since each field is conditional in the tooltip.
+    -- An unmatched LEFT JOIN also yields the column default ('' / 0) rather than NULL, so normalize:
+    -- fetchHud strips only nulls, and an empty string would ship on every ordinary job and make
+    -- "field is present" a false test for "this job is a restart".
+    if(restart_source IS NULL, NULL, nullIf(restart_actor_login, '')) as restartDispatchedBy,
+    -- Only meaningful when it differs: triggering_actor equals the actor on a first attempt, and
+    -- names whoever re-ran the run on later ones. Collapsing the two would hide a human re-running
+    -- a bot's restart.
+    if(
+        restart_source IS NOT NULL
+        AND restart_triggering_actor_login != ''
+        AND restart_triggering_actor_login != restart_actor_login,
+        restart_triggering_actor_login,
+        NULL
+    ) as restartRerunBy,
+    -- Deliberately NOT called runAttempt: commit_jobs_query already ships that name with different
+    -- semantics (the JOB's run_attempt), and the HUD page reads it at
+    -- pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx as `cr.run_attempt >
+    -- (existing.runAttempt ?? 0)` when merging crcr rows. That comparison relies on the field being
+    -- undefined in the HUD path today, so populating it here would silently change which job data
+    -- wins those cells.
+    if(restart_source IS NULL, NULL, nullIf(restart_run_attempt, 0)) as restartRunAttempt
 FROM
     job

--- a/torchci/clickhouse_queries/hud_query/query.sql
+++ b/torchci/clickhouse_queries/hud_query/query.sql
@@ -33,7 +33,6 @@ WITH job AS (
         )  -- Should be filtered out by the workflow_event filters, but workflow_event takes some time to populate
         AND job.workflow_event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
         AND job.workflow_event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
-        AND NOT (job.workflow_event = 'workflow_dispatch' AND job.head_branch LIKE 'trunk/%') -- Filter out restart jobs
         AND job.id in (select id from materialized_views.workflow_job_by_head_sha where head_sha in {shas: Array(String)})
         AND job.repository_full_name = {repo: String}
         AND job.workflow_name != 'Upload test stats while running' -- Continuously running cron job that cancels itself to avoid running concurrently

--- a/torchci/clickhouse_queries/hud_query/query.sql
+++ b/torchci/clickhouse_queries/hud_query/query.sql
@@ -19,17 +19,24 @@ WITH job AS (
         job.torchci_classification_kg.'captures' as captures,
         job.torchci_classification_kg.'line_num' as line_num,
         annotation.annotation as annotation,
-        -- Provenance for the rows the restart clause below now admits: mark a job that came from
-        -- an autorevert restart run, so the tooltip can say so instead of leaving an unexplained
-        -- green cell for a job the commit never naturally ran.
-        -- NULL rather than '' on purpose: fetchHud strips nulls before shipping the grid, so this
-        -- costs nothing on the ordinary jobs that are the vast majority of rows.
-        if(
+        -- Origin of the run, REPORTED but never aggregated on -- aggregation is issuer-agnostic by
+        -- design (mergeCellRuns). A plain push is left NULL rather than spelled out: it is the
+        -- overwhelming majority and the default reading, and fetchHud strips nulls before shipping
+        -- the grid, so ordinary rows cost nothing.
+        -- NULL means specifically a `push` run, so the UI can name the origin without guessing. Any
+        -- other event (schedule, a non-trunk workflow_dispatch, ...) carries its own event name --
+        -- calling those "push" would be wrong, and periodic schedules are one of the reasons a cell
+        -- has several runs in the first place.
+        multiIf(
             job.workflow_event = 'workflow_dispatch'
             AND job.head_branch LIKE 'trunk/%',
             'autorevert',
-            NULL
-        ) AS restart_source,
+            job.run_attempt > 1,
+            'retry',
+            job.workflow_event = 'push',
+            NULL,
+            job.workflow_event
+        ) AS run_origin,
         tupleElement(restart_run.latest, 1) as restart_actor_login,
         tupleElement(restart_run.latest, 2) as restart_triggering_actor_login,
         tupleElement(restart_run.latest, 3) as restart_run_attempt
@@ -79,7 +86,12 @@ WITH job AS (
         )  -- Should be filtered out by the workflow_event filters, but workflow_event takes some time to populate
         AND job.workflow_event != 'workflow_run' -- Filter out workflow_run-triggered jobs, which have nothing to do with the SHA
         AND job.workflow_event != 'repository_dispatch' -- Filter out repository_dispatch-triggered jobs, which have nothing to do with the SHA
-        AND NOT (job.workflow_event = 'workflow_dispatch' AND job.head_branch LIKE 'trunk/%' AND job.conclusion_kg != 'success') -- Autorevert restart jobs count only when they PASSED: fetchHud's failedPreviousRun can label a success that failed before ("F", flaky), but has no way to label a restart that failed, is still running, or was skipped by the dispatch filter
+        -- Autorevert restart runs are no longer filtered out here, and are deliberately NOT filtered
+        -- by conclusion either. Who issued a run must not change how the HUD aggregates it, so a
+        -- restart is admitted on the same terms as a push or a re-run attempt and the cell verdict is
+        -- decided by mergeCellRuns over the whole set of runs. Filtering by conclusion here was the
+        -- issuer-dependent shortcut this replaces: it dropped a restart that failed, was pending or
+        -- was skipped, which silently hid real results rather than aggregating them.
         AND job.id in (select id from materialized_views.workflow_job_by_head_sha where head_sha in {shas: Array(String)})
         AND job.repository_full_name = {repo: String}
         AND job.workflow_name != 'Upload test stats while running' -- Continuously running cron job that cancels itself to avoid running concurrently
@@ -108,21 +120,23 @@ SELECT
     if(line_num = 0, [ ], [ line_num ]) AS failureLineNumbers,
     captures as failureCaptures,
     annotation as failureAnnotation,
-    restart_source as restartSource,
-    -- Every provenance field below is gated on restart_source, so none can ever appear on a job the
-    -- badge does not also mark. The two sides are derived independently -- the badge from
+    run_origin as runOrigin,
+    -- The identity fields below are gated on an autorevert origin, so none can appear on a run the
+    -- origin does not also mark. The two sides are derived independently -- the origin from
     -- workflow_job, the identity from workflow_run -- and nothing guarantees they agree under
-    -- ingestion lag. The reverse case (badge present, identity missing) stays possible and renders
+    -- ingestion lag. The reverse case (origin present, identity missing) stays possible and renders
     -- fine, since each field is conditional in the tooltip.
     -- An unmatched LEFT JOIN also yields the column default ('' / 0) rather than NULL, so normalize:
-    -- fetchHud strips only nulls, and an empty string would ship on every ordinary job and make
-    -- "field is present" a false test for "this job is a restart".
-    if(restart_source IS NULL, NULL, nullIf(restart_actor_login, '')) as restartDispatchedBy,
+    -- fetchHud strips only nulls, and an empty string would ship on every ordinary run and make
+    -- "field is present" a false test for "this run was dispatched by autorevert".
+    -- coalesce, not a bare comparison: run_origin is Nullable, and `NULL != 'autorevert'` is NULL,
+    -- which would make the whole if() condition NULL rather than false.
+    if(coalesce(run_origin, '') = 'autorevert', nullIf(restart_actor_login, ''), NULL) as restartDispatchedBy,
     -- Only meaningful when it differs: triggering_actor equals the actor on a first attempt, and
     -- names whoever re-ran the run on later ones. Collapsing the two would hide a human re-running
     -- a bot's restart.
     if(
-        restart_source IS NOT NULL
+        coalesce(run_origin, '') = 'autorevert'
         AND restart_triggering_actor_login != ''
         AND restart_triggering_actor_login != restart_actor_login,
         restart_triggering_actor_login,
@@ -134,6 +148,6 @@ SELECT
     -- (existing.runAttempt ?? 0)` when merging crcr rows. That comparison relies on the field being
     -- undefined in the HUD path today, so populating it here would silently change which job data
     -- wins those cells.
-    if(restart_source IS NULL, NULL, nullIf(restart_run_attempt, 0)) as restartRunAttempt
+    if(coalesce(run_origin, '') = 'autorevert', nullIf(restart_run_attempt, 0), NULL) as restartRunAttempt
 FROM
     job

--- a/torchci/components/commit/WorkflowBox.tsx
+++ b/torchci/components/commit/WorkflowBox.tsx
@@ -16,6 +16,7 @@ import {
 import { fetcher } from "lib/GeneralUtils";
 import { getConclusionSeverityForSorting } from "lib/JobClassifierUtil";
 import { getDurationDisplay, isFailedJob } from "lib/jobUtils";
+import { describeWorkflowRun } from "lib/runOrigin";
 import { getSearchRes, LogSearchResult } from "lib/searchLogs";
 import { Artifact, IssueData, JobData } from "lib/types";
 import {
@@ -264,11 +265,17 @@ export default function WorkflowBox({
             >
               <option value={""}>Select Workflow ID</option>
               {allWorkflowIds.sort().map((id) => (
+                // A bare id says nothing about which run it is -- "which one of these was the
+                // autorevert restart" was the actual question asked in review. Every entry is
+                // named, not just the interesting ones, so the reader compares like with like
+                // rather than reading meaning into an absent label.
                 <option
                   key={`${id.id} ${id.attempt}`}
                   value={`${id.id} ${id.attempt}`}
                 >
-                  {id.id} (Attempt {id.attempt})
+                  {`${id.id} (Attempt ${id.attempt}) — ${describeWorkflowRun(
+                    id
+                  )}`}
                 </option>
               ))}
             </select>

--- a/torchci/components/job/JobTooltip.tsx
+++ b/torchci/components/job/JobTooltip.tsx
@@ -28,6 +28,26 @@ export default function JobTooltip({
   repoOwner?: string;
   repoName?: string;
 }) {
+  // Which of the cell's runs the detail area below describes. Undefined = the cell itself, which is
+  // what the grid renders. Selecting a run rebinds the log viewer, the links and the failure
+  // classification to it -- on a flaky "F" cell the cell's own fields are the run that PASSED, so
+  // without this the failure that made it flaky is not inspectable from the tooltip at all.
+  //
+  // Keyed by RUN, and scoped to the cell it was chosen in. An index would silently rebind to a
+  // different run when the grid refreshes and the run list grows or reorders; and because this
+  // component can be reused for another cell, a selection made in one cell must not survive into the
+  // next. Storing the cell alongside makes a stale selection resolve to "nothing selected" rather
+  // than to the wrong run.
+  //
+  // Declared ABOVE the does-not-exist early return below: hooks must be called in the same order on
+  // every render, and a cell can gain or lose its `id` between renders as the grid refreshes.
+  const cellKey = `${job.sha ?? ""} ${job.name ?? ""}`;
+  const [selection, setSelection] = useState<{
+    cell: string;
+    runKey?: string;
+    showAll: boolean;
+  }>({ cell: cellKey, showAll: false });
+
   // For nonexistent jobs, just show something basic:
   if (!job.hasOwnProperty("id")) {
     return (
@@ -54,22 +74,6 @@ export default function JobTooltip({
   // sit above a failed restart on exactly the cells that exist to show the restart.
   const showSingleRunOrigin = job.runOrigin != null && cellRuns == null;
 
-  // Which of the cell's runs the detail area below describes. Undefined = the cell itself, which is
-  // what the grid renders. Selecting a run rebinds the log viewer, the links and the failure
-  // classification to it -- on a flaky "F" cell the cell's own fields are the run that PASSED, so
-  // without this the failure that made it flaky is not inspectable from the tooltip at all.
-  //
-  // Keyed by RUN, and scoped to the cell it was chosen in. An index would silently rebind to a
-  // different run when the grid refreshes and the run list grows or reorders; and because this
-  // component can be reused for another cell, a selection made in one cell must not survive into the
-  // next. Storing the cell alongside makes a stale selection resolve to "nothing selected" rather
-  // than to the wrong run.
-  const cellKey = `${job.sha ?? ""} ${job.name ?? ""}`;
-  const [selection, setSelection] = useState<{
-    cell: string;
-    runKey?: string;
-    showAll: boolean;
-  }>({ cell: cellKey, showAll: false });
   const active =
     selection.cell === cellKey ? selection : { cell: cellKey, showAll: false };
   const selectedRun = cellRuns?.find((run) => runKeyOf(run) === active.runKey);

--- a/torchci/components/job/JobTooltip.tsx
+++ b/torchci/components/job/JobTooltip.tsx
@@ -38,9 +38,24 @@ export default function JobTooltip({
     repoName &&
     isJobViableStrictBlocking(job.name, repoOwner, repoName);
 
+  // Compare against the value rather than testing for presence: hud_query normalizes an unmatched
+  // LEFT JOIN to null, but a future '' would otherwise make every ordinary job look like a restart.
+  const isAutorevertRestart = job.restartSource === "autorevert";
+
   return (
     <div>
       {`[${job.conclusion}] ${job.name}`}
+      {isAutorevertRestart && (
+        <div style={{ color: "gray" }}>
+          {"Result came from an autorevert restart run"}
+          {job.restartRunAttempt != null &&
+            ` (attempt ${job.restartRunAttempt})`}
+          {job.restartDispatchedBy &&
+            `, dispatched by ${job.restartDispatchedBy}`}
+          {job.restartRerunBy && `, rerun by ${job.restartRerunBy}`}
+          {"."}
+        </div>
+      )}
       {isAutorevertSignal && (
         <div style={{ color: "red", fontWeight: "bold" }}>
           Failure in this job has triggered autorevert.

--- a/torchci/components/job/JobTooltip.tsx
+++ b/torchci/components/job/JobTooltip.tsx
@@ -5,6 +5,7 @@ import {
   describeRunIdentity,
   describeRunOrigin,
   detailJobForRun,
+  disambiguateCellRuns,
   runKeyOf,
 } from "lib/mergeCellRuns";
 import { useState } from "react";
@@ -106,6 +107,12 @@ export default function JobTooltip({
   const shownRun = selectedRun ?? cellRuns?.find((run) => run.isRepresentative);
   const shownIdentity = shownRun ? describeRunIdentity(shownRun) : "";
 
+  // Computed over EVERY run, not over the collapsed slice below: a label that only disambiguated
+  // against the visible rows would change as the reader expands the tail, and a row that reads
+  // uniquely on screen while colliding with a hidden run is still the wrong answer to "which run is
+  // this?". Empty for any row nothing else in the cell collides with -- which is most of them.
+  const runSuffix = disambiguateCellRuns(cellRuns ?? []);
+
   // Long tails exist -- one cell on a real page merges 82 runs -- and an unbounded list would push
   // the log viewer off the tooltip. Collapse the RENDERING only, never the payload, which would hide
   // the very failure that explains the cell. The list is ordered representative-then-failures, so
@@ -128,7 +135,12 @@ export default function JobTooltip({
 
   return (
     <div>
-      {`[${job.conclusion}] ${job.name}`}
+      {/* `detailJob`, not `job`: the links and the log below describe the SELECTED run, and a heading
+          built from the CELL contradicted them. On a flaky "F" cell the cell's conclusion is the
+          representative's, and rule 2 makes the representative the run that PASSED -- so picking the
+          failed run rendered its failure lines and its log under `[success]`. With nothing picked
+          `detailJobForRun` returns the cell itself, so the default heading is unchanged. */}
+      {`[${detailJob.conclusion}] ${detailJob.name}`}
       {showSingleRunOrigin && (
         <div style={{ color: "gray" }}>
           {`Run: ${describeRunOrigin(job)}`}
@@ -169,6 +181,10 @@ export default function JobTooltip({
                 // key (its run gone after a refresh) would otherwise leave the group with nothing
                 // checked while the detail area described the representative (DP17, gpt-5.6-sol).
                 const isSelected = run === shownRun;
+                // '' unless another row in this cell reads identically, in which case it names this
+                // run's own job -- the one its `gh` link opens -- or, when a job id cannot separate
+                // the collision, its workflow.
+                const suffix = runSuffix.get(run) ?? "";
                 return (
                   <div
                     key={key}
@@ -185,7 +201,7 @@ export default function JobTooltip({
                       // A mouse convenience only. What the row no longer spells out is rendered for
                       // the INSPECTED run below the list, because a title is unreachable on touch and
                       // a screen reader skips it once the row has visible text (DP17, gpt-5.6-sol).
-                      title={describeCellRun(run)}
+                      title={`${describeCellRun(run)}${suffix}`}
                       style={{
                         display: "flex",
                         alignItems: "center",
@@ -199,9 +215,22 @@ export default function JobTooltip({
                         checked={isSelected}
                         // The visible text is the ORIGIN, which two runs can share -- a periodic job
                         // scheduled twice gives two rows reading "schedule". The full description is
-                        // what distinguishes them for a screen reader (DP17, gpt-5.6-sol).
-                        aria-label={describeCellRun(run)}
-                        onClick={(e) => e.stopPropagation()}
+                        // what distinguishes them for a screen reader (DP17, gpt-5.6-sol) -- plus the
+                        // suffix, because the description alone ALSO collapses to one string for two
+                        // ordinary runs sharing an origin and a conclusion.
+                        aria-label={`${describeCellRun(run)}${suffix}`}
+                        // `onChange` alone left the ALREADY-CHECKED row inert: React fires change for
+                        // a radio only when its checked value actually changes, so clicking the
+                        // representative's row -- the one checked on a fresh hover -- ran neither
+                        // `pickRun` nor the `pinCell` inside it, and the unpinned tooltip then
+                        // vanished on mouse-out. Guarded on `isSelected` so an unchecked row is still
+                        // handled by `onChange` exactly once rather than by both handlers.
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          if (isSelected) {
+                            pickRun(key);
+                          }
+                        }}
                         onChange={() => pickRun(key)}
                       />
                       {/* The grid's own status glyph, via the grid's own component -- so a run reads
@@ -223,7 +252,7 @@ export default function JobTooltip({
                       <span
                         style={{ fontWeight: isSelected ? "bold" : "normal" }}
                       >
-                        {describeRunOrigin(run)}
+                        {`${describeRunOrigin(run)}${suffix}`}
                       </span>
                     </label>
                     {run.htmlUrl && (
@@ -232,6 +261,13 @@ export default function JobTooltip({
                         target="_blank"
                         rel="noreferrer"
                         title="open this run on GitHub"
+                        // Its visible text is "gh" on every row, so without this the links are the one
+                        // part of the list a screen reader still cannot tell apart -- the row's own
+                        // suffix reaches the radio and the origin span, not the anchor beside them
+                        // (DP17, gpt-5.6-sol).
+                        aria-label={`open ${describeRunOrigin(
+                          run
+                        )}${suffix} on GitHub`}
                         onClick={(e) => e.stopPropagation()}
                       >
                         gh

--- a/torchci/components/job/JobTooltip.tsx
+++ b/torchci/components/job/JobTooltip.tsx
@@ -1,5 +1,6 @@
 import { AdvisorVerdict } from "lib/advisorVerdictUtils";
 import { isJobViableStrictBlocking } from "lib/JobClassifierUtil";
+import { describeRunOrigin } from "lib/mergeCellRuns";
 import { JobData } from "../../lib/types";
 import { SingleWorkflowDispatcher } from "../commit/WorkflowDispatcher";
 import LogViewer from "../common/log/LogViewer";
@@ -39,21 +40,41 @@ export default function JobTooltip({
     isJobViableStrictBlocking(job.name, repoOwner, repoName);
 
   // Compare against the value rather than testing for presence: hud_query normalizes an unmatched
-  // LEFT JOIN to null, but a future '' would otherwise make every ordinary job look like a restart.
-  const isAutorevertRestart = job.restartSource === "autorevert";
+  // LEFT JOIN to null, but a future '' would otherwise make every push run look like a restart.
+  const isAutorevertRestart = job.runOrigin === "autorevert";
+  const showOrigin = job.runOrigin != null || job.mergedRunCount != null;
 
   return (
     <div>
       {`[${job.conclusion}] ${job.name}`}
-      {isAutorevertRestart && (
+      {showOrigin && (
         <div style={{ color: "gray" }}>
-          {"Result came from an autorevert restart run"}
-          {job.restartRunAttempt != null &&
+          {`Shown run: ${describeRunOrigin(job)}`}
+          {isAutorevertRestart &&
+            job.restartRunAttempt != null &&
             ` (attempt ${job.restartRunAttempt})`}
           {job.restartDispatchedBy &&
             `, dispatched by ${job.restartDispatchedBy}`}
           {job.restartRerunBy && `, rerun by ${job.restartRerunBy}`}
           {"."}
+          {job.mergedRunCount != null && (
+            <div>
+              {`Merged ${job.mergedRunCount} runs for this commit — ${job.mergedRuns}.`}
+              {/* The cell shows the success, so this is the only route to the failure behind an "F". */}
+              {job.mergedFailureUrl && (
+                <>
+                  {" "}
+                  <a
+                    href={job.mergedFailureUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    view the failing run
+                  </a>
+                </>
+              )}
+            </div>
+          )}
         </div>
       )}
       {isAutorevertSignal && (

--- a/torchci/components/job/JobTooltip.tsx
+++ b/torchci/components/job/JobTooltip.tsx
@@ -262,10 +262,14 @@ export default function JobTooltip({
                         rel="noreferrer"
                         title="open this run on GitHub"
                         // Its visible text is "gh" on every row, so without this the links are the one
-                        // part of the list a screen reader still cannot tell apart -- the row's own
-                        // suffix reaches the radio and the origin span, not the anchor beside them
-                        // (DP17, gpt-5.6-sol).
-                        aria-label={`open ${describeRunOrigin(
+                        // part of the list a screen reader cannot tell apart. Built from
+                        // `describeCellRun`, matching the radio above: the origin alone omits the
+                        // conclusion, and two runs differing ONLY in how they concluded get no
+                        // suffix -- both row signatures already separate them -- so a flaky cell's
+                        // passing and failing runs ended up with the same link name and different
+                        // targets. Opens with the visible "gh" so the accessible name contains the
+                        // visible label, which voice control matches on (DP17, gpt-5.6-sol).
+                        aria-label={`gh: open ${describeCellRun(
                           run
                         )}${suffix} on GitHub`}
                         onClick={(e) => e.stopPropagation()}

--- a/torchci/components/job/JobTooltip.tsx
+++ b/torchci/components/job/JobTooltip.tsx
@@ -1,6 +1,12 @@
 import { AdvisorVerdict } from "lib/advisorVerdictUtils";
 import { isJobViableStrictBlocking } from "lib/JobClassifierUtil";
-import { describeRunOrigin } from "lib/mergeCellRuns";
+import {
+  describeCellRun,
+  describeRunOrigin,
+  detailJobForRun,
+  runKeyOf,
+} from "lib/mergeCellRuns";
+import { useState } from "react";
 import { JobData } from "../../lib/types";
 import { SingleWorkflowDispatcher } from "../commit/WorkflowDispatcher";
 import LogViewer from "../common/log/LogViewer";
@@ -42,14 +48,49 @@ export default function JobTooltip({
   // Compare against the value rather than testing for presence: hud_query normalizes an unmatched
   // LEFT JOIN to null, but a future '' would otherwise make every push run look like a restart.
   const isAutorevertRestart = job.runOrigin === "autorevert";
-  const showOrigin = job.runOrigin != null || job.mergedRunCount != null;
+  const cellRuns = job.cellRuns;
+  // Only for a cell with ONE run. When several were merged, the list below names each of them and
+  // this line would both duplicate it and mislead: it describes the representative, so "push" would
+  // sit above a failed restart on exactly the cells that exist to show the restart.
+  const showSingleRunOrigin = job.runOrigin != null && cellRuns == null;
+
+  // Which of the cell's runs the detail area below describes. Undefined = the cell itself, which is
+  // what the grid renders. Selecting a run rebinds the log viewer, the links and the failure
+  // classification to it -- on a flaky "F" cell the cell's own fields are the run that PASSED, so
+  // without this the failure that made it flaky is not inspectable from the tooltip at all.
+  //
+  // Keyed by RUN, and scoped to the cell it was chosen in. An index would silently rebind to a
+  // different run when the grid refreshes and the run list grows or reorders; and because this
+  // component can be reused for another cell, a selection made in one cell must not survive into the
+  // next. Storing the cell alongside makes a stale selection resolve to "nothing selected" rather
+  // than to the wrong run.
+  const cellKey = `${job.sha ?? ""} ${job.name ?? ""}`;
+  const [selection, setSelection] = useState<{
+    cell: string;
+    runKey?: string;
+    showAll: boolean;
+  }>({ cell: cellKey, showAll: false });
+  const active =
+    selection.cell === cellKey ? selection : { cell: cellKey, showAll: false };
+  const selectedRun = cellRuns?.find((run) => runKeyOf(run) === active.runKey);
+  const detailJob = detailJobForRun(job, selectedRun);
+
+  // Long tails exist -- one cell on a real page merges 82 runs -- and an unbounded list would push
+  // the log viewer off the tooltip. Collapse the RENDERING only, never the payload, which would hide
+  // the very failure that explains the cell. The list is ordered representative-then-failures, so
+  // what the reader most needs is never in the collapsed tail.
+  const collapsedRunCount = 5;
+  const visibleRuns =
+    cellRuns == null || active.showAll
+      ? cellRuns
+      : cellRuns.slice(0, collapsedRunCount);
 
   return (
     <div>
       {`[${job.conclusion}] ${job.name}`}
-      {showOrigin && (
+      {showSingleRunOrigin && (
         <div style={{ color: "gray" }}>
-          {`Shown run: ${describeRunOrigin(job)}`}
+          {`Run: ${describeRunOrigin(job)}`}
           {isAutorevertRestart &&
             job.restartRunAttempt != null &&
             ` (attempt ${job.restartRunAttempt})`}
@@ -57,24 +98,68 @@ export default function JobTooltip({
             `, dispatched by ${job.restartDispatchedBy}`}
           {job.restartRerunBy && `, rerun by ${job.restartRerunBy}`}
           {"."}
-          {job.mergedRunCount != null && (
-            <div>
-              {`Merged ${job.mergedRunCount} runs for this commit — ${job.mergedRuns}.`}
-              {/* The cell shows the success, so this is the only route to the failure behind an "F". */}
-              {job.mergedFailureUrl && (
-                <>
-                  {" "}
-                  <a
-                    href={job.mergedFailureUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    view the failing run
-                  </a>
-                </>
-              )}
-            </div>
-          )}
+        </div>
+      )}
+      {cellRuns != null && visibleRuns != null && (
+        <div style={{ color: "gray" }}>
+          <div>
+            {/* Says the status combines them all, rather than naming one as "shown": the cell's
+                conclusion is a function of the whole set, and a mixed cell renders flaky "F" while
+                the run supplying its fields passed. */}
+            {`${cellRuns.length} runs for this commit — the cell's status combines all of them. Click one to inspect it:`}
+            {/* The surrounding cell pins on click and opens the job page on DOUBLE click, and
+                  dblclick bubbles separately from click -- so stopping click alone would still let a
+                  double-click on a run navigate away while toggling the selection twice. */}
+            <ul
+              style={{ margin: 0, paddingLeft: "1.2em" }}
+              onDoubleClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+            >
+              {visibleRuns.map((run) => {
+                const key = runKeyOf(run);
+                const isSelected = key === active.runKey;
+                return (
+                  <li key={key}>
+                    <a
+                      href="#"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        setSelection({
+                          cell: cellKey,
+                          runKey: isSelected ? undefined : key,
+                          showAll: active.showAll,
+                        });
+                      }}
+                      style={{ fontWeight: isSelected ? "bold" : "normal" }}
+                    >
+                      {describeCellRun(run)}
+                    </a>
+                    {run.isRepresentative &&
+                      " (this cell's duration and default links)"}
+                  </li>
+                );
+              })}
+            </ul>
+            {!active.showAll && cellRuns.length > collapsedRunCount && (
+              <a
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setSelection({ ...active, showAll: true });
+                }}
+                onDoubleClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }}
+              >
+                {`show ${cellRuns.length - collapsedRunCount} more`}
+              </a>
+            )}
+          </div>
         </div>
       )}
       {isAutorevertSignal && (
@@ -97,8 +182,9 @@ export default function JobTooltip({
       <div>
         <em>click to pin this tooltip, double-click for job page</em>
       </div>
-      <JobLinks job={job} showCommitLink={true} />
-      <LogViewer job={job} />
+      {/* detailJob, not job: these describe the SELECTED run when the reader picked one. */}
+      <JobLinks job={detailJob} showCommitLink={true} />
+      <LogViewer job={detailJob} />
     </div>
   );
 }

--- a/torchci/components/job/JobTooltip.tsx
+++ b/torchci/components/job/JobTooltip.tsx
@@ -2,6 +2,7 @@ import { AdvisorVerdict } from "lib/advisorVerdictUtils";
 import { isJobViableStrictBlocking } from "lib/JobClassifierUtil";
 import {
   describeCellRun,
+  describeRunIdentity,
   describeRunOrigin,
   detailJobForRun,
   runKeyOf,
@@ -11,6 +12,7 @@ import { JobData } from "../../lib/types";
 import { SingleWorkflowDispatcher } from "../commit/WorkflowDispatcher";
 import LogViewer from "../common/log/LogViewer";
 import AdvisorSection from "./AdvisorSection";
+import JobConclusion from "./JobConclusion";
 import JobLinks from "./JobLinks";
 
 export default function JobTooltip({
@@ -20,6 +22,7 @@ export default function JobTooltip({
   advisorVerdict,
   repoOwner,
   repoName,
+  pinCell,
 }: {
   job: JobData;
   sha?: string;
@@ -27,6 +30,10 @@ export default function JobTooltip({
   advisorVerdict?: AdvisorVerdict;
   repoOwner?: string;
   repoName?: string;
+  // Pin this cell's tooltip open, so a choice made in it survives the pointer leaving the cell. The
+  // caller owns the pinning policy; this component only says when the reader has acted. Passed in
+  // rather than read from PinnedTooltipContext so this component keeps no dependency on the HUD page.
+  pinCell?: () => void;
 }) {
   // Which of the cell's runs the detail area below describes. Undefined = the cell itself, which is
   // what the grid renders. Selecting a run rebinds the log viewer, the links and the failure
@@ -74,20 +81,50 @@ export default function JobTooltip({
   // sit above a failed restart on exactly the cells that exist to show the restart.
   const showSingleRunOrigin = job.runOrigin != null && cellRuns == null;
 
+  // One radio group per CELL. Two tooltips can be mounted at once -- a pinned one and a hovered one
+  // -- and a shared `name` would let picking a run in one clear the selection rendered in the other,
+  // since a radio group is global to the document.
+  const radioGroup = `cellRuns ${cellKey}`;
+
   const active =
     selection.cell === cellKey ? selection : { cell: cellKey, showAll: false };
+
+  function pickRun(runKey: string) {
+    setSelection({ cell: cellKey, runKey, showAll: active.showAll });
+    // A choice has to outlive the pointer. An UNPINNED tooltip is mounted only while the cell is
+    // hovered (TooltipTarget), so it unmounts on mouse-out and takes this component's state with it --
+    // picking a run then looked like nothing had happened, because by the time the reader looked at
+    // the detail area the selection no longer existed. Clicking a run cannot pin via the cell's own
+    // handler either: these rows must stop propagation to keep a double-click from navigating.
+    pinCell?.();
+  }
   const selectedRun = cellRuns?.find((run) => runKeyOf(run) === active.runKey);
   const detailJob = detailJobForRun(job, selectedRun);
+
+  // The run the detail area is describing: the picked one, or the representative while nothing has
+  // been picked -- the same rule the radios are checked by, so the two cannot disagree.
+  const shownRun = selectedRun ?? cellRuns?.find((run) => run.isRepresentative);
+  const shownIdentity = shownRun ? describeRunIdentity(shownRun) : "";
 
   // Long tails exist -- one cell on a real page merges 82 runs -- and an unbounded list would push
   // the log viewer off the tooltip. Collapse the RENDERING only, never the payload, which would hide
   // the very failure that explains the cell. The list is ordered representative-then-failures, so
   // what the reader most needs is never in the collapsed tail.
   const collapsedRunCount = 5;
-  const visibleRuns =
+  let visibleRuns =
     cellRuns == null || active.showAll
       ? cellRuns
       : cellRuns.slice(0, collapsedRunCount);
+  // A run picked before a grid refresh can land in the collapsed tail afterwards: the list is rebuilt
+  // and re-ordered from fresh data. Keep it rendered, or the detail area would describe a run with no
+  // checked radio anywhere on screen (DP17, gpt-5.6-sol).
+  if (
+    visibleRuns != null &&
+    selectedRun != null &&
+    !visibleRuns.includes(selectedRun)
+  ) {
+    visibleRuns = [...visibleRuns, selectedRun];
+  }
 
   return (
     <div>
@@ -110,12 +147,16 @@ export default function JobTooltip({
             {/* Says the status combines them all, rather than naming one as "shown": the cell's
                 conclusion is a function of the whole set, and a mixed cell renders flaky "F" while
                 the run supplying its fields passed. */}
-            {`${cellRuns.length} runs for this commit — the cell's status combines all of them. Click one to inspect it:`}
-            {/* The surrounding cell pins on click and opens the job page on DOUBLE click, and
-                  dblclick bubbles separately from click -- so stopping click alone would still let a
-                  double-click on a run navigate away while toggling the selection twice. */}
-            <ul
-              style={{ margin: 0, paddingLeft: "1.2em" }}
+            {`${cellRuns.length} runs for this commit — the cell's status combines all of them:`}
+            {/* RADIO BUTTONS, not links. These change what the rest of the tooltip describes, and a
+                link is a promise to navigate: the anchors this replaced read as "open this run" while
+                doing something else entirely (Ivan, 2026-08-17). Navigation now has its own affordance
+                per row -- the `gh` link -- so the two behaviours are no longer wearing one control.
+
+                The surrounding cell pins on click and opens the job page on DOUBLE click, and
+                dblclick bubbles separately from click -- so stopping click alone would still let a
+                double-click on a run navigate away while toggling the selection twice. */}
+            <div
               onDoubleClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
@@ -123,31 +164,84 @@ export default function JobTooltip({
             >
               {visibleRuns.map((run) => {
                 const key = runKeyOf(run);
-                const isSelected = key === active.runKey;
+                // Checked = the run the detail area is describing, decided by `shownRun` rather than
+                // re-derived here. Keyed off the RESOLVED run, not off `active.runKey` alone: a stale
+                // key (its run gone after a refresh) would otherwise leave the group with nothing
+                // checked while the detail area described the representative (DP17, gpt-5.6-sol).
+                const isSelected = run === shownRun;
                 return (
-                  <li key={key}>
-                    <a
-                      href="#"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        setSelection({
-                          cell: cellKey,
-                          runKey: isSelected ? undefined : key,
-                          showAll: active.showAll,
-                        });
+                  <div
+                    key={key}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "0.3em",
+                    }}
+                  >
+                    {/* The `gh` link is OUTSIDE the label: nesting a link inside it puts the link's
+                        text into the radio's accessible name, and the row's own name comes from
+                        aria-label below. */}
+                    <label
+                      // A mouse convenience only. What the row no longer spells out is rendered for
+                      // the INSPECTED run below the list, because a title is unreachable on touch and
+                      // a screen reader skips it once the row has visible text (DP17, gpt-5.6-sol).
+                      title={describeCellRun(run)}
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "0.3em",
+                        cursor: "pointer",
                       }}
-                      style={{ fontWeight: isSelected ? "bold" : "normal" }}
                     >
-                      {describeCellRun(run)}
-                    </a>
-                    {run.isRepresentative &&
-                      " (this cell's duration and default links)"}
-                  </li>
+                      <input
+                        type="radio"
+                        name={radioGroup}
+                        checked={isSelected}
+                        // The visible text is the ORIGIN, which two runs can share -- a periodic job
+                        // scheduled twice gives two rows reading "schedule". The full description is
+                        // what distinguishes them for a screen reader (DP17, gpt-5.6-sol).
+                        aria-label={describeCellRun(run)}
+                        onClick={(e) => e.stopPropagation()}
+                        onChange={() => pickRun(key)}
+                      />
+                      {/* The grid's own status glyph, via the grid's own component -- so a run reads
+                        the same way in the tooltip as a cell does on the HUD, monster sprites
+                        included when that setting is on. `failedPreviousRun` is deliberately not
+                        passed: flakiness is a property of the SET, and marking a single run "F"
+                        would say something false about it. */}
+                      <JobConclusion
+                        conclusion={run.conclusion}
+                        // Truthiness, matching what mergeCellRuns carries: fetchHud deletes an empty
+                        // `failureAnnotation` before the merge, so '' never reaches a run here -- and
+                        // testing `!= null` while the carrier drops '' would be the one combination
+                        // that can disagree with itself (DP17, gpt-5.6-sol).
+                        classified={!!run.failureAnnotation}
+                        jobData={{
+                          failureLines: run.failureLines,
+                        }}
+                      />
+                      <span
+                        style={{ fontWeight: isSelected ? "bold" : "normal" }}
+                      >
+                        {describeRunOrigin(run)}
+                      </span>
+                    </label>
+                    {run.htmlUrl && (
+                      <a
+                        href={run.htmlUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        title="open this run on GitHub"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        gh
+                      </a>
+                    )}
+                  </div>
                 );
               })}
-            </ul>
-            {!active.showAll && cellRuns.length > collapsedRunCount && (
+            </div>
+            {!active.showAll && cellRuns.length > visibleRuns.length && (
               <a
                 href="#"
                 onClick={(e) => {
@@ -160,9 +254,17 @@ export default function JobTooltip({
                   e.stopPropagation();
                 }}
               >
-                {`show ${cellRuns.length - collapsedRunCount} more`}
+                {/* Counted against what is actually on screen, not against the collapse limit: a
+                    selected run pulled out of the tail above makes those two differ by one. */}
+                {`show ${cellRuns.length - visibleRuns.length} more`}
               </a>
             )}
+            {/* The dispatch identity of the run being inspected -- attempt, who dispatched it, who
+                re-ran it. Rendered once, here, rather than on every row: that is what let the rows
+                shrink to one line each, and it keeps the information out of a `title` attribute
+                that touch and screen readers cannot reach. Absent for ordinary runs, which have no
+                identity to report. */}
+            {shownIdentity !== "" && <div>{shownIdentity}</div>}
           </div>
         </div>
       )}

--- a/torchci/lib/fetchCommit.ts
+++ b/torchci/lib/fetchCommit.ts
@@ -34,10 +34,13 @@ async function fetchDatabaseInfo(
 
 /**
  * Get a mapping of workflow names to all workflow IDs from a list of job data.
+ *
+ * Exported for tests: this is where the run picker's labelling data is carried, and a formatter
+ * test alone would stay green if the propagation here were dropped (DP17, gpt-5.6-sol).
  * @param jobs
  * @returns
  */
-function getWorkflowIdsByName(
+export function getWorkflowIdsByName(
   jobs: JobData[]
 ): Record<string, [WorkflowRunInfo]> {
   return _(jobs)
@@ -48,6 +51,11 @@ function getWorkflowIdsByName(
           return {
             id: job.workflowId,
             attempt: job.runAttempt,
+            // Every job of one run carries the same origin and dispatcher, so taking them from
+            // whichever job wins the uniqBy below is safe -- it dedups by (id, attempt), which is
+            // exactly the granularity these two describe.
+            runOrigin: job.runOrigin,
+            restartDispatchedBy: job.restartDispatchedBy,
           };
         })
         .filter(

--- a/torchci/lib/fetchCommit.ts
+++ b/torchci/lib/fetchCommit.ts
@@ -51,11 +51,10 @@ export function getWorkflowIdsByName(
           return {
             id: job.workflowId,
             attempt: job.runAttempt,
-            // Every job of one run carries the same origin and dispatcher, so taking them from
-            // whichever job wins the uniqBy below is safe -- it dedups by (id, attempt), which is
-            // exactly the granularity these two describe.
+            // Every job of one run carries the same origin, so taking it from whichever job wins
+            // the uniqBy below is safe -- that dedups by (id, attempt), and origin is a property of
+            // the run.
             runOrigin: job.runOrigin,
-            restartDispatchedBy: job.restartDispatchedBy,
           };
         })
         .filter(

--- a/torchci/lib/fetchHud.ts
+++ b/torchci/lib/fetchHud.ts
@@ -1,14 +1,10 @@
-import { JobStatus } from "components/job/GroupJobConclusion";
 import fetchIssuesByLabel from "lib/fetchIssuesByLabel";
 import _ from "lodash";
 import { queryClickhouseSaved } from "./clickhouse";
 import { commitDataFromResponse, getOctokit } from "./github";
-import {
-  getNameWithoutLF,
-  getNameWithoutOSDC,
-  isFailure,
-} from "./JobClassifierUtil";
+import { getNameWithoutLF, getNameWithoutOSDC } from "./JobClassifierUtil";
 import { isRerunDisabledTestsJob, isUnstableJob } from "./jobUtils";
+import { mergeCellRuns } from "./mergeCellRuns";
 import {
   HudDataAPIResponse,
   HudParams,
@@ -116,13 +112,22 @@ export default async function fetchHud(
     );
   }
 
-  // Construct mapping of sha => job name => job data
-  const jobsBySha: {
-    [sha: string]: { [name: string]: JobData };
+  // Collect every run that reported for a (sha, job name) cell, then merge the whole set at once.
+  //
+  // Q: How can there be more than one run with the same name for a given sha?
+  // A: Periodic builds can be scheduled multiple times for one sha; a job can be re-run, producing a
+  //    new attempt; and autorevert dispatches restart runs against a trunk/<sha> ref.
+  //
+  // All three are just runs. The merge is issuer-agnostic and order-independent by construction --
+  // see mergeCellRuns. It replaced a pairwise newest-id-wins reducer under which the verdict depended
+  // on arrival order, so a natural pass followed by a restart failure rendered plain red while the
+  // reverse order rendered flaky.
+  const runsBySha: {
+    [sha: string]: { [name: string]: JobData[] };
   } = {};
   results!.forEach((job: JobData) => {
-    if (jobsBySha[job.sha!] === undefined) {
-      jobsBySha[job.sha!] = {};
+    if (runsBySha[job.sha!] === undefined) {
+      runsBySha[job.sha!] = {};
     }
     let key = job.name!;
     if (params.mergeEphemeralLF) {
@@ -131,38 +136,18 @@ export default async function fetchHud(
     if (params.mergeOSDC) {
       key = getNameWithoutOSDC(key);
     }
-
-    const existingJob = jobsBySha[job.sha!][key];
-    if (existingJob !== undefined) {
-      // If there are multiple jobs with the same name, we want the most recent.
-      // Q: How can there be more than one job with the same name for a given sha?
-      // A: Periodic builds can be scheduled multiple times for one sha. In those
-      // cases, we want the most recent job to be shown.
-      // Exception: a `skipped` conclusion has lower priority than any other
-      // status, so a real result always wins over a skip even if the skipped
-      // job has a larger id. This matters for the OSDC merge, where the
-      // unselected variant reports as skipped and would otherwise mask a real
-      // failure on the selected variant.
-      const existingSkipped = existingJob.conclusion === JobStatus.Skipped;
-      const jobSkipped = job.conclusion === JobStatus.Skipped;
-      const replace =
-        existingSkipped && !jobSkipped
-          ? true
-          : !existingSkipped && jobSkipped
-          ? false
-          : job.id! > existingJob.id!;
-      if (replace) {
-        jobsBySha[job.sha!][key] = job;
-        jobsBySha[job.sha!][key].failedPreviousRun =
-          existingJob.failedPreviousRun || isFailure(existingJob.conclusion);
-      } else {
-        existingJob.failedPreviousRun =
-          existingJob.failedPreviousRun || isFailure(job.conclusion);
-      }
-    } else {
-      jobsBySha[job.sha!][key] = job;
-    }
+    (runsBySha[job.sha!][key] ??= []).push(job);
   });
+
+  const jobsBySha: {
+    [sha: string]: { [name: string]: JobData };
+  } = {};
+  for (const sha in runsBySha) {
+    jobsBySha[sha] = {};
+    for (const key in runsBySha[sha]) {
+      jobsBySha[sha][key] = mergeCellRuns(runsBySha[sha][key]);
+    }
+  }
 
   const namesSet: Set<string> = new Set();
 

--- a/torchci/lib/mergeCellRuns.ts
+++ b/torchci/lib/mergeCellRuns.ts
@@ -1,0 +1,151 @@
+import { JobStatus } from "components/job/GroupJobConclusion";
+import { JobData } from "./types";
+
+/**
+ * Merge every run that reported for one (sha, job name) cell into the single JobData the HUD grid
+ * renders.
+ *
+ * The governing invariant is that **who issued a run is irrelevant to aggregation**. A run issued by
+ * a push, a GitHub re-run attempt, and an autorevert restart are all just runs; the cell's verdict is
+ * a function of the set of conclusions alone -- never of the issuer, and never of the order they
+ * arrived in. Origin is reported (see `runOrigin`) but never aggregated on.
+ *
+ * Rules:
+ *   1. One run -> show that run.
+ *   2. Success + failure, in any order -> show the success, marked flaky ("F").
+ *   3. Cancelled loses to ANY non-cancelled run.
+ * plus the pre-existing rule that `skipped` loses to a real result, which is the same shape as rule 3
+ * and is preserved.
+ *
+ * This replaces a newest-id-wins reducer, under which a cell's verdict depended on which run happened
+ * to be newer: a natural run that passed followed by a restart that failed rendered as a plain red,
+ * while the reverse order rendered as flaky.
+ */
+
+// JobStatus is only ever read inside a function body. It lives in a component that transitively
+// imports this module, so touching it while this module initializes yields undefined -- the same
+// reason JobClassifierUtil only reads it inside a switch.
+
+/**
+ * A missing or empty conclusion means the run has not concluded. hud_query already maps '' to
+ * queued/pending, so this is defensive normalization for an exported function rather than a live
+ * path, but it keeps ranking and display from silently treating '' as an unknown class.
+ */
+function conclusionOf(job: JobData): string {
+  const c = job.conclusion;
+  return c === undefined || c === null || c === "" ? JobStatus.Pending : c;
+}
+
+/**
+ * Conclusions that are evidence the job genuinely failed.
+ *
+ * Deliberately EXCLUDES `cancelled`, unlike `isFailure()` in JobClassifierUtil. Rule 3 discards a
+ * cancelled run whenever any non-cancelled run exists, and a discarded run must not also contribute
+ * failure evidence -- a cancellation says nothing about whether the job passes. Consequence, measured
+ * over 14 days of pytorch/pytorch: 223 cells that today render "F" purely because a cancelled run
+ * sits beside a success become a plain success. Add Cancelled here to restore the old behaviour;
+ * nothing else needs to change.
+ */
+function isRealFailureConclusion(conclusion: string): boolean {
+  return conclusion === JobStatus.Failure || conclusion === JobStatus.Timed_out;
+}
+
+function isPendingConclusion(conclusion: string): boolean {
+  return conclusion === JobStatus.Queued || conclusion === JobStatus.Pending;
+}
+
+/**
+ * Priority for which run's identity (links, log, duration) represents the cell. Cancelled is NOT
+ * ranked here: rule 3 removes cancelled runs before ranking, so by this point they only survive when
+ * every run was cancelled. Ranking cancelled instead of filtering it made it beat `skipped` and
+ * `neutral`, which contradicts rule 3.
+ *
+ * Success outranks failure because rule 2 renders a mixed cell as a flaky success; the flaky flag,
+ * not the representative, is what tells the reader a failure happened.
+ */
+function classRank(job: JobData): number {
+  const c = conclusionOf(job);
+  if (c === JobStatus.Success) return 0;
+  if (isRealFailureConclusion(c)) return 1;
+  if (isPendingConclusion(c)) return 2;
+  if (c === JobStatus.Neutral) return 3;
+  if (c === JobStatus.Skipped) return 4;
+  if (c === JobStatus.Cancelled) return 5;
+  return 6;
+}
+
+/**
+ * `runOrigin` is absent only for a run whose workflow event is literally `push`; every other event
+ * (schedule, a non-trunk workflow_dispatch, ...) carries its event name, so this never guesses.
+ */
+export function describeRunOrigin(job: JobData): string {
+  if (job.runOrigin === "autorevert") return "autorevert restart";
+  if (job.runOrigin === "retry") return "re-run attempt";
+  return job.runOrigin ?? "push";
+}
+
+export function mergeCellRuns(runs: JobData[]): JobData {
+  if (runs.length === 0) {
+    return {};
+  }
+
+  // Rule 3 as a filter rather than a rank: a cancelled run is discarded outright whenever ANY
+  // non-cancelled run exists, so it can never win against skipped or neutral either.
+  const nonCancelled = runs.filter(
+    (job) => conclusionOf(job) !== JobStatus.Cancelled
+  );
+  const considered = nonCancelled.length > 0 ? nonCancelled : runs;
+
+  // Best class, then newest inside that class. The id tiebreak is numeric: `id` is typed as a string
+  // but carries a numeric GitHub job id, and the reducer this replaced compared them as strings --
+  // which matches numeric order only while every id has the same digit count.
+  const representative = considered.reduce((best, job) => {
+    const d = classRank(job) - classRank(best);
+    if (d !== 0) {
+      return d < 0 ? job : best;
+    }
+    return Number(job.id ?? 0) > Number(best.id ?? 0) ? job : best;
+  });
+
+  // Always a copy, and always with failedPreviousRun computed rather than inherited -- including on a
+  // one-run cell. Returning the input object let a stale flag ride through and render a phantom "F",
+  // and let the caller mutate a row it does not own.
+  const merged: JobData = { ...representative };
+
+  // Rule 2, evaluated over the whole set, so it holds whichever run happens to be newer. Cancelled
+  // runs are excluded from the evidence (see isRealFailureConclusion) but every other run counts,
+  // including ones rule 3 discarded.
+  merged.failedPreviousRun =
+    conclusionOf(representative) === JobStatus.Success &&
+    runs.some((job) => isRealFailureConclusion(conclusionOf(job)));
+
+  if (runs.length > 1) {
+    // Report what was merged so a reader can see the cell summarizes several runs and where each came
+    // from. Set only on genuinely multi-run cells, leaving the grid payload untouched for the
+    // overwhelming majority.
+    merged.mergedRunCount = runs.length;
+    merged.mergedRuns = runs
+      .slice()
+      .sort(
+        (a, b) =>
+          classRank(a) - classRank(b) || Number(a.id ?? 0) - Number(b.id ?? 0)
+      )
+      .map((job) => `${describeRunOrigin(job)}: ${conclusionOf(job)}`)
+      .join(", ");
+
+    // Keep the losing failure reachable. Rule 2 makes the SUCCESS the representative, so without this
+    // the cell renders "F" while its links all point at the run that passed and the failure the
+    // reader actually wants to inspect has no route from the grid.
+    const hiddenFailure = runs
+      .filter(
+        (job) =>
+          job !== representative && isRealFailureConclusion(conclusionOf(job))
+      )
+      .sort((a, b) => Number(b.id ?? 0) - Number(a.id ?? 0))[0];
+    if (hiddenFailure?.htmlUrl) {
+      merged.mergedFailureUrl = hiddenFailure.htmlUrl;
+    }
+  }
+
+  return merged;
+}

--- a/torchci/lib/mergeCellRuns.ts
+++ b/torchci/lib/mergeCellRuns.ts
@@ -1,6 +1,7 @@
 import { JobStatus } from "components/job/GroupJobConclusion";
 // Read only inside a function body, for the same initialization-order reason as JobStatus below.
 import { getConclusionChar } from "lib/JobClassifierUtil";
+import { describeRunOrigin } from "lib/runOrigin";
 import { CellRun, JobData } from "./types";
 
 /**
@@ -97,7 +98,9 @@ function numericId(job: { id?: string }): number | undefined {
  */
 function tiebreakKey(job: {
   id?: string;
-  runOrigin?: string;
+  // Nullable because commit_jobs_query ships a real NULL where hud_query strips the key. The
+  // `?? ""` below already treats the two identically, so this widening changes no behaviour.
+  runOrigin?: string | null;
   conclusion?: string;
   htmlUrl?: string;
 }): string {
@@ -110,26 +113,12 @@ function tiebreakKey(job: {
 }
 
 /**
- * `runOrigin` is ABSENT only for a run whose workflow event is literally `push`; every other event
- * (schedule, a non-trunk workflow_dispatch, ...) carries its event name, so this never guesses.
- *
- * A BLANK value is a third case and not the same claim: `workflow_event` is a dictGet over
- * workflow_run_dict, so it returns the column default until the dictionary catches up -- the
- * query's own comment says it "takes some time to populate", which means blanks land on the
- * FRESHEST rows, i.e. the top of the HUD. Reporting those as "push" would be a guess, and
- * reporting them as "" rendered the tooltip as `Shown run: .`
- *
- * Normalized here rather than in SQL on purpose. `nullIf` in the query would map a blank onto the
- * NULL that already means "push", re-introducing the guess; and this guards every producer of a
- * JobData, not just hud_query.
+ * Re-exported so existing importers (JobTooltip, this module's own callers, the tests) keep
+ * working. The definition moved to the dependency-free `lib/runOrigin`, because the commit page's
+ * run picker needs the same vocabulary and reaching it from there through this module would create
+ * an import cycle -- see that file for the chain.
  */
-export function describeRunOrigin(run: { runOrigin?: string }): string {
-  if (run.runOrigin === "autorevert") return "autorevert restart";
-  if (run.runOrigin === "retry") return "re-run attempt";
-  if (run.runOrigin == null) return "push";
-  const origin = run.runOrigin.trim();
-  return origin === "" ? "unknown" : origin;
-}
+export { describeRunOrigin };
 
 /**
  * Stable identity of a run within its cell -- a React key, and the handle the tooltip remembers a
@@ -472,7 +461,11 @@ export function mergeCellRuns(runs: JobData[]): JobData {
       })
       .map((job) => {
         const run: CellRun = {
-          runOrigin: job.runOrigin,
+          // `?? undefined` normalizes at the boundary rather than widening CellRun: a JobData can
+          // carry a SQL NULL (commit_jobs_query), a CellRun never does -- it is built only from
+          // hud_query rows, whose nulls fetchHud has already stripped. Both spellings mean the
+          // same run, so collapsing them here keeps the narrower type honest.
+          runOrigin: job.runOrigin ?? undefined,
           conclusion: job.conclusion,
           id: job.id,
           workflowId: job.workflowId,
@@ -480,7 +473,7 @@ export function mergeCellRuns(runs: JobData[]): JobData {
           logUrl: job.logUrl,
           durationS: job.durationS,
           restartRunAttempt: job.restartRunAttempt,
-          restartDispatchedBy: job.restartDispatchedBy,
+          restartDispatchedBy: job.restartDispatchedBy ?? undefined,
           restartRerunBy: job.restartRerunBy,
         };
         // Only when there IS one. An unannotated job carries '' rather than null on some producers,

--- a/torchci/lib/mergeCellRuns.ts
+++ b/torchci/lib/mergeCellRuns.ts
@@ -1,5 +1,5 @@
 import { JobStatus } from "components/job/GroupJobConclusion";
-import { JobData } from "./types";
+import { CellRun, JobData } from "./types";
 
 /**
  * Merge every run that reported for one (sha, job name) cell into the single JobData the HUD grid
@@ -31,7 +31,7 @@ import { JobData } from "./types";
  * queued/pending, so this is defensive normalization for an exported function rather than a live
  * path, but it keeps ranking and display from silently treating '' as an unknown class.
  */
-function conclusionOf(job: JobData): string {
+function conclusionOf(job: { conclusion?: string }): string {
   const c = job.conclusion;
   return c === undefined || c === null || c === "" ? JobStatus.Pending : c;
 }
@@ -78,13 +78,129 @@ function classRank(job: JobData): number {
 }
 
 /**
- * `runOrigin` is absent only for a run whose workflow event is literally `push`; every other event
- * (schedule, a non-trunk workflow_dispatch, ...) carries its event name, so this never guesses.
+ * Numeric job id, or undefined when there isn't a usable one. `id` is typed as a string but carries
+ * a numeric GitHub job id; the reducer this module replaced compared them as strings, which matches
+ * numeric order only while every id has the same digit count.
  */
-export function describeRunOrigin(job: JobData): string {
-  if (job.runOrigin === "autorevert") return "autorevert restart";
-  if (job.runOrigin === "retry") return "re-run attempt";
-  return job.runOrigin ?? "push";
+function numericId(job: { id?: string }): number | undefined {
+  if (job.id == null) return undefined;
+  const n = Number(job.id);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+/**
+ * Last-resort ordering key, so no ordering in this module depends on the order the query returned
+ * rows in. `hud_query` has no ORDER BY, and ids can be absent, equal or non-numeric -- in which case
+ * a comparator that returns 0 leaves the outcome to sort stability, i.e. to the query.
+ */
+function tiebreakKey(job: {
+  id?: string;
+  runOrigin?: string;
+  conclusion?: string;
+  htmlUrl?: string;
+}): string {
+  return [
+    job.id ?? "",
+    job.runOrigin ?? "",
+    job.conclusion ?? "",
+    job.htmlUrl ?? "",
+  ].join(" ");
+}
+
+/**
+ * `runOrigin` is ABSENT only for a run whose workflow event is literally `push`; every other event
+ * (schedule, a non-trunk workflow_dispatch, ...) carries its event name, so this never guesses.
+ *
+ * A BLANK value is a third case and not the same claim: `workflow_event` is a dictGet over
+ * workflow_run_dict, so it returns the column default until the dictionary catches up -- the
+ * query's own comment says it "takes some time to populate", which means blanks land on the
+ * FRESHEST rows, i.e. the top of the HUD. Reporting those as "push" would be a guess, and
+ * reporting them as "" rendered the tooltip as `Shown run: .`
+ *
+ * Normalized here rather than in SQL on purpose. `nullIf` in the query would map a blank onto the
+ * NULL that already means "push", re-introducing the guess; and this guards every producer of a
+ * JobData, not just hud_query.
+ */
+export function describeRunOrigin(run: { runOrigin?: string }): string {
+  if (run.runOrigin === "autorevert") return "autorevert restart";
+  if (run.runOrigin === "retry") return "re-run attempt";
+  if (run.runOrigin == null) return "push";
+  const origin = run.runOrigin.trim();
+  return origin === "" ? "unknown" : origin;
+}
+
+/**
+ * Stable identity of a run within its cell -- a React key, and the handle the tooltip remembers a
+ * selection by. Keyed by the run rather than by list position on purpose: a grid refresh can add or
+ * reorder runs, and a positional handle would then silently point the detail area at a different
+ * run. Falls back to content when `id` is absent (it is optional), which two byte-identical rows
+ * would share -- they describe the same run, so that is the right answer.
+ */
+export function runKeyOf(run: CellRun): string {
+  return run.id ?? `- ${tiebreakKey(run)}`;
+}
+
+/**
+ * One run, as a line for the cell tooltip: "<origin>[ (attempt N)][, dispatched by X][, rerun by
+ * Y] -- <conclusion>".
+ *
+ * Only the autorevert restart's attempt is available to name. A "re-run attempt" line therefore
+ * carries no number: hud_query deliberately does not project the job's own run_attempt, because the
+ * HUD page reads `runAttempt` when merging crcr rows and depends on it being undefined on this path.
+ */
+export function describeCellRun(run: CellRun): string {
+  let line = describeRunOrigin(run);
+  if (run.runOrigin === "autorevert" && run.restartRunAttempt != null) {
+    line += ` (attempt ${run.restartRunAttempt})`;
+  }
+  if (run.restartDispatchedBy) {
+    line += `, dispatched by ${run.restartDispatchedBy}`;
+  }
+  if (run.restartRerunBy) {
+    line += `, rerun by ${run.restartRerunBy}`;
+  }
+  return `${line} — ${conclusionOf(run)}`;
+}
+
+/**
+ * The JobData the tooltip's detail area -- log viewer, links, failure classification -- should
+ * render for a selected run, or for the cell itself when nothing is selected.
+ *
+ * This exists because selecting a run is not enough on its own. `failureLines`,
+ * `failureCaptures` and the log URL are all per-run, and the cell carries the REPRESENTATIVE's,
+ * which on a flaky "F" cell is the run that PASSED. Rebinding the detail area is what makes the
+ * tooltip answer "why is this cell F?" rather than merely naming the runs.
+ */
+export function detailJobForRun(cell: JobData, run?: CellRun): JobData {
+  if (run === undefined) {
+    return cell;
+  }
+  // EVERY run-scoped field is assigned explicitly, rather than spreading `run` over the cell.
+  //
+  // A spread would be wrong on the only path that matters. `JSON.stringify` drops keys whose value
+  // is `undefined`, so the CellRun the browser receives has no key at all for a field the run lacks
+  // -- and a spread then leaves the CELL's value standing. Selecting the push run on a flaky "F"
+  // cell would show it with the restart's dispatch identity, or a run with no log pointing at the
+  // representative's log. In-memory objects still carry those keys, so a test that does not
+  // serialize cannot see the difference.
+  return {
+    ...cell,
+    id: run.id,
+    conclusion: run.conclusion,
+    htmlUrl: run.htmlUrl,
+    logUrl: run.logUrl,
+    durationS: run.durationS,
+    runOrigin: run.runOrigin,
+    restartRunAttempt: run.restartRunAttempt,
+    restartDispatchedBy: run.restartDispatchedBy,
+    restartRerunBy: run.restartRerunBy,
+    failureLines: run.failureLines,
+    failureLineNumbers: run.failureLineNumbers,
+    failureCaptures: run.failureCaptures,
+    failureContext: run.failureContext,
+    // A property of the SET, not of any one run: keeping it would mark a single run flaky.
+    failedPreviousRun: undefined,
+  };
 }
 
 export function mergeCellRuns(runs: JobData[]): JobData {
@@ -107,7 +223,18 @@ export function mergeCellRuns(runs: JobData[]): JobData {
     if (d !== 0) {
       return d < 0 ? job : best;
     }
-    return Number(job.id ?? 0) > Number(best.id ?? 0) ? job : best;
+    const jobId = numericId(job);
+    const bestId = numericId(best);
+    if (jobId !== bestId) {
+      // A run with no usable id loses to one that has an id rather than being read as id 0, which
+      // would have made it beat every real id in the "newest" comparison below.
+      if (jobId === undefined) return best;
+      if (bestId === undefined) return job;
+      return jobId > bestId ? job : best;
+    }
+    // Equal or both-absent ids: fall back to a content key so the choice does not depend on the
+    // order the query happened to return rows in.
+    return tiebreakKey(job) > tiebreakKey(best) ? job : best;
   });
 
   // Always a copy, and always with failedPreviousRun computed rather than inherited -- including on a
@@ -118,36 +245,79 @@ export function mergeCellRuns(runs: JobData[]): JobData {
   // Rule 2, evaluated over the whole set, so it holds whichever run happens to be newer. Cancelled
   // runs are excluded from the evidence (see isRealFailureConclusion) but every other run counts,
   // including ones rule 3 discarded.
-  merged.failedPreviousRun =
+  const failedPreviousRun =
     conclusionOf(representative) === JobStatus.Success &&
     runs.some((job) => isRealFailureConclusion(conclusionOf(job)));
+  if (failedPreviousRun) {
+    merged.failedPreviousRun = true;
+  } else {
+    // DELETED rather than assigned false, and deleted unconditionally so a stale `true` inherited
+    // from the representative row still cannot ride through. `false` is not null, so fetchHud's
+    // null-strip cannot drop it: assigning it shipped `"failedPreviousRun":false` on ~19,500 of the
+    // 20,362 cells on a real HUD page, and every consumer already reads absent as false
+    // (JobConclusion defaults it), so those bytes bought nothing.
+    delete merged.failedPreviousRun;
+  }
 
   if (runs.length > 1) {
-    // Report what was merged so a reader can see the cell summarizes several runs and where each came
-    // from. Set only on genuinely multi-run cells, leaving the grid payload untouched for the
-    // overwhelming majority.
-    merged.mergedRunCount = runs.length;
-    merged.mergedRuns = runs
+    // Carry every run, including the representative, so the tooltip can name them and bind its
+    // detail area to any one of them (see detailJobForRun). One consistent list is easier to reason
+    // about than "the cell, plus the others", and it is the only route from a flaky "F" cell to the
+    // failure that made it flaky. Set only on genuinely multi-run cells, so the grid payload is
+    // untouched for the overwhelming majority.
+    //
+    // Ordered by what the reader needs first, NOT by class rank: the representative (so the list
+    // opens with the run the cell renders), then real failures, then everything else, newest first
+    // inside each group. Class rank would have buried the failure that made an "F" cell flaky behind
+    // its successes -- and on a cell with many runs the UI collapses the tail, so a class-ranked list
+    // could hide both the representative and the failure. One cell on a real page has 82 runs.
+    merged.cellRuns = runs
       .slice()
-      .sort(
-        (a, b) =>
-          classRank(a) - classRank(b) || Number(a.id ?? 0) - Number(b.id ?? 0)
-      )
-      .map((job) => `${describeRunOrigin(job)}: ${conclusionOf(job)}`)
-      .join(", ");
-
-    // Keep the losing failure reachable. Rule 2 makes the SUCCESS the representative, so without this
-    // the cell renders "F" while its links all point at the run that passed and the failure the
-    // reader actually wants to inspect has no route from the grid.
-    const hiddenFailure = runs
-      .filter(
-        (job) =>
-          job !== representative && isRealFailureConclusion(conclusionOf(job))
-      )
-      .sort((a, b) => Number(b.id ?? 0) - Number(a.id ?? 0))[0];
-    if (hiddenFailure?.htmlUrl) {
-      merged.mergedFailureUrl = hiddenFailure.htmlUrl;
-    }
+      .sort((a, b) => {
+        if (a === b) return 0;
+        if (a === representative) return -1;
+        if (b === representative) return 1;
+        const aFailed = isRealFailureConclusion(conclusionOf(a)) ? 0 : 1;
+        const bFailed = isRealFailureConclusion(conclusionOf(b)) ? 0 : 1;
+        if (aFailed !== bFailed) return aFailed - bFailed;
+        const aId = numericId(a);
+        const bId = numericId(b);
+        if (aId !== bId) {
+          if (aId === undefined) return 1;
+          if (bId === undefined) return -1;
+          return bId - aId; // newest first
+        }
+        return tiebreakKey(b).localeCompare(tiebreakKey(a));
+      })
+      .map((job) => {
+        const run: CellRun = {
+          runOrigin: job.runOrigin,
+          conclusion: job.conclusion,
+          id: job.id,
+          htmlUrl: job.htmlUrl,
+          logUrl: job.logUrl,
+          durationS: job.durationS,
+          restartRunAttempt: job.restartRunAttempt,
+          restartDispatchedBy: job.restartDispatchedBy,
+          restartRerunBy: job.restartRerunBy,
+        };
+        // Classification text ONLY for runs that actually failed. It is the largest thing a run can
+        // carry -- one run on a real page carries 55 KB of it -- and torchci classifies plenty of
+        // runs that did not fail: measured over the 50 newest pytorch/pytorch trunk commits, runs on
+        // multi-run cells hold 1.35 MB of classification of which just 4.7 KB sits on a run whose
+        // conclusion is failure or timed_out. Carrying it unconditionally would add ~1.3 MB to the
+        // grid to explain nothing, since the only reason to inspect a sibling run is that it FAILED.
+        if (isRealFailureConclusion(conclusionOf(job))) {
+          run.failureLines = job.failureLines;
+          run.failureLineNumbers = job.failureLineNumbers;
+          run.failureCaptures = job.failureCaptures;
+          run.failureContext = job.failureContext;
+        }
+        if (job === representative) {
+          run.isRepresentative = true;
+        }
+        return run;
+      });
   }
 
   return merged;

--- a/torchci/lib/mergeCellRuns.ts
+++ b/torchci/lib/mergeCellRuns.ts
@@ -1,4 +1,6 @@
 import { JobStatus } from "components/job/GroupJobConclusion";
+// Read only inside a function body, for the same initialization-order reason as JobStatus below.
+import { getConclusionChar } from "lib/JobClassifierUtil";
 import { CellRun, JobData } from "./types";
 
 /**
@@ -160,6 +162,159 @@ export function describeCellRun(run: CellRun): string {
     line += `, rerun by ${run.restartRerunBy}`;
   }
   return `${line} — ${conclusionOf(run)}`;
+}
+
+/**
+ * What a row of the run list renders ON SCREEN: the origin text, plus the CHARACTER the status glyph
+ * draws -- `getConclusionChar`, the same function the glyph itself goes through, not the raw
+ * conclusion. Those differ, and the difference is the point: every conclusion outside the known set
+ * collapses to `U`, so two runs concluding `action_required` and `stale` draw the identical glyph while
+ * their conclusion strings do not match (DP17, gpt-5.6-sol).
+ *
+ * `failedPreviousRun` is not passed, matching the row, which deliberately withholds it -- flakiness is
+ * a property of the whole cell rather than of one run.
+ *
+ * `failureAnnotation` is deliberately NOT part of the signature. It does change the glyph's styling,
+ * so it is arguably a visible difference, but a styling difference is a weak thing to rest "the reader
+ * can tell these apart" on -- and over-reporting a collision only ever costs a suffix.
+ */
+function visibleRunSignature(run: CellRun): string {
+  return `${describeRunOrigin(run)} ${getConclusionChar(run.conclusion)}`;
+}
+
+/**
+ * The TEXT a row of the run list presents, so a collision in either counts. Not every way a row
+ * presents a run: the `gh` anchor is a third, and it carries its own label rather than a signature
+ * here, because a suffix cannot fix a link whose name is the word "gh" on every row.
+ *
+ * Neither signature dominates the other, which is why both are here rather than just the coarser one:
+ *   - `describeCellRun` carries the attempt / dispatcher / rerunner, so two autorevert restarts of one
+ *     cell separate under it while both rows still read "autorevert restart" on screen;
+ *   - `visibleRunSignature` goes through the glyph, which folds unknown conclusions onto `U` and an
+ *     absent conclusion onto `~`, while `conclusionOf` folds absent and empty together -- so two runs
+ *     can share a glyph while their descriptions differ, and vice versa.
+ */
+const RUN_ROW_SIGNATURES: ((run: CellRun) => string)[] = [
+  visibleRunSignature,
+  describeCellRun,
+];
+
+/**
+ * Candidate disambiguators, best identification first. Neither is guaranteed to separate a group, which
+ * is why `labelsGroupDistinctly` checks the resulting labels rather than assuming a field works:
+ *
+ *   - `id` is the JOB id, a primary key in `workflow_job`, and it is what the row's `gh` link points
+ *     at (`.../actions/runs/<workflowId>/job/<id>`), so it names the thing the link opens.
+ *   - `workflowId` is `job.run_id`, which every re-run ATTEMPT of one run SHARES -- so two retries of
+ *     the same run carry the same value and it cannot separate them. It is a fallback for rows that
+ *     arrive without a job id, not a second opinion.
+ */
+const RUN_DISAMBIGUATORS: {
+  noun: string;
+  valueOf: (run: CellRun) => string | undefined;
+}[] = [
+  { noun: "job", valueOf: (run) => run.id },
+  { noun: "run", valueOf: (run) => run.workflowId },
+];
+
+function suffixFrom(
+  run: CellRun,
+  candidate: { noun: string; valueOf: (run: CellRun) => string | undefined }
+): string {
+  const value = candidate.valueOf(run);
+  return value == null || value === "" ? "" : ` (${candidate.noun} ${value})`;
+}
+
+/**
+ * Whether one candidate makes every row of a colliding group read differently.
+ *
+ * The test is on the SUFFIXES, not on the underlying values, and that distinction is the whole point:
+ * a run the candidate has no value for contributes '' -- which still separates it from a sibling that
+ * got a suffix. Requiring every member to carry a value would reject `[{id: "7"}, {}]`, whose two rows
+ * read `push` and `push (job 7)` and are perfectly distinguishable (DP17, gpt-5.6-sol).
+ */
+function labelsGroupDistinctly(
+  group: CellRun[],
+  candidate: { noun: string; valueOf: (run: CellRun) => string | undefined }
+): boolean {
+  const suffixes = new Set(group.map((run) => suffixFrom(run, candidate)));
+  return suffixes.size === group.length;
+}
+
+/**
+ * Per-run suffix that makes a cell's run rows tell each other apart. Two different reasons produce '':
+ * the row already reads uniquely in its cell, OR it collides and no candidate can label the collision
+ * distinctly -- the second is a gap none of the candidates above can close, not a claim the row is
+ * unique.
+ *
+ * Why it is needed: a row shows `describeRunOrigin` and a status glyph, and its hover and accessible
+ * text are `describeCellRun` -- all of which collapse to one string for two runs sharing an origin
+ * and a conclusion, since the attempt / dispatcher / rerunner that would separate them are absent on
+ * every ordinary push or periodic run. That covers a periodic job scheduled twice, two pushes, and
+ * two re-run attempts. Over the 50 newest pytorch/pytorch `main` commits it is 1,147 of 2,555
+ * multi-run cells, so it is the common case rather than an edge one.
+ *
+ * An unlabellable group gets no suffix rather than a made-up one: a positional "2 of 3" would be worse
+ * than silence, since the list is re-ordered from fresh data on every grid refresh and an ordinal would
+ * then silently re-point at a different run.
+ *
+ * Scoped to COLLIDING rows, not applied to every row, so a cell whose runs already read differently
+ * keeps the one-short-line-per-run shape Ivan asked for (2026-08-17: the spelled-out identity on
+ * every line was "extremely verbose").
+ *
+ * What this does NOT promise: that the final rendered strings are globally unique across the cell. It
+ * makes each COLLIDING GROUP internally distinct. A suffix could in principle recreate a collision with
+ * some third row whose own text happens to end in the same parenthetical -- type-valid, and not
+ * reachable from `hud_query`, whose conclusions and ids cannot contain one.
+ *
+ * The returned Map is keyed by object identity, which is simply the lookup the caller needs per row;
+ * `visibleRuns` holds the same references. It is not load-bearing for correctness -- two byte-identical
+ * rows compute identical suffixes anyway, since every input to the suffix is one of their equal fields.
+ */
+export function disambiguateCellRuns(runs: CellRun[]): Map<CellRun, string> {
+  const groupsPerSignature = RUN_ROW_SIGNATURES.map((signatureOf) => {
+    const groups = new Map<string, CellRun[]>();
+    for (const run of runs) {
+      const group = groups.get(signatureOf(run));
+      if (group === undefined) {
+        groups.set(signatureOf(run), [run]);
+      } else {
+        group.push(run);
+      }
+    }
+    return { signatureOf, groups };
+  });
+
+  const suffixes = new Map<CellRun, string>();
+  for (const run of runs) {
+    // Every run this one is indistinguishable from, under EITHER signature. A union rather than an
+    // intersection: colliding in one of the places a row renders is enough to need a suffix, and the
+    // chosen candidate then has to label all of them distinctly at once.
+    //
+    // Two runs of one collision can compute DIFFERENT unions -- A may also collide with C under the
+    // other signature while B does not -- and so may pick different candidates. That cannot make their
+    // labels equal: each union contains the whole colliding pair, so a candidate accepted for A already
+    // labels A and B differently, and two different candidates carry different nouns.
+    const indistinguishable = new Set<CellRun>();
+    for (const { signatureOf, groups } of groupsPerSignature) {
+      const group = groups.get(signatureOf(run));
+      if (group !== undefined && group.length > 1) {
+        for (const sibling of group) {
+          indistinguishable.add(sibling);
+        }
+      }
+    }
+    if (indistinguishable.size < 2) {
+      suffixes.set(run, "");
+      continue;
+    }
+    const group = Array.from(indistinguishable);
+    const chosen = RUN_DISAMBIGUATORS.find((candidate) =>
+      labelsGroupDistinctly(group, candidate)
+    );
+    suffixes.set(run, chosen === undefined ? "" : suffixFrom(run, chosen));
+  }
+  return suffixes;
 }
 
 /**

--- a/torchci/lib/mergeCellRuns.ts
+++ b/torchci/lib/mergeCellRuns.ts
@@ -43,8 +43,11 @@ function conclusionOf(job: JobData): string {
  * cancelled run whenever any non-cancelled run exists, and a discarded run must not also contribute
  * failure evidence -- a cancellation says nothing about whether the job passes. Consequence, measured
  * over 14 days of pytorch/pytorch: 223 cells that today render "F" purely because a cancelled run
- * sits beside a success become a plain success. Add Cancelled here to restore the old behaviour;
- * nothing else needs to change.
+ * sits beside a success become a plain success.
+ *
+ * This is intended behaviour, confirmed rather than assumed -- do not "fix" it by adding Cancelled
+ * back to match isFailure(). If cancellation ever needs to be visible on a cell that also has a
+ * success, it wants its own marker rather than overloading the flaky "F".
  */
 function isRealFailureConclusion(conclusion: string): boolean {
   return conclusion === JobStatus.Failure || conclusion === JobStatus.Timed_out;

--- a/torchci/lib/mergeCellRuns.ts
+++ b/torchci/lib/mergeCellRuns.ts
@@ -163,6 +163,30 @@ export function describeCellRun(run: CellRun): string {
 }
 
 /**
+ * The dispatch identity of a run -- restart attempt, who dispatched it, who re-ran it -- or '' when
+ * it has none (every ordinary push or periodic run).
+ *
+ * Exists so the run list can stay ONE SHORT LINE per row while this information is still rendered
+ * for the run being inspected. It used to sit in each row's text, which Ivan called "extremely
+ * verbose" (2026-08-17); moving it into a `title` attribute would have been worse than either, since
+ * touch devices cannot reach a title at all and a screen reader skips it once the row has visible
+ * text of its own.
+ */
+export function describeRunIdentity(run: CellRun): string {
+  const parts: string[] = [];
+  if (run.restartRunAttempt != null) {
+    parts.push(`attempt ${run.restartRunAttempt}`);
+  }
+  if (run.restartDispatchedBy) {
+    parts.push(`dispatched by ${run.restartDispatchedBy}`);
+  }
+  if (run.restartRerunBy) {
+    parts.push(`rerun by ${run.restartRerunBy}`);
+  }
+  return parts.join(", ");
+}
+
+/**
  * The JobData the tooltip's detail area -- log viewer, links, failure classification -- should
  * render for a selected run, or for the cell itself when nothing is selected.
  *
@@ -186,6 +210,8 @@ export function detailJobForRun(cell: JobData, run?: CellRun): JobData {
   return {
     ...cell,
     id: run.id,
+    workflowId: run.workflowId,
+    failureAnnotation: run.failureAnnotation,
     conclusion: run.conclusion,
     htmlUrl: run.htmlUrl,
     logUrl: run.logUrl,
@@ -294,6 +320,7 @@ export function mergeCellRuns(runs: JobData[]): JobData {
           runOrigin: job.runOrigin,
           conclusion: job.conclusion,
           id: job.id,
+          workflowId: job.workflowId,
           htmlUrl: job.htmlUrl,
           logUrl: job.logUrl,
           durationS: job.durationS,
@@ -301,6 +328,12 @@ export function mergeCellRuns(runs: JobData[]): JobData {
           restartDispatchedBy: job.restartDispatchedBy,
           restartRerunBy: job.restartRerunBy,
         };
+        // Only when there IS one. An unannotated job carries '' rather than null on some producers,
+        // and fetchHud strips only nulls -- assigning it unconditionally would ship an empty string
+        // on every run of every multi-run cell to say nothing.
+        if (job.failureAnnotation) {
+          run.failureAnnotation = job.failureAnnotation;
+        }
         // Classification text ONLY for runs that actually failed. It is the largest thing a run can
         // carry -- one run on a real page carries 55 KB of it -- and torchci classifies plenty of
         // runs that did not fail: measured over the 50 newest pytorch/pytorch trunk commits, runs on

--- a/torchci/lib/runOrigin.ts
+++ b/torchci/lib/runOrigin.ts
@@ -1,0 +1,64 @@
+/**
+ * Naming a CI run in prose.
+ *
+ * A dependency-free leaf ON PURPOSE. Two surfaces need this vocabulary -- the HUD cell tooltip
+ * (through `mergeCellRuns`) and the commit page's run picker (through `WorkflowBox`) -- and putting
+ * it in either one's module drags HUD cell aggregation and React components into the other's
+ * dependency graph. Concretely, hanging it off `lib/jobUtils` produces a real cycle:
+ * `jobUtils -> mergeCellRuns -> JobClassifierUtil -> jobUtils` (DP17, gpt-5.6-sol). Keep this file
+ * importing nothing.
+ */
+
+/**
+ * `runOrigin` is ABSENT only for a run whose workflow event is literally `push`; every other event
+ * (schedule, a non-trunk workflow_dispatch, ...) carries its event name, so this never guesses.
+ *
+ * A BLANK value is a third case and not the same claim: `workflow_event` is a dictGet over
+ * workflow_run_dict, so it returns the column default until the dictionary catches up -- the
+ * query's own comment says it "takes some time to populate", which means blanks land on the
+ * FRESHEST rows, i.e. the top of the HUD. Reporting those as "push" would be a guess, and
+ * reporting them as "" rendered the tooltip as `Shown run: .`
+ *
+ * Normalized here rather than in SQL on purpose. `nullIf` in the query would map a blank onto the
+ * NULL that already means "push", re-introducing the guess; and this guards every producer of a
+ * JobData, not just hud_query.
+ *
+ * `null` is accepted alongside `undefined` because commit_jobs_query ships the column as a real
+ * SQL NULL, where hud_query's rows reach the client with the key stripped.
+ */
+export function describeRunOrigin(run: { runOrigin?: string | null }): string {
+  if (run.runOrigin === "autorevert") return "autorevert restart";
+  if (run.runOrigin === "retry") return "re-run attempt";
+  if (run.runOrigin == null) return "push";
+  const origin = run.runOrigin.trim();
+  return origin === "" ? "unknown" : origin;
+}
+
+/**
+ * Name a workflow run for the commit page's run picker, which otherwise offers bare numeric ids
+ * that nothing distinguishes -- the question asked of it in review was literally "which one of
+ * these was the autorevert restart?".
+ *
+ * EVERY run gets named, including a plain push, so a reader scanning a handful of entries compares
+ * like with like instead of inferring from an absence. That is the opposite trade from the HUD
+ * grid, where an origin on every one of thousands of rows would be noise -- which is why
+ * `hud_query` leaves a push's origin NULL and this does not.
+ *
+ * It does NOT distinguish "ordinary push" from "origin missing": both render "push", because
+ * `describeRunOrigin` cannot tell a genuine NULL from an absent key (DP17, gpt-5.6-sol). Only a
+ * BLANK origin is called out, as "unknown".
+ *
+ * The login names whoever DISPATCHED the run, which for a restart is the bot. It is deliberately
+ * not the person who re-ran an attempt: `workflow_run.actor` is the original dispatcher and is
+ * invariant across attempts, while `triggering_actor` differs per attempt. So "attempt 2 ... by
+ * <bot>" means the bot started the run, not that the bot pressed re-run.
+ */
+export function describeWorkflowRun(run: {
+  runOrigin?: string | null;
+  restartDispatchedBy?: string | null;
+}): string {
+  const origin = describeRunOrigin(run);
+  return run.restartDispatchedBy
+    ? `${origin} by ${run.restartDispatchedBy}`
+    : origin;
+}

--- a/torchci/lib/runOrigin.ts
+++ b/torchci/lib/runOrigin.ts
@@ -48,17 +48,20 @@ export function describeRunOrigin(run: { runOrigin?: string | null }): string {
  * `describeRunOrigin` cannot tell a genuine NULL from an absent key (DP17, gpt-5.6-sol). Only a
  * BLANK origin is called out, as "unknown".
  *
- * The login names whoever DISPATCHED the run, which for a restart is the bot. It is deliberately
- * not the person who re-ran an attempt: `workflow_run.actor` is the original dispatcher and is
- * invariant across attempts, while `triggering_actor` differs per attempt. So "attempt 2 ... by
- * <bot>" means the bot started the run, not that the bot pressed re-run.
+ * NO ACTOR IS NAMED, and that is a decision rather than an omission. "autorevert restart by
+ * pytorch-auto-revert[bot]" says autorevert twice (Ivan, 2026-08-19). Naming the actor INSTEAD of
+ * the origin was the alternative, and it is wrong here: actor and origin are independent facts, so
+ * a person hand-dispatching a trunk/<sha> run would read "dispatched by <person>" with the
+ * autorevert nature invisible — the one thing the label exists to show (DP17, gpt-5.6-sol). The
+ * origin alone is the smaller and stronger answer. If the picker ever shows actors for the whole
+ * workflow_dispatch family, revisit: naming both then stops being redundant.
+ *
+ * "dispatch" rather than the tooltip's "restart" because this list enumerates the workflow RUNS
+ * behind a commit, where what matters is that the run was dispatched rather than pushed.
  */
 export function describeWorkflowRun(run: {
   runOrigin?: string | null;
-  restartDispatchedBy?: string | null;
 }): string {
-  const origin = describeRunOrigin(run);
-  return run.restartDispatchedBy
-    ? `${origin} by ${run.restartDispatchedBy}`
-    : origin;
+  if (run.runOrigin === "autorevert") return "autorevert dispatch";
+  return describeRunOrigin(run);
 }

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -45,13 +45,44 @@ export interface JobData extends BasicJobData {
   // Attempt number of the autorevert restart run. Separate from runAttempt on purpose: that field
   // carries the JOB's run_attempt from commit_jobs_query, and the HUD's crcr merge reads it.
   restartRunAttempt?: number;
-  // How many runs this cell merged, and a compact "<origin>: <conclusion>" list of them. Set by
-  // mergeCellRuns only when a cell really had more than one run.
-  mergedRunCount?: number;
-  mergedRuns?: string;
-  // html_url of a failing run that did NOT become the cell's representative. Rule 2 makes the success
-  // the representative, so this is the only route from a flaky cell to the failure itself.
-  mergedFailureUrl?: string;
+  // Every run behind this cell, set by mergeCellRuns only when a cell really had more than one.
+  // The cell renders ONE run's per-row fields (see CellRun.isRepresentative), so without this the
+  // other runs have no route from the grid -- and on a flaky "F" cell, neither does the failure.
+  cellRuns?: CellRun[];
+}
+
+/**
+ * One run behind a HUD cell, carried so the tooltip can name it and show ITS diagnostics.
+ *
+ * Deliberately a compact subset of JobData rather than a nested JobData: it is only read by the
+ * cell tooltip, and embedding whole jobs would both grow the grid payload and couple the cell
+ * format to consumers (Dr.CI, the commit page) that have nothing to do with cell aggregation.
+ *
+ * The failure fields are the load-bearing ones. They are per-run, so a cell rendering a success
+ * holds none of the failed run's classification -- carrying them here is what lets the tooltip
+ * show the failure's log and captures rather than the passing run's (see detailJobForRun).
+ */
+export interface CellRun {
+  runOrigin?: string;
+  conclusion?: string;
+  id?: string;
+  htmlUrl?: string;
+  logUrl?: string;
+  durationS?: number;
+  // The autorevert restart RUN's attempt. There is deliberately no counterpart for the JOB's own
+  // run_attempt: hud_query does not project it, because the HUD page reads `runAttempt` when
+  // merging crcr rows and relies on it being undefined here (see the comment on that column in
+  // hud_query). So a "re-run attempt" line names the origin without an attempt number.
+  restartRunAttempt?: number;
+  restartDispatchedBy?: string;
+  restartRerunBy?: string;
+  failureLines?: string[];
+  failureLineNumbers?: number[];
+  failureCaptures?: string[];
+  failureContext?: string[];
+  // The run whose per-row fields the cell itself renders. The cell's CONCLUSION is a function of
+  // the whole set, not of this run alone -- a mixed cell renders flaky "F" while this run passed.
+  isRepresentative?: boolean;
 }
 
 // Used by Dr.CI

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -31,6 +31,19 @@ export interface JobData extends BasicJobData {
   failureAnnotation?: string;
   failedPreviousRun?: boolean;
   runAttempt?: number;
+  // Set only on a job that came from a restart run dispatched against a trunk/<sha> ref; absent on
+  // ordinary jobs. Currently the only value is "autorevert", matching the source_type spelling in
+  // queued_jobs/query.sql. Compare against the value rather than testing for presence — see the
+  // nullIf() normalization in hud_query.
+  restartSource?: string;
+  // Login that dispatched the restart run.
+  restartDispatchedBy?: string;
+  // Login that triggered the latest attempt, set only when it differs from restartDispatchedBy —
+  // i.e. someone re-ran the restart.
+  restartRerunBy?: string;
+  // Attempt number of the restart run. Separate from runAttempt on purpose: that field carries the
+  // JOB's run_attempt from commit_jobs_query, and the HUD's crcr merge reads it.
+  restartRunAttempt?: number;
 }
 
 // Used by Dr.CI

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -33,12 +33,14 @@ export interface JobData extends BasicJobData {
   runAttempt?: number;
   // Where this run came from. "autorevert" for a restart dispatched against a trunk/<sha> ref
   // ("autorevert" matches the source_type spelling in queued_jobs/query.sql), "retry" for a re-run
-  // attempt, absent for a plain push — the default and overwhelming majority. REPORTED only: origin
+  // attempt, empty for a plain push — the default and overwhelming majority. REPORTED only: origin
   // must never affect how runs are aggregated (see mergeCellRuns). Compare against the value rather
   // than testing for presence.
-  runOrigin?: string;
+  // Both `null` and `undefined` occur and mean the same run: hud_query's rows reach the client with
+  // the key stripped, while commit_jobs_query ships a real SQL NULL.
+  runOrigin?: string | null;
   // Login that dispatched the autorevert restart run.
-  restartDispatchedBy?: string;
+  restartDispatchedBy?: string | null;
   // Login that triggered the latest attempt, set only when it differs from restartDispatchedBy —
   // i.e. someone re-ran the restart.
   restartRerunBy?: string;

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -31,19 +31,27 @@ export interface JobData extends BasicJobData {
   failureAnnotation?: string;
   failedPreviousRun?: boolean;
   runAttempt?: number;
-  // Set only on a job that came from a restart run dispatched against a trunk/<sha> ref; absent on
-  // ordinary jobs. Currently the only value is "autorevert", matching the source_type spelling in
-  // queued_jobs/query.sql. Compare against the value rather than testing for presence — see the
-  // nullIf() normalization in hud_query.
-  restartSource?: string;
-  // Login that dispatched the restart run.
+  // Where this run came from. "autorevert" for a restart dispatched against a trunk/<sha> ref
+  // ("autorevert" matches the source_type spelling in queued_jobs/query.sql), "retry" for a re-run
+  // attempt, absent for a plain push — the default and overwhelming majority. REPORTED only: origin
+  // must never affect how runs are aggregated (see mergeCellRuns). Compare against the value rather
+  // than testing for presence.
+  runOrigin?: string;
+  // Login that dispatched the autorevert restart run.
   restartDispatchedBy?: string;
   // Login that triggered the latest attempt, set only when it differs from restartDispatchedBy —
   // i.e. someone re-ran the restart.
   restartRerunBy?: string;
-  // Attempt number of the restart run. Separate from runAttempt on purpose: that field carries the
-  // JOB's run_attempt from commit_jobs_query, and the HUD's crcr merge reads it.
+  // Attempt number of the autorevert restart run. Separate from runAttempt on purpose: that field
+  // carries the JOB's run_attempt from commit_jobs_query, and the HUD's crcr merge reads it.
   restartRunAttempt?: number;
+  // How many runs this cell merged, and a compact "<origin>: <conclusion>" list of them. Set by
+  // mergeCellRuns only when a cell really had more than one run.
+  mergedRunCount?: number;
+  mergedRuns?: string;
+  // html_url of a failing run that did NOT become the cell's representative. Rule 2 makes the success
+  // the representative, so this is the only route from a flaky cell to the failure itself.
+  mergedFailureUrl?: string;
 }
 
 // Used by Dr.CI

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -80,8 +80,17 @@ export interface CellRun {
   failureLineNumbers?: number[];
   failureCaptures?: string[];
   failureContext?: string[];
+  // Carried so that picking a run rebinds EVERY id-bearing affordance in the tooltip, not just the
+  // ones on the row itself. `canShowODCCommand` reads (workflowId, id, failureLineNumbers) as one
+  // run's identity: with only `id` per-run, picking a sibling produced an ODC command pairing that
+  // run's job id with the REPRESENTATIVE's workflow id. `failureAnnotation` drives the classified
+  // styling, which is per-run for the same reason the classification text is.
+  workflowId?: string;
+  failureAnnotation?: string;
   // The run whose per-row fields the cell itself renders. The cell's CONCLUSION is a function of
   // the whole set, not of this run alone -- a mixed cell renders flaky "F" while this run passed.
+  // It is also what the tooltip shows before the reader picks anything, so the run list can render a
+  // default selection instead of a third "nothing is selected" state.
   isRepresentative?: boolean;
 }
 

--- a/torchci/pages/api/[repoOwner]/[repoName]/commit/[sha].ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/commit/[sha].ts
@@ -5,6 +5,13 @@ import type { NextApiRequest, NextApiResponse } from "next";
 export type WorkflowRunInfo = {
   id: number;
   attempt: number;
+  // Carried so the workflow picker can name a run rather than offer bare numeric ids a reader
+  // cannot tell apart. Same spellings as JobData: "autorevert" for a restart dispatched against a
+  // trunk/<sha> ref, "retry" for a re-run attempt; the login is set only for a restart.
+  // `null`, not just optional: commit_jobs_query ships both as real SQL NULLs for an ordinary push,
+  // and typing them `string | undefined` would have been a lie the runtime never tells.
+  runOrigin?: string | null;
+  restartDispatchedBy?: string | null;
 };
 
 export type CommitApiResponse = {

--- a/torchci/pages/api/[repoOwner]/[repoName]/commit/[sha].ts
+++ b/torchci/pages/api/[repoOwner]/[repoName]/commit/[sha].ts
@@ -7,11 +7,10 @@ export type WorkflowRunInfo = {
   attempt: number;
   // Carried so the workflow picker can name a run rather than offer bare numeric ids a reader
   // cannot tell apart. Same spellings as JobData: "autorevert" for a restart dispatched against a
-  // trunk/<sha> ref, "retry" for a re-run attempt; the login is set only for a restart.
-  // `null`, not just optional: commit_jobs_query ships both as real SQL NULLs for an ordinary push,
-  // and typing them `string | undefined` would have been a lie the runtime never tells.
+  // trunk/<sha> ref, "retry" for a re-run attempt.
+  // `null`, not just optional: commit_jobs_query ships a real SQL NULL for an ordinary push, and
+  // typing it `string | undefined` would have been a lie the runtime never tells.
   runOrigin?: string | null;
-  restartDispatchedBy?: string | null;
 };
 
 export type CommitApiResponse = {

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -120,11 +120,26 @@ export function JobCell({
         tooltipContent={
           <JobTooltip
             job={job}
-            sha={pinnedId.sha || sha}
+            // This cell's own sha, always. It used to be `pinnedId.sha || sha`, which is either
+            // redundant (a pinned CELL is this cell, so the shas match) or wrong: clicking a commit
+            // pins {sha, name: undefined} and leaves hover tooltips live, so hovering a
+            // does-not-exist cell on another row handed SingleWorkflowDispatcher the PINNED row's
+            // sha -- offering to dispatch the job against the wrong commit (DP17, gpt-5.6-sol).
+            sha={sha}
             isAutorevertSignal={isAutorevertSignal}
             advisorVerdict={advisorVerdict}
             repoOwner={repoOwner}
             repoName={repoName}
+            // Deliberately NOT TooltipTarget's own "pin only when nothing is pinned" guard. Pinning a
+            // commit ROW sets {sha, name: undefined}, which leaves hover tooltips live -- so under
+            // that guard picking a run in a hovered tooltip would still be lost on mouse-out, which
+            // is the whole defect being fixed (DP17, gpt-5.6-sol). Moving the pin from the row to
+            // this cell is the intended effect: the reader just acted on this cell.
+            pinCell={() => {
+              if (pinnedId.sha !== sha || pinnedId.name !== job.name) {
+                setPinnedId({ sha: sha, name: job.name as string });
+              }
+            }}
           />
         }
         sha={sha as string}

--- a/torchci/test/mergeCellRuns.test.ts
+++ b/torchci/test/mergeCellRuns.test.ts
@@ -1,6 +1,7 @@
 import { JobStatus } from "components/job/GroupJobConclusion";
 import {
   describeCellRun,
+  describeRunIdentity,
   describeRunOrigin,
   detailJobForRun,
   mergeCellRuns,
@@ -404,6 +405,59 @@ describe("mergeCellRuns", () => {
     expect(byId.get("3")!.id).toBe("3");
   });
 
+  // The ODC command reads (workflowId, id, failureLineNumbers) as ONE run's identity, so a run list
+  // that carried only `id` produced a command pairing the selected run's job with the
+  // representative's workflow -- a pair that never existed.
+  test("each run carries its own workflow id, and an annotation only when it has one", () => {
+    const merged = mergeCellRuns([
+      {
+        id: "1",
+        workflowId: "100",
+        conclusion: JobStatus.Failure,
+        failureAnnotation: "infra flake",
+        name: "w / j",
+      },
+      {
+        id: "2",
+        workflowId: "200",
+        conclusion: JobStatus.Failure,
+        name: "w / j",
+      },
+    ]);
+    const byId = new Map(merged.cellRuns!.map((r) => [r.id, r]));
+    expect(byId.get("1")!.workflowId).toBe("100");
+    expect(byId.get("2")!.workflowId).toBe("200");
+    expect(byId.get("1")!.failureAnnotation).toBe("infra flake");
+    // Absent rather than empty: an unannotated job carries '' on some producers, and fetchHud strips
+    // only nulls -- so assigning it would ship a key saying nothing on every run of every cell.
+    expect("failureAnnotation" in byId.get("2")!).toBe(false);
+  });
+
+  // The run list shows one short line per row, so the dispatch identity is rendered once for the run
+  // being inspected instead of on every row. A run with nothing to report must yield '', not a stray
+  // empty line under the list.
+  test("run identity names attempt, dispatcher and rerunner, and is empty when there are none", () => {
+    expect(
+      describeRunIdentity({
+        runOrigin: "autorevert",
+        restartRunAttempt: 2,
+        restartDispatchedBy: "pytorch-auto-revert[bot]",
+        restartRerunBy: "someone",
+      })
+    ).toBe(
+      "attempt 2, dispatched by pytorch-auto-revert[bot], rerun by someone"
+    );
+    expect(
+      describeRunIdentity({
+        runOrigin: "autorevert",
+        restartDispatchedBy: "pytorch-auto-revert[bot]",
+      })
+    ).toBe("dispatched by pytorch-auto-revert[bot]");
+    expect(describeRunIdentity({ conclusion: JobStatus.Success })).toBe("");
+    // Attempt 1 is still worth naming: it distinguishes a restart from its own re-runs.
+    expect(describeRunIdentity({ restartRunAttempt: 1 })).toBe("attempt 1");
+  });
+
   test("a stale failedPreviousRun on an input row cannot leak into a clean cell", () => {
     const poisoned: JobData = {
       id: "1",
@@ -509,6 +563,40 @@ describe("mergeCellRuns", () => {
       expect(pushDetail.runOrigin).toBeUndefined();
       expect(pushDetail.restartDispatchedBy).toBeUndefined();
       expect(pushDetail.restartRunAttempt).toBeUndefined();
+    });
+
+    test("selecting a run rebinds its workflow id and annotation, and clears one it lacks", () => {
+      // Round-tripped, for the same reason as the test above: the un-annotated run's key is dropped
+      // by JSON.stringify, which is exactly when an implementation that relied on the key being
+      // present would leave the representative's annotation standing.
+      const cell = JSON.parse(
+        JSON.stringify(
+          mergeCellRuns([
+            {
+              id: "2",
+              workflowId: "200",
+              conclusion: JobStatus.Failure,
+              failureAnnotation: "infra flake",
+              failureLines: ["boom"],
+              name: "w / j",
+            },
+            {
+              id: "1",
+              workflowId: "100",
+              conclusion: JobStatus.Failure,
+              name: "w / j",
+            },
+          ])
+        )
+      ) as JobData;
+
+      expect(cell.id).toBe("2");
+      expect(cell.failureAnnotation).toBe("infra flake");
+
+      const other = cell.cellRuns!.find((r) => r.id === "1")!;
+      const detail = detailJobForRun(cell, other);
+      expect(detail.workflowId).toBe("100");
+      expect(detail.failureAnnotation).toBeUndefined();
     });
 
     test("selecting a run without diagnostics does not inherit another run's failure", () => {

--- a/torchci/test/mergeCellRuns.test.ts
+++ b/torchci/test/mergeCellRuns.test.ts
@@ -1,0 +1,245 @@
+import { JobStatus } from "components/job/GroupJobConclusion";
+import { mergeCellRuns } from "lib/mergeCellRuns";
+import { JobData } from "lib/types";
+import nock from "nock";
+
+nock.disableNetConnect();
+
+function run(id: string, conclusion: string, runOrigin?: string): JobData {
+  return { id, conclusion, runOrigin, name: "w / j", sha: "abc" };
+}
+
+describe("mergeCellRuns", () => {
+  test("a single run is shown as-is, whoever issued it", () => {
+    for (const origin of [undefined, "autorevert", "retry"]) {
+      const only = run("1", JobStatus.Failure, origin);
+      const merged = mergeCellRuns([only]);
+      expect(merged.conclusion).toBe(JobStatus.Failure);
+      // No merge annotations on a one-run cell.
+      expect(merged.mergedRunCount).toBeUndefined();
+      expect(merged.mergedRuns).toBeUndefined();
+      expect(merged.failedPreviousRun).toBe(false);
+    }
+  });
+
+  test("a one-run cell is a copy, and a stale flag on it cannot render a phantom F", () => {
+    const poisoned: JobData = {
+      id: "1",
+      conclusion: JobStatus.Success,
+      failedPreviousRun: true,
+      name: "w / j",
+    };
+    const merged = mergeCellRuns([poisoned]);
+    expect(merged.failedPreviousRun).toBe(false);
+    // A copy, so the caller's later `job.name = undefined` cannot mutate the input row.
+    expect(merged).not.toBe(poisoned);
+    expect(poisoned.name).toBe("w / j");
+  });
+
+  // The invariant: the verdict depends on the SET of conclusions, never on the issuer and never on
+  // the order. Every permutation below must agree.
+  test("success + failure renders flaky regardless of order or issuer", () => {
+    const cases: JobData[][] = [
+      [run("1", JobStatus.Failure), run("2", JobStatus.Success, "autorevert")],
+      [run("2", JobStatus.Success, "autorevert"), run("1", JobStatus.Failure)],
+      // The case the old newest-id-wins reducer got wrong: natural run passed, the LATER restart
+      // failed. It used to render a plain red with no flaky marker.
+      [run("1", JobStatus.Success), run("2", JobStatus.Failure, "autorevert")],
+      [run("2", JobStatus.Failure, "autorevert"), run("1", JobStatus.Success)],
+      // Same thing for a plain re-run attempt.
+      [run("1", JobStatus.Success), run("2", JobStatus.Failure, "retry")],
+      // And for two push runs, e.g. a periodic scheduled twice.
+      [run("1", JobStatus.Failure), run("2", JobStatus.Success)],
+    ];
+    for (const runs of cases) {
+      const merged = mergeCellRuns(runs);
+      expect(merged.conclusion).toBe(JobStatus.Success);
+      expect(merged.failedPreviousRun).toBe(true);
+    }
+  });
+
+  test("timed_out counts as a real failure", () => {
+    const merged = mergeCellRuns([
+      run("1", JobStatus.Success),
+      run("2", JobStatus.Timed_out, "autorevert"),
+    ]);
+    expect(merged.conclusion).toBe(JobStatus.Success);
+    expect(merged.failedPreviousRun).toBe(true);
+  });
+
+  test("only failures stays a failure, and is not marked flaky", () => {
+    const merged = mergeCellRuns([
+      run("1", JobStatus.Failure),
+      run("2", JobStatus.Failure, "autorevert"),
+    ]);
+    expect(merged.conclusion).toBe(JobStatus.Failure);
+    expect(merged.failedPreviousRun).toBe(false);
+  });
+
+  test("cancelled loses to any non-cancelled run, in either order", () => {
+    for (const runs of [
+      [
+        run("1", JobStatus.Cancelled),
+        run("2", JobStatus.Success, "autorevert"),
+      ],
+      [
+        run("2", JobStatus.Success, "autorevert"),
+        run("1", JobStatus.Cancelled),
+      ],
+      // Cancelled is newer here, so newest-id-wins used to surface the cancellation.
+      [
+        run("1", JobStatus.Success),
+        run("2", JobStatus.Cancelled, "autorevert"),
+      ],
+    ]) {
+      const merged = mergeCellRuns(runs);
+      expect(merged.conclusion).toBe(JobStatus.Success);
+    }
+    const withFailure = mergeCellRuns([
+      run("1", JobStatus.Cancelled),
+      run("2", JobStatus.Failure),
+    ]);
+    expect(withFailure.conclusion).toBe(JobStatus.Failure);
+  });
+
+  test("a cancelled run is not failure evidence, so it does not make a success flaky", () => {
+    // Documented deliberate divergence from isFailure(), which counts cancelled as a failure. This
+    // is the one behaviour change that is a judgement call rather than a consequence of the rules;
+    // it moves 223 cells over 14 days of pytorch/pytorch from "F" to a plain success.
+    const merged = mergeCellRuns([
+      run("1", JobStatus.Cancelled),
+      run("2", JobStatus.Success, "autorevert"),
+    ]);
+    expect(merged.conclusion).toBe(JobStatus.Success);
+    expect(merged.failedPreviousRun).toBe(false);
+  });
+
+  test("all-cancelled has nothing better to fall back to", () => {
+    const merged = mergeCellRuns([
+      run("1", JobStatus.Cancelled),
+      run("2", JobStatus.Cancelled, "autorevert"),
+    ]);
+    expect(merged.conclusion).toBe(JobStatus.Cancelled);
+  });
+
+  // Rule 3 says ANY non-cancelled run wins, not just success/failure. Ranking cancelled rather than
+  // filtering it made it beat skipped and neutral.
+  test.each([
+    JobStatus.Success,
+    JobStatus.Failure,
+    JobStatus.Timed_out,
+    JobStatus.Neutral,
+    JobStatus.Skipped,
+    JobStatus.Queued,
+    JobStatus.Pending,
+  ])("cancelled loses to %s in both orders", (other) => {
+    expect(
+      mergeCellRuns([run("1", JobStatus.Cancelled), run("2", other)]).conclusion
+    ).toBe(other);
+    expect(
+      mergeCellRuns([run("2", other), run("1", JobStatus.Cancelled)]).conclusion
+    ).toBe(other);
+  });
+
+  test("an empty conclusion is treated as pending, not as an unknown class", () => {
+    // hud_query maps '' to queued/pending before this point; this pins the defensive normalization so
+    // '' can never outrank or underrank a real result by accident.
+    expect(
+      mergeCellRuns([run("1", ""), run("2", JobStatus.Cancelled)]).conclusion
+    ).toBe("");
+    const withSkip = mergeCellRuns([run("1", ""), run("2", JobStatus.Skipped)]);
+    expect(withSkip.conclusion).toBe("");
+  });
+
+  test("the failing run stays reachable from a flaky cell", () => {
+    const failing: JobData = {
+      id: "2",
+      conclusion: JobStatus.Failure,
+      htmlUrl: "https://example.com/failed-run",
+      name: "w / j",
+    };
+    const merged = mergeCellRuns([run("1", JobStatus.Success), failing]);
+    // The success represents the cell, so without this the failure has no route from the grid.
+    expect(merged.conclusion).toBe(JobStatus.Success);
+    expect(merged.failedPreviousRun).toBe(true);
+    expect(merged.mergedFailureUrl).toBe("https://example.com/failed-run");
+  });
+
+  test("no failure url is invented when the representative IS the failure", () => {
+    const merged = mergeCellRuns([
+      run("1", JobStatus.Skipped),
+      { id: "2", conclusion: JobStatus.Failure, htmlUrl: "u", name: "w / j" },
+    ]);
+    expect(merged.conclusion).toBe(JobStatus.Failure);
+    expect(merged.mergedFailureUrl).toBeUndefined();
+  });
+
+  test("an unrecognized origin is reported verbatim rather than called a push", () => {
+    const merged = mergeCellRuns([
+      run("1", JobStatus.Success, "schedule"),
+      run("2", JobStatus.Failure),
+    ]);
+    expect(merged.mergedRuns).toBe("schedule: success, push: failure");
+  });
+
+  test("skipped keeps losing to a real result", () => {
+    const merged = mergeCellRuns([
+      run("2", JobStatus.Skipped),
+      run("1", JobStatus.Failure, "autorevert"),
+    ]);
+    expect(merged.conclusion).toBe(JobStatus.Failure);
+  });
+
+  test("a completed result outranks a still-pending run", () => {
+    const merged = mergeCellRuns([
+      run("2", JobStatus.Pending, "autorevert"),
+      run("1", JobStatus.Success),
+    ]);
+    expect(merged.conclusion).toBe(JobStatus.Success);
+  });
+
+  test("restart-only cells report their real conclusion, including red", () => {
+    // Under the previous success-only SQL filter these rows never reached the grid at all.
+    expect(
+      mergeCellRuns([run("1", JobStatus.Failure, "autorevert")]).conclusion
+    ).toBe(JobStatus.Failure);
+    expect(
+      mergeCellRuns([run("1", JobStatus.Skipped, "autorevert")]).conclusion
+    ).toBe(JobStatus.Skipped);
+  });
+
+  test("the representative within a class is the newest run", () => {
+    const merged = mergeCellRuns([
+      run("10", JobStatus.Success),
+      run("20", JobStatus.Success, "autorevert"),
+    ]);
+    expect(merged.id).toBe("20");
+  });
+
+  test("merge annotations report the count and every origin", () => {
+    const merged = mergeCellRuns([
+      run("1", JobStatus.Failure),
+      run("2", JobStatus.Success, "autorevert"),
+      run("3", JobStatus.Cancelled, "retry"),
+    ]);
+    expect(merged.mergedRunCount).toBe(3);
+    expect(merged.mergedRuns).toBe(
+      "autorevert restart: success, push: failure, re-run attempt: cancelled"
+    );
+  });
+
+  test("a stale failedPreviousRun on an input row cannot leak into a clean cell", () => {
+    const poisoned: JobData = {
+      id: "1",
+      conclusion: JobStatus.Success,
+      failedPreviousRun: true,
+      name: "w / j",
+    };
+    const merged = mergeCellRuns([poisoned, run("2", JobStatus.Success)]);
+    expect(merged.failedPreviousRun).toBe(false);
+  });
+
+  test("an empty cell merges to an empty job rather than throwing", () => {
+    expect(mergeCellRuns([])).toEqual({});
+  });
+});

--- a/torchci/test/mergeCellRuns.test.ts
+++ b/torchci/test/mergeCellRuns.test.ts
@@ -1,5 +1,11 @@
 import { JobStatus } from "components/job/GroupJobConclusion";
-import { mergeCellRuns } from "lib/mergeCellRuns";
+import {
+  describeCellRun,
+  describeRunOrigin,
+  detailJobForRun,
+  mergeCellRuns,
+  runKeyOf,
+} from "lib/mergeCellRuns";
 import { JobData } from "lib/types";
 import nock from "nock";
 
@@ -15,10 +21,9 @@ describe("mergeCellRuns", () => {
       const only = run("1", JobStatus.Failure, origin);
       const merged = mergeCellRuns([only]);
       expect(merged.conclusion).toBe(JobStatus.Failure);
-      // No merge annotations on a one-run cell.
-      expect(merged.mergedRunCount).toBeUndefined();
-      expect(merged.mergedRuns).toBeUndefined();
-      expect(merged.failedPreviousRun).toBe(false);
+      // No run list on a one-run cell -- the cell already describes it.
+      expect(merged.cellRuns).toBeUndefined();
+      expect(merged.failedPreviousRun).toBeUndefined();
     }
   });
 
@@ -30,7 +35,9 @@ describe("mergeCellRuns", () => {
       name: "w / j",
     };
     const merged = mergeCellRuns([poisoned]);
-    expect(merged.failedPreviousRun).toBe(false);
+    expect(merged.failedPreviousRun).toBeUndefined();
+    // Deleted, not assigned false -- `false` is not null, so fetchHud's strip would ship it.
+    expect("failedPreviousRun" in merged).toBe(false);
     // A copy, so the caller's later `job.name = undefined` cannot mutate the input row.
     expect(merged).not.toBe(poisoned);
     expect(poisoned.name).toBe("w / j");
@@ -73,7 +80,7 @@ describe("mergeCellRuns", () => {
       run("2", JobStatus.Failure, "autorevert"),
     ]);
     expect(merged.conclusion).toBe(JobStatus.Failure);
-    expect(merged.failedPreviousRun).toBe(false);
+    expect(merged.failedPreviousRun).toBeUndefined();
   });
 
   test("cancelled loses to any non-cancelled run, in either order", () => {
@@ -111,7 +118,7 @@ describe("mergeCellRuns", () => {
       run("2", JobStatus.Success, "autorevert"),
     ]);
     expect(merged.conclusion).toBe(JobStatus.Success);
-    expect(merged.failedPreviousRun).toBe(false);
+    expect(merged.failedPreviousRun).toBeUndefined();
   });
 
   test("all-cancelled has nothing better to fall back to", () => {
@@ -151,27 +158,84 @@ describe("mergeCellRuns", () => {
     expect(withSkip.conclusion).toBe("");
   });
 
-  test("the failing run stays reachable from a flaky cell", () => {
+  test("the failing run stays reachable from a flaky cell, with its own log", () => {
     const failing: JobData = {
       id: "2",
       conclusion: JobStatus.Failure,
       htmlUrl: "https://example.com/failed-run",
+      logUrl: "https://example.com/failed-log",
+      failureLines: ["boom"],
+      failureCaptures: ["boom"],
       name: "w / j",
     };
     const merged = mergeCellRuns([run("1", JobStatus.Success), failing]);
-    // The success represents the cell, so without this the failure has no route from the grid.
+    // The success represents the cell, so without the run list the failure has no route from the
+    // grid -- and its LOG has none even with a route, because the log url is per-run.
     expect(merged.conclusion).toBe(JobStatus.Success);
     expect(merged.failedPreviousRun).toBe(true);
-    expect(merged.mergedFailureUrl).toBe("https://example.com/failed-run");
+    const failedRun = merged.cellRuns!.find(
+      (r) => r.conclusion === JobStatus.Failure
+    )!;
+    expect(failedRun.htmlUrl).toBe("https://example.com/failed-run");
+    expect(failedRun.logUrl).toBe("https://example.com/failed-log");
+    expect(failedRun.failureLines).toEqual(["boom"]);
+    expect(failedRun.isRepresentative).toBeUndefined();
   });
 
-  test("no failure url is invented when the representative IS the failure", () => {
-    const merged = mergeCellRuns([
-      run("1", JobStatus.Skipped),
-      { id: "2", conclusion: JobStatus.Failure, htmlUrl: "u", name: "w / j" },
+  // The 197-cell bug: the restart LOST the ranking (rule 2 makes the success the representative),
+  // so every restart identity field was dropped and the tooltip called the cell a push -- on exactly
+  // the population the provenance feature exists to explain.
+  test("restart identity survives even when the restart is not the representative", () => {
+    const restart: JobData = {
+      id: "2",
+      conclusion: JobStatus.Failure,
+      runOrigin: "autorevert",
+      restartDispatchedBy: "pytorch-auto-revert[bot]",
+      restartRerunBy: "huydhn",
+      restartRunAttempt: 2,
+      name: "w / j",
+    };
+    const merged = mergeCellRuns([run("1", JobStatus.Success), restart]);
+    // The cell itself is the push run, and says so.
+    expect(merged.runOrigin).toBeUndefined();
+    expect(merged.restartDispatchedBy).toBeUndefined();
+    const restartRun = merged.cellRuns!.find(
+      (r) => r.runOrigin === "autorevert"
+    )!;
+    expect(restartRun.restartDispatchedBy).toBe("pytorch-auto-revert[bot]");
+    expect(restartRun.restartRerunBy).toBe("huydhn");
+    expect(restartRun.restartRunAttempt).toBe(2);
+    expect(describeCellRun(restartRun)).toBe(
+      "autorevert restart (attempt 2), dispatched by pytorch-auto-revert[bot], rerun by huydhn — failure"
+    );
+  });
+
+  // An ordinary GitHub re-run is named, but carries NO attempt number: hud_query deliberately does
+  // not project the job's own run_attempt, because the HUD page reads `runAttempt` when merging crcr
+  // rows and depends on it being undefined here. Only the restart's attempt is available.
+  test("a re-run attempt is named without an attempt number it does not have", () => {
+    const rerun: JobData = {
+      id: "2",
+      conclusion: JobStatus.Failure,
+      runOrigin: "retry",
+      // Set on the input row on purpose: it must NOT reach the run line, because on the real HUD
+      // path it is always undefined and a number here would be a fiction on some other surface.
+      runAttempt: 3,
+      name: "w / j",
+    };
+    const merged = mergeCellRuns([run("1", JobStatus.Success), rerun]);
+    expect(merged.cellRuns!.map(describeCellRun)).toEqual([
+      "push — success",
+      "re-run attempt — failure",
     ]);
-    expect(merged.conclusion).toBe(JobStatus.Failure);
-    expect(merged.mergedFailureUrl).toBeUndefined();
+    // And the restart's attempt is not confused for it.
+    expect(
+      describeCellRun({
+        runOrigin: "autorevert",
+        restartRunAttempt: 2,
+        conclusion: JobStatus.Failure,
+      })
+    ).toBe("autorevert restart (attempt 2) — failure");
   });
 
   test("an unrecognized origin is reported verbatim rather than called a push", () => {
@@ -179,7 +243,20 @@ describe("mergeCellRuns", () => {
       run("1", JobStatus.Success, "schedule"),
       run("2", JobStatus.Failure),
     ]);
-    expect(merged.mergedRuns).toBe("schedule: success, push: failure");
+    expect(merged.cellRuns!.map(describeCellRun)).toEqual([
+      "schedule — success",
+      "push — failure",
+    ]);
+  });
+
+  // The blank is NOT the same claim as the absent value: workflow_event is a dictGet that returns
+  // the column default until the dictionary catches up, so blanks land on the freshest rows on the
+  // page. Calling those "push" is a guess; rendering them raw produced "Shown run: ." on the grid.
+  test("a blank origin reads as unknown, while an absent one is a push", () => {
+    expect(describeRunOrigin({ runOrigin: undefined })).toBe("push");
+    expect(describeRunOrigin({ runOrigin: "" })).toBe("unknown");
+    expect(describeRunOrigin({ runOrigin: "   " })).toBe("unknown");
+    expect(describeRunOrigin({ runOrigin: " schedule " })).toBe("schedule");
   });
 
   test("skipped keeps losing to a real result", () => {
@@ -208,24 +285,123 @@ describe("mergeCellRuns", () => {
     ).toBe(JobStatus.Skipped);
   });
 
-  test("the representative within a class is the newest run", () => {
+  test("the representative within a class is the newest run, compared numerically", () => {
+    // Ids where lexical and numeric order DISAGREE: "9" > "10" as strings. The reducer this
+    // replaced compared them as strings, so equal-digit ids could not tell the two apart.
     const merged = mergeCellRuns([
-      run("10", JobStatus.Success),
-      run("20", JobStatus.Success, "autorevert"),
+      run("9", JobStatus.Success),
+      run("10", JobStatus.Success, "autorevert"),
     ]);
-    expect(merged.id).toBe("20");
+    expect(merged.id).toBe("10");
   });
 
-  test("merge annotations report the count and every origin", () => {
+  test("the run list carries every run, best class first, representative marked", () => {
     const merged = mergeCellRuns([
       run("1", JobStatus.Failure),
       run("2", JobStatus.Success, "autorevert"),
       run("3", JobStatus.Cancelled, "retry"),
     ]);
-    expect(merged.mergedRunCount).toBe(3);
-    expect(merged.mergedRuns).toBe(
-      "autorevert restart: success, push: failure, re-run attempt: cancelled"
+    expect(merged.cellRuns).toHaveLength(3);
+    expect(merged.cellRuns!.map(describeCellRun)).toEqual([
+      "autorevert restart — success",
+      "push — failure",
+      "re-run attempt — cancelled",
+    ]);
+    // Exactly one representative, and it is the run the cell renders -- so the list can never
+    // disagree with the cell about which run supplied its duration and default links.
+    const marked = merged.cellRuns!.filter((r) => r.isRepresentative);
+    expect(marked).toHaveLength(1);
+    expect(marked[0].id).toBe(merged.id);
+    expect(marked[0].id).toBe("2");
+  });
+
+  test("the run list order does not depend on the order the query returned rows in", () => {
+    const runs = [
+      run("1", JobStatus.Failure),
+      run("2", JobStatus.Success, "autorevert"),
+      run("3", JobStatus.Skipped),
+    ];
+    const forward = mergeCellRuns(runs)!.cellRuns!.map((r) => r.id);
+    const reversed = mergeCellRuns(runs.slice().reverse())!.cellRuns!.map(
+      (r) => r.id
     );
+    expect(forward).toEqual(reversed);
+  });
+
+  // The tail of a long list is collapsed in the UI, so burying either the representative or the
+  // failure would hide exactly what the reader opened the tooltip for.
+  test("the list leads with the representative, then failures, then the rest newest-first", () => {
+    const merged = mergeCellRuns([
+      run("10", JobStatus.Success),
+      run("40", JobStatus.Success), // newest success -> representative
+      run("20", JobStatus.Failure),
+      run("30", JobStatus.Skipped),
+      run("50", JobStatus.Failure), // newer failure
+    ]);
+    expect(merged.id).toBe("40");
+    expect(merged.cellRuns!.map((r) => r.id)).toEqual([
+      "40", // representative first
+      "50", // then failures, newest first
+      "20",
+      "30", // then the rest, newest first
+      "10",
+    ]);
+    expect(merged.cellRuns![0].isRepresentative).toBe(true);
+  });
+
+  test("runs with equal or missing ids still produce a stable, complete list", () => {
+    // hud_query has no ORDER BY, so input order is not controlled -- and a comparator that returns 0
+    // would leave the outcome to sort stability, i.e. to the query.
+    const a: JobData = {
+      conclusion: JobStatus.Failure,
+      htmlUrl: "aaa",
+      name: "w / j",
+    };
+    const b: JobData = {
+      conclusion: JobStatus.Failure,
+      htmlUrl: "bbb",
+      name: "w / j",
+    };
+    const forward = mergeCellRuns([a, b]);
+    const reversed = mergeCellRuns([b, a]);
+    expect(forward.cellRuns).toHaveLength(2);
+    expect(forward.cellRuns!.map((r) => r.htmlUrl)).toEqual(
+      reversed.cellRuns!.map((r) => r.htmlUrl)
+    );
+    expect(forward.htmlUrl).toBe(reversed.htmlUrl);
+    expect(forward.cellRuns!.filter((r) => r.isRepresentative)).toHaveLength(1);
+    // A run with no usable id must not be read as id 0 and beat a real id.
+    const withReal = mergeCellRuns([a, run("5", JobStatus.Failure)]);
+    expect(withReal.id).toBe("5");
+    // Distinct keys, so React cannot collapse two rows into one.
+    expect(new Set(forward.cellRuns!.map(runKeyOf)).size).toBe(2);
+  });
+
+  // Classification text is the largest thing a run can carry (55 KB on one run of a real page), and
+  // torchci classifies plenty of runs that did not fail. Over the 50 newest pytorch/pytorch trunk
+  // commits, runs on multi-run cells hold 1.35 MB of it and only 4.7 KB sits on a genuinely failed
+  // run -- so carrying it unconditionally would add ~1.3 MB to the grid to explain nothing.
+  test("classification is carried only for runs that actually failed", () => {
+    const diagnostics = {
+      failureLines: ["boom"],
+      failureCaptures: ["boom"],
+      failureLineNumbers: [7],
+      name: "w / j",
+    };
+    const merged = mergeCellRuns([
+      { id: "1", conclusion: JobStatus.Failure, ...diagnostics },
+      // Cancelled and skipped runs routinely carry a classification line; it is not a failure.
+      { id: "2", conclusion: JobStatus.Cancelled, ...diagnostics },
+      { id: "3", conclusion: JobStatus.Skipped, ...diagnostics },
+    ]);
+    const byId = new Map(merged.cellRuns!.map((r) => [r.id, r]));
+    expect(byId.get("1")!.failureLines).toEqual(["boom"]);
+    expect(byId.get("2")!.failureLines).toBeUndefined();
+    expect(byId.get("2")!.failureCaptures).toBeUndefined();
+    expect(byId.get("3")!.failureLines).toBeUndefined();
+    // Still named and still reachable -- only the bulky classification is withheld.
+    expect(byId.get("2")!.conclusion).toBe(JobStatus.Cancelled);
+    expect(byId.get("3")!.id).toBe("3");
   });
 
   test("a stale failedPreviousRun on an input row cannot leak into a clean cell", () => {
@@ -236,7 +412,123 @@ describe("mergeCellRuns", () => {
       name: "w / j",
     };
     const merged = mergeCellRuns([poisoned, run("2", JobStatus.Success)]);
-    expect(merged.failedPreviousRun).toBe(false);
+    expect(merged.failedPreviousRun).toBeUndefined();
+    expect("failedPreviousRun" in merged).toBe(false);
+  });
+
+  // Selecting a run is not enough on its own: the diagnostics are per-run, and the cell holds the
+  // representative's -- which on a flaky "F" cell is the run that PASSED.
+  describe("detailJobForRun", () => {
+    const failing: JobData = {
+      id: "2",
+      conclusion: JobStatus.Failure,
+      logUrl: "https://example.com/failed-log",
+      htmlUrl: "https://example.com/failed-run",
+      failureLines: ["boom"],
+      failureCaptures: ["boom"],
+      name: "w / j",
+    };
+    const passing: JobData = {
+      id: "1",
+      conclusion: JobStatus.Success,
+      logUrl: "https://example.com/passed-log",
+      name: "w / j",
+    };
+
+    test("with no selection it is the cell itself", () => {
+      const cell = mergeCellRuns([passing, failing]);
+      expect(detailJobForRun(cell, undefined)).toBe(cell);
+    });
+
+    test("selecting the failure rebinds the log and the classification to it", () => {
+      const cell = mergeCellRuns([passing, failing]);
+      expect(cell.logUrl).toBe("https://example.com/passed-log");
+      const failedRun = cell.cellRuns!.find(
+        (r) => r.conclusion === JobStatus.Failure
+      )!;
+      const detail = detailJobForRun(cell, failedRun);
+      expect(detail.logUrl).toBe("https://example.com/failed-log");
+      expect(detail.conclusion).toBe(JobStatus.Failure);
+      expect(detail.failureLines).toEqual(["boom"]);
+      // Cell-level context the run does not carry is kept.
+      expect(detail.name).toBe("w / j");
+      // Not a marker for a consumer of JobData to trip over.
+      expect("isRepresentative" in detail).toBe(false);
+    });
+
+    // The bug this pins is invisible in memory. mergeCellRuns builds each CellRun with explicit
+    // `undefined` properties, so a spread-based implementation overrides correctly here -- but
+    // JSON.stringify DROPS those keys, and the grid reaches the browser as JSON. Every assertion
+    // below must therefore run against a round-tripped payload, which is the only shape that ships.
+    test("a selected run keeps its own identity after a JSON round trip", () => {
+      const cell = JSON.parse(
+        JSON.stringify(
+          mergeCellRuns([
+            {
+              id: "1",
+              conclusion: JobStatus.Success,
+              logUrl: "https://example.com/push-log",
+              htmlUrl: "https://example.com/push-run",
+              durationS: 11,
+              name: "w / j",
+            },
+            {
+              id: "2",
+              conclusion: JobStatus.Failure,
+              runOrigin: "autorevert",
+              restartDispatchedBy: "pytorch-auto-revert[bot]",
+              restartRunAttempt: 2,
+              logUrl: "https://example.com/restart-log",
+              htmlUrl: "https://example.com/restart-run",
+              durationS: 22,
+              name: "w / j",
+            },
+          ])
+        )
+      ) as JobData;
+
+      // The cell is the push run (rule 2 gives a mixed cell to the success) and renders flaky.
+      expect(cell.id).toBe("1");
+      expect(cell.failedPreviousRun).toBe(true);
+
+      const restart = cell.cellRuns!.find((r) => r.id === "2")!;
+      const restartDetail = detailJobForRun(cell, restart);
+      expect(restartDetail.logUrl).toBe("https://example.com/restart-log");
+      expect(restartDetail.htmlUrl).toBe("https://example.com/restart-run");
+      expect(restartDetail.durationS).toBe(22);
+      expect(restartDetail.runOrigin).toBe("autorevert");
+      // A single run is never itself "flaky" -- that is a property of the set.
+      expect(restartDetail.failedPreviousRun).toBeUndefined();
+
+      // And back the other way: the push run must not pick up the restart's identity just because
+      // its own keys were dropped from the JSON for being undefined.
+      const push = cell.cellRuns!.find((r) => r.id === "1")!;
+      expect("runOrigin" in push).toBe(false);
+      const pushDetail = detailJobForRun(cell, push);
+      expect(pushDetail.logUrl).toBe("https://example.com/push-log");
+      expect(pushDetail.runOrigin).toBeUndefined();
+      expect(pushDetail.restartDispatchedBy).toBeUndefined();
+      expect(pushDetail.restartRunAttempt).toBeUndefined();
+    });
+
+    test("selecting a run without diagnostics does not inherit another run's failure", () => {
+      // The subtle one: a CellRun omits the keys it has no value for, so a naive spread would leave
+      // the representative's captures in place and attribute one run's failure to another.
+      //
+      // Two failures, so the representative is the one that CARRIES lines (rule 2 would otherwise
+      // hand the cell to a success, which has none and could not show the bug).
+      const cell = mergeCellRuns([
+        failing,
+        { id: "1", conclusion: JobStatus.Failure, name: "w / j" },
+      ]);
+      expect(cell.id).toBe("2");
+      expect(cell.failureLines).toEqual(["boom"]);
+      const otherFailure = cell.cellRuns!.find((r) => r.id === "1")!;
+      const detail = detailJobForRun(cell, otherFailure);
+      expect(detail.failureLines).toBeUndefined();
+      expect(detail.failureCaptures).toBeUndefined();
+      expect(detail.logUrl).toBeUndefined();
+    });
   });
 
   test("an empty cell merges to an empty job rather than throwing", () => {

--- a/torchci/test/mergeCellRuns.test.ts
+++ b/torchci/test/mergeCellRuns.test.ts
@@ -103,9 +103,9 @@ describe("mergeCellRuns", () => {
   });
 
   test("a cancelled run is not failure evidence, so it does not make a success flaky", () => {
-    // Documented deliberate divergence from isFailure(), which counts cancelled as a failure. This
-    // is the one behaviour change that is a judgement call rather than a consequence of the rules;
-    // it moves 223 cells over 14 days of pytorch/pytorch from "F" to a plain success.
+    // Deliberate, confirmed divergence from isFailure(), which counts cancelled as a failure. Moves
+    // 223 cells over 14 days of pytorch/pytorch from "F" to a plain success. This test exists to stop
+    // that being "fixed" back: a run rule 3 discards must not also turn a success flaky.
     const merged = mergeCellRuns([
       run("1", JobStatus.Cancelled),
       run("2", JobStatus.Success, "autorevert"),

--- a/torchci/test/mergeCellRuns.test.ts
+++ b/torchci/test/mergeCellRuns.test.ts
@@ -1,13 +1,15 @@
 import { JobStatus } from "components/job/GroupJobConclusion";
+import { getConclusionChar } from "lib/JobClassifierUtil";
 import {
   describeCellRun,
   describeRunIdentity,
   describeRunOrigin,
   detailJobForRun,
+  disambiguateCellRuns,
   mergeCellRuns,
   runKeyOf,
 } from "lib/mergeCellRuns";
-import { JobData } from "lib/types";
+import { CellRun, JobData } from "lib/types";
 import nock from "nock";
 
 nock.disableNetConnect();
@@ -456,6 +458,253 @@ describe("mergeCellRuns", () => {
     expect(describeRunIdentity({ conclusion: JobStatus.Success })).toBe("");
     // Attempt 1 is still worth naming: it distinguishes a restart from its own re-runs.
     expect(describeRunIdentity({ restartRunAttempt: 1 })).toBe("attempt 1");
+  });
+
+  // Two runs sharing an origin AND a conclusion produced byte-identical row text, hover text and
+  // accessible name, because the restart fields that would separate them are absent on every ordinary
+  // push or periodic run. The suffix is added only to the rows that would collide.
+  describe("disambiguateCellRuns", () => {
+    test("runs that already read differently get no suffix", () => {
+      const push: CellRun = {
+        id: "1",
+        workflowId: "10",
+        conclusion: "success",
+      };
+      const periodic: CellRun = {
+        id: "2",
+        workflowId: "20",
+        conclusion: "success",
+        runOrigin: "schedule",
+      };
+      const suffixes = disambiguateCellRuns([push, periodic]);
+      expect(suffixes.get(push)).toBe("");
+      expect(suffixes.get(periodic)).toBe("");
+    });
+
+    // Note the scope of the title: conclusions that map to DIFFERENT glyphs are a difference. Two
+    // conclusions that both fall through to `U` are not, which is the `action_required` / `stale` case
+    // further down.
+    test("conclusions that draw different glyphs are already a difference, so neither row is suffixed", () => {
+      const passed: CellRun = {
+        id: "1",
+        workflowId: "10",
+        conclusion: "success",
+      };
+      const failed: CellRun = {
+        id: "2",
+        workflowId: "20",
+        conclusion: "failure",
+      };
+      const suffixes = disambiguateCellRuns([passed, failed]);
+      expect(suffixes.get(passed)).toBe("");
+      expect(suffixes.get(failed)).toBe("");
+    });
+
+    // The REQUIREMENT is that the rendered strings end up unique, not that any particular field was
+    // chosen -- asserting the field would pin the implementation's own guess and could pass while two
+    // rows still read the same (a suffix built from a shared value separates nothing).
+    //
+    // `visible` includes the GLYPH CHARACTER, because that is on the row: a model that dropped it would
+    // report two `U`-drawing runs as already distinct and could not see the defect this covers.
+    function rowStrings(runs: CellRun[]): {
+      visible: string[];
+      accessible: string[];
+    } {
+      const suffixes = disambiguateCellRuns(runs);
+      return {
+        visible: runs.map(
+          (run) =>
+            `${getConclusionChar(run.conclusion)} ${describeRunOrigin(
+              run
+            )}${suffixes.get(run)}`
+        ),
+        accessible: runs.map(
+          (run) => `${describeCellRun(run)}${suffixes.get(run)}`
+        ),
+      };
+    }
+
+    function allDistinct(values: string[]): boolean {
+      return new Set(values).size === values.length;
+    }
+
+    test("colliding runs end up with distinct row text, hover text and accessible name", () => {
+      const first: CellRun = {
+        id: "1",
+        workflowId: "10",
+        conclusion: "success",
+        runOrigin: "schedule",
+      };
+      const second: CellRun = {
+        id: "2",
+        workflowId: "20",
+        conclusion: "success",
+        runOrigin: "schedule",
+      };
+      // Without a suffix these are the same string, which is the defect.
+      expect(describeRunOrigin(first)).toBe(describeRunOrigin(second));
+      expect(describeCellRun(first)).toBe(describeCellRun(second));
+      const rows = rowStrings([first, second]);
+      expect(allDistinct(rows.visible)).toBe(true);
+      expect(allDistinct(rows.accessible)).toBe(true);
+    });
+
+    // `workflowId` is `job.run_id`, which every re-run ATTEMPT of one run shares. A disambiguator
+    // picked by presence rather than by distinctness would hand both rows the same suffix and
+    // separate nothing (DP17, gpt-5.6-sol).
+    test("two retries of ONE run share a workflow id and are still told apart", () => {
+      const attemptTwo: CellRun = {
+        id: "11",
+        workflowId: "500",
+        conclusion: "failure",
+        runOrigin: "retry",
+      };
+      const attemptThree: CellRun = {
+        id: "12",
+        workflowId: "500",
+        conclusion: "failure",
+        runOrigin: "retry",
+      };
+      const suffixes = disambiguateCellRuns([attemptTwo, attemptThree]);
+      expect(suffixes.get(attemptTwo)).not.toBe(suffixes.get(attemptThree));
+      const rows = rowStrings([attemptTwo, attemptThree]);
+      expect(allDistinct(rows.visible)).toBe(true);
+    });
+
+    // The row shows the ORIGIN and a glyph, not the attempt -- so two restarts of one cell read the
+    // same on screen even though `describeCellRun` separates them (DP17, gpt-5.6-sol).
+    test("two restarts differing only by attempt read the same on the row, so they are suffixed", () => {
+      const attemptOne: CellRun = {
+        id: "1",
+        workflowId: "10",
+        conclusion: "failure",
+        runOrigin: "autorevert",
+        restartRunAttempt: 1,
+      };
+      const attemptTwo: CellRun = {
+        id: "2",
+        workflowId: "20",
+        conclusion: "failure",
+        runOrigin: "autorevert",
+        restartRunAttempt: 2,
+      };
+      // `describeCellRun` already differs here; the VISIBLE line does not.
+      expect(describeCellRun(attemptOne)).not.toBe(describeCellRun(attemptTwo));
+      expect(describeRunOrigin(attemptOne)).toBe(describeRunOrigin(attemptTwo));
+      const rows = rowStrings([attemptOne, attemptTwo]);
+      expect(allDistinct(rows.visible)).toBe(true);
+    });
+
+    test("only the colliding group is suffixed, and a distinct row is left alone", () => {
+      const a: CellRun = { id: "1", workflowId: "10", conclusion: "success" };
+      const b: CellRun = { id: "2", workflowId: "20", conclusion: "success" };
+      const restart: CellRun = {
+        id: "3",
+        workflowId: "30",
+        conclusion: "success",
+        runOrigin: "autorevert",
+        restartRunAttempt: 1,
+      };
+      const suffixes = disambiguateCellRuns([a, b, restart]);
+      expect(suffixes.get(a)).not.toBe("");
+      expect(suffixes.get(b)).not.toBe("");
+      expect(suffixes.get(a)).not.toBe(suffixes.get(b));
+      // Its origin already differs, so it keeps the one short line.
+      expect(suffixes.get(restart)).toBe("");
+    });
+
+    // `getConclusionChar` folds every conclusion outside the known set onto `U`, so two runs can draw
+    // the identical glyph while their conclusion strings differ -- which a signature built from the
+    // conclusion rather than the glyph reports as "already different" (DP17, gpt-5.6-sol).
+    test("two unknown conclusions draw the same glyph, so those rows are suffixed", () => {
+      const actionRequired: CellRun = {
+        id: "1",
+        workflowId: "10",
+        conclusion: "action_required",
+      };
+      const stale: CellRun = { id: "2", workflowId: "20", conclusion: "stale" };
+      expect(getConclusionChar(actionRequired.conclusion)).toBe(
+        getConclusionChar(stale.conclusion)
+      );
+      // Their descriptions DO differ, so nothing but the glyph reveals the collision.
+      expect(describeCellRun(actionRequired)).not.toBe(describeCellRun(stale));
+      // The requirement is that the RENDERED rows differ, not that both carry a suffix.
+      expect(allDistinct(rowStrings([actionRequired, stale]).visible)).toBe(
+        true
+      );
+    });
+
+    // The mirror of the case above, and the reason the glyph signature is not the only one consulted:
+    // `conclusionOf` folds both an ABSENT and an EMPTY conclusion onto `pending`, while the glyph draws
+    // `~` for absent and `U` for empty. So these two rows look different on screen but their hover text
+    // and accessible name are the same string -- which a screen reader is all that renders.
+    test("rows that differ only by glyph still share a description, and are suffixed for it", () => {
+      const absent: CellRun = { id: "1", workflowId: "10" };
+      const empty: CellRun = { id: "2", workflowId: "20", conclusion: "" };
+      expect(getConclusionChar(absent.conclusion)).not.toBe(
+        getConclusionChar(empty.conclusion)
+      );
+      expect(describeCellRun(absent)).toBe(describeCellRun(empty));
+      // The ACCESSIBLE name is the one at risk here, so that is what has to come out distinct.
+      expect(allDistinct(rowStrings([absent, empty]).accessible)).toBe(true);
+    });
+
+    test("two runs whose glyphs differ are left alone", () => {
+      const failed: CellRun = {
+        id: "1",
+        workflowId: "10",
+        conclusion: "failure",
+      };
+      const timedOut: CellRun = {
+        id: "2",
+        workflowId: "20",
+        conclusion: "timed_out",
+      };
+      expect(getConclusionChar(failed.conclusion)).not.toBe(
+        getConclusionChar(timedOut.conclusion)
+      );
+      const suffixes = disambiguateCellRuns([failed, timedOut]);
+      expect(suffixes.get(failed)).toBe("");
+      expect(suffixes.get(timedOut)).toBe("");
+    });
+
+    test("a group with no job id falls back to the workflow id when that separates it", () => {
+      const first: CellRun = { workflowId: "10", conclusion: "success" };
+      const second: CellRun = { workflowId: "20", conclusion: "success" };
+      const suffixes = disambiguateCellRuns([first, second]);
+      expect(suffixes.get(first)).toBe(" (run 10)");
+      expect(suffixes.get(second)).toBe(" (run 20)");
+    });
+
+    // A candidate only ONE row of the group has still separates the group: the other row's suffix is
+    // '', and '' differs from a suffix. Testing that the values are all PRESENT would reject this and
+    // leave two identical rows on screen (DP17, gpt-5.6-sol).
+    test("a candidate only one row carries still separates the pair", () => {
+      const withJobId: CellRun = { id: "7", conclusion: "success" };
+      const bare: CellRun = { conclusion: "success" };
+      const suffixes = disambiguateCellRuns([withJobId, bare]);
+      expect(suffixes.get(withJobId)).toBe(" (job 7)");
+      expect(suffixes.get(bare)).toBe("");
+      expect(allDistinct(rowStrings([withJobId, bare]).visible)).toBe(true);
+    });
+
+    test("a group nothing can separate is left bare rather than given a made-up ordinal", () => {
+      // Neither row carries either identifier, so no candidate produces two different suffixes.
+      // Silence is the honest answer -- an ordinal would re-point at a different run on the next
+      // refresh, since the list is rebuilt and re-ordered from fresh data.
+      const twin: CellRun = { conclusion: "success" };
+      const other: CellRun = { conclusion: "success" };
+      const suffixes = disambiguateCellRuns([twin, other]);
+      expect(suffixes.get(twin)).toBe("");
+      expect(suffixes.get(other)).toBe("");
+      // And that is consistent with the rest of the module: these two rows are ONE run as far as
+      // selection is concerned, since `runKeyOf` gives them the same key.
+      expect(runKeyOf(twin)).toBe(runKeyOf(other));
+    });
+
+    test("an empty list is not a special case", () => {
+      expect(disambiguateCellRuns([]).size).toBe(0);
+    });
   });
 
   test("a stale failedPreviousRun on an input row cannot leak into a clean cell", () => {

--- a/torchci/test/runOrigin.test.ts
+++ b/torchci/test/runOrigin.test.ts
@@ -1,0 +1,124 @@
+import { getWorkflowIdsByName } from "lib/fetchCommit";
+import { describeRunOrigin, describeWorkflowRun } from "lib/runOrigin";
+import { JobData } from "lib/types";
+
+describe("describeRunOrigin", () => {
+  test("names the origins the HUD tooltip and the commit page share", () => {
+    expect(describeRunOrigin({ runOrigin: "autorevert" })).toEqual(
+      "autorevert restart"
+    );
+    expect(describeRunOrigin({ runOrigin: "retry" })).toEqual("re-run attempt");
+    expect(describeRunOrigin({ runOrigin: "schedule" })).toEqual("schedule");
+  });
+
+  test("a missing origin means push, whether it arrives absent or as SQL NULL", () => {
+    // hud_query strips the key; commit_jobs_query ships a real NULL. Both mean the same run.
+    expect(describeRunOrigin({})).toEqual("push");
+    expect(describeRunOrigin({ runOrigin: null })).toEqual("push");
+  });
+
+  test("a blank origin is not reported as push, because that would be a guess", () => {
+    expect(describeRunOrigin({ runOrigin: "" })).toEqual("unknown");
+    expect(describeRunOrigin({ runOrigin: "   " })).toEqual("unknown");
+  });
+});
+
+describe("describeWorkflowRun", () => {
+  test("an autorevert restart names both what it is and who dispatched it", () => {
+    expect(
+      describeWorkflowRun({
+        runOrigin: "autorevert",
+        restartDispatchedBy: "pytorch-auto-revert[bot]",
+      })
+    ).toEqual("autorevert restart by pytorch-auto-revert[bot]");
+  });
+
+  test("a restart with no recorded dispatcher still says what it is", () => {
+    expect(describeWorkflowRun({ runOrigin: "autorevert" })).toEqual(
+      "autorevert restart"
+    );
+  });
+
+  test("every run is named, including a plain push", () => {
+    // Deliberate: an unlabelled row in a picker that exists to disambiguate cannot be told apart
+    // from one whose data is missing.
+    expect(describeWorkflowRun({})).toEqual("push");
+    expect(
+      describeWorkflowRun({ runOrigin: null, restartDispatchedBy: null })
+    ).toEqual("push");
+  });
+
+  // The two entries in the reviewer's screenshot differed only by id. This is that case.
+  test("a restart and a push in one picker do not read the same", () => {
+    const push = describeWorkflowRun({ runOrigin: null });
+    const restart = describeWorkflowRun({
+      runOrigin: "autorevert",
+      restartDispatchedBy: "pytorch-auto-revert[bot]",
+    });
+    expect(restart).not.toEqual(push);
+  });
+});
+
+describe("getWorkflowIdsByName", () => {
+  function job(overrides: Partial<JobData>): JobData {
+    return {
+      workflowName: "trunk",
+      workflowId: "1",
+      runAttempt: 1,
+      ...overrides,
+    } as JobData;
+  }
+
+  test("carries the origin and dispatcher through to the picker entries", () => {
+    // Without this the formatter tests above would all still pass while the dropdown showed
+    // nothing but bare ids.
+    const byName = getWorkflowIdsByName([
+      // NULL, not undefined: that is the shape commit_jobs_query actually ships for a push.
+      job({
+        workflowId: "100",
+        runAttempt: 1,
+        runOrigin: null,
+        restartDispatchedBy: null,
+      }),
+      job({
+        workflowId: "200",
+        runAttempt: 1,
+        runOrigin: "autorevert",
+        restartDispatchedBy: "pytorch-auto-revert[bot]",
+      }),
+    ]);
+
+    expect(byName["trunk"]).toEqual([
+      {
+        id: "100",
+        attempt: 1,
+        runOrigin: null,
+        restartDispatchedBy: null,
+      },
+      {
+        id: "200",
+        attempt: 1,
+        runOrigin: "autorevert",
+        restartDispatchedBy: "pytorch-auto-revert[bot]",
+      },
+    ]);
+    expect(byName["trunk"].map(describeWorkflowRun)).toEqual([
+      "push",
+      "autorevert restart by pytorch-auto-revert[bot]",
+    ]);
+  });
+
+  test("dedup is still by (id, attempt), so two attempts stay separate entries", () => {
+    const byName = getWorkflowIdsByName([
+      job({ workflowId: "100", runAttempt: 1 }),
+      job({ workflowId: "100", runAttempt: 1 }),
+      job({ workflowId: "100", runAttempt: 2, runOrigin: "retry" }),
+    ]);
+
+    expect(byName["trunk"].map((run) => run.attempt)).toEqual([1, 2]);
+    expect(byName["trunk"].map(describeWorkflowRun)).toEqual([
+      "push",
+      "re-run attempt",
+    ]);
+  });
+});

--- a/torchci/test/runOrigin.test.ts
+++ b/torchci/test/runOrigin.test.ts
@@ -24,18 +24,26 @@ describe("describeRunOrigin", () => {
 });
 
 describe("describeWorkflowRun", () => {
-  test("an autorevert restart names both what it is and who dispatched it", () => {
-    expect(
-      describeWorkflowRun({
-        runOrigin: "autorevert",
-        restartDispatchedBy: "pytorch-auto-revert[bot]",
-      })
-    ).toEqual("autorevert restart by pytorch-auto-revert[bot]");
+  test("an autorevert run is named by its origin, with no actor to repeat it", () => {
+    // "autorevert restart by pytorch-auto-revert[bot]" said autorevert twice (Ivan, 2026-08-19).
+    expect(describeWorkflowRun({ runOrigin: "autorevert" })).toEqual(
+      "autorevert dispatch"
+    );
   });
 
-  test("a restart with no recorded dispatcher still says what it is", () => {
+  test("the label depends only on the origin, never on who pressed the button", () => {
+    // Why the actor is not named: commit_jobs_query classifies a trunk/<sha> workflow_dispatch as
+    // "autorevert" regardless of WHO dispatched it, so the origin survives a human hand-dispatching
+    // one while an actor-only label ("dispatched by <person>") would hide it. That classification
+    // lives in SQL and is not exercised here; this only pins that the formatter reads the origin
+    // and nothing else, which is what makes the SQL's answer the one the reader sees.
     expect(describeWorkflowRun({ runOrigin: "autorevert" })).toEqual(
-      "autorevert restart"
+      "autorevert dispatch"
+    );
+    // A non-trunk dispatch is a different origin and keeps the raw event name. Not ideal copy;
+    // pre-existing on both surfaces via describeRunOrigin, and deliberately not changed here.
+    expect(describeWorkflowRun({ runOrigin: "workflow_dispatch" })).toEqual(
+      "workflow_dispatch"
     );
   });
 
@@ -43,19 +51,21 @@ describe("describeWorkflowRun", () => {
     // Deliberate: an unlabelled row in a picker that exists to disambiguate cannot be told apart
     // from one whose data is missing.
     expect(describeWorkflowRun({})).toEqual("push");
-    expect(
-      describeWorkflowRun({ runOrigin: null, restartDispatchedBy: null })
-    ).toEqual("push");
+    expect(describeWorkflowRun({ runOrigin: null })).toEqual("push");
+  });
+
+  test("other origins keep the wording they have in the HUD tooltip", () => {
+    expect(describeWorkflowRun({ runOrigin: "retry" })).toEqual(
+      "re-run attempt"
+    );
+    expect(describeWorkflowRun({ runOrigin: "schedule" })).toEqual("schedule");
   });
 
   // The two entries in the reviewer's screenshot differed only by id. This is that case.
   test("a restart and a push in one picker do not read the same", () => {
-    const push = describeWorkflowRun({ runOrigin: null });
-    const restart = describeWorkflowRun({
-      runOrigin: "autorevert",
-      restartDispatchedBy: "pytorch-auto-revert[bot]",
-    });
-    expect(restart).not.toEqual(push);
+    expect(describeWorkflowRun({ runOrigin: "autorevert" })).not.toEqual(
+      describeWorkflowRun({ runOrigin: null })
+    );
   });
 });
 
@@ -69,42 +79,22 @@ describe("getWorkflowIdsByName", () => {
     } as JobData;
   }
 
-  test("carries the origin and dispatcher through to the picker entries", () => {
+  test("carries the origin through to the picker entries", () => {
     // Without this the formatter tests above would all still pass while the dropdown showed
     // nothing but bare ids.
     const byName = getWorkflowIdsByName([
       // NULL, not undefined: that is the shape commit_jobs_query actually ships for a push.
-      job({
-        workflowId: "100",
-        runAttempt: 1,
-        runOrigin: null,
-        restartDispatchedBy: null,
-      }),
-      job({
-        workflowId: "200",
-        runAttempt: 1,
-        runOrigin: "autorevert",
-        restartDispatchedBy: "pytorch-auto-revert[bot]",
-      }),
+      job({ workflowId: "100", runAttempt: 1, runOrigin: null }),
+      job({ workflowId: "200", runAttempt: 1, runOrigin: "autorevert" }),
     ]);
 
     expect(byName["trunk"]).toEqual([
-      {
-        id: "100",
-        attempt: 1,
-        runOrigin: null,
-        restartDispatchedBy: null,
-      },
-      {
-        id: "200",
-        attempt: 1,
-        runOrigin: "autorevert",
-        restartDispatchedBy: "pytorch-auto-revert[bot]",
-      },
+      { id: "100", attempt: 1, runOrigin: null },
+      { id: "200", attempt: 1, runOrigin: "autorevert" },
     ]);
     expect(byName["trunk"].map(describeWorkflowRun)).toEqual([
       "push",
-      "autorevert restart by pytorch-auto-revert[bot]",
+      "autorevert dispatch",
     ]);
   });
 


### PR DESCRIPTION
✴️ iz2: Partial revert of #6954 — the UI half of #8300.

**Problem.** Autorevert's restart runs (`workflow_dispatch` on `trunk/<sha>`) were filtered out of the HUD, so their results — including real failures — never reached the grid. And a multi-run cell was merged pairwise, newest `job.id` wins, with the flaky flag taken from the *loser*: a pass followed by a restart failure rendered plain red, the reverse order rendered flaky `F`.

**Proposed solution.** Invariant: **who issued a run does not change how the HUD aggregates it.** A push, a re-run attempt and a restart are all just runs; a cell's verdict follows from the set of conclusions, not from the issuer and not from arrival order. Origin is reported on the tooltip, never aggregated on. Rules, in the new `torchci/lib/mergeCellRuns.ts`:

- one run → show that run
- success + a real failure, in any order → show the success, marked flaky `F`
- `cancelled` loses to any non-cancelled run, and is deliberately not failure evidence (unlike `isFailure()`); `skipped` loses to a real result, as before
- otherwise rank success > failure > pending > neutral > skipped, newest run breaking a tie within a class

**What changes?** Restart results reach the grid on the same terms as any other run, and a mixed cell renders `F` in either order. This governs every multi-run cell, not just restarts — a twice-scheduled periodic job or a re-run now follows the ranking above instead of newest-id-wins, so an older success outranks a newer pending run.

Measured over 14 days on the 266 `pytorch/pytorch` trunk shas that had restart runs (cells without a restart were not measured): **14,405 cells differ from `main`** — 13,687 restart-only cells now show their real conclusion, 208 turn `F` (restart failed, natural run passed), 195 the reverse, 223 stop being `F` (a cancelled co-run no longer counts as failure), 92 in smaller classes.

**Changed, at a high level**

- `hud_query` — admit restart runs; project the run's origin and dispatching identity
- `mergeCellRuns.ts` + `types.ts` — the rules above and which run represents the cell; unit-tested on both permutation axes (order, issuer)
- `fetchHud.ts` — collect every run per cell and delegate; the old reducer is gone
- `JobTooltip.tsx` — one radio per run behind the cell, with the grid's own status glyph and a `gh` link to that run; picking one rebinds the log viewer, links and failure classification to it
- `commit_jobs_query` — admits restarts that *passed* (all were hidden before); its comment records the divergence below

**Known gaps.** A restart that *failed* still doesn't show on the commit page: `fetchCommit` dedups by newest id with no flaky marker, so admitting one would replace the natural conclusion instead of combining with it. Grid and commit page disagree there until that page can render `F` — tracked as a follow-up. `commit_jobs_batch_query` and its `viable_strict_sole_blocker` mirror are untouched: `is_green()` has no per-job-name dedup and vetoes on the first non-success row, so restarts only add vetoes (17 currently-green commits would go red, 0 red would go green) — #8300's second action item.

Refs #8300
