### PR TITLE
Ship a single ROCm version to the nightly getting-started matrix

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -131,6 +131,10 @@ ENABLE = "enable"
 DISABLE = "disable"
 
 
+def parse_version(version: str) -> Tuple[int, ...]:
+    return tuple(int(part) for part in version.split("."))
+
+
 def arch_type(arch_version: str) -> str:
     if arch_version in CUDA_ARCHES:
         return CUDA
@@ -182,6 +186,8 @@ def initialize_globals(
 
     CUDA_ARCHES = CUDA_ARCHES_DICT[channel]
     ROCM_ARCHES = ROCM_ARCHES_DICT[channel]
+    if getting_started and channel == NIGHTLY:
+        ROCM_ARCHES = [max(ROCM_ARCHES, key=parse_version)]
     if build_python_only:
         # Only select the oldest version of python if building a python only package
         PYTHON_ARCHES = [PYTHON_ARCHES_DICT[channel][0]]

--- a/tools/tests/test_generate_binary_build_matrix.py
+++ b/tools/tests/test_generate_binary_build_matrix.py
@@ -4,7 +4,11 @@ import os
 import sys
 from unittest import main, TestCase
 
-from tools.scripts.generate_binary_build_matrix import generate_build_matrix
+from tools.scripts.generate_binary_build_matrix import (
+    generate_build_matrix,
+    parse_version,
+    ROCM_ARCHES_DICT,
+)
 
 
 ASSETS_DIR = "tools/tests/assets"
@@ -199,6 +203,46 @@ class GenerateBuildMatrixTest(TestCase):
                 # torchvision is not published for these versions yet.
                 self.assertNotIn("torchvision", entry["installation"])
                 self.assertIn("torch", entry["installation"])
+
+    def _rocm_versions(self, channel: str, getting_started: str) -> set:
+        out = generate_build_matrix(
+            "wheel",
+            "linux",
+            channel,
+            "enable",
+            "enable",
+            "enable",
+            "enable",
+            "false",
+            "false",
+            "disable",
+            getting_started,
+            None,
+        )
+        return {
+            entry["gpu_arch_version"]
+            for entry in out["include"]
+            if entry["gpu_arch_type"] == "rocm"
+        }
+
+    def test_parse_version_orders_double_digit_minors(self):
+        self.assertGreater(parse_version("7.14"), parse_version("7.2"))
+        self.assertEqual(
+            max(["7.2", "7.14"], key=parse_version),
+            "7.14",
+        )
+
+    def test_getting_started_nightly_ships_one_rocm(self):
+        versions = self._rocm_versions("nightly", "true")
+        self.assertEqual(len(versions), 1)
+        self.assertEqual(
+            versions, {max(ROCM_ARCHES_DICT["nightly"], key=parse_version)}
+        )
+
+    def test_nightly_builds_keep_every_rocm(self):
+        versions = self._rocm_versions("nightly", "false")
+        self.assertEqual(versions, set(ROCM_ARCHES_DICT["nightly"]))
+        self.assertGreater(len(versions), 1)
 
 
 def parse_args():


### PR DESCRIPTION
pytorch.org/get-started/locally/ advertises **ROCm 7.2** as the nightly ROCm, even though 7.14 is current.

### Why

The getting-started page renders exactly one ROCm choice. `pytorch.github.io`'s `gen_quick_start_module.py` picks which one with a plain `max()` over version *strings*:

```python
acc_arch_ver_map[chan]["rocm5.x"] = ("rocm", max(rocm_ver_list.values()))
```

```
>>> "7.14" > "7.2"
False                      # '1' < '2' at the third character
>>> max({"7.2", "7.14"})
'7.2'
```

So once `ROCM_ARCHES_DICT["nightly"]` became `["7.2", "7.14"]`, the page started showing the older one. This never bit before because ROCm minors were single-digit; 7.14 is the first two-digit minor.

That is also why [pytorch.github.io#2130](https://github.com/pytorch/pytorch.github.io/pull/2130) landed touching only `releases.json` and not `published_versions.json` — the generator recomputed the same `rocm7.2` command it already had, so there was no diff. Re-running or re-deploying it would not help.

### Fix

Send the page one ROCm version instead of two, chosen with a version-aware key:

```python
if getting_started and channel == NIGHTLY:
    ROCM_ARCHES = [max(ROCM_ARCHES, key=parse_version)]
```

Fixing it here rather than in the website's `max()` means the page cannot pick wrong, because it is only ever offered one option.

### Scope

Deliberately narrow — `getting_started` **and** `nightly`:

| | rocm arches |
|---|---|
| nightly, getting-started | `['7.14']` |
| nightly, normal build matrix | `['7.2', '7.14']` unchanged |
| release, getting-started | `['7.1', '7.2']` unchanged |
| test, getting-started | `['7.2', '7.14']` unchanged |

**The binary build matrix is untouched** — nightly still builds every ROCm in `ROCM_ARCHES_DICT`. None of the `tools/tests/assets/*.json` snapshots use `--getting-started`, and all are byte-identical.

Verified end to end by replaying the website's own logic against the new matrix:

```
getting-started=false  rocm_ver_list={'rocm7.2': '7.2', 'rocm7.14': '7.14'}
                       website max() picks -> '7.2'
getting-started=true   rocm_ver_list={'rocm7.14': '7.14'}
                       website max() picks -> '7.14'
```

### Still latent, not addressed here

The `release` channel getting-started matrix still ships two ROCm versions (`7.1`, `7.2`). It happens to be correct today because `"7.2" > "7.1"` as strings too — but it will break the same way the moment a double-digit minor reaches release. Same one-line treatment applies whenever you want it; left out to keep this scoped to the reported problem.

### Test plan

```
$ python -m tools.tests.test_generate_binary_build_matrix
Ran 14 tests in 0.005s
OK
```

Three new tests: `parse_version` orders `7.14` above `7.2`; nightly getting-started yields exactly one ROCm and it is the newest; nightly normal builds still yield every ROCm (guards against this leaking into the build matrix).

mypy, ruff format and usort clean.