### PR TITLE
Update binary build matrix for release 2.14

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -45,13 +45,13 @@ MACOS_PYTHON_POINT_VERSIONS = {
 }
 CUDA_ARCHES_DICT = {
     "nightly": ["12.6", "13.0", "13.2", "13.4"],
-    "test": ["12.6", "13.0", "13.2"],
+    "test": ["12.6", "13.0", "13.2", "13.4"],
     "release": ["12.6", "13.0", "13.2"],
 }
 
 ROCM_ARCHES_DICT = {
     "nightly": ["7.2", "7.14"],
-    "test": ["7.1", "7.2"],
+    "test": ["7.2", "7.14"],
     "release": ["7.1", "7.2"],
 }
 
@@ -99,7 +99,7 @@ XPU = "xpu"
 
 
 CURRENT_NIGHTLY_VERSION = "2.14.0"
-CURRENT_CANDIDATE_VERSION = "2.13.0"
+CURRENT_CANDIDATE_VERSION = "2.14.0"
 CURRENT_STABLE_VERSION = "2.13.0"
 CURRENT_VERSION = CURRENT_STABLE_VERSION
 


### PR DESCRIPTION
The 2.14 branch cut is done, so the test channel now serves 2.14.0 release candidates. This applies the standard post-branch-cut update to `main`, matching what `.github/workflows/release-pytorch-post-branch-cut.yml` does.

## 1. `CURRENT_CANDIDATE_VERSION` 2.13.0 -> 2.14.0

For the test channel `initialize_globals()` sets `CURRENT_VERSION = CURRENT_CANDIDATE_VERSION`, which the generated matrix surfaces as `stable_version` and `smoke_test.py` enforces. Left at 2.13.0, test-channel validation fails with:

```
RuntimeError: Torch version mismatch, expected 2.13.0 for channel test
```

`CURRENT_STABLE_VERSION` stays at 2.13.0 (the current GA release); it moves separately when 2.14 goes live.

## 2. Sync the test channel with nightly in the arch dicts

- `CUDA_ARCHES_DICT`: test gains `13.4`
- `ROCM_ARCHES_DICT`: test `7.1, 7.2` -> `7.2, 7.14`
- `PYTHON_ARCHES_DICT`: already matched nightly, no change

These match what `release/2.14` actually builds. Without them, 2.14 RC validation would skip the `cu134` and `rocm7.14` wheels and try to validate `rocm7.1` wheels that 2.14 does not produce.

The release channel matrix is unchanged.

## Test plan

- `python -m tools.tests.test_generate_binary_build_matrix` — 11 tests pass.
- `python -m tools.tests.test_generate_binary_build_matrix --update-reference-files` — no asset changes.
- Generated linux wheel matrix, before -> after:

| channel | `stable_version` | cuda | rocm |
| --- | --- | --- | --- |
| test | 2.13.0 -> **2.14.0** | +`cu134` | `7.1` -> **`7.14`** |
| release | unchanged (2.13.0) | unchanged | unchanged |
| nightly | unchanged | unchanged | unchanged |

Companion to #8495, which made the equivalent change on `release/2.14`.

Authored with the assistance of Claude Code.