### PR TITLE
[Greenlight] Add ezyang and drisspg to the trusted-author set

### DIFF
--- a/greenlight/src/greenlight/review.py
+++ b/greenlight/src/greenlight/review.py
@@ -53,6 +53,8 @@ TRUSTED_AUTHORS: set[str] = {
     "izaitsevfb",  # Ivan Zaitsev
     "georgehong",  # George Hong
     "jeanschmidt",  # Jean Schmidt
+    "ezyang",  # Edward Yang
+    "drisspg",  # Driss Guessous
 }
 
 # Case-insensitive membership for the two authz gates (target-PR author and recheck requester);


### PR DESCRIPTION
✴️ iz2: opened on Ivan's ask.

Adds `ezyang` (Edward Yang) and `drisspg` (Driss Guessous) to `TRUSTED_AUTHORS`. Both were meant to be in the Greenlight MVP cohort but were never added, so their PRs are never scanned and neither can use `@greenlight recheck`.

Widens only the author gate — both are already in the merge-authorized set `merge_authz.py` resolves from `merge_rules.yaml`.

## Test plan

No test changes needed: every use of `TRUSTED_AUTHORS` is membership-agnostic, and the one test that references it compares against the constant itself. CI green.
