### PR TITLE
Normalize PACKAGE_LINKS_ALLOW_LIST to the spelling lookups actually use

### DIFF
--- a/s3_management/manage_v2.py
+++ b/s3_management/manage_v2.py
@@ -478,7 +478,10 @@ PT_R2_PACKAGES_PROD = {
 # instead of processing wheels in subdirectories
 # For example: whl/nightly/filelock/index.html -> whl/nightly/cu128/filelock/index.html
 PACKAGE_LINKS_ALLOW_LIST = {
-    x.lower()
+    # Normalized to the underscore spelling every lookup uses: package names are
+    # derived from wheel filenames, and get_packages_to_copy_from_parent maps
+    # parent directory names through the same replace() before comparing.
+    x.lower().replace("-", "_")
     for x in [
         "filelock",
         "sympy",
@@ -489,17 +492,11 @@ PACKAGE_LINKS_ALLOW_LIST = {
         "fsspec",
         "typing-extensions",
         "spmd-types",
-        "spmd_types",
         "cuda-bindings",
-        "cuda_bindings",
         "cuda-toolkit",
-        # Underscore spelling is the one that matches; see "spmd_types" above.
         "cuda-pathfinder",
-        "cuda_pathfinder",
         "cuda-python",
-        "cuda_python",
         "nvidia-ml-py",
-        "nvidia_ml_py",
         "nvidia-cuda-nvrtc-cu12",
         "nvidia-cuda-nvrtc",
         "nvidia-cuda-runtime-cu12",


### PR DESCRIPTION
`whl/test/cu134/typing-extensions/` does not exist, so every CUDA 13.4 smoke test on `v2.14.0-rc2` fails:

```
Looking in indexes: https://download.pytorch.org/whl/test/cu134
ERROR: Could not find a version that satisfies the requirement
       typing-extensions>=4.10.0 (from torch) (from versions: none)
```

All 8 Python versions of `manywheel-*-cuda13_4-test` fail this way ([run](https://github.com/pytorch/pytorch/actions/runs/31597398097)). `from versions: none` rather than a version complaint, because the smoke test installs from that single index with no PyPI fallback and the package directory simply is not there.

### Root cause

`typing-extensions` **is** in `PACKAGE_LINKS_ALLOW_LIST`, but the membership test can never succeed.

Every lookup compares an **underscore**-spelled name:

- package names come from wheel filenames via `obj_to_package_name` — `typing_extensions-4.16.0-...whl` -> `typing_extensions`
- `get_packages_to_copy_from_parent` maps parent directory names through the same conversion before comparing:

```python
# manage_v2.py:801-803
pkg_name_with_underscores = parts[0].replace("-", "_")
parent_packages.add(pkg_name_with_underscores)
...
if pkg_name.lower() in PACKAGE_LINKS_ALLOW_LIST:
```

But the set stored whatever spelling was typed, which for most entries is hyphenated. So `"typing_extensions" in {..., "typing-extensions", ...}` is `False`, and the copy step skips it — in every subdirectory, in every channel, always.

This had been hit before and worked around by listing both spellings, with a comment saying as much:

```python
"cuda-bindings",
"cuda_bindings",
"cuda-toolkit",
# Underscore spelling is the one that matches; see "spmd_types" above.
```

Applied to four entries, missed on the rest.

### Scope

**77 of the 102 entries could never be copied.** Only single-word names (`filelock`, `sympy`, `networkx`, `fsspec`, ...) and the four with an explicit underscore twin worked — which is exactly what is published today: `cu134` has filelock/sympy/networkx/fsspec and is missing typing-extensions.

`cuda-toolkit` is on the broken list too, which explains the other cu134 gap reported earlier.

### Fix

Normalize once at definition:

```python
PACKAGE_LINKS_ALLOW_LIST = {
    x.lower().replace("-", "_")
    for x in [...]
}
```

The four underscore twins and the comment documenting the workaround become redundant, so they are dropped. 102 entries -> 97.

Verified by replaying the real code paths (`parent_dir.replace("-","_")` and `wheel_name.split("-",1)[0]`) against the parsed list:

```
packages copyable BEFORE: 20
packages copyable AFTER:  97
newly working: 77          (cuda_toolkit, nvidia_*, rocm_sdk_*, intel_*, onemkl_*, typing_extensions, ...)
regressions:   none
entries that can never match (contain '-'): 0
```

### Please dry-run before applying

This makes the next index run copy ~77 additional package indexes into every arch subdirectory. That is the intended behaviour and each one is already allow-listed, but it is a large one-time change to published indexes, so it is worth running the update in dry-run first and eyeballing the plan.

### Does not retroactively repair existing subdirectories

`get_packages_to_copy_from_parent` only copies packages "in parent but not in subdir", so a subdir is never refreshed once a package exists there. Two consequences:

- `whl/test/cu134/typing-extensions/` will be created by this, since it is absent — so this does fix the rc2 breakage on the next run.
- Already-populated copies stay frozen. `whl/test/cu126/typing-extensions/` still lists 5 versions topping out at 4.15.0 while the parent has 64 up to 4.16.0. Harmless while the floor is `>=4.10.0`, but it is a separate latent issue and not addressed here.

`ruff format` and `ruff check` clean. No test added: `s3_management/` has no test harness and no CI runs pytest over it — happy to add one if you would like that set up.