### PR TITLE
Allow-list the release lines' RC and GA tags for runner groups

### DIFF
--- a/tools/scripts/release_manage_runner_groups.py
+++ b/tools/scripts/release_manage_runner_groups.py
@@ -7,10 +7,12 @@ staging clusters are excluded) in sync with a desired state computed from
 
 - ensure ``pytorch/pytorch`` is an allowed repository (add-only), and
 - restrict allowed workflows to the release workflows discovered in
-  ``pytorch/pytorch``, pinned to ``main``, ``nightly`` and the release branches
+  ``pytorch/pytorch``, pinned to ``main``, ``nightly``, the release branches
   around the test-channel version (the ``release/X.Y`` anchor read from
   ``generate_binary_build_matrix.py`` plus the preceding protected release
-  branch).
+  branch), and each pinned line's release tags (its newest ``v<version>`` and
+  ``v<version>-rc<n>``, which is where the release binaries are actually built
+  from).
 
 Release workflows are discovered, not hardcoded, by the release runner label
 they run on (the ``rel-`` marker, e.g. ``rel-l-x86iavx512-44-340``). An entry
@@ -145,13 +147,89 @@ def select_target_refs(
     return [f"refs/heads/{name}" for name in selected]
 
 
+def release_lines(refs: Iterable[str]) -> List[Tuple[int, int]]:
+    """The ``(major, minor)`` release lines among the selected branch refs."""
+    lines = []
+    for ref in refs:
+        match = RELEASE_BRANCH_RE.match(ref.removeprefix("refs/heads/"))
+        if match is not None:
+            lines.append((int(match.group(1)), int(match.group(2))))
+    return lines
+
+
+def release_tag_re(line: Tuple[int, int]) -> "re.Pattern[str]":
+    """Matches the GA and release-candidate tags on release line ``X.Y``.
+
+    pytorch/pytorch tags releases as ``v<version>``, with candidates numbered
+    ``v<version>-rc<n>``: ``v2.13.0``, ``v2.13.0-rc15``, ``v2.13.1-rc1``.
+    """
+    return re.compile(rf"^v{line[0]}\.{line[1]}\.(\d+)(?:-rc(\d+))?$")
+
+
+def select_target_tags(tag_names: Iterable[str], line: Tuple[int, int]) -> List[str]:
+    """The newest GA tag and the newest release-candidate tag on line ``X.Y``.
+
+    Release binaries are built from tags, not branches: pushing ``v2.14.0-rc1``
+    runs the build workflows at ``refs/tags/v2.14.0-rc1``. GitHub matches
+    ``selected_workflows`` entries on the exact ref, so the
+    ``@refs/heads/release/2.14`` entry does not authorize that run and the tag
+    has to be pinned in its own right.
+
+    Newest wins by ``(patch, rc)``, so a patch release supersedes the line's
+    previous tags (``v2.13.1-rc1`` over ``v2.13.0-rc15``). Only one of each is
+    kept: a new tag supersedes the last, and pinning every one would grow both
+    the allow-list and the per-ref discovery cost by a workflow set per tag
+    (2.13 reached rc15).
+    """
+    pattern = release_tag_re(line)
+    ga: List[Tuple[int, str]] = []
+    candidates: List[Tuple[Tuple[int, int], str]] = []
+    for name in tag_names:
+        match = pattern.match(name)
+        if match is None:
+            continue
+        patch, number = int(match.group(1)), match.group(2)
+        if number is None:
+            ga.append((patch, name))
+        else:
+            candidates.append(((patch, int(number)), name))
+    selected: List[str] = []
+    if ga:
+        selected.append(max(ga)[1])
+    if candidates:
+        selected.append(max(candidates)[1])
+    return [f"refs/tags/{name}" for name in selected]
+
+
+def get_release_tags(client: GitHubClient, line: Tuple[int, int]) -> List[str]:
+    # matching-refs returns every ref under the prefix in a single request;
+    # listing /tags would page through pytorch/pytorch's entire tag history. The
+    # trailing dot keeps a v2.1. prefix off v2.14.0, and the names are still
+    # filtered against the exact tag pattern.
+    prefix = f"v{line[0]}.{line[1]}."
+    refs = client.request(
+        "GET", f"/repos/{TARGET_REPO}/git/matching-refs/tags/{prefix}"
+    ).json()
+    names = [str(ref["ref"]).removeprefix("refs/tags/") for ref in refs]
+    return select_target_tags(names, line)
+
+
 def get_target_refs(client: GitHubClient) -> List[str]:
     anchor = get_test_version_anchor()
     log(f"Test-channel version anchor: release/{anchor[0]}.{anchor[1]}")
     branches = client.paginate(
         f"/repos/{TARGET_REPO}/branches", params={"protected": "true"}
     )
-    return select_target_refs((branch["name"] for branch in branches), anchor)
+    refs = select_target_refs((branch["name"] for branch in branches), anchor)
+    # Every pinned release line gets its tags, not just the candidate's, so a
+    # patch release on the preceding line keeps runner access too.
+    tags = [
+        tag for line in release_lines(refs) for tag in get_release_tags(client, line)
+    ]
+    if not tags:
+        # Expected between a branch cut and the line's first RC tag.
+        log("No release tags cut yet on the pinned release lines")
+    return refs + tags
 
 
 # --- Desired state: workflow discovery -------------------------------------
@@ -301,7 +379,7 @@ def discover_release_workflows(
     """
     paths_by_ref: Dict[str, Set[str]] = {}
     for ref in refs:
-        rev = ref.removeprefix("refs/heads/")
+        rev = ref.removeprefix("refs/heads/").removeprefix("refs/tags/")
         paths = collect_release_workflow_paths(fetch_workflow_files(client, rev))
         log(f"Discovered {len(paths)} release workflow(s) on {TARGET_REPO}@{rev}:")
         for path in sorted(paths):

--- a/tools/tests/test_release_manage_runner_groups.py
+++ b/tools/tests/test_release_manage_runner_groups.py
@@ -81,6 +81,63 @@ class TestSelectTargetRefs(TestCase):
         )
 
 
+class TestReleaseLines(TestCase):
+    def test_only_release_branches(self) -> None:
+        refs = [
+            "refs/heads/main",
+            "refs/heads/nightly",
+            "refs/heads/release/2.14",
+            "refs/heads/release/2.13",
+        ]
+        self.assertEqual(m.release_lines(refs), [(2, 14), (2, 13)])
+
+
+class TestSelectTargetTags(TestCase):
+    def test_ga_and_newest_candidate(self) -> None:
+        names = ["v2.14.0-rc1", "v2.14.0-rc2", "v2.14.0"]
+        self.assertEqual(
+            m.select_target_tags(names, (2, 14)),
+            ["refs/tags/v2.14.0", "refs/tags/v2.14.0-rc2"],
+        )
+
+    def test_candidate_only_before_ga(self) -> None:
+        self.assertEqual(
+            m.select_target_tags(["v2.14.0-rc1"], (2, 14)),
+            ["refs/tags/v2.14.0-rc1"],
+        )
+
+    def test_patch_release_supersedes_shipped_tags(self) -> None:
+        # The preceding line is still patchable: v2.13.1-rc1 must win over the
+        # rc15 that shipped as v2.13.0.
+        names = ["v2.13.0-rc15", "v2.13.0", "v2.13.1-rc1"]
+        self.assertEqual(
+            m.select_target_tags(names, (2, 13)),
+            ["refs/tags/v2.13.0", "refs/tags/v2.13.1-rc1"],
+        )
+
+    def test_sorts_candidates_numerically_not_lexically(self) -> None:
+        # rc9 must rank below rc10 despite string ordering.
+        names = ["v2.13.0-rc9", "v2.13.0-rc10"]
+        self.assertEqual(
+            m.select_target_tags(names, (2, 13)),
+            ["refs/tags/v2.13.0-rc10"],
+        )
+
+    def test_ignores_other_release_lines(self) -> None:
+        names = ["v2.1.0", "v2.1.0-rc1", "v2.14.0-rc1", "v3.1.0-rc1"]
+        self.assertEqual(
+            m.select_target_tags(names, (2, 1)),
+            ["refs/tags/v2.1.0", "refs/tags/v2.1.0-rc1"],
+        )
+
+    def test_ignores_unconventional_tags(self) -> None:
+        names = ["v2.14.0-rc1-test", "v2.14.0rc1", "2.14.0-rc1", "v2.14.0-rc", "v2.14"]
+        self.assertEqual(m.select_target_tags(names, (2, 14)), [])
+
+    def test_no_tags_yet(self) -> None:
+        self.assertEqual(m.select_target_tags([], (2, 14)), [])
+
+
 class TestUsesReleaseLabel(TestCase):
     def test_matches_release_labels(self) -> None:
         self.assertTrue(m.uses_release_label("runs-on: rel-l-x86iavx512-44-340"))


### PR DESCRIPTION
Release binaries are built from **tags, not branches**: pushing `v2.14.0-rc1` runs the build workflows at `refs/tags/v2.14.0-rc1`. GitHub matches `selected_workflows` entries on the exact ref, so the `@refs/heads/release/2.14` entries this script already emits don't authorize those runs — which is why https://github.com/pytorch/pytorch/actions/runs/31528881582 needed the tag added to the runner groups by hand.

Emit tag refs alongside the branch refs, for **every pinned release line**, so a patch release on the preceding line keeps runner access too. Each line contributes its newest GA tag and its newest `v<version>-rc<n>`, ranked by `(patch, rc)` so `v2.13.1-rc1` supersedes the rc15 that shipped as `v2.13.0`.

Only the newest of each is kept — pinning every tag would grow the allow-list and the per-ref discovery cost by a workflow set per tag (2.13 reached rc15). Eviction is safe: the allow-list is checked when a job starts, so in-flight builds are unaffected.

Tags come from `git/matching-refs`, one request instead of paging pytorch/pytorch's whole tag history.

## Testing

8 new unit tests, 22 pass. `lintrunner` clean. End-to-end against the live API in discovery-only mode:

```
Target refs: ['refs/heads/main', 'refs/heads/nightly', 'refs/heads/release/2.14',
              'refs/heads/release/2.13', 'refs/tags/v2.14.0-rc1',
              'refs/tags/v2.13.0', 'refs/tags/v2.13.0-rc15']
Desired allow-list (39 references):
  ...generated-linux-binary-manywheel-nightly.yml@refs/tags/v2.14.0-rc1
```

https://github.com/pytorch/test-infra/actions/runs/31543618002/job/93951275801#step:4:15