### PR TITLE
Record/replay ClickHouse for the vLLM torch-nightly triage

### DIFF
--- a/tools/torchci/tests/fixtures/clickhouse_vllm_builds_jobs_82789.json
+++ b/tools/torchci/tests/fixtures/clickhouse_vllm_builds_jobs_82789.json
@@ -1,0 +1,9869 @@
+{
+ "clickhouse": {
+  "builds": {
+   "columns": [
+    "number",
+    "title",
+    "commit",
+    "created_at",
+    "state",
+    "url"
+   ],
+   "rows": [
+    [
+     83449,
+     "[Profiler] Add minimal Triton Proton profiling backend (#48789)",
+     "a367cdbca0824c8c428fe15b4552fbc4b824d718",
+     {
+      "__datetime__": "2026-08-11T21:51:59.604000"
+     },
+     "running",
+     "https://buildkite.com/vllm/ci/builds/83449"
+    ],
+    [
+     83447,
+     "[4/N][KV-Cache Layout Refactor] Promote local KV cache specs via a class-changing replace helper (#51612)",
+     "61874f9842bd084cc5e9e348de4b3b6a8f46cdc8",
+     {
+      "__datetime__": "2026-08-11T21:29:33.637000"
+     },
+     "running",
+     "https://buildkite.com/vllm/ci/builds/83447"
+    ],
+    [
+     83446,
+     "[Testing] Fix test_sharded_state_loader (#51736)",
+     "cb30f6f8ddca45fd2e2acc3c43735a7c3b2ecdd3",
+     {
+      "__datetime__": "2026-08-11T21:16:12.574000"
+     },
+     "running",
+     "https://buildkite.com/vllm/ci/builds/83446"
+    ],
+    [
+     83443,
+     "Full CI run - daily",
+     "3e372c5ff23438eeeafc86c7d8d51026f3dacb6a",
+     {
+      "__datetime__": "2026-08-11T21:00:04.283000"
+     },
+     "failing",
+     "https://buildkite.com/vllm/ci/builds/83443"
+    ],
+    [
+     83442,
+     "[Bugfix][ROCm] Give KV-first attention blocks their own page in hybrid models (#51837)",
+     "3e372c5ff23438eeeafc86c7d8d51026f3dacb6a",
+     {
+      "__datetime__": "2026-08-11T20:52:33.321000"
+     },
+     "running",
+     "https://buildkite.com/vllm/ci/builds/83442"
+    ],
+    [
+     83438,
+     "[ROCm][MoE] Fix expert_map vs AITER expert_mask for non-AITER experts under EP (#49758)",
+     "0f0cb918b7c6d08aabb86ec4eff4bae05f6736d9",
+     {
+      "__datetime__": "2026-08-11T20:33:05.333000"
+     },
+     "failing",
+     "https://buildkite.com/vllm/ci/builds/83438"
+    ],
+    [
+     83428,
+     "[Bugfix][MoE] Fix fused block-scale orientation (#50727)",
+     "36f4630d8926b8bd16fd6fc80b71e9defce2ad92",
+     {
+      "__datetime__": "2026-08-11T20:05:41.302000"
+     },
+     "failing",
+     "https://buildkite.com/vllm/ci/builds/83428"
+    ],
+    [
+     83423,
+     "[Refactor] Delete dead code in models (#51838)",
+     "fd04edef3e62c8dec19cddd76253c0fc6d56ab62",
+     {
+      "__datetime__": "2026-08-11T19:44:29.454000"
+     },
+     "failing",
+     "https://buildkite.com/vllm/ci/builds/83423"
+    ],
+    [
+     83419,
+     "[Bugfix] Support HF-config compat for Inkling (#51850)",
+     "ded6c452c3657aad7149cedaf50e88aa83336f8f",
+     {
+      "__datetime__": "2026-08-11T19:32:31.411000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83419"
+    ],
+    [
+     83416,
+     "[Docs] Fix broken autorefs cross-reference in TurboQuant v2 docstring (#51857)",
+     "b2ab0960178cc737d8537208f1e1de79404ca1ac",
+     {
+      "__datetime__": "2026-08-11T19:22:59.554000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83416"
+    ],
+    [
+     83415,
+     "[CI][Bugfix][V1] Remove stale FlashAttention metadata arguments (#51854)",
+     "cc668c5b72e7353569a388bb609f1a7644376756",
+     {
+      "__datetime__": "2026-08-11T18:54:59.393000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83415"
+    ],
+    [
+     83407,
+     "[ROCm] Remove stale SDPA and skinny GEMM workarounds (#50907)",
+     "1ab2801ddebe31b75dd6022c69113b610bbdc950",
+     {
+      "__datetime__": "2026-08-11T18:19:21.374000"
+     },
+     "failing",
+     "https://buildkite.com/vllm/ci/builds/83407"
+    ],
+    [
+     83404,
+     "[Bugfix][Attention] Forward per-head FP8 descales through FA4 (#51363)",
+     "4f2f31b82e03917ef33c9008337909ae418dc323",
+     {
+      "__datetime__": "2026-08-11T18:05:23.093000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83404"
+    ],
+    [
+     83397,
+     "feat: allow shared expert overlapping for FlashInfer one-sided all-to-all (#50569)",
+     "52be12cfac0c5a18ba906814b2d2bcadb40a9c4b",
+     {
+      "__datetime__": "2026-08-11T17:06:25.225000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83397"
+    ],
+    [
+     83394,
+     "Enable `MiniCPMV` for vLLM in CI (#45042)",
+     "9cc347ae424e1c8649b2394fe7fb175e93f59066",
+     {
+      "__datetime__": "2026-08-11T16:30:42.123000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83394"
+    ],
+    [
+     83393,
+     "[CI] Support partial torch requirement contexts (#51832)",
+     "ca9c8cbd1bfb6a3fdcd3abf64b7204d967f539f0",
+     {
+      "__datetime__": "2026-08-11T16:25:17.295000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83393"
+    ],
+    [
+     83389,
+     "[Bugfix] Generalize KV block zeroing to `AttentionSpec` (#51749)",
+     "e3fe212eaf0dc06da03d4df615f7d3d1e8bd5f20",
+     {
+      "__datetime__": "2026-08-11T16:13:11.847000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83389"
+    ],
+    [
+     83388,
+     "[Bugfix] Take the sliding window from the layer, not the KV cache group (#51756)",
+     "513f83e7ecee5e39be727fcb7b7de660bd851cf2",
+     {
+      "__datetime__": "2026-08-11T16:10:49.220000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83388"
+    ],
+    [
+     83384,
+     "Bump Transformers version to 5.15.0 (#51668)",
+     "c65aa2ee6cd8286ebe83615afdfab9b77d21f035",
+     {
+      "__datetime__": "2026-08-11T16:00:54.555000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83384"
+    ],
+    [
+     83383,
+     "[Bugfix][MRV2] Support encoder timing stats in model runner V2 (#50020)",
+     "457a5f34db04b082239c11ee34601e5ee5754a7c",
+     {
+      "__datetime__": "2026-08-11T16:00:52.530000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83383"
+    ],
+    [
+     83380,
+     "[Kernel][ROCm][Perf] FlyDSL decode-attention kernel for 4-bit TurboQuant KV cache  (#47896)",
+     "5426311d9115c597c561967ec3f277ee6e970420",
+     {
+      "__datetime__": "2026-08-11T15:45:42.667000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83380"
+    ],
+    [
+     83378,
+     "[XPU][CI] Fix ExampleConnector KV cache device selection (#51806)",
+     "d648236199da3146af2abd236a6e32ce17cbb178",
+     {
+      "__datetime__": "2026-08-11T15:40:31.548000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83378"
+    ],
+    [
+     83377,
+     "[Bugfix] Align Qwen GDN gates with speculative tokens (#51812)",
+     "5af7c8dad798bf899813f8f3c6b9eaf08a748e17",
+     {
+      "__datetime__": "2026-08-11T15:35:32.888000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83377"
+    ],
+    [
+     83375,
+     "[Misc] Enable test_silu_mul_fp8_quant_deep_gemm on XPU (#49444)",
+     "5b5eae23944e94f618895c05a69331bb06d1e3bd",
+     {
+      "__datetime__": "2026-08-11T15:19:17.891000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83375"
+    ],
+    [
+     83370,
+     "[Config] Update default `_max_num_batched_tokens` from 8192 to 16384 (#51726)",
+     "4988df2eb80a8d1debae7de85c3b242fa436f3c1",
+     {
+      "__datetime__": "2026-08-11T15:09:38.142000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83370"
+    ],
+    [
+     83369,
+     "[Bugfix][MoE] Support GELU tanh in FlashInfer B12x MoE (#51819)",
+     "0fb9897df12963e9bd0d58547fc997e0702d95ec",
+     {
+      "__datetime__": "2026-08-11T15:08:01.865000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83369"
+    ],
+    [
+     83365,
+     "[Bugfix] Guard DeepSeek V4 MRV1 piecewise CUDA graphs (#51768)",
+     "87668ab69b3e2c849a607ece36e8a43bde7c7ee5",
+     {
+      "__datetime__": "2026-08-11T14:34:47.639000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83365"
+    ],
+    [
+     83363,
+     "Add MoE output contract for MoE tail fusion (#51407)",
+     "dd7cc85f1720ebcb65b1822cbc5054af66ae292d",
+     {
+      "__datetime__": "2026-08-11T14:24:02.492000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83363"
+    ],
+    [
+     83362,
+     "[Bugfix][ROCm] Fix DeepSeek V4 DSpark probabilistic startup (#51145)",
+     "12bea3eedcdf8e049f2478739b45ccb1456c03c0",
+     {
+      "__datetime__": "2026-08-11T14:15:34.609000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83362"
+    ],
+    [
+     83361,
+     "Bound generation inputs before expensive work (#51447)",
+     "b64a2708b06b6329420702bffce994543c1ec6d2",
+     {
+      "__datetime__": "2026-08-11T14:03:52.939000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83361"
+    ],
+    [
+     83359,
+     "connects vLLM Recipes with vLLM's native config-based deployment and benchmark (#51308)",
+     "5b184f775ae0f71d20cee222314b8866fb2b9d3c",
+     {
+      "__datetime__": "2026-08-11T13:53:54.069000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83359"
+    ],
+    [
+     83356,
+     "[XPU] Fix UVA weight offloading (non-pinned-tensor views and static Triton launcher) (#51770)",
+     "f863387250cfc24c04d07b3593ea18a541ba2b8a",
+     {
+      "__datetime__": "2026-08-11T13:48:50.755000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83356"
+    ],
+    [
+     83353,
+     "[Bugfix][CPU] Make the Apple Silicon BF16 probe fall back instead of raising (#51627)",
+     "78e7fdd1ab81d4203a7522c2bf197b3a4b2b48cb",
+     {
+      "__datetime__": "2026-08-11T13:35:09.780000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83353"
+    ],
+    [
+     83347,
+     "[2/N][Feat][Perf] Add new warmup infrastructure for JITs. Add predicate filtering for JIT warmup, and migrate Inkling FA4 (#49315)",
+     "6c95a641e95c0faa6f3aa802d1fd3cce3f3bc3ce",
+     {
+      "__datetime__": "2026-08-11T11:46:10.990000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83347"
+    ],
+    [
+     83343,
+     "[Model] Enable tower and connector LoRA for Keye (#51780)",
+     "d8f840071efd631f71b06d4b31cb6dba2275a356",
+     {
+      "__datetime__": "2026-08-11T10:36:02.300000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83343"
+    ],
+    [
+     83341,
+     "[Bugfix][KV Offload] Centralize shared mmap cleanup in CPU worker (#51622)",
+     "0fec3d652babd3a4a2919ff7b19a35701b298426",
+     {
+      "__datetime__": "2026-08-11T10:22:17.506000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83341"
+    ],
+    [
+     83340,
+     "[Bugfix][Core] Preserve Mamba running CoW after external hits (#51766)",
+     "ce07118669a8a0a7d8ea66d2ac08787c88c25938",
+     {
+      "__datetime__": "2026-08-11T10:15:26.982000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83340"
+    ],
+    [
+     83338,
+     "Full CI run torch nightly",
+     "490259c1f63faf025b8050504db63d81c817d781",
+     {
+      "__datetime__": "2026-08-11T10:00:03.481000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83338"
+    ],
+    [
+     83336,
+     "profiler: add PrivateUse1 activity support for custom backends (#50977)",
+     "490259c1f63faf025b8050504db63d81c817d781",
+     {
+      "__datetime__": "2026-08-11T09:39:01.518000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83336"
+    ],
+    [
+     83335,
+     "[Perf] Avoid repeated multimodal prompt update scans (#51774)",
+     "3fb7bb46d6202e23988c96746891ec788ee6aaf5",
+     {
+      "__datetime__": "2026-08-11T09:23:27.587000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83335"
+    ],
+    [
+     83332,
+     "[XPU] [Linear] enable torch linear backend for blockwise  gemm on xpu (#50826)",
+     "52c70b210ce9d66e9afb9d18e086c3d05408c492",
+     {
+      "__datetime__": "2026-08-11T08:43:35.797000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83332"
+    ],
+    [
+     83326,
+     "[Doc] Fix typos in speculative decoding docs (#51500)",
+     "529d0103511429f0086a308b6ef2698a87fec4b9",
+     {
+      "__datetime__": "2026-08-11T08:17:08.538000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83326"
+    ],
+    [
+     83309,
+     "[MRV2][Spec] Fuse AR speculator multi-step decodes back into one CUDA graph (#46849)",
+     "a311916a291c1fed3dbfb72e60f74cd778c8419d",
+     {
+      "__datetime__": "2026-08-11T07:06:25.431000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83309"
+    ],
+    [
+     83307,
+     "[ROCm][DSV4] Preserve native MXFP4 TP8 shard allocation (#51473)",
+     "1044d19998df96408832b33ccc7120716c615969",
+     {
+      "__datetime__": "2026-08-11T06:57:30.248000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83307"
+    ],
+    [
+     83305,
+     "Fix docs on `main` (#51773)",
+     "be2e274ef504a09a622a4ea3bf7603b9a41b866f",
+     {
+      "__datetime__": "2026-08-11T06:52:07.209000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83305"
+    ],
+    [
+     83302,
+     "[CPU][Zen] Route BF16 MoE inference through zentorch on AMD (#44201)",
+     "2acb055ed768f07cdf22e718d41b3b3252719dc2",
+     {
+      "__datetime__": "2026-08-11T06:20:07.714000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83302"
+    ],
+    [
+     83301,
+     "[XPU] install xpu-manager for device monitor (#50831)",
+     "b76cf758db961d2641d8437819fd3135cfb9cb72",
+     {
+      "__datetime__": "2026-08-11T06:18:44.503000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83301"
+    ],
+    [
+     83300,
+     "[CI][AMD] Persist the openai-harmony tiktoken vocab cache across jobs (#51666)",
+     "75903e506743180c391bc01ad9bf06a1bab68048",
+     {
+      "__datetime__": "2026-08-11T06:11:10.062000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83300"
+    ],
+    [
+     83298,
+     "Full CI run - nightly",
+     "608c12473f3f93b5452ac3c4fa13fb280b7da674",
+     {
+      "__datetime__": "2026-08-11T06:00:06.926000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83298"
+    ],
+    [
+     83297,
+     "[Attention] Fix MLA prefill workspace allocation size (#51733)",
+     "608c12473f3f93b5452ac3c4fa13fb280b7da674",
+     {
+      "__datetime__": "2026-08-11T05:34:33.079000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83297"
+    ],
+    [
+     83295,
+     "[Kernel] Optimize long-context MLA cache gathers (#51739)",
+     "c76a425278bc41e9d661a377d7c166f5be42cf6b",
+     {
+      "__datetime__": "2026-08-11T05:23:46.595000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83295"
+    ],
+    [
+     83292,
+     "[Bugfix][Frontend] Report Cohere stop sequences correctly (#51556)",
+     "65b7662d3fcb773afaf751ab29ac6960a0cf011d",
+     {
+      "__datetime__": "2026-08-11T04:49:52.023000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83292"
+    ],
+    [
+     83290,
+     "replace batch_norm to numerically identical without cudnn (#51734)",
+     "dc5101fb1b2723fc6264249569f453a803304ca5",
+     {
+      "__datetime__": "2026-08-11T04:43:23.420000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83290"
+    ],
+    [
+     83289,
+     "Preserve revision pins in secondary artifact loaders (#51446)",
+     "90fd4a333fd62b09310924dcb04d8e827bcbcd9b",
+     {
+      "__datetime__": "2026-08-11T04:33:12.998000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83289"
+    ],
+    [
+     83287,
+     "[Misc] Use VLLMValidationError in scoring input validation (#51753)",
+     "adc1200597c0e8e024173bf38270a660b176642d",
+     {
+      "__datetime__": "2026-08-11T04:12:28.740000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83287"
+    ],
+    [
+     83285,
+     "[BugFix][Core] free_blocks: restore prepend (LIFO) reuse order when prefix caching is off (#51482)",
+     "07443bea29db509cfc84b060317c7077b343376a",
+     {
+      "__datetime__": "2026-08-11T03:56:30.100000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83285"
+    ],
+    [
+     83284,
+     "[Perf] Adaptive budget for spec scheduled input tokens, ~60% better Kimi K3 DSpark TTFT (#51725)",
+     "0914ed2e816fa1987951f22afba1c00b7786f110",
+     {
+      "__datetime__": "2026-08-11T03:52:24.485000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83284"
+    ],
+    [
+     83280,
+     "[KV Connector][Offloading] Keep per-layer KV registration when canonical_layout is requested (#51688)",
+     "0f2ea973beebfe2959c74f06e2a412c55c1c7007",
+     {
+      "__datetime__": "2026-08-11T03:04:02.236000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83280"
+    ],
+    [
+     83277,
+     "[Bugfix][ROCm][CI] Stabilize build context and source caches (#51721)",
+     "419b51b38517bd446c6e359d37b1ee8674cd7e84",
+     {
+      "__datetime__": "2026-08-11T02:51:42.090000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83277"
+    ],
+    [
+     83271,
+     "[Bugfix][Model Loader] Defer post-load attention weight processing (#49519)",
+     "99e62b802c2a2fcf8393e0ca87d8b7d8f00297d3",
+     {
+      "__datetime__": "2026-08-11T02:16:59.931000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83271"
+    ],
+    [
+     83268,
+     "[Bugfix] Import each packed IPC export once on the consumer side (#51259)",
+     "f37dff22fc77e21ac857f2023faa7d5b8f9c9591",
+     {
+      "__datetime__": "2026-08-11T02:05:30.321000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83268"
+    ],
+    [
+     83266,
+     "[Frontend] Add content_parts to /inference/v1/generate for raw multim\u2026 (#51478)",
+     "33584901bab6900045b504843a57e172205d3ff1",
+     {
+      "__datetime__": "2026-08-11T02:00:15.435000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83266"
+    ],
+    [
+     83265,
+     "[CI] Solidify speculative decoding E2E coverage (#50713)",
+     "1a1727330a14cfa9f4bdcebfaba403fd02ae7011",
+     {
+      "__datetime__": "2026-08-11T01:56:41.809000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83265"
+    ],
+    [
+     83259,
+     "Fix chat completion 500 on non-object JSON bodies (#51654)",
+     "48bada6ea49ad7f3ecbe03128aa76562089c8b00",
+     {
+      "__datetime__": "2026-08-11T01:31:22.702000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83259"
+    ],
+    [
+     83258,
+     "[Rust Frontend] Support dynamic tools from developer messages (#51144)",
+     "f1e921b6d6404ad1debd14ec0275b007c8c2ee11",
+     {
+      "__datetime__": "2026-08-11T01:30:41.151000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83258"
+    ],
+    [
+     83250,
+     "[MM][CG][BugFix] Fix Ernie-4.5-VL encoder CG postprocess for multi-path outputs (#51461)",
+     "b2506d62aec7e6bccc5959b829221a7ae217abf3",
+     {
+      "__datetime__": "2026-08-11T00:39:07.067000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83250"
+    ],
+    [
+     83247,
+     "[Rust Frontend] Upgrade MiniJinja to 2.22 & remove method lookup workaround (#51235)",
+     "d8c70f22434afcbd6644aa43d3f23aecb6e5a09f",
+     {
+      "__datetime__": "2026-08-11T00:23:26.941000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83247"
+    ],
+    [
+     83246,
+     "Verify optional Buildkite analytics token injection on A100 (ci-infra 07492ed)",
+     "8a9f9f762a47e24ed8b48a8472f6757346cb30ae",
+     {
+      "__datetime__": "2026-08-11T00:14:41.124000"
+     },
+     "canceled",
+     "https://buildkite.com/vllm/ci/builds/83246"
+    ],
+    [
+     83243,
+     "Verify optional Buildkite analytics token injection (ci-infra 07492ed)",
+     "8a9f9f762a47e24ed8b48a8472f6757346cb30ae",
+     {
+      "__datetime__": "2026-08-11T00:06:07.370000"
+     },
+     "canceled",
+     "https://buildkite.com/vllm/ci/builds/83243"
+    ],
+    [
+     83238,
+     "[CI] Parallelize release image publishing (#51735)",
+     "8a9f9f762a47e24ed8b48a8472f6757346cb30ae",
+     {
+      "__datetime__": "2026-08-10T23:38:25.437000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83238"
+    ],
+    [
+     83234,
+     "[Perf] Skip detokenization in offline beam search (#50333)",
+     "8977ea8895b19023f729db474d0f609e5bbac144",
+     {
+      "__datetime__": "2026-08-10T23:17:41.526000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83234"
+    ],
+    [
+     83230,
+     "[Bugfix] Fix DeepSeek V4/3.2 tokenizer vocab size overcount crashing guided decoding (#51727)",
+     "8bcc916a98a90822882455ab30aba02c409da2a6",
+     {
+      "__datetime__": "2026-08-10T23:00:11.168000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83230"
+    ],
+    [
+     83224,
+     "[Model Runner V2][MTP] Share topk index buffer between draft steps (#47352)",
+     "3e174bb73c70b677dd339c59c39d7460abc5d02d",
+     {
+      "__datetime__": "2026-08-10T22:46:15.692000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83224"
+    ],
+    [
+     83221,
+     "[Bugfix][MiMo] Apply vision attention sinks in the window attention path (#49815)",
+     "c3cac8c63d917759a38e94dfa933e71196de40bb",
+     {
+      "__datetime__": "2026-08-10T22:36:44.989000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83221"
+    ],
+    [
+     83219,
+     "[Bugfix] Preserve non-logitproc entry points in tests (#51097)",
+     "98a4144a4197c2b96e4df7bfd9c386d4fbdb1f4f",
+     {
+      "__datetime__": "2026-08-10T22:14:56.057000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83219"
+    ],
+    [
+     83218,
+     "[Rust Frontend][gRPC] Add explicit data-parallel rank routing (#51178)",
+     "fa722b9f0188179a66728f2f882e9d5bc92c9b0c",
+     {
+      "__datetime__": "2026-08-10T22:05:27.733000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83218"
+    ],
+    [
+     83217,
+     "[CI] Add /ci cancel command (#51732)",
+     "3c6b2e9c08447a7f839c6aa201d2683ab52d267e",
+     {
+      "__datetime__": "2026-08-10T21:55:29.438000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83217"
+    ],
+    [
+     83211,
+     "Full CI run - daily",
+     "635dd6aae656f3b47d174461f34d3de799f2dc94",
+     {
+      "__datetime__": "2026-08-10T21:00:03.638000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83211"
+    ],
+    [
+     83205,
+     "[Build][gRPC] Publish protobuf schemas to Buf (#51276)",
+     "635dd6aae656f3b47d174461f34d3de799f2dc94",
+     {
+      "__datetime__": "2026-08-10T20:34:42.683000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83205"
+    ],
+    [
+     83198,
+     "[Kimi-K3] DCP support (#50484)",
+     "63ac04a61e6272b746d82e180e7f6276b3ee1ede",
+     {
+      "__datetime__": "2026-08-10T19:54:29.352000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83198"
+    ],
+    [
+     83197,
+     "[Bugfix] Align deepseek v4 parser thinking default with tokenizer (#51296)",
+     "3f142bd85e962a795c6c484f0249f9c92aed37b2",
+     {
+      "__datetime__": "2026-08-10T19:30:33.955000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83197"
+    ],
+    [
+     83196,
+     "Fix DSpark warmup without sparse index buffer (#50693)",
+     "d40c3e3c00ab904928ab51c9c62b7f514c39647d",
+     {
+      "__datetime__": "2026-08-10T19:12:23.397000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83196"
+    ],
+    [
+     83193,
+     "[ROCm][DistInf] Enable vLLM DI CI with buildkite/slurm (#47030)",
+     "1482d2e015cc71e6ce0d3d92249cb78f4738f2e7",
+     {
+      "__datetime__": "2026-08-10T18:39:29.348000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83193"
+    ],
+    [
+     83191,
+     "[Bugfix][Structured Output] Mask request stop tokens in xgrammar until grammar terminates (#49227)",
+     "05f0a80016a4a12c5f4e241e92e233acd1c2c0b0",
+     {
+      "__datetime__": "2026-08-10T18:29:23.744000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83191"
+    ],
+    [
+     83184,
+     "[Perf] Launch the top-k/top-p Triton sampler kernel with 8 warps (#51507)",
+     "405bc86768d1267f05dd2d4139048eb30a84b6cb",
+     {
+      "__datetime__": "2026-08-10T17:55:38.206000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83184"
+    ],
+    [
+     83183,
+     "[Perf] Narrow DeepSeek V4 eager CUDA graph region (#51430)",
+     "79c865b838e34f7a98a936771284773819d79c8f",
+     {
+      "__datetime__": "2026-08-10T17:52:12.927000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83183"
+    ],
+    [
+     83181,
+     "[Docker] Cache test dependencies before vLLM install (#51184)",
+     "21c667aa64d4023320fb608b81a343e7f9a47250",
+     {
+      "__datetime__": "2026-08-10T17:35:02.143000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83181"
+    ],
+    [
+     83180,
+     "[BugFix][SpecDecode] Fix dspark parallel_drafting_token_id init bug (#51602)",
+     "355a338b8f54befed4ab23a9f09aff301de26b4f",
+     {
+      "__datetime__": "2026-08-10T17:33:13.073000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83180"
+    ],
+    [
+     83172,
+     "[Build] Skip precompiled wheel fetch during metadata hooks (#51424)",
+     "3a749ce81600f67e609eeb4a9b2b8da52dac16f2",
+     {
+      "__datetime__": "2026-08-10T16:38:55.821000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83172"
+    ],
+    [
+     83166,
+     "[Bugfix][Kimi-K3] Give the AMD packed KDA decode kernel the state-index stride (#51682)",
+     "0e2d78028c473bb04fc74bf945eb32da29239b0c",
+     {
+      "__datetime__": "2026-08-10T16:05:23.363000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83166"
+    ],
+    [
+     83164,
+     "Fix DoS via sample-rate forgery bypassing audio decode duration guard (#49948)",
+     "640a09086d1b3c129c4e21f85acbf551eb17b4d1",
+     {
+      "__datetime__": "2026-08-10T15:49:20.268000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83164"
+    ],
+    [
+     83163,
+     "[ROCm][MLA] [K3] Fix fp8 KV cache decode on the AITER MLA backend (#51011)",
+     "37fbf5208413486e5553c1b287af64f6af6afdcf",
+     {
+      "__datetime__": "2026-08-10T15:42:12.644000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83163"
+    ],
+    [
+     83162,
+     "Fix uniform_random routing simulation to sample without replacement (#43680)",
+     "8fea1d306fdfe9b7f47a8f45114b2bb23e8c0d9b",
+     {
+      "__datetime__": "2026-08-10T15:29:00.470000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83162"
+    ],
+    [
+     83159,
+     "Full CI run torch nightly",
+     "fac808b36f502d0d992509a187dca94c68b0360a",
+     {
+      "__datetime__": "2026-08-10T15:14:17.678000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83159"
+    ],
+    [
+     83158,
+     "[Perf][Hybrid] 3D-grid tiling of the state-copy Triton kernels (#49436)",
+     "fac808b36f502d0d992509a187dca94c68b0360a",
+     {
+      "__datetime__": "2026-08-10T15:02:51.922000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83158"
+    ],
+    [
+     83148,
+     "[XPU][Test] Pin block size in test_multi_connector (#51213)",
+     "bd6536071cec4dcd8cf91c0e2aa04aec83fc1c37",
+     {
+      "__datetime__": "2026-08-10T13:57:48.130000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83148"
+    ],
+    [
+     83147,
+     "[Misc] Enable test_fused_moe_wn16 on XPU (#51672)",
+     "ec21f61d82cfe74723bf51e94beb1a6665fb736e",
+     {
+      "__datetime__": "2026-08-10T13:57:05.545000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83147"
+    ],
+    [
+     83143,
+     "[CI] Stabilize DP supervisor lifecycle tests (#51557)",
+     "ea3115e30b1288e3e3ecafd3943695d3f06d1eac",
+     {
+      "__datetime__": "2026-08-10T13:13:55.239000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83143"
+    ],
+    [
+     83142,
+     "[CI] Bump CUTLASS DSL to 4.6.2 (#51566)",
+     "789c4f905eb3f5b73a4de98182fd6eb32c55e15f",
+     {
+      "__datetime__": "2026-08-10T13:06:11.423000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83142"
+    ],
+    [
+     83140,
+     "[2/N] Harden Transformers modelling backend multi-modal path (#51657)",
+     "cf8f3a3bb23ef99d956f3763bc7b6b85cacb125b",
+     {
+      "__datetime__": "2026-08-10T12:57:14.814000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83140"
+    ],
+    [
+     83131,
+     "[ROCm][Bugfix] Use TCP store when AITER custom all-reduce is enabled (#51635)",
+     "436be94e135fd07fc94e4c165a1b6870af72bf31",
+     {
+      "__datetime__": "2026-08-10T11:07:17.527000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83131"
+    ],
+    [
+     83130,
+     "[Bugfix][Core] Emit --no-{key} for false BooleanOptionalAction flags in YAML config (#51573)",
+     "3dafaef02735de08f16298bac42fe18dd930d2ee",
+     {
+      "__datetime__": "2026-08-10T11:05:18.787000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83130"
+    ],
+    [
+     83129,
+     "[Bugfix][Model] Fix Qwen3.5 MTP for text-only checkpoints (#50734)",
+     "900d09f91a1fe164c0df175c334060cad68ce245",
+     {
+      "__datetime__": "2026-08-10T11:04:56.709000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83129"
+    ],
+    [
+     83125,
+     "[Doc] Add Crusoe Managed Inference deployment guide (#49353)",
+     "3a79957b62ade336010cc052e322d0005eb091a2",
+     {
+      "__datetime__": "2026-08-10T10:31:36.769000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83125"
+    ],
+    [
+     83120,
+     "[CI][XPU] Add VLLM_DISABLE_COMPILE_CACHE=1 for other random failed cases in Intel GPU CI (#51604)",
+     "51562de5ab16bacd821d7130187b6bebdd293f93",
+     {
+      "__datetime__": "2026-08-10T09:32:19.228000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83120"
+    ],
+    [
+     83115,
+     "[V1][Scheduler] Apply Mamba alignment before encoder caps (#51603)",
+     "243c63baf5239f961305e25160c1bf6d34096df4",
+     {
+      "__datetime__": "2026-08-10T08:37:19.925000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83115"
+    ],
+    [
+     83112,
+     "[XPU] bump up xpu kernel to v0.1.12.3 (#50441)",
+     "d89ba6481bd0cbe99e1c83ed169131682b366dbd",
+     {
+      "__datetime__": "2026-08-10T08:09:26.140000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83112"
+    ],
+    [
+     83110,
+     "[CI] Upgrade huggingface-hub to 1.27.0 (#51422)",
+     "74c94b9f29ff946647870299e7dbc8d41b206060",
+     {
+      "__datetime__": "2026-08-10T07:59:18.543000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83110"
+    ],
+    [
+     83107,
+     "Fix Gemma 4 for upcoming Transformers version (#49797)",
+     "70b84f0bcbb6d0a35b74b1035673a1c934089dbb",
+     {
+      "__datetime__": "2026-08-10T07:48:30.563000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83107"
+    ],
+    [
+     83106,
+     "[KV Connector] Canonical CPU layout for parallelism-agnostic KV offload (#48414)",
+     "81840a172f2886f4c59dafd9dce9917bb789280c",
+     {
+      "__datetime__": "2026-08-10T07:44:56.642000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83106"
+    ],
+    [
+     83103,
+     "[ROCm][CI] Extend ROCm AITER MHA (FA) coverage (#40958)",
+     "31cd109f18f1ff49cef8dfd25329e7c49d0f2310",
+     {
+      "__datetime__": "2026-08-10T07:35:15.900000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83103"
+    ],
+    [
+     83101,
+     "[Bugfix] Fix lfm2 tool parser dropping calls with brackets or newline\u2026 (#48171)",
+     "7303c66f68ea87573cf29d9a678748a73c8e8c6d",
+     {
+      "__datetime__": "2026-08-10T07:10:08.711000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83101"
+    ],
+    [
+     83100,
+     "[EC Connector] Call to EC Connector update_connector_output from scheduler (#49579)",
+     "61c1dd0966fd8d91954003cf6b7ab746448a46f8",
+     {
+      "__datetime__": "2026-08-10T06:26:00.113000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83100"
+    ],
+    [
+     83096,
+     "`[Model][Quantization] Add Ling-3.0-flash-fp8 support` (#51265)",
+     "ba1cdcfcf05f581d1f58cc911644fed62317c8c6",
+     {
+      "__datetime__": "2026-08-10T06:09:11.146000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83096"
+    ],
+    [
+     83095,
+     "[Bugfix][Quantization] Fix fp32 weight scale for mxfp4 quantization and per-expert checkpoint mapping (#51419)",
+     "3b4c86e489c532f109e602c67b38ac94dc5b78fe",
+     {
+      "__datetime__": "2026-08-10T06:08:55.248000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83095"
+    ],
+    [
+     83094,
+     "Full CI run - nightly",
+     "b22afe45ac797ae58e67a7a3ad79ee5714024420",
+     {
+      "__datetime__": "2026-08-10T06:00:03.490000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83094"
+    ],
+    [
+     83085,
+     "[CPU] Enable GPTQ and AWQ quantization for s390x (#51148)",
+     "b22afe45ac797ae58e67a7a3ad79ee5714024420",
+     {
+      "__datetime__": "2026-08-10T03:41:46.461000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83085"
+    ],
+    [
+     83083,
+     "[CPU] Restore linear dispatch for small unquantized GEMMs (#51379)",
+     "7ce84b99cecc40e94fcee5ee21114fbf1474ad65",
+     {
+      "__datetime__": "2026-08-10T03:30:02.436000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83083"
+    ],
+    [
+     83082,
+     "Add tiering offloading metrics (#48798)",
+     "a123159f7ab0dbacb4d8f45cdeec3cb366982e50",
+     {
+      "__datetime__": "2026-08-10T02:23:17.518000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83082"
+    ],
+    [
+     83079,
+     "[BugFix] Use file:// rendezvous for single-node executors to eliminate startup port races (#50999)",
+     "11ba93f3646d4c5476c3b3fd56835589701f0fb1",
+     {
+      "__datetime__": "2026-08-10T02:00:06.634000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83079"
+    ],
+    [
+     83075,
+     "[Bugfix][Parser] Emit REASONING_END for Inkling tool calls that follow no thinking block (#50528)",
+     "0820125ae99f719f3cd8b0c26c0d3f9789e187e3",
+     {
+      "__datetime__": "2026-08-10T01:04:55.894000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83075"
+    ],
+    [
+     83074,
+     "[Kernel][XPU] Tensor-descriptor operand loads for Triton W8A8 scaled_mm (#47205)",
+     "751f2ccdd3b7ed2ba65dcb04dbd93187edc25b2d",
+     {
+      "__datetime__": "2026-08-10T00:56:14.355000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83074"
+    ],
+    [
+     83071,
+     "[BugFix] Scope divergent hybrid cache hits to capable connectors (#50344)",
+     "d6941300fcb9d4a8bbea19f8b610c2aff9fc5cc3",
+     {
+      "__datetime__": "2026-08-09T22:38:15.681000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83071"
+    ],
+    [
+     83068,
+     "Full CI run - daily",
+     "83ad767eed3be3ee7f2df63be693bfaca5c7c922",
+     {
+      "__datetime__": "2026-08-09T21:00:08.216000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83068"
+    ],
+    [
+     83054,
+     "[CI] fix docs on `main` (#51539)",
+     "83ad767eed3be3ee7f2df63be693bfaca5c7c922",
+     {
+      "__datetime__": "2026-08-09T09:46:15.440000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83054"
+    ],
+    [
+     83051,
+     "[K3] Allow tpu to import kimi_k3.common (#51529)",
+     "04d13b5d653725651f7a750f0022f06d095881dc",
+     {
+      "__datetime__": "2026-08-09T09:06:36.658000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83051"
+    ],
+    [
+     83049,
+     "[KV Offload] Emit self-describing events for partial recurrent blocks (#51243)",
+     "c4239986427a40389fd79c1a4f6afd48aea6512e",
+     {
+      "__datetime__": "2026-08-09T08:28:46.633000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83049"
+    ],
+    [
+     83048,
+     "[ROCm][CI] Reuse equivalent ROCm CI images (#48646)",
+     "7f6432cc0daf97c5b9a2df141641c595a766ff40",
+     {
+      "__datetime__": "2026-08-09T08:25:06.238000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83048"
+    ],
+    [
+     83046,
+     "Bump Flashinfer version to 0.6.16.post3 (#50892)",
+     "f18e10a7e1c1eb37e898c31989ff625d79791657",
+     {
+      "__datetime__": "2026-08-09T07:54:10.225000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83046"
+    ],
+    [
+     83044,
+     "[Bugfix][KV Offload] Handle chunked local attention in offloading scheduler (#51161)",
+     "eb24bc38cfc6818d6dc6d8440faf6e7062396f17",
+     {
+      "__datetime__": "2026-08-09T07:26:00.209000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83044"
+    ],
+    [
+     83043,
+     "[KV Offload] Fix failed-load livelock by marking the lookup verdict as a miss (#49328)",
+     "1b0ce31f3265dce4f0c638cd7e2cf27f5d8c0fbc",
+     {
+      "__datetime__": "2026-08-09T07:25:38.820000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83043"
+    ],
+    [
+     83039,
+     "Full CI run - nightly",
+     "f8d03e77416bf90c49acbe50e233275722f02c4b",
+     {
+      "__datetime__": "2026-08-09T06:00:05.504000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83039"
+    ],
+    [
+     83037,
+     "[Bugfix][Build] Patch stable string memleak fix from 2.14 for 2.13 (#51185)",
+     "f8d03e77416bf90c49acbe50e233275722f02c4b",
+     {
+      "__datetime__": "2026-08-09T04:12:42.090000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83037"
+    ],
+    [
+     83035,
+     "[Migration] Migrate bitsandbytes support to OOT plugin (#43529)",
+     "073c510c916f385315a5366173c883781762bb9e",
+     {
+      "__datetime__": "2026-08-09T02:27:34.235000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83035"
+    ],
+    [
+     83033,
+     "[V1][Metrics] Preserve prefix-cache stats on zero-output steps (#48668)",
+     "dedbf6be8b1afa17a6220473b9c8c98242ac1c03",
+     {
+      "__datetime__": "2026-08-09T01:58:41.270000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83033"
+    ],
+    [
+     83029,
+     "[Build] Upgrade runtime image to Ubuntu 24.04, pick up rdma-core > 44 (#51058)",
+     "cb1a52aee3b31c692a6629ebd7ff5503b3cd13f7",
+     {
+      "__datetime__": "2026-08-09T01:17:53.369000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83029"
+    ],
+    [
+     83027,
+     "[Test] Add ROCm AITER FP8 MLA prefill accuracy test (#51457)",
+     "7581c56c86ce8dd881a84739c0a1eb83f9f2fdd6",
+     {
+      "__datetime__": "2026-08-09T00:42:28.593000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83027"
+    ],
+    [
+     83026,
+     "[Core] Make the GPU sync check thread-local and fix its suppressors (#51455)",
+     "fbff187d593c322c4a221864ce5756bd849e174e",
+     {
+      "__datetime__": "2026-08-09T00:13:43.663000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83026"
+    ],
+    [
+     83025,
+     "[Perf] Avoid some more unnecessary GPU<->CPU syncs (#51458)",
+     "9b0afeb4f6c435a06d394f8a25209d4682a215af",
+     {
+      "__datetime__": "2026-08-09T00:13:28.894000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83025"
+    ],
+    [
+     83024,
+     "[Bugfix][MRV2] Reserve spec-decode lookahead blocks in V2 warmup (#51438)",
+     "d608dfabfdba7e1496e5fef7c66d27c131f59432",
+     {
+      "__datetime__": "2026-08-08T23:58:46.119000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83024"
+    ],
+    [
+     83021,
+     "[Perf][Sparse MLA] Drop the atomic contention in the index remap (#50365)",
+     "9e6be4a72bd29ecf2168a41f659aebfe2cdeda4a",
+     {
+      "__datetime__": "2026-08-08T23:32:42.475000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83021"
+    ],
+    [
+     83020,
+     "[Bugfix][Parser] Confirm reasoning end when an Inkling content block opens (#49876)",
+     "1c1077c6cc4308bdf4c2bf207d7420757a9bfd87",
+     {
+      "__datetime__": "2026-08-08T22:07:42.264000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83020"
+    ],
+    [
+     83018,
+     "Full CI run - daily",
+     "75231eff2f3873e2bce7cc9558bb5227ea70b808",
+     {
+      "__datetime__": "2026-08-08T21:00:02.968000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/83018"
+    ],
+    [
+     83010,
+     "[Bugfix][Parser] Prevent Inkling block-end leakage with tools (#51391)",
+     "75231eff2f3873e2bce7cc9558bb5227ea70b808",
+     {
+      "__datetime__": "2026-08-08T16:34:35.112000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/83010"
+    ],
+    [
+     82996,
+     "[BugFix] Preserve divergent FA hits with external Mamba state (#51468)",
+     "58d3918e3ea0a544ffedadad2ba84559e9c51d8f",
+     {
+      "__datetime__": "2026-08-08T12:20:18.917000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82996"
+    ],
+    [
+     82993,
+     "[Bugfix] Fix LFM2 ShortConv prefix breaking quant ignore list (#51495)",
+     "0fe9a916e88e884d6ee7fa20c4b15f5a9610218f",
+     {
+      "__datetime__": "2026-08-08T11:27:16.347000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82993"
+    ],
+    [
+     82988,
+     "Add torch compile for qwen3_vl encoder (#40116)",
+     "653ebb52dffd8b4653b430302473c771117529f1",
+     {
+      "__datetime__": "2026-08-08T08:23:21.346000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82988"
+    ],
+    [
+     82982,
+     "[ROCm][CI] Baseline legacy extensions in the Torch ABI audit (#50805)",
+     "643c125fab66d5ed5ec3143b7e764a77e7ae8ac7",
+     {
+      "__datetime__": "2026-08-08T06:01:06.437000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82982"
+    ],
+    [
+     82981,
+     "Full CI run - nightly",
+     "643c125fab66d5ed5ec3143b7e764a77e7ae8ac7",
+     {
+      "__datetime__": "2026-08-08T06:00:05.462000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82981"
+    ],
+    [
+     82980,
+     "[Bugfix][MM] Avoid device sync in FusedInputNorm initialization (#51435)",
+     "6e18901195fc3726546484fa86254217a747e9fe",
+     {
+      "__datetime__": "2026-08-08T05:32:26.023000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82980"
+    ],
+    [
+     82978,
+     "[CI] Refresh hybrid Model Runner V2 coverage (#51410)",
+     "44351f81d58861edc873c7678c500a4f40834450",
+     {
+      "__datetime__": "2026-08-08T05:10:57.190000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82978"
+    ],
+    [
+     82977,
+     "[CPU] Optimize routed FP8/MXFP4 MoE GEMM dispatch (#50949)",
+     "700d39b55813fce6fe5339b334beb55d2a39f598",
+     {
+      "__datetime__": "2026-08-08T04:56:16.948000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82977"
+    ],
+    [
+     82976,
+     "[Bugfix][Multimodal] Fix PyNvVideoCodec video backend returning NCHW instead of NHWC (#51076)",
+     "d3621c1eb3c4cb8d8a97e05d8c58d7f7571e34db",
+     {
+      "__datetime__": "2026-08-08T04:49:09.905000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82976"
+    ],
+    [
+     82974,
+     "[BugFix] Reject invalid data-parallel RPC ports (#51469)",
+     "22a175921c4718f195d1eaddf5a26c9aaa07a326",
+     {
+      "__datetime__": "2026-08-08T04:23:29.061000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82974"
+    ],
+    [
+     82972,
+     "[Bugfix][models_multimodal] Remote HF python code misses importing class (#51427)",
+     "d21fed95221a49d2023b3b105339864fdf81a0bb",
+     {
+      "__datetime__": "2026-08-08T04:09:29.447000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82972"
+    ],
+    [
+     82971,
+     "[Bugfix][multi_modal] Fix pos_ids being unitialized for minicpmv2.6 in hf runner (#51432)",
+     "a828536fb53aedc76216eb0c0289d7417e3851f7",
+     {
+      "__datetime__": "2026-08-08T04:09:15.009000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82971"
+    ],
+    [
+     82968,
+     "[CI] Guard remote-code Transformers compatibility (#51451)",
+     "12da9b23ae7009bee11b7da8a661061b327372a8",
+     {
+      "__datetime__": "2026-08-08T04:05:52.210000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82968"
+    ],
+    [
+     82963,
+     "[Bugfix][Quantization] Fix INT8 W8A8 MoE crash in TritonExperts (#51411)",
+     "5eaa70dac58102fe6e243291e2bf25ca192c46f2",
+     {
+      "__datetime__": "2026-08-08T03:07:00.467000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82963"
+    ],
+    [
+     82956,
+     "[Bugfix] Fix ZMQ port TOCTOU race in shm_broadcast MessageQueue (#50960)",
+     "f7ef489e93cf92b8d6ce7403b49f1db867bcc35e",
+     {
+      "__datetime__": "2026-08-08T01:19:05.035000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82956"
+    ],
+    [
+     82953,
+     "[Kimi][MM] disable kimi_vit's dynamic torch.compile for TPU (#51196)",
+     "7f58e8294a19eab37011c21c8da981206ca3849e",
+     {
+      "__datetime__": "2026-08-08T00:42:58.135000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82953"
+    ],
+    [
+     82952,
+     "[Bugfix] Close usage telemetry HTTP sessions (#51219)",
+     "1c008a346c1141dbd6bee3816312f1467ed98b8a",
+     {
+      "__datetime__": "2026-08-08T00:29:38.914000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82952"
+    ],
+    [
+     82948,
+     "[Perf] Optimize DeepSeek V3.2 sequence parallelism (#51434)",
+     "e644c8cd8c734bf3b5e662a4bc363cfa8524d821",
+     {
+      "__datetime__": "2026-08-07T23:51:03.384000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82948"
+    ],
+    [
+     82944,
+     "[CI Test] Add specific unit test for mrv2 offloading (#51440)",
+     "c39076feff40b5638a2b911414bc09b8e6e953bc",
+     {
+      "__datetime__": "2026-08-07T22:49:48.383000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82944"
+    ],
+    [
+     82940,
+     "[Perf] Improve `--linear-backend` filtering (#48735)",
+     "a801e71cb86ecd45cd8cb8f7d1bc08390f2bd68f",
+     {
+      "__datetime__": "2026-08-07T22:15:57.342000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82940"
+    ],
+    [
+     82935,
+     "[Perf] Narrow DeepSeek V3.2 eager CUDA graph region (#51425)",
+     "46b58640541274334e2ee502a9c744841fb310b3",
+     {
+      "__datetime__": "2026-08-07T21:37:46.273000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82935"
+    ],
+    [
+     82925,
+     "[Spec Decode] Register Qwen3.6 dSpark acceptance coverage (#51310)",
+     "c8fe1d5715a75a0e71712ec6717dd7ff71d1a8d0",
+     {
+      "__datetime__": "2026-08-07T21:07:58.747000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82925"
+    ],
+    [
+     82923,
+     "Full CI run - daily",
+     "9823714346164d9a15d6556eb3ee163d5e168cb9",
+     {
+      "__datetime__": "2026-08-07T21:00:05.859000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82923"
+    ],
+    [
+     82922,
+     "[Bugfix] Drop stale layer kwarg from online MXFP4 kernel creation (fix precommit) (#51442)",
+     "9823714346164d9a15d6556eb3ee163d5e168cb9",
+     {
+      "__datetime__": "2026-08-07T20:49:03.713000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82922"
+    ],
+    [
+     82921,
+     "[CI] Fix Batch Invariance (B200) (#51417)",
+     "27d73038025599890772ffc288217a24d08a7953",
+     {
+      "__datetime__": "2026-08-07T20:45:32.600000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82921"
+    ],
+    [
+     82920,
+     "[DSv32/GLM Perf] Skip short prefill topk for dense mha layer, 97.9% kernel level latency reduction (#51298)",
+     "4a11ed5bc4c2f4e818e1e33010da160449d59159",
+     {
+      "__datetime__": "2026-08-07T20:30:45.867000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82920"
+    ],
+    [
+     82919,
+     "[Profiler] Stamp vLLM version/commit into torch profiler trace metadata (#51389)",
+     "99950b0b86463867bfaa210b7da56d7ce41eb35a",
+     {
+      "__datetime__": "2026-08-07T20:30:01.831000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82919"
+    ],
+    [
+     82917,
+     "Add NVFP4 KV 4-over-6 scale search (#45187)",
+     "1c94e8dc7da43d12c8686f05cc5d2eab3fd9528f",
+     {
+      "__datetime__": "2026-08-07T20:22:30.372000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82917"
+    ],
+    [
+     82913,
+     "[Bugfix] when loading weights skip empty expert bias if model does not support them (#50937)",
+     "70456e5e6fb4ee86b8ffd985f918e44ba632d925",
+     {
+      "__datetime__": "2026-08-07T19:45:54.859000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82913"
+    ],
+    [
+     82911,
+     "[Frontend] Disable uvicorn signal handlers instead of racing them (#50916)",
+     "ac70ce96e0b9f69dd834bd1b0cd2d2b4c4a9db46",
+     {
+      "__datetime__": "2026-08-07T19:40:27.466000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82911"
+    ],
+    [
+     82910,
+     "[Online quantization] Add online MXFP4 quantization support (#49347)",
+     "3518110f2f4532c4605d8b1ea2a9bdc7d61b9f04",
+     {
+      "__datetime__": "2026-08-07T19:39:49.052000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82910"
+    ],
+    [
+     82907,
+     "[MRv2 Feature] MR v2 weight offloading support (#51413)",
+     "a671679e9f04742aecb2c9b35cd513a024c1321f",
+     {
+      "__datetime__": "2026-08-07T19:20:24.199000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82907"
+    ],
+    [
+     82906,
+     "[Perf] Raise Blackwell CUDA graph capture default to 1024 (#49390)",
+     "021b7d985b54264393b4c339f2823d783080942a",
+     {
+      "__datetime__": "2026-08-07T19:18:16.769000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82906"
+    ],
+    [
+     82905,
+     "[K3 Perf] Optimize k3 dspark fused kv, 4.5~4.6x kernel performance improvement (#50585)",
+     "56a4b63d44c71784de75e6f2d6cbe28adf74635f",
+     {
+      "__datetime__": "2026-08-07T19:16:13.769000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82905"
+    ],
+    [
+     82904,
+     "[Test] Add packed DeepSeek-V4 KV zeroer geometry regression (#51288)",
+     "0df620d429261fb4e3c1200c6b8414209587a86c",
+     {
+      "__datetime__": "2026-08-07T19:11:12.575000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82904"
+    ],
+    [
+     82902,
+     "[Test] Add ROCm AITER MLA op registration and env gating tests (#50930)",
+     "a0056e103e214d5b0b73ca9e24003e09f8cbec63",
+     {
+      "__datetime__": "2026-08-07T19:07:34.286000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82902"
+    ],
+    [
+     82901,
+     "[ROCm][CI][Bugfix] Do not microbatch a step that splits a prefix from its writer (#51402)",
+     "ebb2972562bf05e949f7bbe73f496a2aeb5fdc25",
+     {
+      "__datetime__": "2026-08-07T18:55:37.872000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82901"
+    ],
+    [
+     82896,
+     "[Attention] Mamba attention module refactor - Final part (#44857)",
+     "4eccf906ca8778bc02cb7549bab38e8b53cd9a90",
+     {
+      "__datetime__": "2026-08-07T18:27:14"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82896"
+    ],
+    [
+     82893,
+     "[1/N] Harden Transformers modelling backend multi-modal path (#51408)",
+     "45273b8dcbfb2d2c300c2f4a55c4dc283adca06a",
+     {
+      "__datetime__": "2026-08-07T17:30:46.232000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82893"
+    ],
+    [
+     82889,
+     "[Refactor] refactor humming linear and moe backends to use explicit layer configs (#49610)",
+     "fcde8e1460589849c8142d617420ccdc406d5bc9",
+     {
+      "__datetime__": "2026-08-07T17:03:22.289000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82889"
+    ],
+    [
+     82886,
+     "[ROCm] Add tuned selective_state_update float32 config for AMD Instinct MI325X (#50007)",
+     "e229fdbc873b689bd9eb61559c4f8828b7e1a2f9",
+     {
+      "__datetime__": "2026-08-07T16:58:39.033000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82886"
+    ],
+    [
+     82884,
+     "[Bugfix][ROCm] Fix ROCM_AITER_FA & ROCM_AITER_UNIFIED_ATTN QK-Norm+RoPE+KVCache fusion for the packed KV-cache [BLOCKS, HEADS, BLOCK_SIZE, 2*HEAD_DIM] layout (#49373)",
+     "34c1cd20a58e96f197d4b5927336a2d9facafa58",
+     {
+      "__datetime__": "2026-08-07T16:54:58.026000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82884"
+    ],
+    [
+     82871,
+     "[ROCm] Enable pinned memory on supported WSL2 kernels (#50126)",
+     "7e85d3a42cc180d8b8fa85ca815c3e90bf2cb970",
+     {
+      "__datetime__": "2026-08-07T15:43:45.477000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82871"
+    ],
+    [
+     82861,
+     "fnrec blocked-step sweep",
+     "b1e12d142d8c9533f857f8da13d8fc368e95a8cd",
+     {
+      "__datetime__": "2026-08-07T14:53:06.831000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82861"
+    ],
+    [
+     82857,
+     "[Bugfix] Fix get_open_port() livelock on DP-reserved ports and cover get_open_ports_list (#50965)",
+     "448344c0e29383adfe606a5c7ede72dd74705321",
+     {
+      "__datetime__": "2026-08-07T14:39:36.624000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82857"
+    ],
+    [
+     82855,
+     "[Bugfix][KV-transfer] MoRIIO: per-layer READ-completion barrier in wait_for_layer_load (#48534)",
+     "47228db84ce59321e6e464f20fabe0ef86e6aef5",
+     {
+      "__datetime__": "2026-08-07T14:23:36.436000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82855"
+    ],
+    [
+     82854,
+     "[PD][NixlPush][Bugfix] Fix prefix caching (#48758)",
+     "d4ecb75ba2f53a1e445cf5ac277ea8a5e78d516b",
+     {
+      "__datetime__": "2026-08-07T14:21:19.915000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82854"
+    ],
+    [
+     82850,
+     "[Model] Enable Qwen3.8 for AMD Rocm (#50068)",
+     "f2bfad9167a29e963f29f9ea79f2811513566ea6",
+     {
+      "__datetime__": "2026-08-07T13:19:09.908000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82850"
+    ],
+    [
+     82847,
+     "[Bugfix] Skip fetching revision for model when model and weights_model are different (#51260)",
+     "a231c5ceac87451b6dcf5ccdf0eef7a3634bc5d4",
+     {
+      "__datetime__": "2026-08-07T12:55:53.681000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82847"
+    ],
+    [
+     82846,
+     "Fix ROCm architecture import on non-ROCm platforms (#51357)",
+     "d5aae2b4641c5091e604e235617e51e60a564710",
+     {
+      "__datetime__": "2026-08-07T12:33:00.369000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82846"
+    ],
+    [
+     82845,
+     "feat: extended EPLB support for Mistral Large 3 and additional MoE backends (#48355)",
+     "ae934ba8a5577c580c33e3489290ff7d8bf1f83e",
+     {
+      "__datetime__": "2026-08-07T12:32:55.377000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82845"
+    ],
+    [
+     82843,
+     "[validation] Verify AMD mirror step keys after ci-infra#458",
+     "8d9b52f7c2514490bdadfd5eb0c931e58625df2e",
+     {
+      "__datetime__": "2026-08-07T11:49:55.317000"
+     },
+     "canceled",
+     "https://buildkite.com/vllm/ci/builds/82843"
+    ],
+    [
+     82838,
+     "[XPU] quick fix online quantization UT break (#51365)",
+     "8d9b52f7c2514490bdadfd5eb0c931e58625df2e",
+     {
+      "__datetime__": "2026-08-07T10:25:34.497000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82838"
+    ],
+    [
+     82834,
+     "[Misc] Add and enable Triton kernel unit tests on XPU (#45694)",
+     "6b5bec7bedffa949fbd393fce720faf35831d746",
+     {
+      "__datetime__": "2026-08-07T09:53:06.258000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82834"
+    ],
+    [
+     82832,
+     "[PD][PushConnector] Record last activity of remotes to allow clean up of stale ones (#50234)",
+     "5ec47f3e48e7f6da9b6caa1c804b3887f832a788",
+     {
+      "__datetime__": "2026-08-07T09:43:31.755000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82832"
+    ],
+    [
+     82823,
+     "[Bugfix][Platform] Stop re-initializing NVML on every device-capability check (fixes #50381) (#50393)",
+     "4f76c8ad9d8ec06e91ac9c84895e07a1913d7726",
+     {
+      "__datetime__": "2026-08-07T08:30:03.184000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82823"
+    ],
+    [
+     82822,
+     "[Bugfix][Quantization] Fix dynamic INT8 W8A8 MoE config being built as W8A16 (#50833)",
+     "b8db7f4abd2c864d5a7045b6d36fa36c2c7bb1e1",
+     {
+      "__datetime__": "2026-08-07T08:21:16.024000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82822"
+    ],
+    [
+     82821,
+     "[Refactor] Remove kernel dead code (#51051)",
+     "c84789c40b506a40d6a1ec15a704d53397c564a6",
+     {
+      "__datetime__": "2026-08-07T08:20:21.910000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82821"
+    ],
+    [
+     82820,
+     "Support DeepSeek-V4 AMD Quark NVFP4 with emulation kernel  (#47972)",
+     "da788334bc0683cc44a58b4624e3f5a3c09a09e0",
+     {
+      "__datetime__": "2026-08-07T08:19:34.042000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82820"
+    ],
+    [
+     82819,
+     "[ROCm][CI] Loosen block-FP8 fused MoE test tolerance for large-K shapes (#48847)",
+     "0de0362ea1c69b93f9ed36126a1b5c94f0ce2f22",
+     {
+      "__datetime__": "2026-08-07T08:19:29.343000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82819"
+    ],
+    [
+     82812,
+     "[Feat][Core] Add disk offloading support to SimpleCPUOffloadConnector (#49644)",
+     "58fcaa0baaa32ba0c34e1119f6ce4554ef8a6256",
+     {
+      "__datetime__": "2026-08-07T07:37:50.994000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82812"
+    ],
+    [
+     82811,
+     "[rl] Stateful Trainer Send: NCCL + Sparse NCCL [3/N] (#50902)",
+     "21ea5b4fa1062a379dd7e6795497ad6becd5a856",
+     {
+      "__datetime__": "2026-08-07T07:36:02.781000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82811"
+    ],
+    [
+     82794,
+     "[ROCm][Perf] Kimi-K3 Shard Latent MoE up-projection for ROCm path (#51253)",
+     "43d691ec6b1d26d3ef3d8725a7c7e4d8556eb984",
+     {
+      "__datetime__": "2026-08-07T06:11:21.039000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82794"
+    ],
+    [
+     82790,
+     "Full CI run - nightly",
+     "b706fd1628b06c216a945176a9fedfa808324803",
+     {
+      "__datetime__": "2026-08-07T06:00:06.222000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82790"
+    ],
+    [
+     82789,
+     "Full CI run torch nightly",
+     "b706fd1628b06c216a945176a9fedfa808324803",
+     {
+      "__datetime__": "2026-08-07T06:00:05.925000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82789"
+    ],
+    [
+     82787,
+     "[CI][XPU] Work around intermittent segfault in Intel XPU CI with VLLM_DISABLE_COMPILE_CACHE=1 (#51337)",
+     "b706fd1628b06c216a945176a9fedfa808324803",
+     {
+      "__datetime__": "2026-08-07T05:18:27.754000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82787"
+    ],
+    [
+     82782,
+     "[Bugfix] Fix Mamba all-mode CPU offload boundary alignment (#51100)",
+     "c810e5ee9976ad86b81d1277b53e76d0ee639414",
+     {
+      "__datetime__": "2026-08-07T04:37:51.234000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82782"
+    ],
+    [
+     82776,
+     "[Bugfix][EPD][Model Runner V2] Skip gather mm embeddings for encoder only instance (#51222)",
+     "dd856e48bbf969e3f0e561e8c76f6e92c76e0795",
+     {
+      "__datetime__": "2026-08-07T03:40:50.114000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82776"
+    ],
+    [
+     82775,
+     "[Feat] Support thinking_token_budget in Model Runner V2 (#46727)",
+     "72c0d6765793e4c7242c3586274af3e1a8aca170",
+     {
+      "__datetime__": "2026-08-07T03:36:21.862000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82775"
+    ],
+    [
+     82772,
+     "fnrec full run",
+     "b1e12d142d8c9533f857f8da13d8fc368e95a8cd",
+     {
+      "__datetime__": "2026-08-07T02:50:25.362000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82772"
+    ],
+    [
+     82771,
+     "[CI] Re-enable FI autotune in GSM8K config for Qwen3.5-35B-A3B (#51293)",
+     "5ac2684976ee22c04fe0d2f968c6cf6096b383f2",
+     {
+      "__datetime__": "2026-08-07T02:42:37.112000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82771"
+    ],
+    [
+     82761,
+     "fix pre-commit broken (#51341)",
+     "0406ba22c431e5fd2000165b594323f5afa312a2",
+     {
+      "__datetime__": "2026-08-07T01:17:42.402000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82761"
+    ],
+    [
+     82760,
+     "fnrec probe",
+     "a07086e4032e66aacae60ac2fc01e738096e9569",
+     {
+      "__datetime__": "2026-08-07T01:16:12.083000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82760"
+    ],
+    [
+     82757,
+     "[Kernel] Support Nvfp4 Cutedsl Moe Swiglu-oai and Relu2(non-gated) Activation (#47106)",
+     "e08111211bc94f5e7f5ebd0f071ef5300f6f5564",
+     {
+      "__datetime__": "2026-08-07T00:42:48.177000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82757"
+    ],
+    [
+     82754,
+     "fnrec probe",
+     "a07086e4032e66aacae60ac2fc01e738096e9569",
+     {
+      "__datetime__": "2026-08-07T00:28:22.446000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82754"
+    ],
+    [
+     82752,
+     "[V1] Copy NaN-in-logits counts to host asynchronously (#51304)",
+     "b1e12d142d8c9533f857f8da13d8fc368e95a8cd",
+     {
+      "__datetime__": "2026-08-07T00:05:06.540000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82752"
+    ],
+    [
+     82751,
+     "[CI] Exclude KV-connector subtree from broad source dependencies (#51046)",
+     "d35eb6c44071ea806018841c490f0d2f3219c485",
+     {
+      "__datetime__": "2026-08-06T23:51:12.780000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82751"
+    ],
+    [
+     82746,
+     "[Quantization] Share online weight scales across TP (#49764)",
+     "8170c23c4fa36ffdc5890e5df46b4825fd9d0745",
+     {
+      "__datetime__": "2026-08-06T23:34:36.515000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82746"
+    ],
+    [
+     82744,
+     "[Model Runner V2] Fix -1 placeholder draft token ids in rejection sam\u2026 (#50939)",
+     "27930df9c2bd14047be35ff2a986ca72fc65631a",
+     {
+      "__datetime__": "2026-08-06T23:32:02.636000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82744"
+    ],
+    [
+     82743,
+     "docs(governance): refresh committers list, add TSC note, update project leads (#51300)",
+     "9bca7d840d7fa4677e58e7d163ddd191cccc40b7",
+     {
+      "__datetime__": "2026-08-06T23:28:19.690000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82743"
+    ],
+    [
+     82734,
+     "[ModelRunner v2] Enable decoder token-wise pooling (#50931)",
+     "946452961265514622b95ea170839b214f39c2a0",
+     {
+      "__datetime__": "2026-08-06T22:21:55.069000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82734"
+    ],
+    [
+     82733,
+     "fix: resolve silent request skipping in PRIORITY scheduling (#49206)",
+     "4d341ca829d7fbad351b3a5a17d1405e63dc5bf2",
+     {
+      "__datetime__": "2026-08-06T22:21:25.949000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82733"
+    ],
+    [
+     82727,
+     "[Misc] Upgrade fastsafetensors version, fix metadata is null (#50827)",
+     "a07086e4032e66aacae60ac2fc01e738096e9569",
+     {
+      "__datetime__": "2026-08-06T21:48:59.311000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82727"
+    ],
+    [
+     82726,
+     "[ModelRunner V2] Minor indexing optimizations (#51210)",
+     "c5d470ac4ccd17ac9663db0d1c0e2060e5ae15ad",
+     {
+      "__datetime__": "2026-08-06T21:44:16.413000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82726"
+    ],
+    [
+     82722,
+     "Full CI run - daily",
+     "d6af803f434397222674e8ea5cc6f25b3a208e62",
+     {
+      "__datetime__": "2026-08-06T21:00:02.109000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82722"
+    ],
+    [
+     82718,
+     "[Bugfix] Fix packed KV block zeroing stride (#50276)",
+     "d6af803f434397222674e8ea5cc6f25b3a208e62",
+     {
+      "__datetime__": "2026-08-06T20:49:09.309000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82718"
+    ],
+    [
+     82716,
+     "[Mypy Fix] Mypy fix for \"vllm/model_executor/models/[aA][bB]\" (#48977)",
+     "adc3e03517d2e7333a3bb2083bb4d394a2986876",
+     {
+      "__datetime__": "2026-08-06T19:30:18.499000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82716"
+    ],
+    [
+     82714,
+     "[ROCm][MLA] Use asm decode for non-divisor small head counts (#50578)",
+     "d8eabdbfbe93ecc8a8d5cb8a55c5067a443a8796",
+     {
+      "__datetime__": "2026-08-06T18:56:56.237000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82714"
+    ],
+    [
+     82711,
+     "[Frontend] Watch frontend processes during engine startup (#43417)",
+     "7b9f2dad8920f115c1caea36e096e43c04c3da68",
+     {
+      "__datetime__": "2026-08-06T18:17:27.031000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82711"
+    ],
+    [
+     82710,
+     "[ROCm][CI] Update AITER AR+RMS e2e fusion counts for final-norm coverage (#51273)",
+     "4f851bef6c4ef3a691aa19f798b220819d19dde4",
+     {
+      "__datetime__": "2026-08-06T18:05:19.003000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82710"
+    ],
+    [
+     82704,
+     "[Bugfix] Keep mamba align prefill chunks block-aligned past last_cache_position (#51113)",
+     "c56f169d9ae46ca420617e2cf5f0c9135da0f651",
+     {
+      "__datetime__": "2026-08-06T17:21:03.035000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82704"
+    ],
+    [
+     82703,
+     "[Weight processing] Copy over `new_data` attributes in `replace_parameter` (#49601)",
+     "81be2e09aebfd1c45b3ed9f73d2850da8a72984c",
+     {
+      "__datetime__": "2026-08-06T17:03:40.046000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82703"
+    ],
+    [
+     82702,
+     "[Attention][MLA] Per-request scheduling for MLA chunked context (#50613)",
+     "b38e111d3e4806a553ec2798e2b075da7a8b03d3",
+     {
+      "__datetime__": "2026-08-06T16:45:48.041000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82702"
+    ],
+    [
+     82699,
+     "Fully generalise input embedding handling in Transformers modelling backend (#51247)",
+     "e7b8d5946095a594af2cf7ca3c314b9806cb7c32",
+     {
+      "__datetime__": "2026-08-06T16:21:28.489000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82699"
+    ],
+    [
+     82698,
+     "[CI] Run basic fullgraph correctness on one GPU (#51271)",
+     "566c80edf9e770524b1506a9d681922d4601c70c",
+     {
+      "__datetime__": "2026-08-06T16:09:33.029000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82698"
+    ],
+    [
+     82696,
+     "attn_res kernel latency improvements (#50185)",
+     "7b4ed49628abd7860a435d6798feef76a944cb02",
+     {
+      "__datetime__": "2026-08-06T15:53:23.504000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82696"
+    ],
+    [
+     82694,
+     "Update vllm to point to flash-attention commit that builds FA3 with torch stable API. (Retry) (#49599)",
+     "41e7746b82b43dd3454cd842d1bcfc30665eddb2",
+     {
+      "__datetime__": "2026-08-06T15:37:49.694000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82694"
+    ],
+    [
+     82682,
+     "Full CI run torch nightly",
+     "62a86318de3655f970baf7c2ff89c81a72c1a1b3",
+     {
+      "__datetime__": "2026-08-06T13:21:38.892000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82682"
+    ],
+    [
+     82679,
+     "[VocabParallelEmbedding] fix extra_repr fields concat (#51224)",
+     "62a86318de3655f970baf7c2ff89c81a72c1a1b3",
+     {
+      "__datetime__": "2026-08-06T12:22:21.547000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82679"
+    ],
+    [
+     82678,
+     "Remove the XPU branch of topk_softplus_sqrt (#51242)",
+     "1e05b21d61e6126e4811313f39c961bf8b314470",
+     {
+      "__datetime__": "2026-08-06T12:18:49.294000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82678"
+    ],
+    [
+     82677,
+     "[Bugfix][KV Offload] Clean up resources after initialization failure (#51227)",
+     "46e6a83ce12b5968d956279a1bd4611de16d69eb",
+     {
+      "__datetime__": "2026-08-06T11:42:16.583000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82677"
+    ],
+    [
+     82676,
+     "[Bugfix][Model] Add missing fused_qkv_a_proj to Kimi-Linear packed_modules_mapping (#51249)",
+     "5fba75aefeedcf5b6cc27abf9bc145b6a49873a7",
+     {
+      "__datetime__": "2026-08-06T11:39:20.306000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82676"
+    ],
+    [
+     82675,
+     "[Rust Frontend] Add standalone Rust renderer (#50289)",
+     "865781e62769fc469e5b1859773bb17bc36e5b3c",
+     {
+      "__datetime__": "2026-08-06T11:23:30.029000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82675"
+    ],
+    [
+     82674,
+     "[Bugfix][KV Offload] Fall back when MADV_POPULATE_WRITE is unsupported (#51116)",
+     "ef2615c2e011d9e3b064f483574f47ad45fa8c38",
+     {
+      "__datetime__": "2026-08-06T10:48:03.799000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82674"
+    ],
+    [
+     82671,
+     "Interns2mobius support (#51149)",
+     "22013f74ffb0ae22deb29233cbe9fcd3efb1b374",
+     {
+      "__datetime__": "2026-08-06T10:39:38.025000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82671"
+    ],
+    [
+     82669,
+     "[MISC][Bench] refactor throughput and reuse serve's get samples (#50981)",
+     "e07532b0358784069ed37c36276a14b697cb3d47",
+     {
+      "__datetime__": "2026-08-06T10:31:26.835000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82669"
+    ],
+    [
+     82666,
+     "[Bugfix][LoRA] Guard TrtLlm BF16 MoE LoRA gate on activation type (#51002)",
+     "872fd5973ede6acc07bfa48ef895e41fc3fe6c66",
+     {
+      "__datetime__": "2026-08-06T10:12:57.302000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82666"
+    ],
+    [
+     82665,
+     "[Model] Fused mm preprocess normalisation on the Device (#50411)",
+     "2fa490470ddf0fe578f7b70cd3aa8f6c1e06b2c6",
+     {
+      "__datetime__": "2026-08-06T10:11:16.700000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82665"
+    ],
+    [
+     82660,
+     "[Quantization] Preserve precision in online NVFP4 expert packing (#50029)",
+     "9c22668436a4d94aab87ea74a220e060415cf1d8",
+     {
+      "__datetime__": "2026-08-06T09:23:57.677000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82660"
+    ],
+    [
+     82659,
+     "[XPU] Register fake meta kernel for fp4_gemm (#50946)",
+     "276f0bb5c1afef985f3f8729fc7794db6cc177ed",
+     {
+      "__datetime__": "2026-08-06T09:18:45.529000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82659"
+    ],
+    [
+     82654,
+     "[CPU] Add MLA backend so DeepSeek-V2/V3 can run on CPU (#49453)",
+     "13726c80fe5758443b4e1508611ccf504a06085c",
+     {
+      "__datetime__": "2026-08-06T08:51:43.847000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82654"
+    ],
+    [
+     82652,
+     "[GLM Perf] DSv32/glm use skip topk for MTP case, 2.0x kernel performance improvement (#50904)",
+     "ad5280255ba6e37dd11cf697bd7145d2a90213ff",
+     {
+      "__datetime__": "2026-08-06T08:48:38.991000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82652"
+    ],
+    [
+     82648,
+     "[Perf][CUDA] Programmatic dependent launch for the DSA decode kernels (#50230)",
+     "2dfb8ba59098eb489197e1b4c643addffd51592e",
+     {
+      "__datetime__": "2026-08-06T07:53:20.656000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82648"
+    ],
+    [
+     82646,
+     "[Model] Fix weight prefix mapping for native Qwen3.5 text-only checkp\u2026 (#50355)",
+     "febea17f6aa9141b3a0044e9690d6e6501f5c9d3",
+     {
+      "__datetime__": "2026-08-06T07:40:47.051000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82646"
+    ],
+    [
+     82645,
+     "[HPC Attention Backend] hpc attention backend support bf16 kv cache with fp8 weight  (#50980)",
+     "470297c143c9465d4cfff4b854f63f0a283ec5de",
+     {
+      "__datetime__": "2026-08-06T07:40:17.436000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82645"
+    ],
+    [
+     82641,
+     "[ROCm] Fix AITER all-reduce fusion coverage (#50802)",
+     "7e724dca897dda9e3fd05abcfe5b0f6d77c564b1",
+     {
+      "__datetime__": "2026-08-06T06:52:25.603000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82641"
+    ],
+    [
+     82640,
+     "[BugFix][KV Cache] Fix hybrid prefix caching with hidden-state extraction (#51108)",
+     "537046164944cbd34ac940d8655f91704e5a0bf1",
+     {
+      "__datetime__": "2026-08-06T06:42:40.737000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82640"
+    ],
+    [
+     82639,
+     "[Linear] [Kernel] add block-wise scaled_mm (#49932)",
+     "8060260e1d1718d831419b5e9fe7a1757d6cc27b",
+     {
+      "__datetime__": "2026-08-06T06:40:29.602000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82639"
+    ],
+    [
+     82637,
+     "[XPU] update warning of XPU Graph (#50236)",
+     "8c0f029ac7718af4400d7542bb99417cb901d220",
+     {
+      "__datetime__": "2026-08-06T06:33:36.290000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82637"
+    ],
+    [
+     82632,
+     "[Bugfix][Quantization] Fix MXFP4 conversion for FlashInfer CUTLASS (#51038)",
+     "2e35c529b8decf545b2b037569e5b31640e093dd",
+     {
+      "__datetime__": "2026-08-06T06:19:25.160000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82632"
+    ],
+    [
+     82629,
+     "Full CI run - nightly",
+     "c0202c560333e8e475819a93a7cc00d9b2a115db",
+     {
+      "__datetime__": "2026-08-06T06:00:04.194000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82629"
+    ],
+    [
+     82626,
+     "[Bugfix][Spec Decode] Auto-enable async scheduling for draft models (#48341)",
+     "c0202c560333e8e475819a93a7cc00d9b2a115db",
+     {
+      "__datetime__": "2026-08-06T05:51:42.828000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82626"
+    ],
+    [
+     82625,
+     "[XPU] Route AWQ linear through choose_mp_linear_kernel (#50840)",
+     "b976e980efdfb95d0ade2ff6658ca736c737f1bf",
+     {
+      "__datetime__": "2026-08-06T05:50:13.565000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82625"
+    ],
+    [
+     82624,
+     "[XPU][Test] Support MultiConnector accuracy testing on XPU (#51160)",
+     "2a0323b4e0f08b29d11a6f3bfa154b3bd7bb7975",
+     {
+      "__datetime__": "2026-08-06T05:49:50.711000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82624"
+    ],
+    [
+     82620,
+     "[XPU] Support MXFP8 linear weights for INC DeepSeek V4 model (#48476)",
+     "d779835a1196d45225c8429ee23bff293517f77e",
+     {
+      "__datetime__": "2026-08-06T05:17:51.253000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82620"
+    ],
+    [
+     82617,
+     "[MM][CG] Support ViT full CUDA graph for Ernie-4.5-VL image inference (#45254)",
+     "777b01d1a86e4036fdd7368a63ca0c4d4803b488",
+     {
+      "__datetime__": "2026-08-06T05:04:22.417000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82617"
+    ],
+    [
+     82614,
+     "[BugFix][Pooling] Skip weight-prefix probe when model has WeightsMapper (#50890)",
+     "821717118fc26667dd474b9b0ab81d29259dfc5c",
+     {
+      "__datetime__": "2026-08-06T04:12:36.300000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82614"
+    ],
+    [
+     82613,
+     "[Bugfix][MM] Fix MiniCPM-V placeholder replacement and image processor loading on Transformers v5 (#48413)",
+     "f84df12c6ac30fb96a24491bb9846b28f04cf24c",
+     {
+      "__datetime__": "2026-08-06T04:12:03.366000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82613"
+    ],
+    [
+     82611,
+     "[Feature] Parse request priority from HTTP header (#51089)",
+     "22170354d83a8a9a845a3f50348301e007b9d81a",
+     {
+      "__datetime__": "2026-08-06T04:10:32.636000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82611"
+    ],
+    [
+     82606,
+     "[Docs] List Intel XPU attention backends (#51215)",
+     "2e09247c2d7b6b97d13af6e71a85bf8d1271deb6",
+     {
+      "__datetime__": "2026-08-06T02:58:30.813000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82606"
+    ],
+    [
+     82603,
+     "[Hardware] Use torch.accelerator.empty_host_cache() for host cache cl\u2026 (#51107)",
+     "d54b58cc4880ba45bc6d2c56b555d68634f6498c",
+     {
+      "__datetime__": "2026-08-06T02:27:59.949000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82603"
+    ],
+    [
+     82601,
+     "[Model Runner V2] Cache draft logits in model's LM head dtype (#50910)",
+     "81bc196913653c9e06b957e39a606002a09db171",
+     {
+      "__datetime__": "2026-08-06T02:12:49.026000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82601"
+    ],
+    [
+     82599,
+     "K3: remove the add operation for megamoe path (#51146)",
+     "f85c1d2f84f55b061e9b27f1a64e7c2ab5dea82c",
+     {
+      "__datetime__": "2026-08-06T01:48:28.961000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82599"
+    ],
+    [
+     82598,
+     "[ROCm][CI] Add MLA decode accuracy and determinism tests (#50480)",
+     "71f975af437ae5316679752e8cdb72cd1c8b7b1d",
+     {
+      "__datetime__": "2026-08-06T01:35:59.412000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82598"
+    ],
+    [
+     82595,
+     "[MoE] Align TRTLLM MXFP4 autotune buckets (#50942)",
+     "9f3169960a37f230f9fe9629b6bc8e1bbf5969eb",
+     {
+      "__datetime__": "2026-08-06T01:17:56.292000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82595"
+    ],
+    [
+     82594,
+     "[Bugfix] Fix level-2 sleep/wake/reload with enable_lora=True (#39935)",
+     "b50fdebce0698c1f2d57ba7ff94211323655557e",
+     {
+      "__datetime__": "2026-08-06T01:13:12.906000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82594"
+    ],
+    [
+     82592,
+     "[BugFix] Dense multinode DP rescope with regression test (#49212)",
+     "8cfa01cdd2357b4137f06c605e11634bef7cf8ba",
+     {
+      "__datetime__": "2026-08-06T01:12:06.800000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82592"
+    ],
+    [
+     82590,
+     "[Bugfix][Spec Decode] Fix NaN handling in rejection sampler tl.argmax (#50183)",
+     "47a4e410ba3e027a69ec34ca03b3dd313b4350d2",
+     {
+      "__datetime__": "2026-08-06T01:01:12.059000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82590"
+    ],
+    [
+     82584,
+     "[KV Connector][Mooncake] Add tenant ID support to MooncakeStoreConnector (#48069)",
+     "d36f24b66a9ce71cf15f1cb9249f5d4092f32d11",
+     {
+      "__datetime__": "2026-08-06T00:31:20.867000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82584"
+    ],
+    [
+     82583,
+     "[Bugfix] Size and iterate w13 by shard count for non-gated MoE (#51125)",
+     "7c77868cdf57c3f711ba971fa68d421b5b39a9c4",
+     {
+      "__datetime__": "2026-08-06T00:24:50.496000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82583"
+    ],
+    [
+     82575,
+     "[Refactor][PCP] Make PCPManager construction extensible (#50066)",
+     "811622c410c2f1baf2fa7056ca19753264b95815",
+     {
+      "__datetime__": "2026-08-05T23:05:16.897000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82575"
+    ],
+    [
+     82574,
+     "[EPD] Remove duplicate image preprocessing in EPD and enable preprocess on GPU (#50390)",
+     "b30291cf0c9a15898589f0347906bad07f3b538b",
+     {
+      "__datetime__": "2026-08-05T22:59:57.426000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82574"
+    ],
+    [
+     82573,
+     "[ROCm] Relax MLA rope+cache test tolerances for bf16 (#51083)",
+     "38ebd97bcab958cbca63eeca87eb1fb57116b772",
+     {
+      "__datetime__": "2026-08-05T22:50:54.924000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82573"
+    ],
+    [
+     82568,
+     "[K3 Perf] Combine multiple all gather together for SP, 1.5~3x kernel level performance improvement (#51070)",
+     "877975897d68f5e837e25d2f8ba80f5355adbe5b",
+     {
+      "__datetime__": "2026-08-05T21:42:43.711000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82568"
+    ],
+    [
+     82565,
+     "[MoE Refactor] Remove MoE legacy code (#51078)",
+     "373fe8b83ee772d27b1a5b2b908618a1a414bb11",
+     {
+      "__datetime__": "2026-08-05T21:35:38.836000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82565"
+    ],
+    [
+     82564,
+     "[ROCm][CI] Add More AITER quantization/MoE kernel tests (#49375)",
+     "4282fe52d5353084a5773e924a508e9346dc2718",
+     {
+      "__datetime__": "2026-08-05T21:27:36.657000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82564"
+    ],
+    [
+     82563,
+     "[Bugfix][Humming] Preserve ModelOpt FP8 weight dimensions (#51093)",
+     "482c6134236d96ebab3c749cd02d245516adad1d",
+     {
+      "__datetime__": "2026-08-05T21:08:58.356000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82563"
+    ],
+    [
+     82561,
+     "Full CI run - daily",
+     "e76b71f659859f1793ab730e798eb4b4236bce1f",
+     {
+      "__datetime__": "2026-08-05T21:00:03.580000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82561"
+    ],
+    [
+     82559,
+     "[CI Bug] Fix `pydantic_core._pydantic_core.ValidationError: Input should be a valid integer` (#51179)",
+     "e76b71f659859f1793ab730e798eb4b4236bce1f",
+     {
+      "__datetime__": "2026-08-05T20:57:50.682000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82559"
+    ],
+    [
+     82557,
+     "[ROCm][CI] Keep rocprofiler-sdk out of DeepEP HT MoE test workers (#51173)",
+     "65addac701c0f019152cc00ffedb6edec442a3e2",
+     {
+      "__datetime__": "2026-08-05T20:28:44.199000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82557"
+    ],
+    [
+     82554,
+     "[ROCm] Work around DeepEP teardown SIGSEGV in MoE test harness (#51174)",
+     "c2d8009044abb174576dab6439dda56d66c83847",
+     {
+      "__datetime__": "2026-08-05T19:44:45.012000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82554"
+    ],
+    [
+     82550,
+     "[CI] Prune PyTorch Fullgraph Test (#51074)",
+     "e6d67fddb4b27d4772ae714348a22af7fe7e35e5",
+     {
+      "__datetime__": "2026-08-05T19:27:30.375000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82550"
+    ],
+    [
+     82547,
+     "[MoE] Share apply_moe_activation support metadata (#44359)",
+     "8f158d0ee2475c64f66ee9ebd55a3606209db92f",
+     {
+      "__datetime__": "2026-08-05T19:05:50.830000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82547"
+    ],
+    [
+     82544,
+     "[Docker][KVConnector] Install mooncake from official wheels instead of a custom build (#51067)",
+     "14e57ad47dec65059f4f04700439a8465ea83a87",
+     {
+      "__datetime__": "2026-08-05T18:58:46.849000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82544"
+    ],
+    [
+     82540,
+     "[CI Bug] Fix `Chunked prefill is required for mamba cache mode 'align'.` (#51177)",
+     "613411a90ccfd884383aab84875ce95fe2871a3c",
+     {
+      "__datetime__": "2026-08-05T18:33:48.385000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82540"
+    ],
+    [
+     82535,
+     "Revert [Misc] Avoid importing `nixl_ep` on every `vllm serve` config (#50879) (#51176)",
+     "bc37fc970eb04a0e393e5517d39700acaad8aee3",
+     {
+      "__datetime__": "2026-08-05T18:04:43.213000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82535"
+    ],
+    [
+     82534,
+     "[CI bug] Fix `Each KV cache group's real block_size must be divisible by has h_block_size` (#51180)",
+     "23c0f337b7c25508fce2b98cbf655bdc8cf166b4",
+     {
+      "__datetime__": "2026-08-05T18:03:20.388000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82534"
+    ],
+    [
+     82533,
+     "[Bugfix] Fail fast with a clear error when CPU offload region exceeds available space (#50358)",
+     "9833aa53d5a9559b4cc8d174ae49d6e282c30423",
+     {
+      "__datetime__": "2026-08-05T17:59:57.838000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82533"
+    ],
+    [
+     82532,
+     "[Build] Remove Ubuntu build-stage option from the CUDA dockerfile (#51060)",
+     "e8586b28788ee9ef2286bca9d6e98724041f185b",
+     {
+      "__datetime__": "2026-08-05T17:51:01.400000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82532"
+    ],
+    [
+     82529,
+     "[KV Offload] Support out-of-tree secondary tier managers via `module_path` (#51007)",
+     "8543522ca792de824c026e1b9e3eb51ca809550d",
+     {
+      "__datetime__": "2026-08-05T17:30:56.066000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82529"
+    ],
+    [
+     82520,
+     "[Model][Frontend] Add Ling 3.0 Flash BF16, MTP, and parser support (#51045)",
+     "d4da0c55af3aa231b6209bf77871f3ed36eab0d2",
+     {
+      "__datetime__": "2026-08-05T16:38:31.228000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82520"
+    ],
+    [
+     82501,
+     "[Kernel][Model] Optimize FA4 mm_prefix range lookup (#50294)",
+     "66b3c0e61f1e477820212201adf1ed871df7ee98",
+     {
+      "__datetime__": "2026-08-05T14:33:52.766000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82501"
+    ],
+    [
+     82500,
+     "[KV Offloading] Support partial-tail prefix reuse with fine-grained prefix matching (#50507)",
+     "62c5e2162186a369d9fba40b8795d06b9144e8fe",
+     {
+      "__datetime__": "2026-08-05T14:31:53.177000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82500"
+    ],
+    [
+     82498,
+     "[Bugfix][Model] Fix MiniMax-M3 NVFP4 inference correctness (#48929)",
+     "08b8613b7b15643e9675595997968b307724596b",
+     {
+      "__datetime__": "2026-08-05T14:25:50.806000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82498"
+    ],
+    [
+     82497,
+     "[Bugfix] Fix MLA kv_b_proj activation dtype with Marlin FP8 (#38771)",
+     "cd930c8e786bcfb84397e0aa424d789ebec58433",
+     {
+      "__datetime__": "2026-08-05T14:25:44.704000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82497"
+    ],
+    [
+     82492,
+     "Resolve revision to commit_hash once per model load, via huggingface_hub's `resolve_revision` (#49990)",
+     "397094da1768c7a6f29dfa4f70079d793ac747df",
+     {
+      "__datetime__": "2026-08-05T13:49:59.669000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82492"
+    ],
+    [
+     82491,
+     "[Bugfix] Enable chunked prefill for qwen3.5-0.8B ppl test (#51153)",
+     "a9b39d6dcbe9970a33b5d1ceb9848ba975167b1b",
+     {
+      "__datetime__": "2026-08-05T13:21:46.851000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82491"
+    ],
+    [
+     82479,
+     "[BugFix][K3] Skip moe_intermediate padding when EP is enabled (#51131)",
+     "beca88e59ea75a7aa1af72a5ae50188fa91d4e3d",
+     {
+      "__datetime__": "2026-08-05T09:22:58.098000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82479"
+    ],
+    [
+     82477,
+     "[CI] Fix CI authorization notification fallback (#51095)",
+     "a3b86752fbcd2fb1a9adfe44634ac0d955228e2a",
+     {
+      "__datetime__": "2026-08-05T08:34:51.186000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82477"
+    ],
+    [
+     82476,
+     "[Rust Frontend] Deduplicate request preprocessing for `/tokenize` (#50448)",
+     "5bf32605a950ee50ed05f230243d54e0baf7d12d",
+     {
+      "__datetime__": "2026-08-05T08:27:38.084000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82476"
+    ],
+    [
+     82475,
+     "[KV Connector][Mooncake] Add store group semantics (#44956)",
+     "fd859d2e0689ce254bfb0e67483fba76405ca9df",
+     {
+      "__datetime__": "2026-08-05T08:25:41.403000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82475"
+    ],
+    [
+     82472,
+     "[Perf][KV Offload] Avoid quadratic ARC batch eviction (#50992)",
+     "b92352ca2c5625a8ca61da597046d50a121c54ad",
+     {
+      "__datetime__": "2026-08-05T07:58:39.433000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82472"
+    ],
+    [
+     82466,
+     "[CI] Run control-plane workflows on vLLM runners (#51127)",
+     "96e333e81ad3203fc3980426daa136c213339b46",
+     {
+      "__datetime__": "2026-08-05T07:14:30.489000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82466"
+    ],
+    [
+     82465,
+     "[XPU] Alias is_current_stream_capturing to XPU in cuda wrapper (#50526)",
+     "999dd8b49031a7bc0f98a0fe88a1ddc2ead6a754",
+     {
+      "__datetime__": "2026-08-05T07:10:20.015000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82465"
+    ],
+    [
+     82456,
+     "[Bugfix][Spec Decode] Fix EAGLE3 DeepSeek draft crash on non-YaRN rope configs (#51092)",
+     "4719a9b8f5cbfef78508369ba1a51abe2f5a79ce",
+     {
+      "__datetime__": "2026-08-05T06:10:54.644000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82456"
+    ],
+    [
+     82455,
+     "Full CI run - nightly",
+     "50c51682a18cf2417c229ee4253fb2a089d5cb78",
+     {
+      "__datetime__": "2026-08-05T06:00:06.315000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82455"
+    ],
+    [
+     82454,
+     "Full CI run torch nightly",
+     "50c51682a18cf2417c229ee4253fb2a089d5cb78",
+     {
+      "__datetime__": "2026-08-05T06:00:05.311000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82454"
+    ],
+    [
+     82453,
+     "[Bugfix][EC Connector] Don't stop an encoder-instance request before its images are encoded (#50275)",
+     "50c51682a18cf2417c229ee4253fb2a089d5cb78",
+     {
+      "__datetime__": "2026-08-05T05:54:02.019000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82453"
+    ],
+    [
+     82451,
+     "[Bugfix] Skip Qwen3 deepstack buffers without vision (#49397)",
+     "7794b1e08bf505ff28664515ffaaeeec955ab796",
+     {
+      "__datetime__": "2026-08-05T04:46:26.530000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82451"
+    ],
+    [
+     82450,
+     "[Bugfix][Model] Gemma3n/Gemma4: pad variable-length audio batches (#50958)",
+     "eb3dce975758f19c37f2cc892a6effd35a30a228",
+     {
+      "__datetime__": "2026-08-05T04:46:02.640000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82450"
+    ],
+    [
+     82449,
+     "[Kernel] Batch invariant NVFP4 MoE using cutlass (#40372)",
+     "c25093a30580a5e81604f36147500cfdb739e2a6",
+     {
+      "__datetime__": "2026-08-05T04:31:35.030000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82449"
+    ],
+    [
+     82447,
+     "[KV Offload] Support partial secondary-tier load results (#50321)",
+     "41a7e7da0c893ff5476d8e6a6a7d2444bb9846d8",
+     {
+      "__datetime__": "2026-08-05T03:49:02.034000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82447"
+    ],
+    [
+     82444,
+     "[R3] Unify routed expert shape configuration (#50940)",
+     "6153dbe036abe11628ab5f7e120707e4f7331652",
+     {
+      "__datetime__": "2026-08-05T03:20:44.246000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82444"
+    ],
+    [
+     82442,
+     "[CPU] Enable tcmalloc for s390x (#50841)",
+     "0187f4c88e7ef19cee9ff67b9822f143d142ea2a",
+     {
+      "__datetime__": "2026-08-05T02:55:42.100000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82442"
+    ],
+    [
+     82441,
+     "[BUGFIX][Quant]Fix test_kv_scale_reload failed (#50405)",
+     "2cb3ff88cc6b0cd1e4f2eb96530b1664d4accb6b",
+     {
+      "__datetime__": "2026-08-05T02:50:56.538000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82441"
+    ],
+    [
+     82440,
+     "[Model] Fix Kimi-K3 MLA with disabled context parallelism (#50404)",
+     "c416f15710bbaf3e1d843c9e08403ca19fa49427",
+     {
+      "__datetime__": "2026-08-05T02:33:17.116000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82440"
+    ],
+    [
+     82439,
+     "[ROCm][CI] Add aiter per-token FP8 quant roundtrip and RMSNorm determinism tests (#50905)",
+     "bb543efdfd1ed340147f51a31141988e68d8990a",
+     {
+      "__datetime__": "2026-08-05T02:32:11.354000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82439"
+    ],
+    [
+     82438,
+     "Prune redundant tests points in `correctness_e2e/[test_sequence_parallel,test_async_tp]` (#51068)",
+     "9cd9f8c20bc34e1a3f57f8a258f5cc8751e76919",
+     {
+      "__datetime__": "2026-08-05T02:18:53.437000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82438"
+    ],
+    [
+     82437,
+     "[ROCm] Restore Inkling MTP backend parity (#50806)",
+     "33c50587d2679ba9bacc2a51ae19901f7eb3a129",
+     {
+      "__datetime__": "2026-08-05T02:02:59.694000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82437"
+    ],
+    [
+     82436,
+     "[CI] Prune `PyTorch Compilation Unit Tests` (#51069)",
+     "d16e7f9da4c12c9487d4ccd6c97fb30d8bf74376",
+     {
+      "__datetime__": "2026-08-05T01:53:53.555000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82436"
+    ],
+    [
+     82433,
+     "[CI][Bugfix] Fix `test_shutdown_on_engine_failure` startup deadlock (#51050)",
+     "77b519912bdba6b5a587df00c662cee663991cac",
+     {
+      "__datetime__": "2026-08-05T01:29:37.607000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82433"
+    ],
+    [
+     82428,
+     "[ROCm]: Bump torch 2.12, triton 3.7, torchaudio, torchvision (#50607)",
+     "d0ce3dadb6741d8184a10abde4e72b1aed64eb14",
+     {
+      "__datetime__": "2026-08-05T01:14:14.199000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82428"
+    ],
+    [
+     82420,
+     "[CI] Add run-all comment commands (#51087)",
+     "43c4bdcae9e589fde99984d1d5d03cbdeecf716b",
+     {
+      "__datetime__": "2026-08-05T00:34:30.215000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82420"
+    ],
+    [
+     82418,
+     "[BugFix][Mooncake] Use global data_parallel_index for the DP engine index (#48061)",
+     "ffee32460d7acdcfe774a468bd7e5cdaac40b562",
+     {
+      "__datetime__": "2026-08-05T00:10:54.305000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82418"
+    ],
+    [
+     82409,
+     "[CI] Detect and fail evals on when NaNs appear in logits (#50323)",
+     "12292d94b25869be2af6b6d4f8eea6c2445e935f",
+     {
+      "__datetime__": "2026-08-04T23:03:01.718000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82409"
+    ],
+    [
+     82406,
+     "[Kernel][SM100] Add a CuTeDSL fused query kernel (#49792)",
+     "3756bf1e2ba0909500fbe77e03fe02eafb7f7080",
+     {
+      "__datetime__": "2026-08-04T22:23:09.219000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82406"
+    ],
+    [
+     82389,
+     "[ci] Update CI notify workflow with PR write permissions (#51079)",
+     "c687c1abb8dc04bd224c7d98d520e30953400b86",
+     {
+      "__datetime__": "2026-08-04T21:15:30.145000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82389"
+    ],
+    [
+     82388,
+     "[CI] Stabilize GLM-5.2 PCP evaluation (#51015)",
+     "a5149b2feeb74c15990dafb1d8bf16cdb98616e4",
+     {
+      "__datetime__": "2026-08-04T21:14:02.610000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82388"
+    ],
+    [
+     82382,
+     "Full CI run - daily",
+     "05b7876f50391d5ee5062bf2605d1f33f200272d",
+     {
+      "__datetime__": "2026-08-04T21:00:05.308000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82382"
+    ],
+    [
+     82365,
+     "[MoE][Humming] Support SiTU activation for Kimi-K3 (#50510)",
+     "05b7876f50391d5ee5062bf2605d1f33f200272d",
+     {
+      "__datetime__": "2026-08-04T19:39:21.619000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82365"
+    ],
+    [
+     82354,
+     "[Kernel][Inkling] Fuse shared-expert partial addition into the Lamport collective (#50697)",
+     "edbc4969a76b25c531f7b9bb16b79984e65ef023",
+     {
+      "__datetime__": "2026-08-04T18:41:39.097000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82354"
+    ],
+    [
+     82348,
+     "[Spec Decode] Enable fused non-causal TokenSpeed MLA for DSpark (#50911)",
+     "8ae8337ffa6eed0823b0b827618090937512d503",
+     {
+      "__datetime__": "2026-08-04T18:05:44.085000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82348"
+    ],
+    [
+     82346,
+     "[Kimi K3 Perf] option to shard the shared expert for non mega case, 16.98 GiB memory/GPU saved (#50912)",
+     "d31de3c421c0281a959ac1a3cbe1a7f354bae179",
+     {
+      "__datetime__": "2026-08-04T18:00:47.723000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82346"
+    ],
+    [
+     82338,
+     "[MM][CG] Support ViT full CUDA graph for Kimi-K2.5 (#50929)",
+     "7cab4368f22271dd562e3cef1d59232ebf07e8fb",
+     {
+      "__datetime__": "2026-08-04T17:15:59.917000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82338"
+    ],
+    [
+     82336,
+     "[Core] Explicitly manage torch CPU threads in workers (#49919)",
+     "7635a9002baecca64909dbcf8b1d461d26fb879d",
+     {
+      "__datetime__": "2026-08-04T17:06:40.832000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82336"
+    ],
+    [
+     82332,
+     "[Kernel] Add support for Flashinfer Mamba SSU algorithm selection (#50157)",
+     "52c0e3cb08b8178829e1f2db4ac90e9bb98c8a5f",
+     {
+      "__datetime__": "2026-08-04T16:40:26.570000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82332"
+    ],
+    [
+     82330,
+     "[Kimi-K3][AMD] Fuse AttnRes state updates and norms (#50593)",
+     "7ac2ec758208a27bbe0c4155a136969463e8e6c8",
+     {
+      "__datetime__": "2026-08-04T16:32:16.149000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82330"
+    ],
+    [
+     82329,
+     "[Bugfix][MoE] Filter packed expert weights during EP loading (#49558)",
+     "7153fd70f6128c85b0f670f082634174c9b38e2e",
+     {
+      "__datetime__": "2026-08-04T16:32:07.146000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82329"
+    ],
+    [
+     82323,
+     "fix: fuse weightless RMSNorms at their declared width (#50867)",
+     "166f4e2dc3a6ed1dfc3641611c9a07d8f0e87f9c",
+     {
+      "__datetime__": "2026-08-04T16:03:12.227000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82323"
+    ],
+    [
+     82317,
+     "[Model Runner v2] E/P/D disaggregation support (#38390)",
+     "4f819f801b7702e39d9588cc9f2ecd28560b31f5",
+     {
+      "__datetime__": "2026-08-04T15:52:25.912000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82317"
+    ],
+    [
+     82316,
+     "[Frontend] DeepSeek V4 0731 reasoning effort prompts & mappings (#50580)",
+     "77434861904a9f01ea4818fe9f0c7b2a5c05686e",
+     {
+      "__datetime__": "2026-08-04T15:51:35.339000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82316"
+    ],
+    [
+     82307,
+     "[Mamba] enable prefix cache by default (#50991)",
+     "f9c74b4b9c25c202cb84e0e9908b82a503a8c7c4",
+     {
+      "__datetime__": "2026-08-04T15:20:53.691000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82307"
+    ],
+    [
+     82303,
+     "[Misc] Avoid importing `nixl_ep` on every `vllm serve` config (#50879)",
+     "7b50d2c0bcee44ad89ee7ec75377560ed37915e3",
+     {
+      "__datetime__": "2026-08-04T14:56:57.475000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82303"
+    ],
+    [
+     82302,
+     "[Bugfix][CPU] Fix macOS build: std::sqrt is not constexpr under libc++ (#50915)",
+     "122b3d46b674f8b005a7c9902e27cf3b37b109ec",
+     {
+      "__datetime__": "2026-08-04T14:56:36.758000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82302"
+    ],
+    [
+     82288,
+     "[Bugfix][Attention] Guard sparse MLA masked MHA workspace (#50906)",
+     "199644d410dbfd94255d6b0cde08479858032266",
+     {
+      "__datetime__": "2026-08-04T13:59:36.674000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82288"
+    ],
+    [
+     82284,
+     "[Bugfix] Flatten >2D multimodal embeddings, not just 3D (#50250)",
+     "7c40d61eaf6bdd80bb493cf94032efbbe0ed0ee4",
+     {
+      "__datetime__": "2026-08-04T13:35:01.699000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82284"
+    ],
+    [
+     82281,
+     "[Bugfix][Core] Log KV cache capacity after block-size resolution (#50462)",
+     "5f2ee2fa8c59d9f9cddd07c79806e6418b0d841a",
+     {
+      "__datetime__": "2026-08-04T12:53:35.506000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82281"
+    ],
+    [
+     82279,
+     "[Spec Decode] Add top-k DSpark Markov projection (#49969)",
+     "5789897aa40fbab6bdfcffaa9e83da64939286fb",
+     {
+      "__datetime__": "2026-08-04T12:52:55.848000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82279"
+    ],
+    [
+     82274,
+     "[Docs] Fix two docs build warnings (#51014)",
+     "1eb3694521a67446ae23ce1e6dd04093e944a08e",
+     {
+      "__datetime__": "2026-08-04T12:29:07.409000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82274"
+    ],
+    [
+     82271,
+     "Support MLA properly in the Transformers modeling backend (#48250)",
+     "59b2fdfc4e237794c2b26f0781054ced73f5b8df",
+     {
+      "__datetime__": "2026-08-04T12:24:14.113000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82271"
+    ],
+    [
+     82267,
+     "[XPU] fix collecting oneccl version info (#47104)",
+     "24c939c47df59d0d3e9af2fe63046e21e65b5924",
+     {
+      "__datetime__": "2026-08-04T11:53:31.806000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82267"
+    ],
+    [
+     82263,
+     "[Bugfix] Resolve seq-cls `num_labels` from the top-level config for multimodal checkpoints (#50950)",
+     "6a9fdf0dc75844de3fff993c32e6f2a35f6fbf0d",
+     {
+      "__datetime__": "2026-08-04T11:39:42.398000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82263"
+    ],
+    [
+     82241,
+     "[Bugfix][Build] Fix DeepGEMM CUDA 12.9 FP8 header visibility (#51003)",
+     "a1657a0235a77ce85f8d348c83ff4adb29918b71",
+     {
+      "__datetime__": "2026-08-04T10:06:06.654000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82241"
+    ],
+    [
+     82237,
+     "[Rust Frontend][gRPC] Add multimodal image inference (#50368)",
+     "e98a8774cba6f518a8de4433801cc32323a46071",
+     {
+      "__datetime__": "2026-08-04T09:34:34.699000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82237"
+    ],
+    [
+     82227,
+     "[Rust Frontend] Align tool rendering for Kimi K3 (#50540)",
+     "0b1c151cbcacd12e207f2a91e4ca9f5b6961ec8a",
+     {
+      "__datetime__": "2026-08-04T08:03:49.159000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82227"
+    ],
+    [
+     82197,
+     "[Rust][Benchmark] Preserve UTF-8 across benchmark stream chunks (#50868)",
+     "72cd5424da80a4a9caa3f42fd65bc0b94e61cbf0",
+     {
+      "__datetime__": "2026-08-04T06:15:04.949000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82197"
+    ],
+    [
+     82196,
+     "Full CI run - nightly",
+     "cb8104839c141609d99f1254459ef3a4f1bd4263",
+     {
+      "__datetime__": "2026-08-04T06:00:12.657000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82196"
+    ],
+    [
+     82195,
+     "Full CI run torch nightly",
+     "cb8104839c141609d99f1254459ef3a4f1bd4263",
+     {
+      "__datetime__": "2026-08-04T06:00:12.210000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82195"
+    ],
+    [
+     82161,
+     "[XPU][CI]Adjust Samplers test ENV for Intel GPU (#50199)",
+     "cb8104839c141609d99f1254459ef3a4f1bd4263",
+     {
+      "__datetime__": "2026-08-04T03:05:47.892000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82161"
+    ],
+    [
+     82157,
+     "[Bugfix][Reasoning] kimi_k3: O(delta) reasoning-end check on the decode path (#50886)",
+     "adbf08d977fb3fa26c4f19826745a02abd6dd7ca",
+     {
+      "__datetime__": "2026-08-04T02:37:06.147000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82157"
+    ],
+    [
+     82147,
+     "[ROCm][AITER] Hotfix for `memory access fault` errors in AITER triton MOE routing (#50859)",
+     "385d4c084ef0c52fe0f7baf7dd2dc4bf86fbe548",
+     {
+      "__datetime__": "2026-08-04T02:07:49.720000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82147"
+    ],
+    [
+     82130,
+     "[CI][Bugfix] Fix flaky `test_store_orders_after_compute_write` (#50926)",
+     "74295e3bd47b64964fe6a51825079e75c84cc172",
+     {
+      "__datetime__": "2026-08-04T00:54:52.089000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82130"
+    ],
+    [
+     82128,
+     "Perf/h20 moe config e256 n512 (#48825)",
+     "413e70d52c3f2645b3c4bdf95458488f7d517217",
+     {
+      "__datetime__": "2026-08-04T00:48:00.959000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82128"
+    ],
+    [
+     82124,
+     "[ROCm][Test] Use BF16 for Jina v5 nano MTEB test (#50917)",
+     "8adc840c4553b8f70cda82e5e59a7f9977f64a11",
+     {
+      "__datetime__": "2026-08-04T00:33:07.988000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82124"
+    ],
+    [
+     82122,
+     "[Kimi-K3] Migrate FlashKDA to PyTorch stable ABI (#50818)",
+     "11f88260a240e6e8ee33410f9c65f00043c3e6f7",
+     {
+      "__datetime__": "2026-08-04T00:18:11.239000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82122"
+    ],
+    [
+     82121,
+     "[Bugfix][Kimi-K3] Enforce packed rows and op availability in AttnRes dispatch (#50567)",
+     "41ba11b8413cefc8b8f0c917d01594cbb26fdfa7",
+     {
+      "__datetime__": "2026-08-04T00:13:36.260000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82121"
+    ],
+    [
+     82120,
+     "llmd+vllm+mori-ep(inter node wide-ep)+mori-io(write) for 2p2d with dp=ep=16 tp=1 (#45043)",
+     "f42761204fb508bc205418c77b80bd50d0d11774",
+     {
+      "__datetime__": "2026-08-04T00:13:18.412000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82120"
+    ],
+    [
+     82117,
+     "[Kernel] Extend CuTe DSL skinny GEMM to GLM-5.2 (#49791)",
+     "c8109375733e6b788e73c7cc1ed2004234834392",
+     {
+      "__datetime__": "2026-08-03T23:49:44.475000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82117"
+    ],
+    [
+     82113,
+     "[Bugfix] Fix Qwen3-Omni crash on video with no audio track when use_audio_in_video=True (#48420)",
+     "6a9109d865d8abbfe70777ea52520425f1be6d3f",
+     {
+      "__datetime__": "2026-08-03T23:22:02.501000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82113"
+    ],
+    [
+     82109,
+     "[Bugfix][Hybrid] Fix cross-block race on num_accepted in MRv2 align prefix cache (#50432)",
+     "c2881ce60302b5455867d2c29cdfae5fbeddecac",
+     {
+      "__datetime__": "2026-08-03T22:54:27.055000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82109"
+    ],
+    [
+     82107,
+     "fix: NVFP4 quantization out_dtype should match model dtype, not torch default (#48861)",
+     "0b37d8389f4b8378adab0d3dfa1beffbb152e303",
+     {
+      "__datetime__": "2026-08-03T22:47:40.618000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82107"
+    ],
+    [
+     82101,
+     "feat(frontend): session id plumbing into requests (#48048)",
+     "f57123aa2dbc1badb1865b18c724b308f90dceda",
+     {
+      "__datetime__": "2026-08-03T22:19:01.311000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82101"
+    ],
+    [
+     82097,
+     "[ModelRunnerV2] Fix scalar Mamba state update with int32 mappings (#50327)",
+     "e578de311c2416e66c6a8b9819586bb91de10f9d",
+     {
+      "__datetime__": "2026-08-03T22:05:14.778000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82097"
+    ],
+    [
+     82094,
+     "[ROCm] Enable AITER and FP8 inference on GFX120x (#43615)",
+     "f43e1d26e3e6b40398be27b218cf2f2786432028",
+     {
+      "__datetime__": "2026-08-03T21:45:40.458000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82094"
+    ],
+    [
+     82091,
+     "[Bugfix][Model Runner V2] Restore multimodal draft capability detection (#50417)",
+     "4a3447d200e5aa428d68d1a00aa00f1a19a1a729",
+     {
+      "__datetime__": "2026-08-03T21:18:16.619000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82091"
+    ],
+    [
+     82084,
+     "[MRV2] Enable routed-experts capture (#50721)",
+     "42ab184ea74ee6cf2966529c77bb51fd825a5d0c",
+     {
+      "__datetime__": "2026-08-03T21:00:16.481000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82084"
+    ],
+    [
+     82083,
+     "Full CI run - daily",
+     "42ab184ea74ee6cf2966529c77bb51fd825a5d0c",
+     {
+      "__datetime__": "2026-08-03T21:00:03.328000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82083"
+    ],
+    [
+     82082,
+     "[ROCm][Test] Fix AITER MXFP4 oracle contract (#50728)",
+     "e279f7158322d81f7b10ec9733fd7f9420d2fdc6",
+     {
+      "__datetime__": "2026-08-03T20:53:20.811000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82082"
+    ],
+    [
+     82080,
+     "[Bugfix][Frontend] Reject empty gRPC stop strings (#50746)",
+     "c4e9f09de74aa1bf885af8cafd949c3c4dca67db",
+     {
+      "__datetime__": "2026-08-03T20:50:18.846000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82080"
+    ],
+    [
+     82073,
+     "[Hybrid] Stage the postprocess inputs with a single loop over the request list (#48120)",
+     "755513d9a24fb639a8985172e645c7fe5a263154",
+     {
+      "__datetime__": "2026-08-03T20:24:25.388000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82073"
+    ],
+    [
+     82056,
+     "[Bugfix] Default Gemma3 Model intermediate_tensors to None (#50777)",
+     "1c0d20791556861f4c1804b43b03d9cc03ffa6b8",
+     {
+      "__datetime__": "2026-08-03T19:08:01.916000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82056"
+    ],
+    [
+     82053,
+     "[Bugfix] Emit a valid media type from encode_{audio,image,video}_url (#49056)",
+     "7f2e78ba4df2f7091c247155fc5aeecaa73a486d",
+     {
+      "__datetime__": "2026-08-03T19:02:26.198000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82053"
+    ],
+    [
+     82052,
+     "[ROCm][Kimi-K3] aiter moe environment variable cleanup (#50582)",
+     "8f50685c48d6bc88d199d9560ab67615e1b2c2a4",
+     {
+      "__datetime__": "2026-08-03T18:54:07.957000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82052"
+    ],
+    [
+     82051,
+     "[Bugfix] Validate NIXL speculative config compatibility (#49230)",
+     "952694e3843e478dd99cffd132c756d582fe8a94",
+     {
+      "__datetime__": "2026-08-03T18:51:07.112000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82051"
+    ],
+    [
+     82050,
+     "[Kernel] Skip fully masked key blocks in windowed Triton prefill (#50776)",
+     "65cf1276a25b5e7dbbed7d3febdd54a815ced8c8",
+     {
+      "__datetime__": "2026-08-03T18:48:50.485000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82050"
+    ],
+    [
+     82047,
+     "[CI][ROCm] Export Helion benchmark script in test artifacts (#50726)",
+     "76d995df2c80fd1f81901723fa05c992714693b2",
+     {
+      "__datetime__": "2026-08-03T18:09:47.199000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82047"
+    ],
+    [
+     82042,
+     "[Bugfix] Shard UniformTypeKVCacheSpecs block table width under DCP (#50823)",
+     "f0de1a604cad003379e5bb4dfc3cc5d2a1f25fa8",
+     {
+      "__datetime__": "2026-08-03T17:34:32.141000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82042"
+    ],
+    [
+     82021,
+     "[Kimi-K3] Add option to shard the shared expert instead of replicating (#50656)",
+     "5df9999fcfaa72d9eb61348a789058fff805f142",
+     {
+      "__datetime__": "2026-08-03T15:41:27.189000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82021"
+    ],
+    [
+     82016,
+     "[Misc] Remove deprecated calculate_kv_scales runtime KV scale calculation (#49389)",
+     "dd11df04f3b7046c40f13e586ac38a3725bc3c03",
+     {
+      "__datetime__": "2026-08-03T15:15:15.817000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/82016"
+    ],
+    [
+     82012,
+     "[Refactor] Remove multiple dead codes (#50285)",
+     "0cf49a5d15d18275972d0cd35c6968731a5d18e1",
+     {
+      "__datetime__": "2026-08-03T14:59:10.391000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82012"
+    ],
+    [
+     82002,
+     "[Bugfix] Remove bad startup assertion (#50869)",
+     "68ca6fd02c6cd705c4fa6872317611c83b26b4c6",
+     {
+      "__datetime__": "2026-08-03T14:21:53.412000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/82002"
+    ],
+    [
+     81997,
+     "[CI] Mooncake PD integration tests (#46844)",
+     "8ba87e01813271fec7841b6bec63595aa1698a91",
+     {
+      "__datetime__": "2026-08-03T13:55:53.614000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81997"
+    ],
+    [
+     81996,
+     "docs: document `reasoning_content` output removal as a breaking client change (#50624)",
+     "005fa017566177e1a66d75eba7908d326c5acd60",
+     {
+      "__datetime__": "2026-08-03T13:45:26.382000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81996"
+    ],
+    [
+     81995,
+     "[Model] Add K-EXAONE-2.0-750B-A37B (#50524)",
+     "9ae11a6b895dea5b2275e0b6ad96327af67d3b0c",
+     {
+      "__datetime__": "2026-08-03T13:33:05.026000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81995"
+    ],
+    [
+     81991,
+     "Support quantized DSpark Markov heads (#50424)",
+     "b977407d8be3bc076c1e2d6f3df02b9bdbd1fab9",
+     {
+      "__datetime__": "2026-08-03T12:35:41.976000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81991"
+    ],
+    [
+     81985,
+     "[CI] KimiLinear PD in nightlies  (#50266)",
+     "ad0bf3963eef4c3cf267f78199324b1b340b6a12",
+     {
+      "__datetime__": "2026-08-03T12:20:44.179000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81985"
+    ],
+    [
+     81979,
+     "[CPU] Fix torch.compile crash from torch.accelerator.synchronize on CPU-only hosts (#49960)",
+     "ec40f6a8a62d588dbd216d0509374666caea2f4a",
+     {
+      "__datetime__": "2026-08-03T11:48:51.033000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81979"
+    ],
+    [
+     81976,
+     "[UX] remove torch compile warning when using breakable cudagraph (#50750)",
+     "32c42c4f2f894bfd18e9b2fff1fede7fea4885e8",
+     {
+      "__datetime__": "2026-08-03T11:25:52.690000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81976"
+    ],
+    [
+     81975,
+     "[CI] And PPL test for multimodal generation models  (#50839)",
+     "9acb7b3699b2c9e76db380983850c7e4c12941ab",
+     {
+      "__datetime__": "2026-08-03T11:25:11.184000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81975"
+    ],
+    [
+     81965,
+     "[CPU] Refine CPU kernel dispatch (#50801)",
+     "c8602c79062440074a018c1d5f875a5571eb6881",
+     {
+      "__datetime__": "2026-08-03T09:42:55.539000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81965"
+    ],
+    [
+     81963,
+     "K3: Move LatentMoERunner (#50678)",
+     "b9d1e2437e1ad6d98d301939949072b5c56dfef1",
+     {
+      "__datetime__": "2026-08-03T09:36:20.982000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81963"
+    ],
+    [
+     81949,
+     "fix: remove stray duplicate from serving benchmark config (#46870)",
+     "d9dac2b3d4cdd57ff2f7c5311bc8aaf3eef3feec",
+     {
+      "__datetime__": "2026-08-03T08:34:15.250000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81949"
+    ],
+    [
+     81947,
+     "[Perf] Speed up multimodal placeholder and token-match scanning (#50716)",
+     "89ac407e3d8bdb34901dc63af71e4b5732de5ca0",
+     {
+      "__datetime__": "2026-08-03T08:27:59.357000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81947"
+    ],
+    [
+     81944,
+     "fix(security): classify DeepStream as GPU backend and enforce pixel limits (#50755)",
+     "d83eb0b36bfbe26fc856ffdb60f05c8bd460f2fd",
+     {
+      "__datetime__": "2026-08-03T08:23:12.134000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81944"
+    ],
+    [
+     81936,
+     "Shard the K3 Latent-MoE up-projection on large batches (#50383)",
+     "4635cc3e8f609755ad45f9fc2cdb54fa7552038e",
+     {
+      "__datetime__": "2026-08-03T07:49:42.036000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81936"
+    ],
+    [
+     81928,
+     "[CPU] Migrate unquantized MoE to the modular-kernel experts structure (#50133)",
+     "0a6446005d51c9e6bfa09352f7f288ddeff17c77",
+     {
+      "__datetime__": "2026-08-03T06:55:06.689000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81928"
+    ],
+    [
+     81926,
+     "[Frontend] Require cache_salt to be non-empty via schema (#50816)",
+     "b3f97dae24a8d73535feca70b1c75cf6db4737e1",
+     {
+      "__datetime__": "2026-08-03T06:51:30.083000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81926"
+    ],
+    [
+     81922,
+     "[XPU] [Linear] add torch as xpu linear backend (#49664)",
+     "e481da9508066465566ce9f0ea843ac3cd15cff9",
+     {
+      "__datetime__": "2026-08-03T06:30:24.161000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81922"
+    ],
+    [
+     81921,
+     "[INC]  fix w4a4 model (#50807)",
+     "2755489a261b15ddcd8ced19f0bdf4ea63aad688",
+     {
+      "__datetime__": "2026-08-03T06:29:00.810000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81921"
+    ],
+    [
+     81913,
+     "Full CI run - nightly",
+     "f5bb701fa270f5c801f1572e1478b56f292d8dfc",
+     {
+      "__datetime__": "2026-08-03T06:00:04.528000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81913"
+    ],
+    [
+     81911,
+     "[Bugfix][Frontend] Constrain Anthropic cache_salt to non-empty (#50764)",
+     "f5bb701fa270f5c801f1572e1478b56f292d8dfc",
+     {
+      "__datetime__": "2026-08-03T05:33:17.440000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81911"
+    ],
+    [
+     81908,
+     "cpu_model_runner.py: skip the warm up if CompilationMode.NONE (#50547)",
+     "5e35a6f4f9bbc217c599692157ca985c894373f7",
+     {
+      "__datetime__": "2026-08-03T04:34:32.223000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81908"
+    ],
+    [
+     81888,
+     "[Bugfix][KV Connector] Propagate EAGLE state across merged Mooncake store groups (#49069)",
+     "5c4fe4b17eaf42eda9698d9dccb4b2f2e0561641",
+     {
+      "__datetime__": "2026-08-03T02:32:28.918000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81888"
+    ],
+    [
+     81885,
+     "[Bugfix] serving_llama70B_tp4 benchmark was silently running at tensor_parallel_size=1 (#50766)",
+     "e42c230e4ff4e3b44b100ced7d731a5190948d2e",
+     {
+      "__datetime__": "2026-08-03T02:26:51.810000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81885"
+    ],
+    [
+     81875,
+     "[Model] Support jina-embeddings-v5-text-nano (EuroBERT encoder backbone) (#50688)",
+     "9a4fd57cac19b334b420ae24226c1d2151566799",
+     {
+      "__datetime__": "2026-08-03T01:37:11.575000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81875"
+    ],
+    [
+     81866,
+     "[Test][V1] Add sleep/wake correctness regression test for hybrid GDN/\u2026 (#44972)",
+     "0033211c0bcf3d42d3b1f27059922c30e664b8e7",
+     {
+      "__datetime__": "2026-08-02T22:02:45.262000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81866"
+    ],
+    [
+     81865,
+     "Full CI run - daily",
+     "0055b8bfa3a2c7c49c51ff5962c162ba85f6de38",
+     {
+      "__datetime__": "2026-08-02T21:00:02.712000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81865"
+    ],
+    [
+     81864,
+     "[Attention][MiniMax-M3] Add MSA speculative decode verification (#50032)",
+     "0055b8bfa3a2c7c49c51ff5962c162ba85f6de38",
+     {
+      "__datetime__": "2026-08-02T20:46:58.521000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81864"
+    ],
+    [
+     81862,
+     "[ROCm][Bugfix][Kimi-K3] Preserve MoE correction bias in FP32 (#50761)",
+     "c6668106760e1f8222abd19a6ee9e93fc060cb19",
+     {
+      "__datetime__": "2026-08-02T20:30:57.333000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81862"
+    ],
+    [
+     81845,
+     "[Model Runner v2] Enable BGE M3 pooling embed token_classify (#50661)",
+     "55c98e370aa058f567a9e682dc0652bdfba6b0bb",
+     {
+      "__datetime__": "2026-08-02T16:46:06.357000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81845"
+    ],
+    [
+     81842,
+     "[Elastic EP] Fix non-contiguous weight transfers (#50641)",
+     "96add737ff022430b17034ce50dc55504c04094f",
+     {
+      "__datetime__": "2026-08-02T15:13:50.732000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81842"
+    ],
+    [
+     81823,
+     "Full CI run - nightly",
+     "0601850791155003afbe5a0d5d086350cada8deb",
+     {
+      "__datetime__": "2026-08-02T06:00:07.676000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81823"
+    ],
+    [
+     81817,
+     "[Bugfix][Models] Accept Qwen3_5MoeTextConfig in Qwen3_5MoeProcessingInfo for transformers 5.x compatibility (#50704)",
+     "0601850791155003afbe5a0d5d086350cada8deb",
+     {
+      "__datetime__": "2026-08-02T05:50:43.339000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81817"
+    ],
+    [
+     81809,
+     "[1/N] Unify multiple-path encoder cuda graph support (#49934)",
+     "e2fa28594f7baad142a426b0b6a2cfe2c79201c7",
+     {
+      "__datetime__": "2026-08-02T02:33:26.227000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81809"
+    ],
+    [
+     81808,
+     "[Bugfix][Doc] Fix references to FusedMoE in doc (#50701)",
+     "c67fe497a25d5af10a6ca0be9d18bcdd42cac4f1",
+     {
+      "__datetime__": "2026-08-02T01:13:09.587000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81808"
+    ],
+    [
+     81806,
+     "Full CI run - daily",
+     "38a466e7b6e087d67c35e7f924c04c245423c99f",
+     {
+      "__datetime__": "2026-08-01T21:00:03.884000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81806"
+    ],
+    [
+     81803,
+     "[DSV4] Implement Sequence Parallelism (#46789)",
+     "38a466e7b6e087d67c35e7f924c04c245423c99f",
+     {
+      "__datetime__": "2026-08-01T17:22:36.387000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81803"
+    ],
+    [
+     81802,
+     "[GPT-OSS] Strict tool call and constrained decoding for Harmony (#45560)",
+     "dc818c198d3ff50a16f38eba567da006478239c8",
+     {
+      "__datetime__": "2026-08-01T16:10:28.947000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81802"
+    ],
+    [
+     81801,
+     "Add @hongxiayang as code owner for AMD-specific model files and ROCm docs (#50608)",
+     "127a7cebc9e3b76b7558fe96b4156a55a5905375",
+     {
+      "__datetime__": "2026-08-01T16:02:46.660000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81801"
+    ],
+    [
+     81800,
+     "[model registry] some simple typos (#50673)",
+     "03c782eb91f70ba990432aace77f94be66aaeb2e",
+     {
+      "__datetime__": "2026-08-01T15:37:32.293000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81800"
+    ],
+    [
+     81796,
+     "[Core] Offload raw-prompt preprocessing to renderer thread pool in AsyncLLM (#49608)",
+     "39f55ffdaacbf4f2ac06e395c3f9c6e55a54dbd0",
+     {
+      "__datetime__": "2026-08-01T15:10:54.575000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81796"
+    ],
+    [
+     81793,
+     "[Benchmark] Add probe requests to vllm bench serve (#49611)",
+     "63e78ce3652f4f94e9f484f40db71ca4cf019f21",
+     {
+      "__datetime__": "2026-08-01T14:10:59.356000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81793"
+    ],
+    [
+     81791,
+     "[Bugfix][Kernel] Fix dangling temporary in AWQ gemm torch::stable::sum dim arg (#46805)",
+     "ab06486175e833925be065438b067cec488029e8",
+     {
+      "__datetime__": "2026-08-01T13:56:58.046000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81791"
+    ],
+    [
+     81786,
+     "[Model Runner V2] Enable encoder token embedding (#50574)",
+     "652ba59229499eb65fc4115b7feadeddf9bcb75d",
+     {
+      "__datetime__": "2026-08-01T11:55:39.266000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81786"
+    ],
+    [
+     81779,
+     "(feat): optionally disable lookup on PD decode (#50498)",
+     "3986b967b249468fc1bd052f89a1eeeada6377b4",
+     {
+      "__datetime__": "2026-08-01T09:41:46.130000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81779"
+    ],
+    [
+     81774,
+     "[Frontend] Add cache_salt support to Anthropic Messages API (#49498)",
+     "81a42d37b1d76a34ce75b6871bba57a30cddc812",
+     {
+      "__datetime__": "2026-08-01T07:36:45.542000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81774"
+    ],
+    [
+     81773,
+     "[ROCm][MLA] Mask the AITER MLA small-head verify flatten causally (#50476)",
+     "77469c9057bec3212a64877dbbf3b9c48c22d786",
+     {
+      "__datetime__": "2026-08-01T07:17:20.425000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81773"
+    ],
+    [
+     81769,
+     "Add Understanding the Latency Metrics docs (#50600)",
+     "4ee9702bee668a447e9983a6aefc16ebbc3ad32e",
+     {
+      "__datetime__": "2026-08-01T06:22:42.610000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81769"
+    ],
+    [
+     81767,
+     "Full CI run - nightly",
+     "9c110fa522f0bdd1ab3df34727b71ce2c9454d7d",
+     {
+      "__datetime__": "2026-08-01T06:00:09.180000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81767"
+    ],
+    [
+     81766,
+     "[Frontend] Cohere chat v2 api support (#47189)",
+     "9c110fa522f0bdd1ab3df34727b71ce2c9454d7d",
+     {
+      "__datetime__": "2026-08-01T05:53:57.356000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81766"
+    ],
+    [
+     81759,
+     "[Bugfix][Parser] Forward model_config to nested reasoning parsers (#50642)",
+     "6c91de36897932ba9b5adb11992235a2a789e009",
+     {
+      "__datetime__": "2026-08-01T05:07:37.168000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81759"
+    ],
+    [
+     81758,
+     "Add @shen-shanshan to CODEOWNERS (#50655)",
+     "124154a8843d1f8e4d4e2d5d466e2d3ebc3716da",
+     {
+      "__datetime__": "2026-08-01T04:34:38.954000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81758"
+    ],
+    [
+     81754,
+     "[Bugfix][CI] Prevent common ops imports from initializing CUDA (#50639)",
+     "f7097a92fd5374ff8a44167b7bc16eec42393559",
+     {
+      "__datetime__": "2026-08-01T04:13:32.539000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81754"
+    ],
+    [
+     81747,
+     "[Rust][Benchmark] Prevent invalid token IDs in random benchmarks (#50058)",
+     "62195e9784ebec1ece42b88a861734e0702cc2d5",
+     {
+      "__datetime__": "2026-08-01T03:20:32.058000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81747"
+    ],
+    [
+     81746,
+     "[Build] Update pin to build ABI stable FA2 (#50474)",
+     "eb6453d95b6d47d7e877f96992c68f0da81424dd",
+     {
+      "__datetime__": "2026-08-01T03:09:39.239000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81746"
+    ],
+    [
+     81742,
+     "[Bugfix][Test] Fix monolithic routing replay test buffer capacity (#50640)",
+     "c4a4a42d80a50901baec34c39e7c3e8c68e7890b",
+     {
+      "__datetime__": "2026-08-01T02:38:07.854000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81742"
+    ],
+    [
+     81729,
+     "[CI] Organize speculative decoding E2E tests by coverage (#50330)",
+     "fcdc7c2e9c9b75c923751ea7d2dd79ef66572c81",
+     {
+      "__datetime__": "2026-08-01T01:05:45.226000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81729"
+    ],
+    [
+     81726,
+     "[Kernel][Helion] Add numerics checks to benchmark script (#48968)",
+     "b40d859c7b07ae244bcd8c6eecdcdbd9a3afaa07",
+     {
+      "__datetime__": "2026-08-01T00:16:04.881000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81726"
+    ],
+    [
+     81722,
+     "Enable ModelOpt FP8 emulation on SM80 (#50019)",
+     "e3be89673db6143c1f9c8689d853b9c7c7a5eb29",
+     {
+      "__datetime__": "2026-07-31T21:48:30.230000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81722"
+    ],
+    [
+     81720,
+     "[MoE Refactor] Combine CompressedTensorsWNA16MarlinMoEMethod with CompressedTensorsWNA16MoEMethod (#44570)",
+     "454ea5b52611c933e00581723e2db56f0144cea7",
+     {
+      "__datetime__": "2026-07-31T21:13:05.827000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81720"
+    ],
+    [
+     81716,
+     "Full CI run - daily",
+     "0c4dc7c488754e6c895ff785b86b76b9c26923c4",
+     {
+      "__datetime__": "2026-07-31T21:00:04.225000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81716"
+    ],
+    [
+     81715,
+     "[graceful shutdown] fix http server start firstly before app signal handler register (#49668)",
+     "0c4dc7c488754e6c895ff785b86b76b9c26923c4",
+     {
+      "__datetime__": "2026-07-31T20:51:35.943000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81715"
+    ],
+    [
+     81712,
+     "[UX] Reduce startup log noise (#50590)",
+     "90329913e945cb3ed515bd8e1712094cecb76a0c",
+     {
+      "__datetime__": "2026-07-31T20:04:37.447000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81712"
+    ],
+    [
+     81711,
+     "[Bugfix][Responses] Add tests for Chat Completions Responses API Render Parity (#50334)",
+     "e8b358b4c0df5cf136072747c97a95526bd59df1",
+     {
+      "__datetime__": "2026-07-31T19:45:42.730000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81711"
+    ],
+    [
+     81708,
+     "[ROCm][ViT] Detect Triton-AMD kernels at their new aiter location (#40289)",
+     "4fdd3e0b74ab5bfcf86341a304cc894c09705d5b",
+     {
+      "__datetime__": "2026-07-31T19:30:12.635000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81708"
+    ],
+    [
+     81706,
+     "[chore] log process manager shutdown with more details (#49437)",
+     "9a7ae4b80866a322678ece31ca2854d9a174ab8d",
+     {
+      "__datetime__": "2026-07-31T18:55:12.270000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81706"
+    ],
+    [
+     81704,
+     "[chore] delete useless code (#49424)",
+     "726ef437a160798c4312586fdbf38d1d112c5c9a",
+     {
+      "__datetime__": "2026-07-31T18:54:10.617000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81704"
+    ],
+    [
+     81696,
+     "Bump Helion to 1.4.0 (#50307)",
+     "963a658674045d460ef370214d7d73575efffb98",
+     {
+      "__datetime__": "2026-07-31T18:06:52.241000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81696"
+    ],
+    [
+     81691,
+     "[Bugfix][TurboQuant] Add KV quant mode for turboquant  (#50533)",
+     "aef85aed5d8970052fa14407b716cdac1a8164ac",
+     {
+      "__datetime__": "2026-07-31T17:42:35.148000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81691"
+    ],
+    [
+     81685,
+     "[ROCm][Quark][7/N] Use MXFP4 linear kernel abstraction for `emulation` backend (#48949)",
+     "e67a2e0a56b7ba535bae8bfd98c1c4e4fa742e63",
+     {
+      "__datetime__": "2026-07-31T17:07:18.843000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81685"
+    ],
+    [
+     81684,
+     "[Compressed-Tensors] Support Kimi-K3 quantized models (#50500)",
+     "d87d2ca74791fe23ca2a0ba68c997de1618b33b6",
+     {
+      "__datetime__": "2026-07-31T17:06:33.285000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81684"
+    ],
+    [
+     81676,
+     "[ROCm][CI] Restore Mistral tool-parser compatibility after unification (#50515)",
+     "8d8a4e0f2b118dc975bbba930aeb7c6cbd623c2a",
+     {
+      "__datetime__": "2026-07-31T16:32:47.250000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81676"
+    ],
+    [
+     81669,
+     "Upgrade tpu-inference to v0.26.0 (#50522)",
+     "7c08664f5c628ade14d2bf28f764ee1cfbbcedb1",
+     {
+      "__datetime__": "2026-07-31T16:22:46.587000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81669"
+    ],
+    [
+     81666,
+     "Update torch version to 2.13.0+cpu (#50412)",
+     "10ad649d6c1c4e1f1be986e928169a5351b9f6a7",
+     {
+      "__datetime__": "2026-07-31T15:57:19.182000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81666"
+    ],
+    [
+     81663,
+     "[Doc] Add BgeM3EmbeddingModel to embedding supported models (#50571)",
+     "c036cb257f39dd022c30fd5738c6a12c14784a28",
+     {
+      "__datetime__": "2026-07-31T15:56:04.325000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81663"
+    ],
+    [
+     81662,
+     "[Bugfix] Universally align block table width to 128 tokens (#50302)",
+     "a0cd2b69b3dac2b43be02fc16ff940b856d6791b",
+     {
+      "__datetime__": "2026-07-31T15:52:20.878000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81662"
+    ],
+    [
+     81657,
+     "[Bugfix] Don't transpose fused MoE quantization scales in `RoutedExperts.load_weights` (#50137)",
+     "94e9ef0768d0297299069502bf46813dc7479ce5",
+     {
+      "__datetime__": "2026-07-31T15:46:55.017000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81657"
+    ],
+    [
+     81656,
+     "[DSv4 Perf] Optimize workspace reuse for eager break, 3.9% E2E TTFT improvement. (#49236)",
+     "df71917cf17c97d81f48122e6baa7c13d184ff90",
+     {
+      "__datetime__": "2026-07-31T15:46:01.690000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81656"
+    ],
+    [
+     81649,
+     "[ROCm][CI] Fall back to lossless Kimi K3 MXFP4 emulation on gfx942 (#50516)",
+     "5233368daccd3d84293bab7b04bacae1433ea0e4",
+     {
+      "__datetime__": "2026-07-31T15:33:19.337000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81649"
+    ],
+    [
+     81632,
+     "[2/N][Attention] Enable masked MHA for sparse MLA prefills (#48770)",
+     "82ae4164ee016d4daecd2033c26f5c0827984a80",
+     {
+      "__datetime__": "2026-07-31T13:01:27.116000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81632"
+    ],
+    [
+     81629,
+     "[Kernel][CI] `--jit-monitor-mode error` e2e tests for kernel warmup infra (#50109)",
+     "864a87febb5b4f3fe15b50520a6857b241d5bf63",
+     {
+      "__datetime__": "2026-07-31T12:53:20.245000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81629"
+    ],
+    [
+     81626,
+     "[CI] Remove default_torch_num_threads workaround from llava-onevision-transformers test (#50560)",
+     "7fdc1ab29e3d34b2a12b7b40256b53d5586d4aad",
+     {
+      "__datetime__": "2026-07-31T12:29:34.980000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81626"
+    ],
+    [
+     81621,
+     "[Bugfix][Frontend] Raise VLLMValidationError for user-facing errors in chat_utils.py (#50491)",
+     "0b5b49dde81ca27b27b010fb257138686b056aba",
+     {
+      "__datetime__": "2026-07-31T11:54:46.214000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81621"
+    ],
+    [
+     81619,
+     "[Renderer] Warm up the renderer properly. (#50408)",
+     "f5ffc59b6abbf317708d4c319702bac2b2aa8e72",
+     {
+      "__datetime__": "2026-07-31T11:46:56.612000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81619"
+    ],
+    [
+     81618,
+     "[KV Connector] Add per-layer canonical KV page mappings for parallelism-agnostic offload (#48408)",
+     "2c4d3488483a4ce90b44661aefdb0cd31c6fbffa",
+     {
+      "__datetime__": "2026-07-31T11:42:56.722000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81618"
+    ],
+    [
+     81617,
+     "[Attention]: Use KVCacheSpec for AttentionMetadataBuilder type hints (#50148)",
+     "b2fb83e7ffbc30a1aa4667b1dad7ca3e2c342bcf",
+     {
+      "__datetime__": "2026-07-31T11:20:21.141000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81617"
+    ],
+    [
+     81616,
+     "K3 DSpark AR fusion (#50242)",
+     "92643d68f551fe36c35a26b4a2e3bfd894d7d92a",
+     {
+      "__datetime__": "2026-07-31T11:12:06.515000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81616"
+    ],
+    [
+     81614,
+     "[Misc] Clarify mono audio requirement (#50141)",
+     "17beffd55f6fcc28f2e777d47d3e8aab6ea34c9a",
+     {
+      "__datetime__": "2026-07-31T10:46:56.346000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81614"
+    ],
+    [
+     81611,
+     "[MoE Refactor] Rename FusedMoE to FusedMoEFactory (#44941)",
+     "6e311c6e2014a54868e2cbedf944a6873d06228b",
+     {
+      "__datetime__": "2026-07-31T10:28:21.635000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81611"
+    ],
+    [
+     81610,
+     "[ROCm][CI] Update Transformers AR+RMS fusion expectation (#50517)",
+     "c911120a6f499a50f46a484109bf9bb2971ead5f",
+     {
+      "__datetime__": "2026-07-31T10:16:55.364000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81610"
+    ],
+    [
+     81609,
+     "[chore] clean-up weight prepack for INT8 MoE (#50116)",
+     "0e9b50074e1cd3c498830b9124364037899a5c98",
+     {
+      "__datetime__": "2026-07-31T10:15:42.349000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81609"
+    ],
+    [
+     81603,
+     "[CPU][s390x] Optimize inference perf and add oneDNN INT8 GEMM for s390x (#50219)",
+     "88bc8fb56f69667bcb67b482ecf729385d7ae972",
+     {
+      "__datetime__": "2026-07-31T09:49:34.313000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81603"
+    ],
+    [
+     81602,
+     "[XPU] Unify XPU RMSNorm kernels with vllm_c and drop redundant XPU-specific implementation (#46981)",
+     "482cfc20f05fd7d08401f646ce44ba1f7086dde3",
+     {
+      "__datetime__": "2026-07-31T09:28:21.159000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81602"
+    ],
+    [
+     81590,
+     "[UT] add skipif for rocm aiter sampler UT (#50530)",
+     "5d7647a1092aba8eb4f41be91f89ef352854b318",
+     {
+      "__datetime__": "2026-07-31T08:32:52.360000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81590"
+    ],
+    [
+     81577,
+     "[CI] Add M3 MSA tests to CI (#49143)",
+     "34bb795ff3efee6cc08c9dd104deceefff2c4d55",
+     {
+      "__datetime__": "2026-07-31T08:01:51.418000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81577"
+    ],
+    [
+     81573,
+     "[Bugfix] Re-land MiniMax M3 default video processor (#50305)",
+     "f727951d3f0dbeb9acdb8a2f7ebfecaeb67090b3",
+     {
+      "__datetime__": "2026-07-31T07:46:21.626000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81573"
+    ],
+    [
+     81569,
+     "[CPU][BugFix] Remove redundant kv cache write (#50437)",
+     "10e6b400150c8d2cbedad54260def4871d464667",
+     {
+      "__datetime__": "2026-07-31T07:28:47"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81569"
+    ],
+    [
+     81567,
+     "Fix duplicate HunyuanVL image boundary tokens (#49691)",
+     "3ee2bd13211e830b1b170d146d551c253801d3d1",
+     {
+      "__datetime__": "2026-07-31T07:20:08.646000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81567"
+    ],
+    [
+     81541,
+     "[XPU][CI]Adjust source_file_dependencies for NixlConnector PD accuracy (4 GPUs) (#50373)",
+     "0351e9aa1fdf1a51329d1906881528dfe61fc88e",
+     {
+      "__datetime__": "2026-07-31T06:06:11.965000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81541"
+    ],
+    [
+     81539,
+     "Full CI run - nightly",
+     "1180b604f8d5559a00d17b8f384ddcdbc9a41d16",
+     {
+      "__datetime__": "2026-07-31T06:00:03.084000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81539"
+    ],
+    [
+     81538,
+     "Full CI run torch nightly",
+     "1180b604f8d5559a00d17b8f384ddcdbc9a41d16",
+     {
+      "__datetime__": "2026-07-31T06:00:02.668000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81538"
+    ],
+    [
+     81534,
+     "[Multimodal] Expose mm hash algothrim selection to cli args (#49686)",
+     "1180b604f8d5559a00d17b8f384ddcdbc9a41d16",
+     {
+      "__datetime__": "2026-07-31T05:25:22.471000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81534"
+    ],
+    [
+     81518,
+     "[Model Runner V2] Enable encoder token classification (#50293)",
+     "0f17394564fa2fccd332cf63321314884c15ee37",
+     {
+      "__datetime__": "2026-07-31T04:15:39.256000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81518"
+    ],
+    [
+     81506,
+     "[Bugfix][Model] Reject encoder-backbone jina-embeddings-v5 checkpoints with a clear error (fixes #50337) (#50352)",
+     "bebf918044ae05f0121c05f712417e53b287e1c9",
+     {
+      "__datetime__": "2026-07-31T03:43:34.315000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81506"
+    ],
+    [
+     81501,
+     "[DSv4] Remove sparse-MLA q-head padding for FlashInfer >=0.6.14 (#48047)",
+     "b49eaf205a7546267ef4dd1ec6563ba01d940b5b",
+     {
+      "__datetime__": "2026-07-31T03:30:24.122000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81501"
+    ],
+    [
+     81499,
+     "[ROCm][CI] Use explicit wvSplitKrc skinny-GEMM test tolerance for bf16 (gfx950) (#49309)",
+     "2773ec31b3c75b994351643e25e019e1168e6aed",
+     {
+      "__datetime__": "2026-07-31T03:25:45.119000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81499"
+    ],
+    [
+     81496,
+     "[KV Offload] Enable single-copy MLA layout for CPUOffloadingSpec (#50301)",
+     "541128bdeb623d9acee8abee53facb4e46848009",
+     {
+      "__datetime__": "2026-07-31T03:20:50.209000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81496"
+    ],
+    [
+     81493,
+     "[XPU] [BugFix] Add deepseek_v4_fp8 to xpu supported_quantization list (#50434)",
+     "1d8be5cb44322aa6f516050a5ed0732dbb9459a9",
+     {
+      "__datetime__": "2026-07-31T03:12:07.404000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81493"
+    ],
+    [
+     81490,
+     "[XPU] Fix FP8 block scale layout for MLA compatibility (#50349)",
+     "ef0d084b4b11141f009bf2210d5eac9b00b90ed0",
+     {
+      "__datetime__": "2026-07-31T03:05:38.069000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81490"
+    ],
+    [
+     81489,
+     "[CI/Build][AMD] Install triton_kernels via CMake (#50328)",
+     "6724051c5766fe5bff71ed4b5df5c9dd590a2329",
+     {
+      "__datetime__": "2026-07-31T03:05:22.493000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81489"
+    ],
+    [
+     81482,
+     "[ROCm] Add tuned selective_state_update float16 config for AMD Instinct MI325X (#50006)",
+     "4689c7dd61548b30216cfe49060ddbce1344f871",
+     {
+      "__datetime__": "2026-07-31T02:43:56.470000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81482"
+    ],
+    [
+     81481,
+     "[ROCm][CI] Use larger atol value for INT3 in test_quick_all_reduce.py (#50450)",
+     "5d5f22ed7a556ecafc005bfeb34b89cadf91501b",
+     {
+      "__datetime__": "2026-07-31T02:41:48.469000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81481"
+    ],
+    [
+     81480,
+     "[Hardware][AMD][Kernel][CI][Bugfix] Fix ROCm DeepEP FP8 max (#50467)",
+     "d91f7af7d05d7bad61088418e305830778c27f0e",
+     {
+      "__datetime__": "2026-07-31T02:37:38.999000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81480"
+    ],
+    [
+     81471,
+     "[CI] Retry Buildkite API rate limits (#50481)",
+     "60399d48eb67785dd130fa8db13debbcf310e2ed",
+     {
+      "__datetime__": "2026-07-31T02:09:47.749000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81471"
+    ],
+    [
+     81470,
+     "[Frontend][Bugfix] Use default tool call IDs for Kimi K3 for conversation-level uniqueness (#50420)",
+     "ab98034d4ccccd62e814ebcdc3f3831586b1c8d7",
+     {
+      "__datetime__": "2026-07-31T02:02:19.884000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81470"
+    ],
+    [
+     81463,
+     "[Bugfix][ROCm] AITER MLA: size MTP verification decode metadata for real qlen/dtype (#45227)",
+     "f1899b2ffdf87598350c416a074c8c291c845902",
+     {
+      "__datetime__": "2026-07-31T01:50:36.531000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81463"
+    ],
+    [
+     81456,
+     "Enable gfx1250 ROCm architecture (#46516)",
+     "4f1da84eb55db17a20227e22db59dd0082ac18a0",
+     {
+      "__datetime__": "2026-07-31T01:41:15.553000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81456"
+    ],
+    [
+     81447,
+     "[CI] Retry Hugging Face processor loading (#49908)",
+     "553fcb82d5602c75fb6ab41b6dc3c46f480c1785",
+     {
+      "__datetime__": "2026-07-31T00:48:11.485000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81447"
+    ],
+    [
+     81445,
+     "[Bugfix][Rust Frontend] Select earliest-completing stop string (#50200)",
+     "d6938b7408ccc9e34b57b684c04f3c103e23bda6",
+     {
+      "__datetime__": "2026-07-31T00:33:22.579000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81445"
+    ],
+    [
+     81442,
+     "[ROCm]: bump AITER to 0.1.19 (#49361)",
+     "3333d7cb6391d27bac146f8eaf869e6e318f429f",
+     {
+      "__datetime__": "2026-07-31T00:15:21.957000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81442"
+    ],
+    [
+     81440,
+     "[Kimi K3 Bug] Fix deepgemm support for kimi k3 (#50458)",
+     "0bff0ce5d39249d5119b8d688071671736f3f01f",
+     {
+      "__datetime__": "2026-07-31T00:10:19.546000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81440"
+    ],
+    [
+     81431,
+     "[CI] Fix `tests/entrypoints/multimodal/openai/chat_completion/test_audio.py::test_chat_streaming_audio` (#50451)",
+     "8700f86a7012b2354c3f2834c1a0d2b6023b0bcd",
+     {
+      "__datetime__": "2026-07-30T23:18:55.806000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81431"
+    ],
+    [
+     81428,
+     "[Model Runner V2][Spec Decode] Add multi-layer MTP speculator (#48892)",
+     "dec13a33b712e686b1fa26796d51aba4a2e2b3f5",
+     {
+      "__datetime__": "2026-07-30T22:54:17.849000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81428"
+    ],
+    [
+     81422,
+     "[CI] Retire the v1 PR label rule, add mrv2 (#50475)",
+     "7fe5312332cbc4a974a54a8be2e87e280f1c5bfa",
+     {
+      "__datetime__": "2026-07-30T22:25:31.073000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81422"
+    ],
+    [
+     81416,
+     "[Bugfix] Preserve Marlin runtime tensor storage across weight reload (#48438)",
+     "68fb303a4177f52b2a2795abe602031a6d330b83",
+     {
+      "__datetime__": "2026-07-30T21:50:06.431000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81416"
+    ],
+    [
+     81412,
+     "[Rust Frontend] Improve startup failure and readiness logs (#50406)",
+     "e9096fcb123181467a6fff5326fe8387d578760c",
+     {
+      "__datetime__": "2026-07-30T21:18:20.097000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81412"
+    ],
+    [
+     81408,
+     "Full CI run - daily",
+     "45b60e39140a5576505d986c37b382b3985a3d9e",
+     {
+      "__datetime__": "2026-07-30T21:00:01.641000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81408"
+    ],
+    [
+     81406,
+     "[Kernel][Helion] Disable unsafe B200 RMS reduction warp specialization (#50345)",
+     "45b60e39140a5576505d986c37b382b3985a3d9e",
+     {
+      "__datetime__": "2026-07-30T20:37:55.872000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81406"
+    ],
+    [
+     81405,
+     "Add Humming indexed-MoE regression test (#50468)",
+     "0eec856cc31cf9d9518b547c37a610d3f02ccddb",
+     {
+      "__datetime__": "2026-07-30T20:26:27.549000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81405"
+    ],
+    [
+     81404,
+     "[Quantization] Honor `--linear-backend` for ModelOpt W4A16 (#50273)",
+     "70bd10930bbb91af38fc243c53df4b94da80a8c9",
+     {
+      "__datetime__": "2026-07-30T20:19:59.249000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81404"
+    ],
+    [
+     81402,
+     "[compile] Fix fake kernel return dtype (#50444)",
+     "c27b080d262ee5966cf8d362d3a9d0cefd930908",
+     {
+      "__datetime__": "2026-07-30T19:50:06.808000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81402"
+    ],
+    [
+     81400,
+     "[ROCm] Pass pointers to FlyDSL MoE kernels (#50378)",
+     "3f90c7e9e6d3f8e874756ada2dbcd353bf0803d9",
+     {
+      "__datetime__": "2026-07-30T19:49:29.525000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81400"
+    ],
+    [
+     81394,
+     "[CI] Initialize fused gated RMSNorm weights (#50377)",
+     "bdc98bf5060db48f5844fa35f9ffe1608710ba51",
+     {
+      "__datetime__": "2026-07-30T19:34:13.379000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81394"
+    ],
+    [
+     81393,
+     "[Bugfix] Shut down private Tensorizer engines (#49840)",
+     "30e333ca5f0119385123e7e713462ffc7c8d7e45",
+     {
+      "__datetime__": "2026-07-30T19:33:25.240000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81393"
+    ],
+    [
+     81391,
+     "[Frontend] Preserve bare Inkling text in Python and Rust parsers (#50403)",
+     "629a938a928476a167efc6428bf2fbd43b1dc888",
+     {
+      "__datetime__": "2026-07-30T19:25:13.495000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81391"
+    ],
+    [
+     81383,
+     "[ROCm][DSV4] B-preshuffle the attention fp8 projections (#46720)",
+     "12a34a6bc794135e3b93dd721a6bdcdb1bf734b9",
+     {
+      "__datetime__": "2026-07-30T18:59:55.463000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81383"
+    ],
+    [
+     81382,
+     "[Build] Fix CUDA release wheel builds (#50243)",
+     "5f8f72866c4923fb06902cf60cf219a2340982e8",
+     {
+      "__datetime__": "2026-07-30T18:48:11.941000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81382"
+    ],
+    [
+     81380,
+     "[Bugfix][MoE] Write Humming results to the supplied output buffer (#50338)",
+     "61cacd272f5a95aa2a091d711ed91a4aa85522d5",
+     {
+      "__datetime__": "2026-07-30T18:34:14.102000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81380"
+    ],
+    [
+     81347,
+     "[DSv4 Perf] Remove redundant full kernel for dsv4, 1.88x kernel performance improvement (#50298)",
+     "837eae64580c885101ee95b073aafb27a485e7ce",
+     {
+      "__datetime__": "2026-07-30T15:39:11.485000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81347"
+    ],
+    [
+     81346,
+     "[DSv4 Perf] Fix redundant memory allocation and copy for dsv4 pp buffer, 448 MiB GPU memory saved (#50312)",
+     "904fae8be12f1592b8e489fc0f1004fa49460a89",
+     {
+      "__datetime__": "2026-07-30T15:38:54.208000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81346"
+    ],
+    [
+     81343,
+     "[XPU][CI] skip kimi-k3 test (#50447)",
+     "f388dd6592a3873636a3b5325e9db4849eb9e70f",
+     {
+      "__datetime__": "2026-07-30T15:27:31.098000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81343"
+    ],
+    [
+     81342,
+     "[FlexAttention] Avoid encoder block-mask compile explosion (#50339)",
+     "5b958907420e3e4dcbccd47ce912218475c885cc",
+     {
+      "__datetime__": "2026-07-30T15:24:16.572000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81342"
+    ],
+    [
+     81322,
+     "[rl] Stateful Trainer Send: IPC [2/N] (#48981)",
+     "30b4e7f479674a9c4d8889d4857294d3bd5e6849",
+     {
+      "__datetime__": "2026-07-30T13:59:11.580000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81322"
+    ],
+    [
+     81316,
+     "[Compilation]Fuse Transformers Residual Add + RMSNorm (#48757)",
+     "59e831c09a22bdd2732b86a158ff771584b14793",
+     {
+      "__datetime__": "2026-07-30T13:46:39.237000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81316"
+    ],
+    [
+     81315,
+     "[PARSER][Mistral] unified engine-based parser for reasoning and tool calls (#48947)",
+     "1a20d23dab6eef0ce6ab97b7e03c944683cdf90b",
+     {
+      "__datetime__": "2026-07-30T13:38:03.439000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81315"
+    ],
+    [
+     81314,
+     "[ROCm]Migrating Deepseek V3.2 to vllm/models/deepseek_v32/ (#47207)",
+     "e2efe79695e0f92395c029a6a7907c02a0374678",
+     {
+      "__datetime__": "2026-07-30T13:37:46.243000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81314"
+    ],
+    [
+     81300,
+     "[MyPy][1/N] Fix mypy errors in some tests/ directories and enforce follow-imports=silent (#49570)",
+     "38a267cdd5b30841bb2e2913d67ba18544098c3a",
+     {
+      "__datetime__": "2026-07-30T12:02:54.140000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81300"
+    ],
+    [
+     81297,
+     "docs(security): document Ray cluster trust model and env var propagation (#50397)",
+     "89d97d9a165a7fb2c84ffb77c8da816093bba0ed",
+     {
+      "__datetime__": "2026-07-30T11:52:58.552000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81297"
+    ],
+    [
+     81291,
+     "[CPU] Bump up CPU kernels to latest version (#50387)",
+     "072a4727820732fb9e1480dd3deffb9070520b41",
+     {
+      "__datetime__": "2026-07-30T11:18:45.761000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81291"
+    ],
+    [
+     81288,
+     "[New model] Kimi K3 (#50000)",
+     "aeeb36b1f17145975c6713242f2447bb8b98782b",
+     {
+      "__datetime__": "2026-07-30T10:50:00.929000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81288"
+    ],
+    [
+     81287,
+     "[Test][ROCm] Account for gfx950 FP8 RMSNorm rounding (#49839)",
+     "0c64be8873307c8db5901178f00945ce41866f2d",
+     {
+      "__datetime__": "2026-07-30T10:46:39.337000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81287"
+    ],
+    [
+     81282,
+     "[CI] Stabilize speculator memory teardown (#50284)",
+     "61c1d098e5124f3566b22a3178ef46551a4bd8e3",
+     {
+      "__datetime__": "2026-07-30T10:42:57.670000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81282"
+    ],
+    [
+     81281,
+     "[CI][ROCm] Stabilize LLM GC teardown check (#50340)",
+     "165ed33327c04db3e26c6e433f721a1f68754558",
+     {
+      "__datetime__": "2026-07-30T10:42:06.092000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81281"
+    ],
+    [
+     81277,
+     "[CI] Improve comment-triggered authorization and retries (#50414)",
+     "48a077e4cfaa5425ac5df67ce95f07a99c6d26d5",
+     {
+      "__datetime__": "2026-07-30T09:48:38.606000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81277"
+    ],
+    [
+     81248,
+     "[Frontend] Lazily initialize chat media connectors (#49914)",
+     "e04a30a77cb17d5a9753c53c51ee30bba887053c",
+     {
+      "__datetime__": "2026-07-30T06:56:39.774000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81248"
+    ],
+    [
+     81247,
+     "[CI] Retry failed steps on new PR commits (#50318)",
+     "445d3aac0a0720f38e80c256c884f4aa45cb8ab8",
+     {
+      "__datetime__": "2026-07-30T06:54:54.583000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81247"
+    ],
+    [
+     81243,
+     "[DOC][CPU] remove tcmalloc warning from CPU docs (#50308)",
+     "8122a105361600b2c634824b09d96ff9176ee73e",
+     {
+      "__datetime__": "2026-07-30T06:30:24.225000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81243"
+    ],
+    [
+     81241,
+     "[ROCm] Add AITER FP8 ViT encoder attention (#49937)",
+     "f1e8fd27aea5563172a9b2559c42188419a100b2",
+     {
+      "__datetime__": "2026-07-30T06:22:13.464000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81241"
+    ],
+    [
+     81239,
+     "[XPU][CI]Add back skipped V1 test (#50207)",
+     "0028fc8d8dd6e2d12a4e07240b948819ebc2eca8",
+     {
+      "__datetime__": "2026-07-30T06:18:41.098000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81239"
+    ],
+    [
+     81236,
+     "Full CI run - nightly",
+     "a7a204cc6ec99b375985e564f4f271e68ee8f5b8",
+     {
+      "__datetime__": "2026-07-30T06:00:06.269000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81236"
+    ],
+    [
+     81224,
+     "Add FlashMLA H100 tests to CI, fix them after #32810 (#50322)",
+     "a7a204cc6ec99b375985e564f4f271e68ee8f5b8",
+     {
+      "__datetime__": "2026-07-30T05:06:20.930000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81224"
+    ],
+    [
+     81221,
+     "[ROCm] [CI] Support cached K/V (key/value=None) in Triton prefix-prefill (#48257)",
+     "b88916617d3d2249bff0dae5cecb6b727c980a20",
+     {
+      "__datetime__": "2026-07-30T04:31:53.697000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81221"
+    ],
+    [
+     81211,
+     "[CI/Build] Limit wheel size check to CUDA 13 (#50357)",
+     "1ad5182ba95a6f1de23b537d57b860082912b28e",
+     {
+      "__datetime__": "2026-07-30T03:10:44.989000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81211"
+    ],
+    [
+     81197,
+     "[Quantization][Autoround][XPU] Add W4A16(moe) / MXFP4(linear/moe) Support (#47124)",
+     "e5f48dfda2b53090f539a2b3988e075e8ac0eba8",
+     {
+      "__datetime__": "2026-07-30T01:52:15.642000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81197"
+    ],
+    [
+     81194,
+     "[PD][Bugfix] Rebase KV lease deadlines onto worker clock (#50326)",
+     "4e582c5b54b866a2cc0d44c8f8bbedb52cf5c605",
+     {
+      "__datetime__": "2026-07-30T01:25:45.514000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81194"
+    ],
+    [
+     81193,
+     "[BugFix] Fix P/D preemption race condition (#50297)",
+     "437e0b7f8eb787e1cd7bdf090e47a015b54fd22c",
+     {
+      "__datetime__": "2026-07-30T01:11:21.635000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81193"
+    ],
+    [
+     81191,
+     "[Frontend] Add detokenization streaming derender for disaggregated serving (#47301)",
+     "0a31372e5fe7cc8bbaf96df0a3e88db9040cf8d5",
+     {
+      "__datetime__": "2026-07-30T01:01:22.837000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81191"
+    ],
+    [
+     81190,
+     "[Bugfix][Kernel] Fix integer overflow in libtorch_stable/activation_kernels.cu (#49660)",
+     "451227cb3ff07989698fed982c2d3e4300257924",
+     {
+      "__datetime__": "2026-07-30T00:50:47.326000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81190"
+    ],
+    [
+     81185,
+     "Fix: FusedMoE AssertionError with Speculative Decoding on Quark-Quantized Models (#38293)",
+     "b28c178ffd50cbdff1da87bfb8b786c514e0efaf",
+     {
+      "__datetime__": "2026-07-30T00:03:42.227000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81185"
+    ],
+    [
+     81181,
+     "[Bugfix] Prevent stale multiproc RPC deadlines from becoming unbounded waits (#41357)",
+     "48aa8d8d7529d2314858d8487cc0a21789fc7ec1",
+     {
+      "__datetime__": "2026-07-29T23:41:37.412000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81181"
+    ],
+    [
+     81177,
+     "[Frontend] Add diarized_json support for MOSS-Transcribe-Diarize (#48543)",
+     "9d1aa4dda85a58c74b23ff79aa4a20594ee6f359",
+     {
+      "__datetime__": "2026-07-29T23:24:33.767000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81177"
+    ],
+    [
+     81175,
+     "[CI Bugfix] Temp disable Humming wNa8 INT8 H100 CI (#50329)",
+     "1cb3fe5844592696e9a428f0239f0508462a56f7",
+     {
+      "__datetime__": "2026-07-29T23:14:15.108000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81175"
+    ],
+    [
+     81164,
+     "[CI][ROCm] Fix AMD nightly distributed regressions (#50304)",
+     "fa2a2589bd2a1fce0851df7fd42ffb54b6195f04",
+     {
+      "__datetime__": "2026-07-29T22:02:15.369000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81164"
+    ],
+    [
+     81158,
+     "[ROCm][CI] Avoid Ray worker startup env race (#50311)",
+     "435c4dad97f90d7f1f72523be9d03dab2663bcd0",
+     {
+      "__datetime__": "2026-07-29T21:30:31.641000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81158"
+    ],
+    [
+     81149,
+     "Full CI run - daily",
+     "5fa01544480b60275edf913e1a620d229e40553d",
+     {
+      "__datetime__": "2026-07-29T21:00:06.784000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81149"
+    ],
+    [
+     81148,
+     "[Rubin] Enable NVLink all-reduce paths on SM107 (#49647)",
+     "5fa01544480b60275edf913e1a620d229e40553d",
+     {
+      "__datetime__": "2026-07-29T20:53:28.600000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81148"
+    ],
+    [
+     81144,
+     "feat(grpc): add KV event source discovery (#50033)",
+     "48fc2e2797ec3f35605c3ff399bbaab7938b0459",
+     {
+      "__datetime__": "2026-07-29T20:46:43.287000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81144"
+    ],
+    [
+     81143,
+     "Revert \"[Misc][Minimax-M3]add default video_processor (#50092)\" (#50313)",
+     "2ecd8645d87e7c0716e5bc4347620e91e137619d",
+     {
+      "__datetime__": "2026-07-29T20:46:09.815000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81143"
+    ],
+    [
+     81142,
+     "[Perf] RMSNorm uncontiguous support, 1.2~3.1x kernel performance improvement (#49750)",
+     "82642d7d6c332fefdec06b260a246bd1a4ebf5ff",
+     {
+      "__datetime__": "2026-07-29T20:45:42.018000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81142"
+    ],
+    [
+     81111,
+     "[torch.compile] Compile `CustomOp.forward_native` for ReLU^2 to avoid raw torch ops inside opaque custom ops (#50244)",
+     "93477454f9155d4f74352e3d725c83f91c6894bf",
+     {
+      "__datetime__": "2026-07-29T18:27:34.846000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81111"
+    ],
+    [
+     81102,
+     "[docs] Add documentation for pynvvideocodec video decoding backend (#49066)",
+     "5c7a7f9462c97ff8b2f63e6458488b820f2bbd86",
+     {
+      "__datetime__": "2026-07-29T17:23:07.303000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81102"
+    ],
+    [
+     81095,
+     "fix(step3p5-mtp): honor exclude_modules for the MTP head via prefix (#48883)",
+     "f98061ce6cb0326978363fb6c0489fe75a9aac5d",
+     {
+      "__datetime__": "2026-07-29T16:58:32.032000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81095"
+    ],
+    [
+     81089,
+     "[KV Connector] Fix NIXL mamba state pairing for multi-slot block tables (#50153)",
+     "82553692b899059d2ec967ece7677a76bf2daab2",
+     {
+      "__datetime__": "2026-07-29T16:45:56.806000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81089"
+    ],
+    [
+     81077,
+     "[ROCm][CI] Fix Kimi K3 KDA on ROCm (#50262)",
+     "381b6916202035f997467324a6b1495ab84d98a6",
+     {
+      "__datetime__": "2026-07-29T15:47:54.333000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81077"
+    ],
+    [
+     81073,
+     "[Spec Decode][Perf] Replicate DSpark Markov head across TP ranks (#49731)",
+     "d6247d71731249c65c829b4cbfb782b647849e4e",
+     {
+      "__datetime__": "2026-07-29T15:43:54.141000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81073"
+    ],
+    [
+     81047,
+     "[BugFix] Fix `num_output_placeholders` preemption underflow (#48245)",
+     "a0c092ee72c0dcefbb3b3e74f97ac62d842e5f4b",
+     {
+      "__datetime__": "2026-07-29T13:41:57.837000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81047"
+    ],
+    [
+     81042,
+     "[ModelRunner V2] Enable sequence pooling for embedding and classification models (#48791)",
+     "43eaefba5a5dbccb71d2404e4bf28e21bb74fce6",
+     {
+      "__datetime__": "2026-07-29T13:30:48.321000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81042"
+    ],
+    [
+     81037,
+     "[Bugfix][Frontend] Return transcription and translation verbose as float (#49073)",
+     "e0cfa52d22a00f755a53bbed925b0c92d4290f39",
+     {
+      "__datetime__": "2026-07-29T13:16:16.600000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81037"
+    ],
+    [
+     81034,
+     "[Rust Frontend] Send multimodal tensors in auxiliary frames (#49341)",
+     "242c591d5a38be6c80ff5197e83e4fa34c5f74b5",
+     {
+      "__datetime__": "2026-07-29T12:21:12.902000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81034"
+    ],
+    [
+     81032,
+     "[CI][Test] Fix pooling truncation test after VLLMError hierarchy change (#50241)",
+     "625871b52c487077658582f72a0abbda559383e8",
+     {
+      "__datetime__": "2026-07-29T12:15:59.084000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81032"
+    ],
+    [
+     81019,
+     "[XPU] Route weightless RMSNorm to _C dispatch (#47121)",
+     "72297d859ba34e019da4d7e5de58abbbd59961d4",
+     {
+      "__datetime__": "2026-07-29T11:00:00.641000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81019"
+    ],
+    [
+     81018,
+     "[Kernel][Mamba] Fused-kernel support for align-mode DS-conv state migration with num_accepted_tokens > 1 (#49291)",
+     "f51193b9aefe665904d793ca782002320224d27a",
+     {
+      "__datetime__": "2026-07-29T10:54:55.413000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81018"
+    ],
+    [
+     81016,
+     "[Bugfix][Multimodal] Include media IO config in MM cache hash (#49975)",
+     "aeaa50a71c4f53a8b38ae043ab5914fed2504d4a",
+     {
+      "__datetime__": "2026-07-29T10:48:43.380000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81016"
+    ],
+    [
+     81012,
+     "[KV Offload] Move CPUOffloadingSpec onto SharedOffloadRegion (#50094)",
+     "542a8fad6da059a0fd4a8b0a03b4476e9ec9b66a",
+     {
+      "__datetime__": "2026-07-29T10:05:53.180000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81012"
+    ],
+    [
+     81007,
+     "[CI/Perf] Fix malformed serving benchmark config (#43538)",
+     "9a4e5f95390fc759ada001444637fe2e96a29ad9",
+     {
+      "__datetime__": "2026-07-29T09:52:45.531000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81007"
+    ],
+    [
+     81002,
+     "[Rust Frontend] Add --limit-mm-per-prompt support (#49604)",
+     "c44e191b014db0619bd51921e94c86b901ab952e",
+     {
+      "__datetime__": "2026-07-29T09:21:44.045000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/81002"
+    ],
+    [
+     81000,
+     "[CI] Fix MXFP8 MOE backend selection tests on gfx942 (#50222)",
+     "5b14019576475224d86044b262e28a04a85d4086",
+     {
+      "__datetime__": "2026-07-29T09:17:14"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/81000"
+    ],
+    [
+     80995,
+     "[EC Connector] Add has_pending_push_work  (#49582)",
+     "dad7a6383b7d86709cea420d9594f48b9b42cf69",
+     {
+      "__datetime__": "2026-07-29T09:04:25.040000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/80995"
+    ],
+    [
+     80987,
+     "[XPU] upgrade to torch 2.13 (#48677)",
+     "5b29c958c713d367c7caf9313529d4fb2dd6b762",
+     {
+      "__datetime__": "2026-07-29T08:24:58.783000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/80987"
+    ],
+    [
+     80986,
+     "[Misc][Minimax-M3]add default video_processor (#50092)",
+     "df2735ea2e14b377ce71571ed27a63b9ceae2ba3",
+     {
+      "__datetime__": "2026-07-29T08:24:54.705000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/80986"
+    ],
+    [
+     80985,
+     "[BugFix] eagle draft max position embeddings (#49343)",
+     "32e657e6894a8709d60f8edeffb5a2b1b1cb59a3",
+     {
+      "__datetime__": "2026-07-29T08:24:50.680000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/80985"
+    ],
+    [
+     80984,
+     "[Model] Support Qwen3.5 text-only dense and MoE models (#50210)",
+     "ad5d29db702ce5bce78d9d3b2da1a76eab72e9c2",
+     {
+      "__datetime__": "2026-07-29T08:22:00.545000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/80984"
+    ],
+    [
+     80981,
+     "[Model] Add Kimi K3 support: Python frontend [2/2] (#50093)",
+     "f5a7cce9b6a61f4d995629a7418c7ea822e34a64",
+     {
+      "__datetime__": "2026-07-29T08:06:04.071000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/80981"
+    ],
+    [
+     80980,
+     "[Frontend] Reuse prefill token ids on the decode chat path for disaggregated serving (#48145)",
+     "6370e53f246c97649615ccd7fca5366ee73f54aa",
+     {
+      "__datetime__": "2026-07-29T08:03:00.567000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/80980"
+    ],
+    [
+     80975,
+     "[CPU] Fix FP8 attention scratchpad sizing (#50194)",
+     "65a1a16594995bdc8b8feae2bf2ecf208d585be8",
+     {
+      "__datetime__": "2026-07-29T07:34:40.129000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/80975"
+    ],
+    [
+     80970,
+     "[CI] Allow PR comment acknowledgements (#50211)",
+     "100d655a23e20c7995821e0349b56a0b5060988c",
+     {
+      "__datetime__": "2026-07-29T06:53:58.914000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/80970"
+    ],
+    [
+     80966,
+     "[XPU][UT][CI] add xpu config to run gpt-oss accuracy in ut and ci (#48703)",
+     "7de49bab7e91a2a77e98a31fae4b1c615b34dce8",
+     {
+      "__datetime__": "2026-07-29T06:16:18.412000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/80966"
+    ],
+    [
+     80965,
+     "[Model] Add Kimi K3 support: model files and kernels [1/N] (#50089)",
+     "7c6729b769597541d327f666273cd972b8a5318d",
+     {
+      "__datetime__": "2026-07-29T06:11:00.872000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/80965"
+    ],
+    [
+     80964,
+     "Full CI run - nightly",
+     "6f00a1ae3bd4b86168667bce673998218f461c0f",
+     {
+      "__datetime__": "2026-07-29T06:00:05.134000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/80964"
+    ],
+    [
+     80963,
+     "Full CI run torch nightly",
+     "6f00a1ae3bd4b86168667bce673998218f461c0f",
+     {
+      "__datetime__": "2026-07-29T06:00:04.398000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/80963"
+    ],
+    [
+     80956,
+     "fused_moe: add VLLM_TRITON_USE_TD tensor-descriptor path (#42436)",
+     "6f00a1ae3bd4b86168667bce673998218f461c0f",
+     {
+      "__datetime__": "2026-07-29T05:15:13.144000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/80956"
+    ],
+    [
+     80954,
+     "[Test] dynamic_shapes_compilation (#49974)",
+     "6f91edf96d3f3272945809c04702380053bff4de",
+     {
+      "__datetime__": "2026-07-29T04:55:00.421000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/80954"
+    ],
+    [
+     80952,
+     "[CPU] Fix s390x builds and update torch version in dockerfile (#50144)",
+     "db7a79cbf74ec0b21e009faa7f1b563f1f88aeb2",
+     {
+      "__datetime__": "2026-07-29T04:52:19.839000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/80952"
+    ],
+    [
+     80948,
+     "Add CachePolicyFactory for pluggable/external eviction policies (#49114)",
+     "dc1be79031d948d7a18c37600881e45ca708d913",
+     {
+      "__datetime__": "2026-07-29T04:34:57.978000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/80948"
+    ],
+    [
+     80946,
+     "[CI][ROCm] Stabilize Qwen2-VL LoRA test (#50161)",
+     "0bb548b60e88b74304008817b4908b65ec8b2393",
+     {
+      "__datetime__": "2026-07-29T04:27:48.734000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/80946"
+    ],
+    [
+     80944,
+     "[Frontend][Core] Standardize request error handling with VLLMError hierarchy (#49665)",
+     "58f96593971b6287cdc8867024a6dfb9985c545c",
+     {
+      "__datetime__": "2026-07-29T04:20:43.198000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/80944"
+    ],
+    [
+     80939,
+     "[KV Connector] Support NIXL P/D for hybrid MLA+SSM models  (#49762)",
+     "f37f03db4af69e4969242767734db3d9175055f7",
+     {
+      "__datetime__": "2026-07-29T03:50:33.199000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/80939"
+    ],
+    [
+     80927,
+     "Integrate CuTeDSL MoE for ReLU2 NVFP4 (#49580)",
+     "32a423ac0aad67f94f93e97f73338f484b55faec",
+     {
+      "__datetime__": "2026-07-29T02:46:41.372000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/80927"
+    ],
+    [
+     80924,
+     "[CompressedTensors] FP4 Qutlass Integration (#43229)",
+     "30c2718eaafc230927f0d8ac47439d040b46a7c3",
+     {
+      "__datetime__": "2026-07-29T02:34:23.191000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/80924"
+    ],
+    [
+     80920,
+     "[ROCm][CI] Stabilize ngram and suffix correctness test (#50190)",
+     "7398a30d79758559704d4f28173b3594b2ec1345",
+     {
+      "__datetime__": "2026-07-29T02:29:02.632000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/80920"
+    ],
+    [
+     80917,
+     "[Model] Add Inkling compressed-tensors dynamic FP8 support (#48876)",
+     "17a74b745b459eb72ea9eea2945bc83b1c17e0a0",
+     {
+      "__datetime__": "2026-07-29T02:27:04.364000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/80917"
+    ],
+    [
+     80914,
+     "[CI] Allow comment-triggered builds past pipeline filters (#50197)",
+     "54ab69b14eeafd5c8dcf818cfcc0eeb26d2ebddb",
+     {
+      "__datetime__": "2026-07-29T02:11:07.021000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/80914"
+    ],
+    [
+     80910,
+     "[CI] Add comment-based Buildkite triggers (#50132)",
+     "7f4c52f2ba38a77d5341fb90a31c2cedfc0066b8",
+     {
+      "__datetime__": "2026-07-29T01:41:50.418000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/80910"
+    ],
+    [
+     80906,
+     "[BugFix] Stop dummy runs from writing mamba state through stale block-table rows (#49757)",
+     "6fbbcf2151c34cd9313c223b8cbf19afa77f2ea6",
+     {
+      "__datetime__": "2026-07-29T01:09:44.368000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/80906"
+    ],
+    [
+     80900,
+     "[Bugfix] Fix /wake_up crash on hybrid models (Mamba/DeltaNet) (#41602)",
+     "56f31af62afe6553369b14af225bfafb788e99a0",
+     {
+      "__datetime__": "2026-07-29T00:17:38.851000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/80900"
+    ],
+    [
+     80899,
+     "[CI][NIXL] Fix flaky DP+EP test port conflict (#50171)",
+     "fe65aa6a97981c815800daa4bf49d8356b8c4988",
+     {
+      "__datetime__": "2026-07-29T00:12:53.379000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/80899"
+    ],
+    [
+     80898,
+     "[ROCm][CI] Stabilize ROCm audio streaming test (#50163)",
+     "176256b9628d2d8d22db41d7a72c15540f438026",
+     {
+      "__datetime__": "2026-07-28T23:58:12.966000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/80898"
+    ],
+    [
+     80897,
+     "[MXFP8][ROCm] Fix MXFP8 MoE backend selection (#49747)",
+     "5369f7b7b89e48d396fa98a9d33f3fba654af8ee",
+     {
+      "__datetime__": "2026-07-28T23:57:23.781000"
+     },
+     "failed",
+     "https://buildkite.com/vllm/ci/builds/80897"
+    ],
+    [
+     80896,
+     "[Test] Make EPD correctness tests configurable for XPU (#50110)",
+     "e7f6a39db8d1f05ea923b5f976141db838b11c44",
+     {
+      "__datetime__": "2026-07-28T23:47:51.524000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/80896"
+    ],
+    [
+     80895,
+     "[Perf] Zero-copy torch.Tensor pickling in shm_broadcast MessageQueue (#48442)",
+     "a07fac758f2cae58f6ebad29da726e9432012c13",
+     {
+      "__datetime__": "2026-07-28T23:28:30.632000"
+     },
+     "passed",
+     "https://buildkite.com/vllm/ci/builds/80895"
+    ]
+   ]
+  },
+  "jobs": {
+   "columns": [
+    "job_name",
+    "shard",
+    "tn_state",
+    "tn_exit",
+    "tn_url",
+    "tn_agent",
+    "base_state",
+    "in_tn",
+    "in_base"
+   ],
+   "rows": [
+    [
+     "Kernels Core Operation Test",
+     1,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f255-4cec-8e8b-e6e70eb7fe3c",
+     "h200-ci-4",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Basic Models Tests (Extra Initialization) 3",
+     2,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f28a-4c16-89f5-b86d41ac8993",
+     "h200-ci-3",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Distributed Compile + Comm (4 GPUs)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1cd-44d0-9c45-4471e1e03ef4",
+     "ip-10-0-37-73.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Qwen3-30B-A3B-FP8 DP4 Async EPLB Accuracy",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1dd-47a5-9379-da10c131dfd6",
+     "buildkite-019fdacf-f1dd-47a5-9379-da10c131dfd6-8l8qw",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Spec Decode Draft Model Nightly (B200)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdba1-3450-4aa5-a7f8-9da7b2bfad94",
+     "dgxB200-01",
+     "passed",
+     1,
+     1
+    ],
+    [
+     ":docker: :smoking: Non-root smoke tests",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f16d-42e3-a959-59c6661cd248",
+     "ip-10-0-138-189.ec2.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "PyTorch Compilation Unit Tests",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2ae-47ce-91ad-0f72b03a882b",
+     "h200-ci-4",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Multi-Modal Models (Extended Generation 1) (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f23b-42ca-94af-f621bb722da4",
+     "buildkite-019fdacf-f23b-42ca-94af-f621bb722da4-snhlz",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Multi-Modal Models (Standard) 4: other + whisper (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f23d-4b5f-a906-b04d9630229c",
+     "buildkite-019fdacf-f23d-4b5f-a906-b04d9630229c-zrl6f",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Model Runner V2 Distributed (2 GPUs)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f284-4895-a555-11a2674e4ede",
+     "ip-10-0-189-184.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Spec Decode Eagle Nightly (B200)",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2d7-4ae7-9878-70e01dd5c892",
+     "dgxb200-11",
+     "failed",
+     1,
+     1
+    ],
+    [
+     "CPU-Quantization Model Tests",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1a0-4fb1-9208-9bf7256f801d",
+     "aicf-jf-cicd-01",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "V1 attention (B200)",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f17e-4d44-a837-910950268b62",
+     "dgxb200-11",
+     "failed",
+     1,
+     1
+    ],
+    [
+     "Kernels Fp4 MoE Test (B200)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f257-4f86-abde-2d7aa58941a7",
+     "dgxB200-09",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "2 Node Test (4 GPUs)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1cd-4198-8ed6-5c216123a623",
+     "ip-10-0-144-93.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AsyncTP Correctness Tests (2xB200)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1ae-439a-a92b-18bb0f137ec4",
+     "dgxB200-01",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Basic Correctness (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f21f-427b-a248-d540b68e5944",
+     "buildkite-019fdacf-f21f-427b-a248-d540b68e5944-bj89g",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Entrypoints Integration (API Server)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1f1-49e9-a14a-135d4f1d7207",
+     "h200-ci-3",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "CrossLayer KV layout Distributed NixlConnector PD accuracy tests (4 GPUs)",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1b6-4ca1-91c2-6566e146bc0b",
+     "ip-10-0-172-169.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Samplers Test",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2cf-42f6-9c8e-8d7ffd75c0c3",
+     "h200-ci-2",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "RayExecutorV2 (4 GPUs)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1d0-4735-bf17-6c7d5ee43505",
+     "ip-10-0-253-228.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Spec Decode AL MTP + Other Acceptance Nightly",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdbb0-dc8b-41fc-85c5-767d16b5408d",
+     "h200-ci-3",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Async Engine, Inputs, Utils, Worker, Config (CPU)",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f277-4bdf-8d21-4adb173b902a",
+     "ip-10-0-173-40.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "CPU-Multi-Modal Model Tests 2",
+     1,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1a0-49b1-8843-dfb37014e410",
+     "aicf-jf-cicd-08",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Model Runner V2 Spec Decode",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f285-432c-8166-3cdd40b7c2fa",
+     "h200-ci-3",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Kernels FusedMoE Layer Test (2 H100s)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f257-48be-a36b-f3eeea2de8ad",
+     "buildkite-019fdacf-f257-48be-a36b-f3eeea2de8ad-vk94t",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Hybrid SSM NixlConnector PD accuracy tests (4 GPUs)",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1be-4043-b188-b89ecd450cbc",
+     "ip-10-0-135-3.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "LM Eval KV-Offload (4xH100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f266-42ad-8125-741bb268fc18",
+     "buildkite-019fdacf-f266-42ad-8125-741bb268fc18-pq2s9",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Model Executor",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f27f-49cb-99be-64c94d9ed829",
+     "h200-ci-2",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "V1 Others (CPU)",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f27a-4281-99d2-da28b0d725b4",
+     "ip-10-0-21-46.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Entrypoints Integration (LLM)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1f2-42b0-aa50-e7e8bf302cbd",
+     "h200-ci-3",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Multi-Modal Processor (CPU) 3",
+     2,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2a4-48b8-b516-faf85964d679",
+     "ip-10-0-57-251.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Multi-Modal Models (Standard) 3: llava + qwen2_vl",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2a0-44fe-9679-2175b7193e5f",
+     "h200-ci-3",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: LM Eval Large Models (8xH200) (mi300_8)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f232-4b8e-8ac1-01c4ec563b00",
+     "buildkite-019fdacf-f232-4b8e-8ac1-01c4ec563b00-cwn76",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: e2e Scheduling (1 GPU) (mi250_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f22e-4600-9173-c40cf0991a1b",
+     "buildkite-019fdacf-f22e-4600-9173-c40cf0991a1b-w7cj2",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Kernels Root Misc Test (B200)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f25b-4b7b-8308-46251fa9445c",
+     "dgxb200-11",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "LoRA 1",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f270-4995-a9e1-26d5a8fc2a5a",
+     "h200-ci-6",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Model Executor (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f239-4247-b1a7-a01da07ebb3d",
+     "buildkite-019fdacf-f239-4247-b1a7-a01da07ebb3d-rsgdf",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Multi-Modal Models (Standard) 2: qwen3 + gemma (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f23d-4a8e-bda3-3619d53f2f3a",
+     "buildkite-019fdacf-f23d-4a8e-bda3-3619d53f2f3a-lrggp",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Multi-Modal Processor (CPU) 4",
+     3,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2a4-4ebd-ac86-08406e9dccef",
+     "ip-10-0-100-8.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Distributed Tests (4xA100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1cf-401e-9694-02bac639a77e",
+     "buildkite-019fdacf-f1cf-401e-9694-02bac639a77e-dgjc9",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Acceptance Length Test (Large Models)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f276-4ff8-bef4-e29367209aa8",
+     "h200-ci-4",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Arm CPU Test",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f197-4d80-b5f8-035b7ba98b9b",
+     "ip-100-70-1-95.eu-west-1.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Quantization",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2b6-4f38-8274-2bb70f859355",
+     "h200-ci-6",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "e2e Scheduling (1 GPU)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1eb-464c-a892-ad0a5370126a",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "e2e Core (1 GPU)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1eb-4d68-b282-03837844b45d",
+     "h200-ci-2",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "EPLB Execution",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1f9-475d-b085-ab9871eb54c1",
+     "ip-10-0-177-243.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Extract Hidden States Integration (2 GPUs)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f278-42c5-a416-a9a084b6f922",
+     "ip-10-0-154-16.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Language Models Tests (Extra Standard) 1 (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f23a-45fd-95e0-9133d2e177bd",
+     "buildkite-019fdacf-f23a-45fd-95e0-9133d2e177bd-b9pn9",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "LoRA TP (Distributed)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f271-4b6e-a45b-df92e4749ce9",
+     "ip-10-0-207-10.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "V1 Core + KV + Metrics",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f279-4a32-96bb-eb9c3a74d606",
+     "h200-ci-6",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: LoRA 2 (mi300_1)",
+     1,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f237-4b62-9cb9-496111ff24ec",
+     "buildkite-019fdacf-f237-4b62-9cb9-496111ff24ec-gqvff",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Kernels Attention Test 2 (mi300_1)",
+     1,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f230-4362-946b-b69d8e86adb4",
+     "buildkite-019fdacf-f230-4362-946b-b69d8e86adb4-xpgp5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "CPU-Distributed Tests (DP+TP)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f19b-447e-897e-ce4971854a60",
+     "aicf-jf-cicd-03",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "MultiConnector (Nixl+Offloading) PD accuracy (2 GPUs)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1be-4884-8986-16b7f1d560b7",
+     "ip-10-0-136-244.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Fusion E2E Config Sweep (B200)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1af-4d4a-b55b-16300d9155a6",
+     "dgxB200-09",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Multi-Modal Models (Standard) 2: qwen3 + gemma",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2a0-4f71-9947-561efdc1e469",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Fusion E2E Config Sweep (H100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1af-40c2-a227-47109df22e71",
+     "buildkite-019fdacf-f1af-40c2-a227-47109df22e71-x5qmr",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Hybrid SSM NixlConnector PD prefix cache test (2 GPUs)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1be-4ad6-abdc-933ef2cc1c16",
+     "ip-10-0-171-69.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Kernels MoE Test 1 (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f230-4b69-ba25-bffdfbc0b0e0",
+     "buildkite-019fdacf-f230-4b69-ba25-bffdfbc0b0e0-k2g2p",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Batch Invariance (A100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f277-426e-a8ee-ee9f06649009",
+     "buildkite-019fdacf-f277-426e-a8ee-ee9f06649009-jhr4l",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "LM Eval Humming Act fp8/int8 (H100 - TEMPORARY)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f264-4434-8884-d7de23ae3537",
+     "buildkite-019fdacf-f264-4434-8884-d7de23ae3537-tj8k9",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Rust Frontend OpenAI Coverage",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2c9-41cd-8474-f475fa6801a0",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "PyTorch Fullgraph Test",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2af-4509-bc1b-a364db8e50c5",
+     "h200-ci-2",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Multi-Modal Models (Extended Generation 2)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f29e-4854-a3b4-edc607efdf31",
+     "h200-ci-2",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Language Models Tests (Granite L4 Compatibility)",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f298-4a19-9a2a-958e3a1b97d4",
+     "ip-10-0-100-176.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Kernels Helion Test",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f257-4b6c-9ed9-de554e38cb87",
+     "buildkite-019fdacf-f257-4b6c-9ed9-de554e38cb87-drgkq",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Spec Decode AL DSpark Nightly",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2d5-45ad-adc3-213b5c931834",
+     "h200-ci-2",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Entrypoints Integration (API Server OpenAI - Part 1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1f0-44d5-988a-9a2a74f86d98",
+     "h200-ci-3",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: V1 e2e (2 GPUs) (mi300_2)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f22d-4c61-b2a3-b67a8edc3d8c",
+     "buildkite-019fdacf-f22d-4c61-b2a3-b67a8edc3d8c-7gxr2",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "MoE Refactor Integration Test (B200 - TEMPORARY)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f26b-46ce-87e3-e90abc01f0b1",
+     "dgxB200-09",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "PyTorch Compilation Passes Unit Tests",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2ae-46da-996d-d673aeaf2dab",
+     "ip-10-0-99-23.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Language Models Test (Extended Pooling) (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f239-4afd-a356-da82d6ed82d0",
+     "buildkite-019fdacf-f239-4afd-a356-da82d6ed82d0-hxkjh",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "DP EP Distributed NixlConnector PD accuracy tests (4 GPUs)",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1b9-4e28-893e-0f4a6e4e3c76",
+     "ip-10-0-183-17.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Engine",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1e6-45fa-91fe-85cf548c48f3",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: e2e Core (1 GPU) (mi250_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f22d-4663-b3dc-bb058ec9bb3a",
+     "buildkite-019fdacf-f22d-4663-b3dc-bb058ec9bb3a-sfwmw",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Fault Tolerance E2E (2xH100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1fe-4973-8fa7-75a0ea5939ec",
+     "buildkite-019fdacf-f1fe-4973-8fa7-75a0ea5939ec-xtzmr",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: EPLB Algorithm (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f22f-4121-9390-1f69ce7dfb20",
+     "buildkite-019fdacf-f22f-4121-9390-1f69ce7dfb20-n5s4b",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Kernels FlashMLA Test (H100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f257-48b7-b0a9-3866d94d563a",
+     "buildkite-019fdacf-f257-48b7-b0a9-3866d94d563a-5628r",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Entrypoints Integration (API Server Generate)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1f0-4205-8832-742acba5654f",
+     "h200-ci-2",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Kernels FusedMoE Layer Test (2 B200s)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f257-4ff7-ad86-da3b388f9416",
+     "dgxB200-12",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Entrypoints Integration (API Server Generate) (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f22e-4324-a71b-820a858880b1",
+     "buildkite-019fdacf-f22e-4324-a71b-820a858880b1-9nlhz",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Distributed Tests (2xH100-2xMI300)",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1ce-4f8c-8439-054ad267d6c9",
+     "buildkite-019fdacf-f1ce-4f8c-8439-054ad267d6c9-8qdpj",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Kernels MoE Test 5",
+     4,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f259-4613-8f3b-b4af2a90caba",
+     "ip-10-0-219-210.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: CrossLayer KV layout Distributed NixlConnector PD accuracy tests (4 GPUs) (mi300_4)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f220-4848-a725-e2c41bfb2a85",
+     "buildkite-019fdacf-f220-4848-a725-e2c41bfb2a85-z4pck",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Kernels Attention Test 1",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f255-4657-affe-a980b55cc3af",
+     "ip-10-0-39-104.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     ":docker: Build image",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f179-473f-9546-9f7f93aa87df",
+     "ip-10-0-160-141.ec2.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Basic Correctness",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f18a-4e55-8e16-cd65c2ba6bf5",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Metrics, Tracing (2 GPUs)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f279-4f92-8324-b78905a4c96d",
+     "ip-10-0-223-100.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "GPQA Eval (GPT-OSS) (DGX Spark)",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f260-4a43-ac3a-eb9166d0b0df",
+     "spark-0df9",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: LoRA 3 (mi300_1)",
+     2,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f237-4a9c-bf0f-ae53ad451aab",
+     "buildkite-019fdacf-f237-4a9c-bf0f-ae53ad451aab-fch6k",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Distributed Torchrun + Shutdown Tests (2 GPUs)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1d0-4cd1-bc53-21e8809a2698",
+     "ip-10-0-193-88.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Entrypoints Integration (Pooling)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1f2-4a41-bd44-e8ed628c3269",
+     "h200-ci-6",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Engine (1 GPU) (mi250_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f229-4b6c-b0ef-80cfcb0d303e",
+     "buildkite-019fdacf-f229-4b6c-b0ef-80cfcb0d303e-9plk2",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Kernels Quantization Test 2 (mi300_1)",
+     1,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f232-4ab0-95f0-551dd928747e",
+     "buildkite-019fdacf-f232-4ab0-95f0-551dd928747e-4w6pz",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Fusion and Compile Unit Tests (2xB200)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1b0-4e9a-bdaf-e48555b08557",
+     "dgxB200-14",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: V1 attention (H100-MI300) (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f21b-44ac-9e5b-0994218ee2ff",
+     "buildkite-019fdacf-f21b-44ac-9e5b-0994218ee2ff-wlg6w",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "OpenAI API Correctness",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1f3-4d35-b1a8-d06d02092b1d",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Language Models Tests (Extra Standard) 2",
+     1,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f297-425c-a085-914af7050bc0",
+     "h200-ci-3",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "LM Eval Humming f16 (H100 - TEMPORARY)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f265-4ce4-8251-7d2e506021e9",
+     "buildkite-019fdacf-f265-4ce4-8251-7d2e506021e9-5xkct",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Distributed Tests (2xB200)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdcb5-68c0-4008-9183-07b3a68cc1e5",
+     "dgxB200-14",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Kimi-Linear-48B-A3B Disaggregated DP EP",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1be-4001-bf42-38e282c1bc17",
+     "h200-ci-1",
+     "expired",
+     1,
+     1
+    ],
+    [
+     "LM Eval Humming Act int8 (A100 - TEMPORARY)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f265-4fc4-8957-6a09b05271ec",
+     "buildkite-019fdacf-f265-4fc4-8957-6a09b05271ec-fqrm2",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Multi-Modal Models (Extended Pooling)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f29e-4639-a990-acd5e91248b2",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Engine (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f229-4ef7-a5b0-ee28e535fb96",
+     "buildkite-019fdacf-f229-4ef7-a5b0-ee28e535fb96-q4hr2",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Rust Frontend Cargo Tests",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2c2-46d7-9d11-c62befd875e0",
+     "ip-10-0-126-178.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Attention Benchmarks Smoke Test (B200)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f192-4d92-8337-294b8784b08c",
+     "dgxB200-09",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Basic Models Tests (Extra Initialization) 4",
+     3,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f28b-4ee4-9910-08cc5b294386",
+     "h200-ci-3",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "V1 attention (H100-MI300)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f182-4ec6-bc3c-199f2de947bf",
+     "buildkite-019fdacf-f182-4ec6-bc3c-199f2de947bf-znk7d",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Weight Loading Multiple GPU (mi300_2)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f240-4eb9-810b-0a09826752a0",
+     "buildkite-019fdacf-f240-4eb9-810b-0a09826752a0-cjd2s",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Language Models Tests (Hybrid) 2 (mi300_1)",
+     1,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f23b-44c4-9a23-20aac44a37d9",
+     "buildkite-019fdacf-f23b-44c4-9a23-20aac44a37d9-hbmx7",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Weight Loading Multiple GPU",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2e3-4856-9e5a-8ad413716410",
+     "ip-10-0-138-60.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: :docker: refresh ROCm base",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f215-4a11-bbe1-77a0d398fc4b",
+     "aus-turin-sr06-01",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Distributed Torchrun + Examples (4 GPUs)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1d0-4523-bc24-d1e65d29fbfb",
+     "ip-10-0-253-202.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Spec Decode Speculators + MTP (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f23f-498a-85e8-b0d13e3b51a9",
+     "buildkite-019fdacf-f23f-498a-85e8-b0d13e3b51a9-7wm4s",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Multi-Modal Models (Extended Generation 3)",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f29e-49f6-bc5a-acbc1dbf0190",
+     "h200-ci-4",
+     "failed",
+     1,
+     1
+    ],
+    [
+     "Kernels Core Operation Test",
+     2,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f256-4ce1-8be8-41a601dcc498",
+     "h200-ci-3",
+     "passed",
+     1,
+     1
+    ],
+    [
+     ":docker: Build HPU image",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f179-4435-a339-73c42d2ed18c",
+     "ip-10-0-229-68.ec2.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Platform Tests",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1a9-4eb0-a7dc-2b1567c43047",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Spec Decode Eagle (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f23e-4a8d-9bf7-3d46f933a2ab",
+     "buildkite-019fdacf-f23e-4a8d-9bf7-3d46f933a2ab-gs25j",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Kernels MoE Test 4 (mi300_1)",
+     3,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f232-482c-a345-ca369deeed72",
+     "buildkite-019fdacf-f232-482c-a345-ca369deeed72-pb4jr",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "LM Eval Humming f16 (B200 - TEMPORARY)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f265-49e2-ba09-9adda08ecd9a",
+     "dgxB200-09",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Basic Models Tests (Other) (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f239-4f9c-a912-3ff2e6c302aa",
+     "buildkite-019fdacf-f239-4f9c-a912-3ff2e6c302aa-nd6np",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Multi-Modal Models (PPL) (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f23c-4520-9b3d-040ab8ce3651",
+     "buildkite-019fdacf-f23c-4520-9b3d-040ab8ce3651-lj5gd",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Basic Models Tests (Extra Initialization) 1",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f28a-408a-a8b1-d92aefa5c95c",
+     "h200-ci-2",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Kernels Quantization Test 1",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f25a-4ed0-bde5-aa83cc3d106a",
+     "ip-10-0-194-8.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Kernels MoE Test 2",
+     1,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f259-45f0-8101-996f42c20792",
+     "ip-10-0-12-106.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Kernels (B200)",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f254-425e-912d-3cc7534a3fee",
+     "dgxB200-09",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Spec Decode DeepSeek MTP Parallel Load (B200)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2d5-43dd-a04f-c819d804fb54",
+     "dgxB200-12",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Distributed Tests (8xH100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1cf-4b6c-bbdc-41bb1c656422",
+     "buildkite-019fdacf-f1cf-4b6c-bbdc-41bb1c656422-496xx",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "bootstrap",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdace-ae04-4ff8-8c6b-4c0b670cb587",
+     "ip-10-0-180-65.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Docker Build Metadata",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1d5-45ec-800b-4b4affc2be6d",
+     "ip-10-0-66-94.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Multi-Modal Models (Standard) 4: other + whisper",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2a0-4190-bdff-9c5a19046dc1",
+     "h200-ci-2",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "DeepSeek V2-Lite Prefetch Offload Accuracy (H100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1dd-4644-a49e-19ef2ddcc622",
+     "buildkite-019fdacf-f1dd-4644-a49e-19ef2ddcc622-z4zq5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Spec Decode Eagle",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2d7-46f1-90d4-6e8becfcee93",
+     "h200-ci-6",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Kernels Quantization Test 1 (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f232-4312-b9ad-8b32996f7367",
+     "buildkite-019fdacf-f232-4312-b9ad-8b32996f7367-jzp5r",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "CPU-Multi-Modal Model Tests 1",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1a0-4759-9062-3080ce3afdd1",
+     "aicf-jf-cicd-01",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Samplers Test (mi250_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f23e-4530-9957-b3892ddc1225",
+     "buildkite-019fdacf-f23e-4530-9957-b3892ddc1225-lddbf",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Model Runner V2 Pipeline Parallelism (4 GPUs)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f285-46b2-8540-18ac98a84a3f",
+     "ip-10-0-171-249.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Language Models Tests (Hybrid) 2",
+     1,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f298-45e5-9b67-72cbfccc4ce4",
+     "h200-ci-2",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Distributed Comm Ops",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1cd-4b06-964f-58bf6e6d1b2c",
+     "ip-10-0-195-146.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: V1 Spec Decode (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f240-4d33-b788-c0f46d56eb34",
+     "buildkite-019fdacf-f240-4d33-b788-c0f46d56eb34-sfb7n",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Spec Decode Speculators + MTP Nightly (B200)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2d8-4fcc-9893-fe2dbafaa57f",
+     "dgxB200-14",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Metrics, Tracing (2 GPUs) (mi300_2)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f238-41ba-9d97-4cafa2193ad4",
+     "buildkite-019fdacf-f238-41ba-9d97-4cafa2193ad4-jv8qd",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Entrypoints Integration (API Server OpenAI - Part 2)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1f1-4870-9e4b-c6ef1861e7c6",
+     "h200-ci-6",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Distributed Compile + RPC Tests (2 GPUs)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1cd-43d2-8457-294a5cd3d587",
+     "ip-10-0-230-148.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     ":docker: Build CPU image",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f178-4284-a568-44d0774b2ac0",
+     "ip-10-0-251-54.ec2.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Pytorch Nightly Dependency Override Check",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2af-4c4c-9465-cf875801fd4d",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Kernels MoE Test 5 (mi300_1)",
+     4,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f232-49a7-b75d-0847c912062b",
+     "buildkite-019fdacf-f232-49a7-b75d-0847c912062b-b42qb",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "LM Eval Large Models (8xH200)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f267-44b6-bc71-4f0094e3a1b9",
+     "h200-ci-1",
+     "expired",
+     1,
+     1
+    ],
+    [
+     "LM Eval Humming Act fp8/int8 (B200 - TEMPORARY)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f264-41a3-80eb-4db9db497354",
+     "dgxb200-11",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Kernels MiniMax Reduce RMS Test (2 GPUs)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f259-4f03-b848-85ed8edd85de",
+     "buildkite-019fdacf-f259-4f03-b848-85ed8edd85de-lzb8d",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Cudagraph",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1a6-47c9-aa2b-e08ff2148134",
+     "h200-ci-4",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "XPU example Test",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f249-47bd-b991-9ed484a4ec60",
+     "aicf-jf-cicd-05",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Distributed Model Tests (2 GPUs)",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f291-4e80-ac5e-0ba72b070632",
+     "ip-10-0-253-223.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Entrypoints Integration (API Server OpenAI - Part 2) (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f22e-4060-bddd-67a3991979d9",
+     "buildkite-019fdacf-f22e-4060-bddd-67a3991979d9-t74bn",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Distributed Compile Unit Tests (2xH100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1ae-4cf0-a2b5-beaddd2c9b42",
+     "buildkite-019fdacf-f1ae-4cf0-a2b5-beaddd2c9b42-zrrxx",
+     "passed",
+     1,
+     1
+    ],
+    [
+     ":docker: Build CPU arm64 image",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f175-4d5a-b414-3fca87ca0383",
+     "ip-10-0-65-56.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Examples (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f237-4dbf-a96d-d4e6b4888161",
+     "buildkite-019fdacf-f237-4dbf-a96d-d4e6b4888161-dqrmw",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Multi-Modal Accuracy Eval (Small Models)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f29d-4a7c-a4d9-bcdd01cfb20a",
+     "h200-ci-3",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Entrypoints Integration (LLM) (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f22f-476d-b590-d4d0b355e799",
+     "buildkite-019fdacf-f22f-476d-b590-d4d0b355e799-dwgzb",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Multi-Modal Processor (CPU) 1",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2a0-49b7-b87b-cd7749267006",
+     "ip-10-0-153-172.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Language Models Tests (Hybrid) 1",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f298-409c-b821-bf628ac2c477",
+     "h200-ci-6",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Fusion E2E TP2 AsyncTP Config Sweep (H100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1b0-46f1-ba4f-dffbe07e1c5e",
+     "buildkite-019fdacf-f1b0-46f1-ba4f-dffbe07e1c5e-g577j",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: V1 Sample + Logits (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f238-4bc5-8a72-9e7e17aba88b",
+     "buildkite-019fdacf-f238-4bc5-8a72-9e7e17aba88b-zc2ft",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "CPU-Language Generation and Pooling Model Tests",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f19f-4cee-88b9-82ce7fca739d",
+     "aicf-jf-cicd-01",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Multi-Modal Models (Extended Pooling) (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f23c-45ce-81b8-b8506c65ef5c",
+     "buildkite-019fdacf-f23c-45ce-81b8-b8506c65ef5c-k86fx",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "V1 attention (H100-MI300)",
+     1,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f185-4ee6-a641-ce121237cf3a",
+     "buildkite-019fdacf-f185-4ee6-a641-ce121237cf3a-djghm",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Kimi K3 Unit Tests (B200)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f28c-4b53-976b-e66ec32a23d1",
+     "dgxB200-12",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Language Models Tests (Extra Standard) 2 (mi300_1)",
+     1,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f23a-41f1-80b6-2084fd254f64",
+     "buildkite-019fdacf-f23a-41f1-80b6-2084fd254f64-8psz9",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Spec Decode AL DFlash Nightly",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2d4-4139-9daa-764671a26a94",
+     "h200-ci-3",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: V1 Core + KV + Metrics (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f238-4dca-b5a0-dba6cf60671d",
+     "buildkite-019fdacf-f238-4dca-b5a0-dba6cf60671d-xkrcd",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: NixlConnector PD + Spec Decode acceptance (2 GPUs) (mi300_2)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f225-4a9a-9959-0fe2a3a6212b",
+     "buildkite-019fdacf-f225-4a9a-9959-0fe2a3a6212b-mdctm",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "GPQA Eval (GPT-OSS) (2xH100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f260-41ef-ba9e-c0f55f99ef20",
+     "buildkite-019fdacf-f260-41ef-ba9e-c0f55f99ef20-lxzn6",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Entrypoints Integration (Speech to Text)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1f3-423d-b0b3-b9b234efad15",
+     "h200-ci-4",
+     "passed",
+     1,
+     1
+    ],
+    [
+     ":docker: Build XPU image",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f245-4430-9dcb-783b4cb126b6",
+     "ip-10-0-9-79.ec2.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Multi-Modal Models (Extended Generation 1)",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f29e-4465-9aa1-e781c69bfcc1",
+     "h200-ci-2",
+     "failed",
+     1,
+     1
+    ],
+    [
+     "AMD: Distributed DP Tests (2 GPUs) (mi300_2)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f229-49b8-a00d-a0bd5868b343",
+     "buildkite-019fdacf-f229-49b8-a00d-a0bd5868b343-dkx84",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: DP EP Distributed NixlConnector PD accuracy tests (4 GPUs) (mi300_4)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f223-4cee-98b3-536a75f435cc",
+     "buildkite-019fdacf-f223-4cee-98b3-536a75f435cc-6kkkz",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: V1 attention (H100-MI300) (mi300_1)",
+     1,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f21e-439b-801f-79b2a98e67e9",
+     "buildkite-019fdacf-f21e-439b-801f-79b2a98e67e9-lp6lh",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Deepseek V4 Kernel Test (B200)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f253-4000-a586-06a59984e70d",
+     "dgxB200-09",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Deepseek V4 Kernel Test (H100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f254-45a8-a9dc-b2afcbf891d7",
+     "buildkite-019fdacf-f254-45a8-a9dc-b2afcbf891d7-kdrxn",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Kernels MoE Test 1",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f259-4a63-b132-cc59a377472f",
+     "ip-10-0-147-55.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Distributed DP Tests (2 GPUs)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1ce-4e3c-aee7-4e57acca5f84",
+     "ip-10-0-220-65.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Language Models Test (Extended Pooling)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f297-4699-9abf-48ac86c69495",
+     "h200-ci-6",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Basic Models Tests (Extra Initialization) 2",
+     1,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f28a-491d-a942-d3f4cbbfb325",
+     "h200-ci-2",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Kernels Quantization Test 2",
+     1,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f25a-4ac8-a5e6-9bf1c37386db",
+     "ip-10-0-114-187.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Language Models Test (Extended Generation)",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f296-4d61-b491-1b815689d4b3",
+     "h200-ci-2",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Push NixlConnector PP prefill PD accuracy (4 GPUs)",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1c3-4545-baec-0160ec788f88",
+     "ip-10-0-196-134.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Qwen3-30B-A3B-FP8-block Sync EPLB Accuracy (4xH100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1de-49e0-a83e-807353d53793",
+     "buildkite-019fdacf-f1de-49e0-a83e-807353d53793-f8vbb",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Kernels MoE Test 3 (mi300_1)",
+     2,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f231-4e8b-bb23-a706dbce8ee1",
+     "buildkite-019fdacf-f231-4e8b-bb23-a706dbce8ee1-66pwv",
+     "passed",
+     1,
+     1
+    ],
+    [
+     ":docker: Build arm64 image",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f179-41a3-ab0d-46840a502819",
+     "ip-10-0-247-90.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "CPU-Qwen2.5-VL Multimodal Tests",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1a1-4eab-a7a8-794bbf30d091",
+     "aicf-jf-cicd-02",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Extract Hidden States Integration",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f278-44ca-adb3-9e00cba137fe",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Inkling Unit Tests (B200)",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f28c-456a-86c9-cad0a953f7bd",
+     "dgxB200-14",
+     "failed",
+     1,
+     1
+    ],
+    [
+     "CPU-ModelRunnerV2 Tests",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1a0-48de-9f66-1e7f32dcb97a",
+     "aicf-jf-cicd-05",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Distributed NixlConnector PD accuracy (4 GPUs)",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1bd-4fb6-a8a8-66fb3bfb0c1b",
+     "ip-10-0-165-119.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Rust Frontend Distributed",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2c9-409f-8a70-9b91cd2b9179",
+     "ip-10-0-170-88.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "LM Eval Large Models (4xH100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f267-4aac-bba2-d54afb475f37",
+     "buildkite-019fdacf-f267-4aac-bba2-d54afb475f37-qfw7v",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "DeepSeek V2-Lite Sync EPLB Accuracy (4xH100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1dd-4ca4-8a69-bd18c884ddb9",
+     "buildkite-019fdacf-f1dd-4ca4-8a69-bd18c884ddb9-szn2b",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Entrypoints Integration (API Server OpenAI - Part 1) (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f22e-4210-a38d-d88d09b771ab",
+     "buildkite-019fdacf-f22e-4210-a38d-d88d09b771ab-vjfgd",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Batch Invariance (B200)",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f277-4664-83f5-b87a44826645",
+     "dgxB200-12",
+     "failed",
+     1,
+     1
+    ],
+    [
+     "Multi-Modal Models (Standard) 1: qwen2",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f29f-48e6-ba4c-fb8b0c7b489d",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "LM Eval Small Models Distributed (2xB200)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f269-4178-946d-3d230e0955a1",
+     "dgxb200-11",
+     "failed",
+     1,
+     1
+    ],
+    [
+     "AMD: Python-only Installation (mi250_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f238-4818-a410-ae94e2a2c351",
+     "buildkite-019fdacf-f238-4818-a410-ae94e2a2c351-jcj6w",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Quantized MoE Test (B200)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2b7-4ca6-9905-5a4eb5344af0",
+     "dgxB200-01",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Entrypoints Unit Tests",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1f3-4625-baed-fccd8c23beae",
+     "h200-ci-4",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Language Models Tests (Extra Standard) 1",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f297-421e-886e-2d7131dde374",
+     "h200-ci-6",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Fusion E2E Quick (H100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1af-48c6-973a-6aeef34f246a",
+     "buildkite-019fdacf-f1af-48c6-973a-6aeef34f246a-62gx2",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Spec Decode Ngram + Suffix",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2d7-4c2c-9590-0d76c84af79f",
+     "h200-ci-6",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "MRCR Eval Small Models",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f26a-43c9-be33-b1cd9be525f2",
+     "h200-ci-3",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Python-only Installation",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f279-41bf-a81f-247887e837e6",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Rust Frontend Tool Use",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2ca-484a-b29f-310a373391f3",
+     "h200-ci-6",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Kernels Attention Test 1 (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f230-4aab-9437-7061fb97f78e",
+     "buildkite-019fdacf-f230-4aab-9437-7061fb97f78e-km8dv",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Entrypoints Integration (API Server) (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f22f-44ed-935d-42ee792ef2b1",
+     "buildkite-019fdacf-f22f-44ed-935d-42ee792ef2b1-jbc49",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Distributed DP Tests (4 GPUs)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1ce-40fc-83bb-7ba8b9b0874a",
+     "ip-10-0-252-186.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "LM Eval Large Models EP (2xB200)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f268-4996-bc18-d63f6c2617c1",
+     "dgxB200-01",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Language Models Tests (Standard) (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f23b-4bef-8c70-64a6b4a39555",
+     "buildkite-019fdacf-f23b-4bef-8c70-64a6b4a39555-6m869",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Kernels MoE Test 4",
+     3,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f259-4a25-8ed2-58e77048edda",
+     "ip-10-0-129-163.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Fusion E2E TP2 AR-RMS Config Sweep (H100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1b0-47ca-9b45-0c050a4bda94",
+     "buildkite-019fdacf-f1b0-47ca-9b45-0c050a4bda94-kgszp",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Kernels DeepGEMM Test (H100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f256-473b-ba95-9c0515a083a9",
+     "buildkite-019fdacf-f256-473b-ba95-9c0515a083a9-8jgb6",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "LM Eval Small Models (1xB200)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f269-4980-bdf1-fa089566ec41",
+     "dgxB200-14",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "LoRA 3",
+     2,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f271-4c7f-a564-95a80360d914",
+     "h200-ci-3",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "XPU V1 test",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f245-474a-846c-82fae1bb0fa8",
+     "aicf-jf-cicd-08",
+     "failed",
+     1,
+     1
+    ],
+    [
+     "Fusion E2E TP2 (B200)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1b0-4fa0-8d79-d8792730db43",
+     "dgxB200-01",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Kernels Attention Test 2",
+     1,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f255-4a94-a781-11203e1db1f8",
+     "ip-10-0-162-178.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Rust Frontend Serve/Admin Coverage",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2ca-4ddb-a3a1-c233917cc31e",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "V1 Sample + Logits",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f27a-4de4-b0b9-c2b53504282e",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "LoRA 2",
+     1,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdb97-3a1d-447a-9a71-d257aa19267b",
+     "h200-ci-3",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Hybrid SSM NixlConnector PD accuracy tests (4 GPUs) (mi300_4)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f224-4d79-ae00-e643332ab6d3",
+     "buildkite-019fdacf-f224-4d79-ae00-e643332ab6d3-lztb8",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "CPU-Distributed Tests (PP+TP)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f19e-484a-8f29-3380b0fd8020",
+     "aicf-jf-cicd-05",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "LM Eval PCP (4xB200)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f268-41f9-aada-0a79e851212a",
+     "dgxB200-14",
+     "failed",
+     1,
+     1
+    ],
+    [
+     "Pipeline + Context Parallelism (4 GPUs)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1d0-4291-8462-d8703669faca",
+     "ip-10-0-23-92.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "LM Eval KV-Offload (2xH100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f266-4be6-8820-65286f8c8c5a",
+     "buildkite-019fdacf-f266-4be6-8820-65286f8c8c5a-zfkkf",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "MoE Refactor Integration Test (B200 DP - TEMPORARY)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f26b-421f-871c-db0a10942fa4",
+     "dgxB200-12",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Spec Decode Ngram + Suffix (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f23f-4901-a1e3-42f69de5a727",
+     "buildkite-019fdacf-f23f-4901-a1e3-42f69de5a727-fks9t",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Quantized Models Test",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2b7-418b-826d-1ad6957f78c0",
+     "h200-ci-2",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Multi-Modal Accuracy Eval (Small Models) (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f23b-4b3f-b2cc-b1a4d1e34fa9",
+     "buildkite-019fdacf-f23b-4b3f-b2cc-b1a4d1e34fa9-nfmb4",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Multi-Modal Processor",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2a0-42e0-aed3-741dc69cc97a",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "DSv4-Flash Disaggregated DP EP",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1b9-4ff7-8408-2815d673f497",
+     "h200-ci-1",
+     "failed",
+     1,
+     1
+    ],
+    [
+     "Kernels Mamba Test",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fec39-78c4-4687-a0b2-1d340a37808c",
+     "h200-ci-3",
+     "passed",
+     2,
+     1
+    ],
+    [
+     "Examples",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f278-4836-adf9-03ac7d54c945",
+     "h200-ci-4",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Plugin Tests (2 GPUs)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2a9-48fd-a261-8b806c668107",
+     "ip-10-0-249-67.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Torch Stable ABI Audit",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2dd-4f29-8040-d768e66d8e9b",
+     "ip-10-0-187-122.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Rust Frontend Core Correctness",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2c9-4c18-a4af-c6eee60b6829",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Multi-Modal Models (Standard) 1: qwen2 (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f23d-48ed-9b70-1e5b39618da7",
+     "buildkite-019fdacf-f23d-48ed-9b70-1e5b39618da7-7vcp5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Kernels Attention DiffKV Test (H100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f254-4255-8be1-87ed1b84855e",
+     "buildkite-019fdacf-f254-4255-8be1-87ed1b84855e-zqgcv",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: OpenAI API Correctness (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f22f-4986-85d0-d536c086bbc4",
+     "buildkite-019fdacf-f22f-4986-85d0-d536c086bbc4-d8bz9",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Model Runner V2 Examples",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f284-4ce6-a8c4-e244f3d913ea",
+     "h200-ci-4",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Language Models Test (PPL)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f297-490b-b471-23896f779fa5",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: LoRA 4 (mi300_1)",
+     3,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f237-4aac-915f-4186bfd378e3",
+     "buildkite-019fdacf-f237-4aac-915f-4186bfd378e3-tfxch",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Batch Invariance (H100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f277-410b-b5e2-1950974189dd",
+     "buildkite-019fdacf-f277-410b-b5e2-1950974189dd-n7p8w",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "EPLB Algorithm",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1f8-4d19-8783-f9dd914ae046",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Sequence Parallel Correctness Tests (2xB200)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1b1-42cd-bc38-360aff1e79d2",
+     "dgxB200-14",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Benchmarks CLI Test",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f193-4eef-8587-f1d57f249965",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Language Models Tests (Standard)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f298-470c-a519-0c08965b6ee2",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "GPQA Eval (GPT-OSS) (2xB200)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f260-41cc-89e3-421282e76445",
+     "dgxb200-11",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Rust Frontend Cargo Style + Clippy",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2c2-4210-80b1-d12d922d6c27",
+     "ip-10-0-113-140.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: LM Eval Small Models (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f236-4176-a969-1172c8b669be",
+     "buildkite-019fdacf-f236-4176-a969-1172c8b669be-85tmj",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "V1 attention (B200)",
+     1,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f182-42d8-b718-31720b7d03a0",
+     "dgxB200-01",
+     "failed",
+     1,
+     1
+    ],
+    [
+     "Regression",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f279-41f8-8379-5e4e5801d11b",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Model Runner V2 Core Tests",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f284-4f07-a4a2-090f5e0ae5dc",
+     "h200-ci-4",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Ray Dependency Compatibility Check",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2bd-4458-82a2-38c4cc42a51c",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Speculators Correctness Nightly (H100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2d8-499a-8cc1-6d05a98af0b2",
+     "buildkite-019fdacf-f2d8-499a-8cc1-6d05a98af0b2-hr9xt",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Entrypoints Integration (Multimodal)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1f2-4bf8-a2ff-55a49d0f5c25",
+     "h200-ci-4",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "PyTorch Fullgraph CUDAGraph (L4 Compatibility)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2af-4933-a93a-3092d08f125d",
+     "ip-10-0-137-59.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Multi-Modal Models (PPL)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f29e-4ad0-a455-a3ce991f2778",
+     "h200-ci-6",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "MoE Refactor Integration Test (H100 - TEMPORARY)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f26b-42e1-b118-5c787a7c1c60",
+     "buildkite-019fdacf-f26b-42e1-b118-5c787a7c1c60-5lh9l",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Basic Models Test (Other CPU)",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f28a-46d3-8624-777c5c3aa6c0",
+     "ip-10-0-101-131.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "XPU server test",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f249-43ec-a6e6-0a07a5e47023",
+     "aicf-hf-cicd-02",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "PyTorch Compilation Unit Tests (H100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2af-42fc-ba2e-312316d69e66",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Fusion E2E TP2 Quick (H100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1b0-44e2-adad-ca78809a34bd",
+     "buildkite-019fdacf-f1b0-44e2-adad-ca78809a34bd-wpq42",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Spec Decode Draft Model",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2d6-47f9-b8d9-ccd874e9faf4",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Language Models Tests (Hybrid) 1 (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f23a-4803-b9af-a50e39414efd",
+     "buildkite-019fdacf-f23a-4803-b9af-a50e39414efd-d2gcd",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Quantized Fusions",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2b7-43cd-a4b6-2f5ab5e2ef29",
+     "h200-ci-2",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "NixlConnector PD edge case test (2 GPUs)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1c3-429b-a563-284eed06952d",
+     "ip-10-0-250-42.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Kernels Core Operation Test",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f255-46d0-b2e0-fcbefb21fc33",
+     "h200-ci-2",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: LoRA 1 (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f237-46a3-a2e5-3c0d0bbd9784",
+     "buildkite-019fdacf-f237-46a3-a2e5-3c0d0bbd9784-d642k",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: :docker: ensure ci_base",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f215-45fe-9370-7ac7208281a9",
+     "aus-turin-sr06-01",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Elastic EP Scaling Test",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1f9-4e63-827a-837fc73d67e4",
+     "buildkite-019fdacf-f1f9-4e63-827a-837fc73d67e4-4hgq6",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "V1 Spec Decode",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2d8-4bec-ac64-d4f2b7a6fd31",
+     "h200-ci-4",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Basic Models Tests (Initialization)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f28b-48a9-9e38-f88a45ef30c8",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "V1 e2e (2 GPUs)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1eb-4c3a-ac52-bb2fef61df11",
+     "ip-10-0-138-130.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Pytorch Nightly Dependency Override Check (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f23e-4e57-bf01-ab99c30447d7",
+     "buildkite-019fdacf-f23e-4e57-bf01-ab99c30447d7-zjs8r",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Spec Decode Draft Model (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f23e-407a-9457-9d033a004f32",
+     "buildkite-019fdacf-f23e-407a-9457-9d033a004f32-tfjsd",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Spec Decode Speculators + MTP",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2d8-4c23-9f55-e04550d7c1d6",
+     "h200-ci-6",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Distributed FlashInfer NixlConnector PD accuracy (4 GPUs)",
+     0,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1bd-46c3-974b-93dd0fe1f64a",
+     "ip-10-0-157-235.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "CPU-Kernel Tests",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f19e-4446-b432-3f355bb31c47",
+     "aicf-jf-cicd-03",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "LM Eval TurboQuant KV Cache",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f26a-4f02-83ef-9f6f2eec3028",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Kernels Helion Test",
+     1,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f258-47eb-be82-ec92ee9a3d33",
+     "buildkite-019fdacf-f258-47eb-be82-ec92ee9a3d33-87hmr",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Kernels MoE Test 3",
+     2,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f259-468c-9ab3-865879594dcc",
+     "ip-10-0-132-27.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Engine (1 GPU)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1e7-4ca5-a636-7411a1db53c3",
+     "ip-10-0-22-81.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Kernels FP8 MoE Test (1xH100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f256-48b7-96ea-1b3c658ffb5f",
+     "buildkite-019fdacf-f256-48b7-96ea-1b3c658ffb5f-zdczs",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "V1 e2e (4xH100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1eb-4c2a-abb7-c1394227e8e0",
+     "buildkite-019fdacf-f1eb-4c2a-abb7-c1394227e8e0-lgqws",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Multi-Modal Processor (CPU) 2",
+     1,
+     "failed",
+     1,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f2a4-4bda-9b41-57663d0a6117",
+     "ip-10-0-171-38.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "LM Eval Humming f16 (A100 - TEMPORARY)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f265-40b8-bea0-8e0c3af9aa9f",
+     "buildkite-019fdacf-f265-40b8-bea0-8e0c3af9aa9f-vhzzp",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "LoRA 4",
+     3,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f271-486e-b0eb-40fccd61c003",
+     "h200-ci-4",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Entrypoints Integration (Responses API)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1f2-4013-b033-723524d2680d",
+     "h200-ci-6",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "No Runtime JITs e2e tests",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f24f-486d-8537-79c2086806c8",
+     "h200-ci-4",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "vLLM IR Tests",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f25b-4b0d-89f7-f112f8e4de70",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Distributed MooncakeConnector PD accuracy (4 GPUs)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1c7-4a51-bdd7-177e714c5d97",
+     "dgxb200-11",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Multi-Modal Models (Standard) 3: llava + qwen2_vl (mi250_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f23d-439f-8f44-c001e91453db",
+     "buildkite-019fdacf-f23d-439f-8f44-c001e91453db-7rbnc",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "LM Eval Qwen3.5 Models (2xB200)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f268-4c8e-8485-9c12949d7ef6",
+     "dgxB200-09",
+     "failed",
+     1,
+     1
+    ],
+    [
+     "Basic Models Tests (Other)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f28b-4967-b6ad-879a6c3ab5b1",
+     "h200-ci-6",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "LM Eval KV-Offload (1xH200)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f265-41c1-903e-a9a5623c9729",
+     "h200-ci-2",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Distributed NixlConnector PD accuracy (4 GPUs) (mi300_4)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f224-45d4-ad54-7f65cee98959",
+     "buildkite-019fdacf-f224-45d4-ad54-7f65cee98959-b4smc",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Async Engine, Inputs, Utils, Worker",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdb8a-fa6a-4f8d-b4c5-0c255f456558",
+     "h200-ci-3",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "LM Eval Small Models",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f269-4b2a-9c82-85fff6ddf49b",
+     "h200-ci-4",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "MultiConnector (Nixl+Offloading) PD edge cases (2 GPUs)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1bf-4396-b046-d7d02c92ad1e",
+     "ip-10-0-129-140.us-west-2.compute.internal",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Benchmarks CLI Test (mi300_1)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f220-4ec6-ae22-f0faa1569cc2",
+     "buildkite-019fdacf-f220-4ec6-ae22-f0faa1569cc2-ng5gg",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Qwen3-30B-A3B-FP8-block Sync EPLB Accuracy (2xB200)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fec39-70b1-4e9a-a9ea-8321c5e16826",
+     "dgxB200-01",
+     "passed",
+     2,
+     1
+    ],
+    [
+     "Language Models Test (MTEB)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f297-498c-affd-32add94785d8",
+     "h200-ci-5",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: :docker: build test image and artifacts",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f212-4233-9afb-3d145ebc18ff",
+     "aus-turin-sr06-01",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "NixlConnector PD + Spec Decode acceptance (2 GPUs)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1bf-49fa-8d0d-488ac7ea7037",
+     "buildkite-019fdacf-f1bf-49fa-8d0d-488ac7ea7037-mw6mv",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "CPU-Multi-Modal Model Tests 3",
+     2,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1a0-4def-817d-3cd42a5aff1e",
+     "aicf-jf-cicd-04",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "Kernels FP8 MoE Test (2xH100)",
+     0,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f256-45ff-8af0-245e63087cae",
+     "buildkite-019fdacf-f256-45ff-8af0-245e63087cae-lv5kr",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "CPU-Multi-Modal Model Tests 4",
+     3,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f1a0-41b7-b3a3-b2be23314e65",
+     "aicf-jf-cicd-08",
+     "passed",
+     1,
+     1
+    ],
+    [
+     "AMD: Kernels MoE Test 2 (mi300_1)",
+     1,
+     "passed",
+     0,
+     "https://buildkite.com/vllm/ci/builds/82789#019fdacf-f231-4330-a0c3-eac36477a030",
+     "buildkite-019fdacf-f231-4330-a0c3-eac36477a030-97hz2",
+     "passed",
+     1,
+     1
+    ]
+   ]
+  }
+ }
+}

--- a/tools/torchci/tests/test_vllm_torch_nightly_triage.py
+++ b/tools/torchci/tests/test_vllm_torch_nightly_triage.py
@@ -1,0 +1,168 @@
+"""Tests for the torch-nightly regression detector, driven by a recorded fixture.
+
+The fixture is the two raw ClickHouse result sets, captured with
+``--record-clickhouse`` from the run that produced build pair 82789/82790
+(https://github.com/pytorch/test-infra/actions/runs/31517070041). Replaying it
+reproduces that run's report.md byte for byte, so these tests pin real behaviour
+rather than hand-built rows.
+
+Note report.json is *not* usable here: it holds the pipeline's output (the
+regressed/both buckets), not the inputs, so it cannot exercise the pair selection
+or bucketing that produced it.
+"""
+
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+from torchci.vllm_torch_nightly_triage import (
+    agent_concentration,
+    cluster_key,
+    compare,
+    find_latest_pair,
+    render,
+    ReplayClient,
+)
+
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+FIXTURE = FIXTURES_DIR / "clickhouse_vllm_builds_jobs_82789.json"
+
+# The pair the fixture was recorded around, and its bucket counts.
+TORCH_NIGHTLY_BUILD = 82789
+BASELINE_BUILD = 82790
+COMMIT = "b706fd1628b06c216a945176a9fedfa808324803"
+
+
+def client() -> ReplayClient:
+    return ReplayClient.from_file(str(FIXTURE))
+
+
+class TestReplayClient(unittest.TestCase):
+    def test_routes_queries_by_table(self) -> None:
+        c = client()
+        builds = c.query("SELECT 1 FROM vllm.vllm_buildkite_builds FINAL")
+        jobs = c.query("SELECT 1 FROM vllm.vllm_buildkite_jobs FINAL")
+        self.assertNotEqual(builds.result_rows, jobs.result_rows)
+        self.assertIn("number", builds.column_names)
+        self.assertIn("job_name", jobs.column_names)
+
+    def test_rejects_unknown_query(self) -> None:
+        with self.assertRaises(ValueError):
+            client().query("SELECT 1 FROM some.other_table")
+
+    def test_datetimes_round_trip(self) -> None:
+        """created_at must come back as a datetime; find_latest_pair subtracts them."""
+        rows = client().query("SELECT 1 FROM vllm.vllm_buildkite_builds").result_rows
+        created_at_index = 3
+        self.assertTrue(rows)
+        self.assertIsInstance(rows[0][created_at_index], datetime)
+
+
+class TestFindLatestPair(unittest.TestCase):
+    def test_selects_the_same_commit_pair(self) -> None:
+        tn, base = find_latest_pair(client(), 14)
+        self.assertEqual(tn["number"], TORCH_NIGHTLY_BUILD)
+        self.assertEqual(base["number"], BASELINE_BUILD)
+        self.assertEqual(tn["commit"], COMMIT)
+        self.assertEqual(tn["commit"], base["commit"])
+
+    def test_prefers_the_plain_nightly_over_the_daily(self) -> None:
+        _, base = find_latest_pair(client(), 14)
+        self.assertTrue(base["title"].startswith("Full CI run - nightly"))
+
+    def test_skips_newer_torch_nightlies_that_have_no_sibling(self) -> None:
+        """The newest torch-nightly is not always the answer.
+
+        This fixture holds two off-schedule torch-nightly builds (#83338, #83159)
+        newer than the pair, neither with a same-commit baseline. Taking
+        nightlies[0] would return None and report nothing; the walk must continue
+        past them. Guards the loop in find_latest_pair against being simplified.
+        """
+        rows = client().query("SELECT 1 FROM vllm.vllm_buildkite_builds").result_rows
+        title_index, number_index = 1, 0
+        torch_nightlies = [
+            r[number_index]
+            for r in rows
+            if str(r[title_index]).startswith("Full CI run torch nightly")
+        ]
+        self.assertGreater(max(torch_nightlies), TORCH_NIGHTLY_BUILD)
+
+        tn, _ = find_latest_pair(client(), 14)
+        self.assertEqual(tn["number"], TORCH_NIGHTLY_BUILD)
+
+
+class TestCompare(unittest.TestCase):
+    def setUp(self) -> None:
+        self.buckets = compare(client(), TORCH_NIGHTLY_BUILD, BASELINE_BUILD)
+
+    def test_bucket_counts(self) -> None:
+        self.assertEqual(len(self.buckets["regressed"]), 26)
+        self.assertEqual(len(self.buckets["both"]), 8)
+        self.assertEqual(len(self.buckets["baseline_only"]), 4)
+
+    def test_regressed_means_failed_here_and_passed_on_baseline(self) -> None:
+        for job in self.buckets["regressed"]:
+            self.assertIn(job["state"], ("failed", "timed_out"))
+            self.assertEqual(job["baseline_state"], "passed")
+
+    def test_both_bucket_fails_on_baseline_too(self) -> None:
+        for job in self.buckets["both"]:
+            self.assertIn(job["state"], ("failed", "timed_out"))
+            self.assertIn(job["baseline_state"], ("failed", "timed_out"))
+
+    def test_sharded_jobs_are_labelled_individually(self) -> None:
+        """Shards of one job name disagree, so each needs its own row."""
+        sharded = [j for j in self.buckets["regressed"] if "[shard " in j["name"]]
+        self.assertTrue(sharded)
+        self.assertEqual(len(sharded), len({j["name"] for j in sharded}))
+
+
+class TestClusterKey(unittest.TestCase):
+    def test_collapses_shard_suffix(self) -> None:
+        self.assertEqual(
+            cluster_key("Multi-Modal Processor 4"), "Multi-Modal Processor"
+        )
+
+    def test_collapses_hardware_qualifier(self) -> None:
+        self.assertEqual(cluster_key("Fusion E2E TP2 (B200)"), "Fusion E2E TP2")
+
+    def test_collapses_both(self) -> None:
+        self.assertEqual(
+            cluster_key("Multi-Modal Processor (CPU) 3"), "Multi-Modal Processor"
+        )
+
+    def test_never_returns_empty(self) -> None:
+        self.assertEqual(cluster_key("(B200)"), "(B200)")
+
+    def test_fixture_regressions_collapse_into_fewer_clusters(self) -> None:
+        buckets = compare(client(), TORCH_NIGHTLY_BUILD, BASELINE_BUILD)
+        clusters = {cluster_key(j["name"]) for j in buckets["regressed"]}
+        self.assertEqual(len(clusters), 25)
+        self.assertLess(len(clusters), len(buckets["regressed"]))
+
+
+class TestRender(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tn, self.base = find_latest_pair(client(), 14)
+        self.buckets = compare(client(), self.tn["number"], self.base["number"])
+        self.report = render(self.tn, self.base, self.buckets)
+
+    def test_headline_counts_the_regressions(self) -> None:
+        self.assertIn("**26 job(s) regressed**", self.report)
+
+    def test_links_both_builds_and_the_shared_commit(self) -> None:
+        self.assertIn(f"#{TORCH_NIGHTLY_BUILD}", self.report)
+        self.assertIn(f"#{BASELINE_BUILD}", self.report)
+        self.assertIn(COMMIT[:12], self.report)
+
+    def test_reports_no_single_agent_concentration(self) -> None:
+        """22 agents carry 26 failures here, so this is real signal, not a sick host."""
+        agents = agent_concentration(self.buckets["regressed"])
+        self.assertEqual(len(agents), 22)
+        self.assertLess(agents[0][1] / len(self.buckets["regressed"]), 0.5)
+        self.assertIn("No single-host concentration", self.report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/torchci/vllm_torch_nightly_triage.py
+++ b/tools/torchci/vllm_torch_nightly_triage.py
@@ -21,6 +21,16 @@ This script finds the most recent such pair and reports the delta. It reads only
 job metadata from ClickHouse -- log *contents* are not ingested (the tables carry
 ``log_url`` pointers only), so this identifies *which* jobs regressed and groups
 them, but not *why*. Root-causing means reading the linked logs.
+
+ClickHouse access can be recorded and replayed, so the detection logic is
+runnable and testable without credentials::
+
+    # once, with credentials
+    python3 -m torchci.vllm_torch_nightly_triage --record-clickhouse rows.json ...
+    # thereafter, anywhere
+    python3 -m torchci.vllm_torch_nightly_triage --replay-clickhouse rows.json ...
+
+Replaying a recording reproduces that run's report.md and report.json exactly.
 """
 
 from __future__ import annotations
@@ -30,7 +40,8 @@ import json
 import re
 import sys
 from collections import Counter, defaultdict
-from typing import Any, Dict, List, Optional, Tuple
+from datetime import date, datetime
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
 from torchci.clickhouse import get_clickhouse_client
 from torchci.vllm_log_parser import parse_log, strip_markers
@@ -73,6 +84,98 @@ def cluster_key(job_name: str) -> str:
 
 def _rows(client: Any, query: str, params: Dict[str, Any]) -> List[Tuple]:
     return client.query(query, parameters=params).result_rows
+
+
+# --- record/replay -----------------------------------------------------------
+#
+# ClickHouse holds the only inputs this script cannot reconstruct offline, and the
+# credentials to read it are not something every contributor has. Recording the raw
+# result sets makes the detection half (find_latest_pair, compare, render) runnable
+# and testable from a file. report.json is not a substitute: it is the *output* of
+# that pipeline, carrying only the regressed/both buckets, so it can exercise the
+# issue-filing half but not the bucketing that produced it.
+#
+# Result sets are keyed by the table the query reads rather than by query text or
+# call order, so a fixture survives reformatting the SQL and stays readable.
+
+
+def _table_key(query: str) -> str:
+    if "vllm_buildkite_builds" in query:
+        return "builds"
+    if "vllm_buildkite_jobs" in query:
+        return "jobs"
+    raise ValueError(f"cannot map query to a recorded result set: {query[:80]!r}")
+
+
+def _encode(value: Any) -> Any:
+    """Tag the types JSON cannot round-trip. Everything here is scalar."""
+    if isinstance(value, datetime):
+        return {"__datetime__": value.isoformat()}
+    if isinstance(value, date):
+        return {"__date__": value.isoformat()}
+    return value
+
+
+def _decode(value: Any) -> Any:
+    if isinstance(value, dict):
+        if "__datetime__" in value:
+            return datetime.fromisoformat(value["__datetime__"])
+        if "__date__" in value:
+            return date.fromisoformat(value["__date__"])
+    return value
+
+
+class _Result:
+    """The subset of clickhouse_connect's QueryResult that this script touches."""
+
+    def __init__(self, columns: Sequence[str], rows: List[Tuple]) -> None:
+        self.column_names = list(columns)
+        self.result_rows = rows
+
+
+class RecordingClient:
+    """Passes queries through to ClickHouse, keeping each raw result set."""
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+        self.recorded: Dict[str, Dict[str, Any]] = {}
+
+    def query(self, query: str, parameters: Optional[Dict[str, Any]] = None) -> Any:
+        result = self._inner.query(query, parameters=parameters)
+        self.recorded[_table_key(query)] = {
+            "columns": list(result.column_names),
+            "rows": [[_encode(v) for v in row] for row in result.result_rows],
+        }
+        return result
+
+    def dump(self, path: str) -> None:
+        with open(path, "w") as f:
+            json.dump({"clickhouse": self.recorded}, f, indent=1)
+
+
+class ReplayClient:
+    """Serves the result sets from a recorded dump; needs no credentials."""
+
+    def __init__(self, tables: Dict[str, Dict[str, Any]]) -> None:
+        self._tables = tables
+
+    @classmethod
+    def from_file(cls, path: str) -> "ReplayClient":
+        with open(path) as f:
+            return cls(json.load(f)["clickhouse"])
+
+    def query(self, query: str, parameters: Optional[Dict[str, Any]] = None) -> Any:
+        key = _table_key(query)
+        try:
+            payload = self._tables[key]
+        except KeyError:
+            raise KeyError(
+                f"recording has no {key!r} result set (has: {sorted(self._tables)})"
+            ) from None
+        rows: Iterable[List[Any]] = payload["rows"]
+        return _Result(
+            payload["columns"], [tuple(_decode(v) for v in row) for row in rows]
+        )
 
 
 def find_latest_pair(
@@ -437,9 +540,28 @@ def main() -> int:
         "(requires BUILDKITE_TOKEN)",
     )
     parser.add_argument("--log-tail-lines", type=int, default=400)
+    parser.add_argument(
+        "--record-clickhouse",
+        metavar="PATH",
+        help="also write the raw ClickHouse result sets here, for offline replay",
+    )
+    parser.add_argument(
+        "--replay-clickhouse",
+        metavar="PATH",
+        help="read the result sets from a --record-clickhouse dump instead of "
+        "querying ClickHouse (needs no credentials)",
+    )
     args = parser.parse_args()
 
-    client = get_clickhouse_client()
+    if args.replay_clickhouse:
+        if args.record_clickhouse:
+            parser.error("--record-clickhouse and --replay-clickhouse are exclusive")
+        client: Any = ReplayClient.from_file(args.replay_clickhouse)
+    else:
+        client = get_clickhouse_client()
+        if args.record_clickhouse:
+            client = RecordingClient(client)
+
     pair = find_latest_pair(client, args.lookback_days)
     if pair is None:
         print(
@@ -447,11 +569,19 @@ def main() -> int:
             f"{args.lookback_days} days; nothing to compare.",
             file=sys.stderr,
         )
+        # Still worth dumping: a recording of this case is what reproduces it.
+        if args.record_clickhouse:
+            client.dump(args.record_clickhouse)
         return 0
 
     tn, base = pair
     buckets = compare(client, tn["number"], base["number"])
     report = render(tn, base, buckets)
+
+    # After compare(), so the dump holds both result sets.
+    if args.record_clickhouse:
+        client.dump(args.record_clickhouse)
+        print(f"recorded ClickHouse rows to {args.record_clickhouse}", file=sys.stderr)
 
     if args.output:
         with open(args.output, "w") as f:


### PR DESCRIPTION
Makes the ClickHouse data behind the [vLLM torch-nightly triage](https://github.com/pytorch/test-infra/actions/runs/31517070041) extractable to a file, so the detection logic can be run and tested without credentials.

### Why report.json isn't enough

The workflow already uploads `report.json`, but that is the pipeline's **output**, not its input. It carries `regressed` and `both` only — `baseline_only` is dropped, and the builds list never appears at all. So it can drive the issue-filing half (which is exactly what the `file-issues` job uses it for) but cannot exercise the pair selection or bucketing that produced it.

### What this adds

- `--record-clickhouse PATH` — dump the two raw result sets (`vllm_buildkite_builds`, `vllm_buildkite_jobs`) alongside the normal report.
- `--replay-clickhouse PATH` — run the whole pipeline from that dump, no credentials needed.

Result sets are keyed by the table the query reads rather than by query text or call order, so a recording survives reformatting the SQL and stays readable/hand-editable.

```bash
# once, with credentials
python3 -m torchci.vllm_torch_nightly_triage --record-clickhouse rows.json --output report.md
# thereafter, anywhere
python3 -m torchci.vllm_torch_nightly_triage --replay-clickhouse rows.json --output report.md
```

### Fixture and tests

Commits a recording from build pair **82789/82790** (the pair run 31517070041 found) and adds 18 tests against it. `vllm_torch_nightly_triage.py` had no tests before this.

Verified: replaying the committed fixture with `CLICKHOUSE_*` unset from the environment reproduces that run's `report.md` **byte for byte**.

`report.json` matches on every scalar field and on the exact contents of both buckets, with two known differences:

- `torch_version` is empty on replay. It is scraped from Buildkite **log bodies**, which replay does not fetch, so it is not recoverable from ClickHouse alone.
- Array **order** differs. The jobs query is `GROUP BY job_name, shard` with no `ORDER BY`, so ClickHouse returns groups in an arbitrary order — the buckets are the same 26 and 8 jobs either way. This is pre-existing and means `report.json` array order is already nondeterministic run to run; adding an `ORDER BY` would fix it, but that changes the production query so I have left it out of this PR.

The recording also happens to capture a case worth pinning — two off-schedule torch-nightly builds (#83338, #83159) newer than the pair, neither with a same-commit baseline. `find_latest_pair` has to walk past both; a `nightlies[0]` simplification would return `None` and report nothing. That is now a test.

Provenance of the fixture: re-querying ClickHouse ~12 minutes after recording returns the jobs result set with an identical multiset of rows (0 differing in either direction, order aside) and 633 of 634 builds rows identical — the one difference is build #83442 advancing `running` -> `failing` while it ran. The builds snapshot is from ~22:01 UTC, after the 17:20 UTC run, so it includes builds the run itself never saw; it still selects the same pair, which is why report.md is unaffected.

Fixture is 255KB, about half the size of the existing `raw_log_64854_elastic_ep_scaling.txt`. Contents are public Buildkite metadata plus CI agent hostnames, both of which already appear in the run's published step summary and in the issues this workflow files.

### Test plan

```
$ PYTHONPATH=. python -m pytest torchci/tests/test_vllm_torch_nightly_triage.py -q
18 passed

# existing tests unaffected
$ PYTHONPATH=. python -m pytest torchci/tests/test_vllm_log_parser.py -q
74 passed
```

mypy and ruff format clean on both files.