### PR TITLE
Publish cuda-pathfinder to the torch CUDA arch indexes

### DIFF
--- a/s3_management/update_dependencies.py
+++ b/s3_management/update_dependencies.py
@@ -768,7 +768,33 @@ PACKAGES_PER_PROJECT: Dict[str, List[Dict[str, str]]] = {
     # vLLM
     "ninja": [{"project": "vllm"}],
     "cuda-python": [{"project": "vllm"}],
-    "cuda-pathfinder": [{"project": "vllm"}],
+    "cuda-pathfinder": [
+        {
+            "project": "torch",
+            "target": "cu126",
+        },
+        {
+            "project": "torch",
+            "target": "cu128",
+        },
+        {
+            "project": "torch",
+            "target": "cu129",
+        },
+        {
+            "project": "torch",
+            "target": "cu130",
+        },
+        {
+            "project": "torch",
+            "target": "cu132",
+        },
+        {
+            "project": "torch",
+            "target": "cu134",
+        },
+        {"project": "vllm"},
+    ],
     "pynvml": [{"project": "vllm"}],
     "nvidia-ml-py": [{"project": "vllm"}],
     "einops": [{"project": "vllm"}],


### PR DESCRIPTION
`https://download.pytorch.org/whl/test/cu134/cuda-pathfinder/` returns 403 while the cu134 index advertises it:

```html
<a href="cuda-pathfinder/">cuda-pathfinder</a>   ->  403
```

### Why it is needed

torch declares `cuda-bindings` in `PYTORCH_EXTRA_INSTALL_REQUIREMENTS`, and `cuda-bindings` in turn requires:

```
cuda-pathfinder>=1.4.2
```

Release smoke tests install from a single arch index with no PyPI fallback (`Looking in indexes: https://download.pytorch.org/whl/test/cu134`), so a transitive dependency of a declared dependency has to be resolvable in that same index.

### Why it is missing

`cuda-pathfinder` was registered under the **vllm** project only:

```python
"cuda-python": [{"project": "vllm"}],
"cuda-pathfinder": [{"project": "vllm"}],
```

so `update_dependencies.py` never writes `whl/{test,nightly}/cu*/cuda-pathfinder/`. Confirmed against a live run ([job](https://github.com/pytorch/test-infra/actions/runs/31634011548/job/94242564311)) — it uploaded the identical 18 packages to cu126, cu130, cu132 and cu134, with neither cuda-pathfinder nor cuda-python among them:

```
cu134   cuda-bindings cuda-toolkit nvidia-cublas nvidia-cuda-cccl nvidia-cuda-cupti
        nvidia-cuda-nvrtc nvidia-cuda-runtime nvidia-cudnn-cu13 nvidia-cufft ...
```

The older arches still serve `cuda-pathfinder`, but that is residue from before it stopped being produced — nothing regenerates it today, which is why cu134, the newest arch, is the one that broke.

### The change

Give `cuda-pathfinder` the same torch targets as `cuda-bindings` (cu126, cu128, cu129, cu130, cu132, cu134), keeping the existing vllm entry. It exists to satisfy `cuda-bindings`, so it should follow it exactly.

```
cuda-bindings      before=[cu126, cu128, cu129, cu130, cu132, cu134, vllm]
                   after =[cu126, cu128, cu129, cu130, cu132, cu134, vllm]
cuda-pathfinder    before=[vllm]
                   after =[cu126, cu128, cu129, cu130, cu132, cu134, vllm]   <-- changed
cuda-python        before=[vllm]
                   after =[vllm]
```

**`cuda-python` is deliberately left alone.** torch never depends on it — it is vllm-only — so its absence from the torch arch indexes is correct, and its 403 on cu134 is harmless for torch smoke tests. Worth noting the cu134 listing still advertises it, so that dangling link remains; it just is not on the path to anything torch installs.
