### PR TITLE
Poll for new RC tags in the runner-group reconcile

### DIFF
--- a/.github/workflows/release-manage-runner-groups.yml
+++ b/.github/workflows/release-manage-runner-groups.yml
@@ -1,20 +1,29 @@
 name: Release manage runner groups
 
 on:
-  # The desired state only changes at release milestones, so run on demand and
-  # when the test-channel version is advanced (the go-live bump), rather than on
-  # a cron.
   workflow_dispatch:
     inputs:
       apply:
         description: "Apply changes (otherwise dry-run)"
         type: boolean
         default: false
+  schedule:
+    # The allow-list pins the newest RC per release line, and RC tags are cut in
+    # pytorch/pytorch -- which cannot trigger anything in this repo. So the only
+    # way to notice a new RC is to poll. Without this the allow-list goes stale
+    # the moment a tag is cut and every release build queues indefinitely, since
+    # GitHub matches selected_workflows on the exact ref. Off the hour to dodge
+    # the top-of-hour scheduling backlog.
+    - cron: "23 * * * *"
   push:
     branches:
       - main
     paths:
       - tools/scripts/generate_binary_build_matrix.py
+      # This workflow and its script must redeploy themselves; a change to the
+      # reconcile logic that never runs is not deployed.
+      - tools/scripts/release_manage_runner_groups.py
+      - .github/workflows/release-manage-runner-groups.yml
   pull_request:
     paths:
       - .github/workflows/release-manage-runner-groups.yml
@@ -26,8 +35,12 @@ permissions:
   contents: read
 
 concurrency:
+  # Not cancel-in-progress: the applying run mutates runner-group config, and
+  # now that a schedule fires hourly it can collide with a release-time manual
+  # dispatch. Killing that mid-apply would leave the allow-list half-written.
+  # Runs are short API calls, so queueing them costs little.
   group: release-manage-runner-groups
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   reconcile:
@@ -49,10 +62,11 @@ jobs:
           # read-only discovery on PRs.
           RUNNER_GROUP_TOKEN: ${{ secrets.RUNNER_GROUP_TOKEN }}
           GITHUB_TOKEN: ${{ github.token }}
-          # Apply only from main, and only for the go-live push (matrix version
-          # bump) or an explicit dispatch with apply=true. Everything else is a
-          # dry-run.
-          SHOULD_APPLY: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || inputs.apply) }}
+          # Apply only from main, and only for a push (matrix or reconcile-logic
+          # change), the schedule, or an explicit dispatch with apply=true.
+          # Everything else is a dry-run. The schedule must apply or it would
+          # poll forever and never act on the new RC it just discovered.
+          SHOULD_APPLY: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'schedule' || inputs.apply) }}
         run: |
           SCRIPT=tools/scripts/release_manage_runner_groups.py
           if [ "${SHOULD_APPLY}" = "true" ]; then


### PR DESCRIPTION
`v2.14.0-rc2` was tagged at 12:36 UTC today, and all 7 `mt-rel-*` jobs of its [docker-release run](https://github.com/pytorch/pytorch/actions/runs/31597398139) have been queued ever since. The runner-group allow-list still pins `v2.14.0-rc1`, and GitHub matches `selected_workflows` on the exact ref, so nothing is authorized to pick them up.

### Why the allow-list is stale

#8502 taught the reconcile to allow-list RC tags — that part works. What is missing is anything that re-runs it when a tag is cut.

RC tags are created in **pytorch/pytorch**, which cannot trigger a workflow in **test-infra**. The only automatic trigger here was a push touching `generate_binary_build_matrix.py`. So:

| time (UTC) | event |
|---|---|
| Aug 11 19:09 | `v2.14.0-rc1` tagged |
| Aug 11 23:15 | #8502 merges — **no run triggered**, its own script is not in the push paths |
| Aug 11 23:16, 23:17 | manual dispatches — this is what actually deployed #8502, pinning rc1 |
| Aug 11 23:34 | push run via #8503, still rc1 |
| **Aug 12 12:36** | **`v2.14.0-rc2` tagged** |
| Aug 12 12:38 | 7 jobs queue at `refs/tags/v2.14.0-rc2` |
| — | no run on `main` since Aug 11 23:34 |

The allow-list is only ever as fresh as the last unrelated matrix change, or the last time somebody remembered to dispatch by hand.

#8502 deliberately skipped a cron — *"the desired state only changes at release milestones, so run on demand"*. That reasoning is right about frequency and wrong about observability: a new RC **is** a milestone, but it happens in another repo, so "on demand" silently means "a human notices the queue".

### Changes

**Hourly schedule, which applies.** A polling run that only ever dry-ran would discover the new RC and then do nothing about it, so `SHOULD_APPLY` now includes `schedule`. Cron is at `:23` to dodge the top-of-hour scheduling backlog. This caps staleness at ~1h instead of unbounded.

**`release_manage_runner_groups.py` and this workflow added to the push paths.** They were absent, so a change to the reconcile logic never deployed itself — exactly why #8502 needed a manual dispatch a minute after merging. Second-order, but it is how the first hole stayed invisible.

**`cancel-in-progress: false`.** Harmless when runs were rare; with an hourly trigger it would let the scheduled run kill a release-time manual dispatch mid-apply and leave the allow-list half-written. Runs are short API calls, so queueing costs little.

### Verified

`actionlint` (1.6.21, the pinned version) clean. The apply gate resolves as intended for every event:

| ref | event | `apply` input | applies? | |
|---|---|---|---|---|
| main | push | — | yes | matrix / script change lands |
| main | schedule | — | **yes** | hourly poll picks up a new RC |
| main | workflow_dispatch | true | yes | manual apply |
| main | workflow_dispatch | false | no | manual dry-run (the default) |
| PR ref | pull_request | — | no | discovery only, no token |

The PR path stays discovery-only: the token is gated behind `environment: ${{ github.ref == 'refs/heads/main' && 'runner-group' || '' }}`, so forks and PRs never see it.

### This does not unblock rc2 by itself

Landing this starts the polling, but the currently-queued jobs need the allow-list updated now. Someone with access should dispatch [release-manage-runner-groups](https://github.com/pytorch/test-infra/actions/workflows/release-manage-runner-groups.yml) on `main` with **`apply: true`** — the allow-list is evaluated when a job starts, so the queued jobs should pick up without a re-run. Worth doing a dry run first to confirm `v2.14.0-rc2` appears in the computed set.

I inferred the stale-allow-list diagnosis from the run history plus #8502's newest-only pinning; I cannot read the runner-group config directly, since that needs `RUNNER_GROUP_TOKEN`. If an `apply: true` run does not release the queue, the cause is elsewhere and this PR is still worth having on its own merits.

### Frequency is a judgement call

Hourly trades ~24 cheap API-only runs/day against a worst case of ~1h of queued release builds. Happy to tighten to `*/30` or `*/15` if a release-day hour of dead queue is too much.