### PR TITLE
Don't advertise CUDA 13.4 on the getting-started page

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -75,6 +75,13 @@ CUDA_AARCH64_ARCHES = ["12.6-aarch64", "13.0-aarch64", "13.2-aarch64", "13.4-aar
 # CUDA_ARCHES_NO_WINDOWS in pytorch/pytorch.
 CUDA_ARCHES_NO_WINDOWS = ["13.4"]
 
+# CUDA versions that are built and validated, but must not be advertised on the
+# pytorch.org getting-started page yet. Without this, update-quick-start-module
+# in pytorch/pytorch.github.io publishes an install selector for a CUDA version
+# users cannot rely on. Only affects the getting-started matrix; nightly, test
+# and release builds and their validation are unchanged.
+CUDA_ARCHES_NO_GETTING_STARTED = ["13.4"]
+
 PACKAGE_TYPES = ["wheel", "libtorch"]
 CXX11_ABI = "cxx11-abi"
 RELEASE = "release"
@@ -181,6 +188,10 @@ def initialize_globals(
         CURRENT_VERSION = CURRENT_STABLE_VERSION
 
     CUDA_ARCHES = CUDA_ARCHES_DICT[channel]
+    if getting_started:
+        CUDA_ARCHES = [
+            arch for arch in CUDA_ARCHES if arch not in CUDA_ARCHES_NO_GETTING_STARTED
+        ]
     ROCM_ARCHES = ROCM_ARCHES_DICT[channel]
     if build_python_only:
         # Only select the oldest version of python if building a python only package


### PR DESCRIPTION
`update-quick-start-module.yml` in pytorch/pytorch.github.io calls `generate_binary_build_matrix.yml@main` with `getting-started: true` for linux/windows/macos-arm64 on the nightly and release channels, and publishes the result as the pytorch.org install selector.

Because 13.4 is in `CUDA_ARCHES_DICT["nightly"]`, that bot has started adding a `cu134` option — see pytorch/pytorch.github.io#2130, which introduces:

```
pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu134
```

13.4 is built and validated, but it is not ready to be offered to users, so this gates it out of **the getting-started matrix only**.

## Approach

`initialize_globals` already accepted a `getting_started` argument that was never used — this gives it a purpose. The filter follows the existing `CUDA_ARCHES_NO_WINDOWS` convention immediately above it:

```python
CUDA_ARCHES_NO_GETTING_STARTED = ["13.4"]
```

To re-enable 13.4 on the page later, drop it from that list — no other change needed.

`CUDA_AARCH64_ARCHES` is deliberately untouched: the getting-started workflow never requests `linux-aarch64`, and that list is a module constant with no per-channel dict behind it, so filtering it in place would leak into later calls in the same process.

## Test plan

- `python -m tools.tests.test_generate_binary_build_matrix` — 11 tests pass.
- `--update-reference-files` — no asset changes.
- Getting-started matrix (`--getting-started true`), `cu134` entry count before -> after, across all six jobs the quick-start workflow runs:

| os | channel | before | after |
| --- | --- | --- | --- |
| linux | nightly | **2** | **0** |
| linux | release | 0 | 0 |
| windows | nightly / release | 0 | 0 |
| macos-arm64 | nightly / release | 0 | 0 |

  The two linux/nightly entries are the wheel + libtorch options #2130 was adding. Windows was already 0 via `CUDA_ARCHES_NO_WINDOWS`.

- **Non**-getting-started matrices are byte-identical (md5) for `{linux, linux-aarch64, windows, macos-arm64}` x `{nightly, test, release}` — builds and binary validation are unaffected.
- Verified the filter does not leak across calls: after a `getting_started=True` call, a subsequent default call still sees `['12.6', '13.0', '13.2', '13.4']`.

Authored with the assistance of Claude Code.