### PR TITLE
[Cherry-pick for release/2.13 branch]: Guard "Build clean" step to setup-py builds only- #8305

### DIFF
--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -176,6 +176,9 @@ jobs:
           repository: ${{ inputs.repository  }}
           script: ${{ inputs.pre-script }}
       - name: Build clean
+        # Only relevant for setup-py builds; python-build-package projects may
+        # not have a setup.py (e.g. scikit-build-core based builds).
+        if: ${{ inputs.build-platform == 'setup-py' }}
         working-directory: ${{ inputs.repository }}
         run: |
           set -euxo pipefail

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -236,7 +236,9 @@ jobs:
           echo SSL_CERT_FILE=%CERT_PATH% >> %GITHUB_ENV%
           echo REQUESTS_CA_BUNDLE=%CERT_PATH% >> %GITHUB_ENV%
       - name: Build clean
-        if: inputs.architecture == 'x64'
+        # Only relevant for setup-py builds; python-build-package projects may
+        # not have a setup.py (e.g. scikit-build-core based builds).
+        if: inputs.build-platform == 'setup-py' && inputs.architecture == 'x64'
         working-directory: ${{ inputs.repository }}
         env:
           ENV_SCRIPT: ${{ inputs.env-script }}


### PR DESCRIPTION
Cherry-pick of https://github.com/pytorch/test-infra/pull/8305 that I need to release TorchCodec (I'm releasing now, hence against the 2.13 branch without waiting for 2.14).