### PR TITLE
[vllm-triage] Detect test-level regressions in jobs that fail on both twins

### DIFF
--- a/.github/workflows/vllm-torch-nightly-triage.yml
+++ b/.github/workflows/vllm-torch-nightly-triage.yml
@@ -170,6 +170,13 @@ jobs:
               - cluster-logs/*.log  one representative Buildkite log per cluster,
                 ANSI-stripped and tail-trimmed. The first lines of each file give the
                 cluster name, job name, job URL, state and exit status.
+                Files prefixed `both_` are red-on-both-twins clusters (see report.json
+                "regressed_tests"): the job fails on both the torch-nightly and
+                baseline build, but fails MORE tests on nightly. A "shared failure(s)"
+                section pairs each shared failure's torch_nightly_exception_chain and
+                baseline_exception_chain so you can judge whether a shared failure
+                changed. Only the torch-nightly-only tests listed above that section
+                are definitely new.
 
             For each cluster, identify the actual failure: the failed test IDs and the
             real exception. Remember that "Engine core initialization failed. See root

--- a/tools/torchci/tests/test_vllm_log_parser.py
+++ b/tools/torchci/tests/test_vllm_log_parser.py
@@ -893,7 +893,9 @@ class TestGetTestSignature(unittest.TestCase):
     """Signature is the (test_id, pytest_exception_class) 2-tuple."""
 
     def test_signature_is_id_and_class(self) -> None:
-        log = "FAILED tests/test_a.py::test_one - ValueError: bad\n= 1 failed in 1.00s ="
+        log = (
+            "FAILED tests/test_a.py::test_one - ValueError: bad\n= 1 failed in 1.00s ="
+        )
         failure = parse_log(log).pytest_results[0].test_failures[0]
         self.assertEqual(
             get_test_signature(failure),
@@ -903,9 +905,7 @@ class TestGetTestSignature(unittest.TestCase):
     def test_signature_empty_class_for_bare_failed(self) -> None:
         log = "FAILED tests/test_a.py::test_one\n= 1 failed in 1.00s ="
         failure = parse_log(log).pytest_results[0].test_failures[0]
-        self.assertEqual(
-            get_test_signature(failure), ("tests/test_a.py::test_one", "")
-        )
+        self.assertEqual(get_test_signature(failure), ("tests/test_a.py::test_one", ""))
 
 
 if __name__ == "__main__":

--- a/tools/torchci/tests/test_vllm_log_parser.py
+++ b/tools/torchci/tests/test_vllm_log_parser.py
@@ -7,7 +7,7 @@ raw_log_snippet.bin has ANSI + BKT markers for strip testing.
 import unittest
 from pathlib import Path
 
-from torchci.vllm_log_parser import parse_log, strip_markers
+from torchci.vllm_log_parser import get_test_signature, parse_log, strip_markers
 
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
@@ -887,6 +887,25 @@ class TestNonInfraNotTagged(unittest.TestCase):
             "ImportError: /lib/libtorch.so: undefined symbol: _ZN3c10\n"
         )
         self.assertFalse(parsed_log.job_is_infra)
+
+
+class TestGetTestSignature(unittest.TestCase):
+    """Signature is the (test_id, pytest_exception_class) 2-tuple."""
+
+    def test_signature_is_id_and_class(self) -> None:
+        log = "FAILED tests/test_a.py::test_one - ValueError: bad\n= 1 failed in 1.00s ="
+        failure = parse_log(log).pytest_results[0].test_failures[0]
+        self.assertEqual(
+            get_test_signature(failure),
+            ("tests/test_a.py::test_one", "ValueError"),
+        )
+
+    def test_signature_empty_class_for_bare_failed(self) -> None:
+        log = "FAILED tests/test_a.py::test_one\n= 1 failed in 1.00s ="
+        failure = parse_log(log).pytest_results[0].test_failures[0]
+        self.assertEqual(
+            get_test_signature(failure), ("tests/test_a.py::test_one", "")
+        )
 
 
 if __name__ == "__main__":

--- a/tools/torchci/tests/test_vllm_torch_nightly_triage.py
+++ b/tools/torchci/tests/test_vllm_torch_nightly_triage.py
@@ -5,14 +5,15 @@ captured logs: the parser is already trusted, so each case isolates exactly one
 diff/compare behaviour.
 """
 
+import email.message
 import tempfile
 import unittest
 import urllib.error
 from pathlib import Path
 from unittest import mock
 
-from torchci.vllm_log_parser import parse_log
 import torchci.vllm_torch_nightly_triage as triage
+from torchci.vllm_log_parser import parse_log
 from torchci.vllm_torch_nightly_triage import diff_failing_tests
 
 
@@ -236,9 +237,7 @@ class TestDiffBothClusters(unittest.TestCase):
         body = make_pytest_body(
             [("tests/test_a.py::test_foo", "AssertionError", "shared boom")]
         )
-        self.assertEqual(
-            triage.diff_both_clusters([("Job A", rep, body, body)]), []
-        )
+        self.assertEqual(triage.diff_both_clusters([("Job A", rep, body, body)]), [])
 
 
 class TestWriteBothArtifacts(unittest.TestCase):
@@ -389,9 +388,7 @@ class TestReportJsonWiring(unittest.TestCase):
                 triage, "compare", return_value=buckets
             ), mock.patch.object(
                 triage, "fetch_cluster_logs", side_effect=_fake_fetch_cluster_logs
-            ), mock.patch.dict(
-                os.environ, {"BUILDKITE_TOKEN": "tok"}
-            ):
+            ), mock.patch.dict(os.environ, {"BUILDKITE_TOKEN": "tok"}):
                 rc = triage.main()
             self.assertEqual(rc, 0)
             with open(json_path) as f:
@@ -435,7 +432,7 @@ class TestBaselineLogAvailabilityGuard(unittest.TestCase):
 
     def test_baseline_401_skips_cluster(self) -> None:
         error = urllib.error.HTTPError(
-            "http://x", 401, "Unauthorized", hdrs=None, fp=None
+            "http://x", 401, "Unauthorized", hdrs=email.message.Message(), fp=None
         )
         self.assertEqual(self._fetch_with_baseline_error(error), [])
 

--- a/tools/torchci/tests/test_vllm_torch_nightly_triage.py
+++ b/tools/torchci/tests/test_vllm_torch_nightly_triage.py
@@ -1,0 +1,452 @@
+"""Tests for the red->red test-set regression gap in the nightly triage.
+
+Inputs are small, hand-written pytest bodies (see make_pytest_body), never
+captured logs: the parser is already trusted, so each case isolates exactly one
+diff/compare behaviour.
+"""
+
+import tempfile
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+from torchci.vllm_log_parser import parse_log
+import torchci.vllm_torch_nightly_triage as triage
+from torchci.vllm_torch_nightly_triage import diff_failing_tests
+
+
+def _both_job(name, tn_body_url, baseline_url):
+    return {
+        "name": name,
+        "state": "failed",
+        "exit_status": 1,
+        "url": tn_body_url,
+        "agent": "agent-1",
+        "baseline_state": "failed",
+        "baseline_url": baseline_url,
+    }
+
+
+def make_pytest_body(failures, duration="1.23s"):
+    """Build a minimal parseable pytest tail from failure tuples.
+
+    Each failure is ``(test_id, exception_class, message)``. An empty
+    exception_class yields a bare ``FAILED`` line (no class on the summary line),
+    which parse_log leaves with an empty pytest_exception_class.
+    """
+    lines = [
+        "=========================== short test summary info ============================"
+    ]
+    for test_id, exception_class, message in failures:
+        if not exception_class:
+            lines.append(f"FAILED {test_id}")
+        elif message:
+            lines.append(f"FAILED {test_id} - {exception_class}: {message}")
+        else:
+            lines.append(f"FAILED {test_id} - {exception_class}")
+    lines.append(
+        f"===================== {len(failures)} failed in {duration} ====================="
+    )
+    return "\n".join(lines)
+
+
+class TestMakePytestBody(unittest.TestCase):
+    def test_body_parses_to_expected_failures(self) -> None:
+        body = make_pytest_body(
+            [
+                ("tests/test_a.py::test_foo", "AssertionError", "1 == 2"),
+                ("tests/test_b.py::test_bar", "ValueError", "boom"),
+            ]
+        )
+        parsed = parse_log(body)
+        failures = [
+            failure
+            for result in parsed.pytest_results
+            for failure in result.test_failures
+        ]
+        self.assertEqual(len(failures), 2)
+        by_id = {failure.test_id: failure for failure in failures}
+        self.assertEqual(
+            by_id["tests/test_a.py::test_foo"].pytest_exception_class, "AssertionError"
+        )
+        self.assertEqual(
+            by_id["tests/test_b.py::test_bar"].pytest_exception_class, "ValueError"
+        )
+
+    def test_bare_failed_leaves_class_empty(self) -> None:
+        body = make_pytest_body([("tests/test_c.py::test_baz", "", "")])
+        parsed = parse_log(body)
+        failure = parsed.pytest_results[0].test_failures[0]
+        self.assertEqual(failure.test_id, "tests/test_c.py::test_baz")
+        self.assertEqual(failure.pytest_exception_class, "")
+
+    def test_summary_count_matches(self) -> None:
+        body = make_pytest_body(
+            [
+                ("tests/test_a.py::test_one", "ValueError", "bad"),
+                ("tests/test_a.py::test_two", "TypeError", "wrong"),
+            ]
+        )
+        parsed = parse_log(body)
+        self.assertEqual(parsed.pytest_results[0].expected_test_failure_count, 2)
+
+
+class TestDiffFailingTests(unittest.TestCase):
+    def test_identical_bodies_all_shared(self) -> None:
+        body = make_pytest_body(
+            [
+                ("tests/test_a.py::test_foo", "AssertionError", "1 == 2"),
+                ("tests/test_b.py::test_bar", "ValueError", "boom"),
+            ]
+        )
+        diff = diff_failing_tests(body, body)
+        self.assertEqual(diff.skipped, "")
+        self.assertEqual(diff.new_failures, [])
+        self.assertEqual(len(diff.shared_failures), 2)
+
+    def test_extra_nightly_failure_is_new(self) -> None:
+        torch_nightly = make_pytest_body(
+            [
+                ("tests/test_a.py::test_foo", "AssertionError", "nightly says 1 == 2"),
+                ("tests/test_b.py::test_bar", "ValueError", "nightly boom"),
+            ]
+        )
+        baseline = make_pytest_body(
+            [
+                ("tests/test_a.py::test_foo", "AssertionError", "baseline says 1 == 2"),
+            ]
+        )
+        diff = diff_failing_tests(torch_nightly, baseline)
+        self.assertEqual(diff.skipped, "")
+        self.assertEqual(len(diff.new_failures), 1)
+        self.assertEqual(diff.new_failures[0].test_id, "tests/test_b.py::test_bar")
+
+        self.assertEqual(len(diff.shared_failures), 1)
+        nightly_side, baseline_side = diff.shared_failures[0]
+        self.assertEqual(nightly_side.test_id, "tests/test_a.py::test_foo")
+        self.assertEqual(baseline_side.test_id, "tests/test_a.py::test_foo")
+        # Both chains are recorded raw for the agent, never compared.
+        self.assertIn("nightly says 1 == 2", nightly_side.exception_chain)
+        self.assertIn("baseline says 1 == 2", baseline_side.exception_chain)
+
+    def test_changed_exception_class_is_new(self) -> None:
+        torch_nightly = make_pytest_body(
+            [("tests/test_a.py::test_foo", "TypeError", "wrong type")]
+        )
+        baseline = make_pytest_body(
+            [("tests/test_a.py::test_foo", "ValueError", "bad value")]
+        )
+        diff = diff_failing_tests(torch_nightly, baseline)
+        self.assertEqual(diff.skipped, "")
+        self.assertEqual(len(diff.new_failures), 1)
+        self.assertEqual(diff.new_failures[0].pytest_exception_class, "TypeError")
+        self.assertEqual(diff.shared_failures, [])
+
+
+class TestDiffFailClosed(unittest.TestCase):
+    """A broken diff never emits new failures -- it sets `skipped`."""
+
+    def test_no_pytest_session_either_side_skips(self) -> None:
+        no_session = "Step 1: building wheel...\nBuild failed.\n"
+        good = make_pytest_body([("tests/test_a.py::test_foo", "ValueError", "boom")])
+
+        diff_nightly_broken = diff_failing_tests(no_session, good)
+        self.assertNotEqual(diff_nightly_broken.skipped, "")
+        self.assertEqual(diff_nightly_broken.new_failures, [])
+
+        diff_baseline_broken = diff_failing_tests(good, no_session)
+        self.assertNotEqual(diff_baseline_broken.skipped, "")
+        self.assertEqual(diff_baseline_broken.new_failures, [])
+
+    def test_parse_raises_skips(self) -> None:
+        good = make_pytest_body([("tests/test_a.py::test_foo", "ValueError", "boom")])
+        with mock.patch.object(triage, "parse_log", side_effect=RuntimeError("boom")):
+            diff = diff_failing_tests(good, good)
+        self.assertNotEqual(diff.skipped, "")
+        self.assertEqual(diff.new_failures, [])
+
+
+class TestCompareCarriesBaselineUrl(unittest.TestCase):
+    """A `both`-bucket job must carry the baseline-side web_url for log fetch."""
+
+    def test_both_job_has_baseline_url(self) -> None:
+        # Column order matches the compare() SELECT:
+        # job_name, shard, tn_state, tn_exit, tn_url, tn_agent,
+        # base_state, base_url, in_tn, in_base
+        row = (
+            "Job A",
+            0,
+            "failed",
+            1,
+            "https://buildkite/tn#job",
+            "agent-1",
+            "failed",
+            "https://buildkite/base#job",
+            1,
+            1,
+        )
+        with mock.patch.object(triage, "_rows", return_value=[row]):
+            buckets = triage.compare(client=None, tn_number=82789, base_number=82790)
+        self.assertEqual(len(buckets["both"]), 1)
+        both_job = buckets["both"][0]
+        self.assertEqual(both_job["url"], "https://buildkite/tn#job")
+        self.assertEqual(both_job["baseline_url"], "https://buildkite/base#job")
+        self.assertEqual(both_job["baseline_state"], "failed")
+
+
+def _superset_fetched(cluster="Job A"):
+    """A fetched cluster whose nightly failing set is a superset of baseline's."""
+    rep = _both_job(cluster, "tn#job", "base#job")
+    torch_nightly_body = make_pytest_body(
+        [
+            ("tests/test_a.py::test_foo", "AssertionError", "boom"),
+            ("tests/test_b.py::test_bar", "ValueError", "new failure"),
+        ]
+    )
+    baseline_body = make_pytest_body(
+        [("tests/test_a.py::test_foo", "AssertionError", "boom")]
+    )
+    return [(cluster, rep, torch_nightly_body, baseline_body)]
+
+
+class TestDiffBothClusters(unittest.TestCase):
+    """The pure diff stage surfaces the extra nightly failures per cluster."""
+
+    def test_superset_nightly_surfaces_new_failure(self) -> None:
+        cluster_diffs = triage.diff_both_clusters(_superset_fetched())
+        self.assertEqual(len(cluster_diffs), 1)
+        cluster_diff = cluster_diffs[0]
+        self.assertEqual(cluster_diff.cluster, "Job A")
+        new_ids = [failure.test_id for failure in cluster_diff.diff.new_failures]
+        self.assertEqual(new_ids, ["tests/test_b.py::test_bar"])
+
+    def test_entry_carries_cluster_and_baseline_url(self) -> None:
+        [cluster_diff] = triage.diff_both_clusters(_superset_fetched())
+        entry = triage._build_regressed_entry(
+            cluster_diff.cluster, cluster_diff.rep, cluster_diff.diff
+        )
+        self.assertEqual(entry["cluster"], "Job A")
+        self.assertEqual(entry["baseline_url"], "base#job")
+        new_ids = [nf["test_id"] for nf in entry["new_failures"]]
+        self.assertEqual(new_ids, ["tests/test_b.py::test_bar"])
+
+    def test_no_new_failures_dropped(self) -> None:
+        rep = _both_job("Job A", "tn#job", "base#job")
+        body = make_pytest_body(
+            [("tests/test_a.py::test_foo", "AssertionError", "shared boom")]
+        )
+        self.assertEqual(
+            triage.diff_both_clusters([("Job A", rep, body, body)]), []
+        )
+
+
+class TestWriteBothArtifacts(unittest.TestCase):
+    """The write stage emits one artifact per surfaced cluster with shared chains."""
+
+    def _artifacts_for(self, torch_nightly_body, baseline_body):
+        rep = _both_job("Job A", "tn#job", "base#job")
+        cluster_diffs = triage.diff_both_clusters(
+            [("Job A", rep, torch_nightly_body, baseline_body)]
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            written = triage._write_both_artifacts(
+                cluster_diffs, Path(tmp), tail_lines=50
+            )
+            contents = [Path(path).read_text() for path in written]
+        return written, contents
+
+    def test_new_failures_write_artifact_with_shared_chains(self) -> None:
+        torch_nightly_body = make_pytest_body(
+            [
+                ("tests/test_a.py::test_foo", "AssertionError", "shared boom"),
+                ("tests/test_b.py::test_bar", "ValueError", "new-failure-marker"),
+            ]
+        )
+        baseline_body = make_pytest_body(
+            [("tests/test_a.py::test_foo", "AssertionError", "baseline-only-marker")]
+        )
+        written, contents = self._artifacts_for(torch_nightly_body, baseline_body)
+
+        self.assertEqual(len(written), 1)
+        artifact = contents[0]
+        self.assertIn("red on both sides", artifact)
+        self.assertIn("tests/test_b.py::test_bar", artifact)  # the new failure
+        self.assertIn("new-failure-marker", artifact)
+        # The shared section records the baseline chain, not just the nightly one.
+        self.assertIn("baseline-only-marker", artifact)
+
+    def test_no_surfaced_clusters_writes_nothing(self) -> None:
+        self.assertEqual(triage._write_both_artifacts([], Path("/nonexistent"), 50), [])
+
+
+def _regressed_entry():
+    return {
+        "name": "Job A",
+        "cluster": "Job A",
+        "url": "https://buildkite/tn#job",
+        "baseline_url": "https://buildkite/base#job",
+        "state": "failed",
+        "baseline_state": "failed",
+        "new_failures": [
+            {
+                "test_id": "tests/test_b.py::test_bar",
+                "exception_class": "ValueError",
+                "torch_nightly_exception_chain": "ValueError: new-failure-marker",
+            }
+        ],
+        "shared_failures": [
+            {
+                "test_id": "tests/test_a.py::test_foo",
+                "exception_class": "AssertionError",
+                "torch_nightly_exception_chain": "AssertionError: shared",
+                "baseline_exception_chain": "AssertionError: shared",
+            }
+        ],
+    }
+
+
+class TestRenderRegressedTests(unittest.TestCase):
+    """render() surfaces the test-set regressions even when no job flipped green->red."""
+
+    def _tn_base(self):
+        tn = {
+            "number": 82789,
+            "url": "u_tn",
+            "state": "failed",
+            "commit": "b706fd1628b0abcdef",
+        }
+        base = {"number": 82790, "url": "u_base", "state": "failed"}
+        return tn, base
+
+    def test_section_present_when_regressed_tests(self) -> None:
+        tn, base = self._tn_base()
+        buckets = {"regressed": [], "both": [], "baseline_only": []}
+        out = triage.render(tn, base, buckets, [_regressed_entry()])
+        self.assertIn("Test-set regressions", out)
+        self.assertIn("tests/test_b.py::test_bar", out)
+        self.assertIn("ValueError", out)
+        # The shared count rides along as context.
+        self.assertIn("1 shared", out)
+
+    def test_no_section_when_empty(self) -> None:
+        tn, base = self._tn_base()
+        buckets = {"regressed": [], "both": [], "baseline_only": []}
+        out = triage.render(tn, base, buckets, [])
+        self.assertNotIn("Test-set regressions", out)
+
+
+class TestReportJsonWiring(unittest.TestCase):
+    """main() writes a regressed_tests array into report.json."""
+
+    def test_json_has_regressed_tests_key(self) -> None:
+        import json
+        import os
+
+        tn = {
+            "number": 82789,
+            "url": "u_tn",
+            "state": "failed",
+            "commit": "b706fd1628b0abcdef",
+        }
+        base = {"number": 82790, "url": "u_base", "state": "failed"}
+        # A `both` job so main() decides to fetch logs (the diff path).
+        buckets = {
+            "regressed": [],
+            "both": [_both_job("Job A", "u_tn#job", "u_base#job")],
+            "baseline_only": [],
+        }
+
+        def _fake_fetch_cluster_logs(
+            buckets_arg,
+            logs_dir,
+            token,
+            tail_lines,
+            torch_versions=None,
+            regressed_tests=None,
+        ):
+            if regressed_tests is not None:
+                regressed_tests.append(_regressed_entry())
+            return []
+
+        with tempfile.TemporaryDirectory() as tmp:
+            json_path = f"{tmp}/report.json"
+            logs_dir = f"{tmp}/logs"
+            argv = [
+                "prog",
+                "--json-output",
+                json_path,
+                "--logs-dir",
+                logs_dir,
+                "--output",
+                f"{tmp}/report.md",
+            ]
+            with mock.patch.object(triage.sys, "argv", argv), mock.patch.object(
+                triage, "get_clickhouse_client", return_value=object()
+            ), mock.patch.object(
+                triage, "find_latest_pair", return_value=(tn, base)
+            ), mock.patch.object(
+                triage, "compare", return_value=buckets
+            ), mock.patch.object(
+                triage, "fetch_cluster_logs", side_effect=_fake_fetch_cluster_logs
+            ), mock.patch.dict(
+                os.environ, {"BUILDKITE_TOKEN": "tok"}
+            ):
+                rc = triage.main()
+            self.assertEqual(rc, 0)
+            with open(json_path) as f:
+                report = json.load(f)
+        self.assertIn("regressed_tests", report)
+        self.assertEqual(len(report["regressed_tests"]), 1)
+        self.assertEqual(
+            report["regressed_tests"][0]["new_failures"][0]["test_id"],
+            "tests/test_b.py::test_bar",
+        )
+
+
+class TestBaselineLogAvailabilityGuard(unittest.TestCase):
+    """A baseline fetch failure fails closed -- the cluster is skipped, not surfaced.
+
+    Without the guard a baseline 401/URLError would either crash the whole run or,
+    worse, be swallowed into "every nightly failure is new."
+    """
+
+    def _fetch_with_baseline_error(self, error):
+        tn_url = "https://buildkite/x/builds/82789#0197-tn"
+        base_url = "https://buildkite/x/builds/82790#0197-base"
+        torch_nightly_body = make_pytest_body(
+            [("tests/test_a.py::test_foo", "AssertionError", "boom")]
+        )
+
+        def _fetch(job_url, token, timeout=120):
+            if job_url == tn_url:
+                return torch_nightly_body
+            if job_url == base_url:
+                raise error
+            raise AssertionError(f"unexpected fetch url {job_url!r}")
+
+        buckets = {
+            "regressed": [],
+            "both": [_both_job("Job A", tn_url, base_url)],
+            "baseline_only": [],
+        }
+        with mock.patch.object(triage, "_fetch_job_log", side_effect=_fetch):
+            return triage._fetch_both_clusters(buckets, token="tok")
+
+    def test_baseline_401_skips_cluster(self) -> None:
+        error = urllib.error.HTTPError(
+            "http://x", 401, "Unauthorized", hdrs=None, fp=None
+        )
+        self.assertEqual(self._fetch_with_baseline_error(error), [])
+
+    def test_baseline_urlerror_skips_cluster(self) -> None:
+        self.assertEqual(
+            self._fetch_with_baseline_error(
+                urllib.error.URLError("connection refused")
+            ),
+            [],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/torchci/vllm_log_parser.py
+++ b/tools/torchci/vllm_log_parser.py
@@ -82,6 +82,21 @@ INFRA_PATTERNS = [
 ]
 
 
+def get_test_signature(failed_test: "FailedTest") -> tuple[str, str]:
+    """Build the diff key for a failing test.
+
+    The exception_chain is deliberately excluded: it is not stable build-to-build
+    across the torch-nightly/baseline A/B.
+
+    Args:
+        failed_test: Parsed pytest failure to key.
+
+    Returns:
+        The (test_id, exception_class) pair.
+    """
+    return (failed_test.test_id, failed_test.pytest_exception_class)
+
+
 def strip_markers(text: str) -> str:
     """Remove escape sequences from raw Buildkite log text.
 

--- a/tools/torchci/vllm_torch_nightly_triage.py
+++ b/tools/torchci/vllm_torch_nightly_triage.py
@@ -346,9 +346,7 @@ def render_regressed_tests_section(regressed_tests: List[Dict]) -> List[str]:
         )
         out.append(f"- [{entry['name']}]({entry['url']}) — `{entry['state']}`")
         for failure in new_failures:
-            out.append(
-                f"  - `{failure['test_id']}` — `{failure['exception_class']}`"
-            )
+            out.append(f"  - `{failure['test_id']}` — `{failure['exception_class']}`")
         out.append("\n</details>")
     return out
 
@@ -431,9 +429,7 @@ def render(
     return "\n".join(out)
 
 
-def _render_shared_section(
-    shared_failures: List[Tuple[FailedTest, FailedTest]]
-) -> str:
+def _render_shared_section(shared_failures: List[Tuple[FailedTest, FailedTest]]) -> str:
     """Render the shared failures, each with its nightly and baseline chain.
 
     Args:
@@ -641,9 +637,12 @@ def _fetch_both_clusters(
     fetched: List[Tuple[str, Dict, str, str]] = []
     for key, jobs in sorted(clusters.items(), key=lambda kv: (-len(kv[1]), kv[0])):
         rep = sorted(jobs, key=lambda j: j["name"])[0]
+        baseline_url = rep.get("baseline_url")
+        if baseline_url is None:
+            continue
         try:
             torch_nightly_body = _fetch_job_log(rep["url"], token)
-            baseline_body = _fetch_job_log(rep.get("baseline_url"), token)
+            baseline_body = _fetch_job_log(baseline_url, token)
         except urllib.error.HTTPError as exc:
             print(
                 f"skip {key} diff: HTTP {exc.code} {exc.reason}{_http_error_hint(exc)}",
@@ -660,7 +659,7 @@ def _fetch_both_clusters(
 
 
 def diff_both_clusters(
-    fetched: List[Tuple[str, Dict, str, str]]
+    fetched: List[Tuple[str, Dict, str, str]],
 ) -> List[BothClusterDiff]:
     """Diff each fetched `both`-cluster; keep only those with new failures.
 

--- a/tools/torchci/vllm_torch_nightly_triage.py
+++ b/tools/torchci/vllm_torch_nightly_triage.py
@@ -29,11 +29,19 @@ import argparse
 import json
 import re
 import sys
+import urllib.error
+import urllib.request
 from collections import Counter, defaultdict
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
 from torchci.clickhouse import get_clickhouse_client
-from torchci.vllm_log_parser import parse_log, strip_markers
+from torchci.vllm_log_parser import (
+    FailedTest,
+    get_test_signature,
+    parse_log,
+    strip_markers,
+)
 
 
 VLLM_REPO = "https://github.com/vllm-project/vllm.git"
@@ -73,6 +81,81 @@ def cluster_key(job_name: str) -> str:
 
 def _rows(client: Any, query: str, params: Dict[str, Any]) -> List[Tuple]:
     return client.query(query, parameters=params).result_rows
+
+
+@dataclass
+class DiffResult:
+    """Failing-test diff between the torch-nightly and baseline logs.
+
+    Keyed on (test_id, exception_class); the exception_chain is never compared,
+    only recorded for the root-cause agent.
+
+    Attributes:
+        new_failures: Failures on torch-nightly only (definitely new).
+        shared_failures: (nightly, baseline) pairs sharing a signature.
+        skipped: Reason the diff is unusable, or "" when usable.
+    """
+
+    new_failures: List[FailedTest] = field(default_factory=list)
+    shared_failures: List[Tuple[FailedTest, FailedTest]] = field(default_factory=list)
+    skipped: str = ""
+
+
+def all_failures(parsed) -> List[FailedTest]:
+    return [
+        failure
+        for pytest_result in parsed.pytest_results
+        for failure in pytest_result.test_failures
+    ]
+
+
+def diff_failing_tests(torch_nightly_body: str, baseline_body: str) -> DiffResult:
+    """Diff the failing-test signatures of two same-commit job logs.
+
+    Baseline-only failures are ignored; they are not torch-attributable. Fails
+    closed: if either side has no pytest session or parsing raises, the result is
+    marked skipped and no new failures are emitted.
+
+    Args:
+        torch_nightly_body: Raw log body from the torch-nightly job.
+        baseline_body: Raw log body from the same-commit baseline job.
+
+    Returns:
+        A DiffResult; new_failures is empty when skipped is set.
+    """
+    try:
+        torch_nightly_parsed = parse_log(torch_nightly_body)
+        baseline_parsed = parse_log(baseline_body)
+    except Exception as exc:  # parser asserts an invariant; never emit on that
+        return DiffResult(skipped=f"parse raised: {exc}")
+
+    if not torch_nightly_parsed.pytest_results:
+        return DiffResult(skipped="no pytest session in torch-nightly log")
+    if not baseline_parsed.pytest_results:
+        return DiffResult(skipped="no pytest session in baseline log")
+
+    torch_nightly_failures = all_failures(torch_nightly_parsed)
+    baseline_failures = all_failures(baseline_parsed)
+
+    baseline_by_signature = {
+        get_test_signature(failure): failure for failure in baseline_failures
+    }
+
+    result = DiffResult()
+    seen_signatures = set()
+    for failure in torch_nightly_failures:
+        signature = get_test_signature(failure)
+        # A retry pass re-lists the same failure in a second summary block; count
+        # each signature once.
+        if signature in seen_signatures:
+            continue
+        seen_signatures.add(signature)
+        baseline_match = baseline_by_signature.get(signature)
+        if baseline_match is None:
+            result.new_failures.append(failure)
+        else:
+            result.shared_failures.append((failure, baseline_match))
+    return result
 
 
 def find_latest_pair(
@@ -174,6 +257,9 @@ def compare(client: Any, tn_number: int, base_number: int) -> Dict[str, List[Dic
             argMaxIf(lowerUTF8(tupleElement(job, 'state')),
                      tupleElement(job, 'finished_at'),
                      toUInt32(tupleElement(build, 'number')) = {base: UInt32}) AS base_state,
+            argMaxIf(tupleElement(job, 'web_url'),
+                     tupleElement(job, 'finished_at'),
+                     toUInt32(tupleElement(build, 'number')) = {base: UInt32}) AS base_url,
             countIf(toUInt32(tupleElement(build, 'number')) = {tn: UInt32}) AS in_tn,
             countIf(toUInt32(tupleElement(build, 'number')) = {base: UInt32}) AS in_base
         FROM vllm.vllm_buildkite_jobs FINAL
@@ -195,6 +281,7 @@ def compare(client: Any, tn_number: int, base_number: int) -> Dict[str, List[Dic
         tn_url,
         tn_agent,
         base_state,
+        base_url,
         in_tn,
         in_base,
     ) in rows:
@@ -210,6 +297,7 @@ def compare(client: Any, tn_number: int, base_number: int) -> Dict[str, List[Dic
             "url": tn_url,
             "agent": tn_agent,
             "baseline_state": base_state,
+            "baseline_url": base_url,
         }
         tn_bad = tn_state in BAD_STATES
         if tn_bad and base_state in BAD_STATES:
@@ -232,8 +320,44 @@ def agent_concentration(regressed: List[Dict]) -> List[Tuple[str, int]]:
     return sorted(counts.items(), key=lambda kv: -kv[1])
 
 
+def render_regressed_tests_section(regressed_tests: List[Dict]) -> List[str]:
+    """Render the red-on-both test-set regressions that job state alone misses.
+
+    Args:
+        regressed_tests: The regressed_tests entries to render.
+
+    Returns:
+        Markdown lines for the report.
+    """
+    out = [
+        f"\n### Test-set regressions ({len(regressed_tests)})\n",
+        "These jobs are red on **both** twins, so job state calls them pre-existing, "
+        "but they fail *more* tests on torch nightly. Each new failing test below is "
+        "torch-nightly-only; shared failures are recorded in the artifacts for the "
+        "root-cause agent.\n",
+    ]
+    for entry in sorted(regressed_tests, key=lambda e: e["cluster"]):
+        new_failures = entry["new_failures"]
+        shared_count = len(entry["shared_failures"])
+        out.append(
+            f"<details><summary><b>{entry['cluster']}</b> — "
+            f"{len(new_failures)} new failing test(s), "
+            f"{shared_count} shared</summary>\n"
+        )
+        out.append(f"- [{entry['name']}]({entry['url']}) — `{entry['state']}`")
+        for failure in new_failures:
+            out.append(
+                f"  - `{failure['test_id']}` — `{failure['exception_class']}`"
+            )
+        out.append("\n</details>")
+    return out
+
+
 def render(
-    tn: Dict[str, Any], base: Dict[str, Any], buckets: Dict[str, List[Dict]]
+    tn: Dict[str, Any],
+    base: Dict[str, Any],
+    buckets: Dict[str, List[Dict]],
+    regressed_tests: Optional[List[Dict]] = None,
 ) -> str:
     regressed = buckets["regressed"]
     clusters: Dict[str, List[Dict]] = defaultdict(list)
@@ -260,8 +384,18 @@ def render(
         f"- fails on baseline only: {len(buckets['baseline_only'])}\n"
     )
 
-    if not regressed:
+    if not regressed and not regressed_tests:
         out.append("No torch-attributable regressions in this run.")
+        return "\n".join(out)
+
+    # Test-set regressions are independent of the job-state regressed bucket -- a
+    # red-on-both job can hide one even when nothing flipped green->red.
+    if regressed_tests:
+        out.extend(render_regressed_tests_section(regressed_tests))
+
+    # The cluster and infrastructure sections describe the regressed bucket; both
+    # index into agents/ordered, which are empty when nothing flipped green->red.
+    if not regressed:
         return "\n".join(out)
 
     out.append(f"\n### Clusters ({len(ordered)})\n")
@@ -297,11 +431,41 @@ def render(
     return "\n".join(out)
 
 
+def _render_shared_section(
+    shared_failures: List[Tuple[FailedTest, FailedTest]]
+) -> str:
+    """Render the shared failures, each with its nightly and baseline chain.
+
+    Args:
+        shared_failures: (nightly, baseline) failure pairs.
+
+    Returns:
+        The rendered section text.
+    """
+    sections = [f"\n# {len(shared_failures)} shared failure(s) (red on both sides)\n"]
+    for torch_nightly_side, baseline_side in shared_failures:
+        sections.append(f"## {torch_nightly_side.test_id}")
+        sections.append(
+            f"pytest_exception_class: {torch_nightly_side.pytest_exception_class}"
+        )
+        sections.append("")
+        sections.append("### torch_nightly_exception_chain")
+        sections.append(torch_nightly_side.exception_chain)
+        sections.append("")
+        sections.append("### baseline_exception_chain")
+        sections.append(baseline_side.exception_chain)
+        sections.append("")
+    return "\n".join(sections)
+
+
 def _render_cluster_artifact(
-    body: str, cluster_key: str, representative: Dict, tail_lines: int
+    body: str,
+    cluster_key: str,
+    representative: Dict,
+    tail_lines: int,
+    shared_failures: Optional[List[Tuple[FailedTest, FailedTest]]] = None,
 ) -> str:
     """Serialize one cluster's representative log for the root-cause agent.
-
     parse_log extracts per-test signatures (test id, exception class, the raw
     traceback body) from anywhere in the log, so a failure far from the end of a
     huge log is still captured. When there are no pytest failures -- a build/crash
@@ -341,6 +505,8 @@ def _render_cluster_artifact(
             sections.append("")
             sections.append(failure.exception_chain)
             sections.append("")
+        if shared_failures:
+            sections.append(_render_shared_section(shared_failures))
         return "\n".join(sections)
 
     cleaned_lines = strip_markers(body).splitlines()
@@ -357,23 +523,226 @@ def _render_cluster_artifact(
     return header + fallback_notes + "\n".join(cleaned_lines[-tail_lines:])
 
 
+def _fetch_job_log(job_url: str, token: str, timeout: int = 120) -> Optional[str]:
+    """GET one Buildkite job's raw log body.
+
+    Args:
+        job_url: Job url of the form .../builds/<n>#<job-uuid>.
+        token: Buildkite API token.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        The log body, or None when job_url can't be parsed into build + job ids.
+
+    Raises:
+        urllib.error.URLError: On HTTP or network failure; the caller decides
+            whether that is a skip or a fail-closed.
+    """
+    # job_url is .../builds/<n>#<job-uuid>; the log endpoint needs both parts.
+    match = re.search(r"/builds/(\d+)#([0-9a-f-]+)$", job_url or "")
+    if not match:
+        return None
+    build_number, job_id = match.group(1), match.group(2)
+    url = (
+        "https://api.buildkite.com/v2/organizations/vllm/pipelines/"
+        f"{PIPELINE.lower()}/builds/{build_number}/jobs/{job_id}/log.txt"
+    )
+    request = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return response.read().decode("utf-8", errors="replace")
+
+
+def _http_error_hint(exc: urllib.error.HTTPError) -> str:
+    if exc.code == 401:
+        return (
+            "  (401 => token invalid for this org. Check it has read_builds "
+            "and read_build_logs, that the vllm organization is selected, and "
+            "that the value has no trailing newline.)"
+        )
+    return ""
+
+
+def _failure_dict(failure: FailedTest) -> Dict[str, str]:
+    return {
+        "test_id": failure.test_id,
+        "exception_class": failure.pytest_exception_class,
+        "torch_nightly_exception_chain": failure.exception_chain,
+    }
+
+
+def _build_regressed_entry(cluster: str, rep: Dict, diff: DiffResult) -> Dict:
+    """Build the regressed_tests entry for one `both`-cluster with new failures.
+
+    Args:
+        cluster: Cluster name.
+        rep: Representative job for the cluster.
+        diff: The failing-test diff for the cluster.
+
+    Returns:
+        The regressed_tests entry.
+    """
+    return {
+        "name": rep["name"],
+        "cluster": cluster,
+        "url": rep["url"],
+        "baseline_url": rep.get("baseline_url"),
+        "state": rep["state"],
+        "baseline_state": rep["baseline_state"],
+        "new_failures": [_failure_dict(failure) for failure in diff.new_failures],
+        "shared_failures": [
+            {
+                "test_id": torch_nightly_side.test_id,
+                "exception_class": torch_nightly_side.pytest_exception_class,
+                "torch_nightly_exception_chain": torch_nightly_side.exception_chain,
+                "baseline_exception_chain": baseline_side.exception_chain,
+            }
+            for torch_nightly_side, baseline_side in diff.shared_failures
+        ],
+    }
+
+
+@dataclass
+class BothClusterDiff:
+    """A surfaced `both`-cluster: its diff plus what rendering needs.
+
+    Attributes:
+        cluster: Cluster name.
+        rep: Representative job for the cluster.
+        torch_nightly_body: Raw nightly log, kept for the artifact.
+        diff: The failing-test diff; new_failures is non-empty.
+    """
+
+    cluster: str
+    rep: Dict
+    torch_nightly_body: str
+    diff: DiffResult
+
+
+def _fetch_both_clusters(
+    buckets: Dict[str, List[Dict]], token: str
+) -> List[Tuple[str, Dict, str, str]]:
+    """Fetch the nightly and baseline logs for each `both`-bucket cluster.
+
+    Fail closed: a cluster whose nightly or baseline log 401s, errors, or has an
+    unparseable url is skipped rather than returned, so a fetch failure can never
+    fall through to "every nightly failure is new."
+
+    Args:
+        buckets: The compare() buckets.
+        token: Buildkite API token.
+
+    Returns:
+        (cluster, rep, torch_nightly_body, baseline_body) per fetchable cluster.
+    """
+    clusters: Dict[str, List[Dict]] = defaultdict(list)
+    for job in buckets["both"]:
+        clusters[cluster_key(job["name"])].append(job)
+
+    fetched: List[Tuple[str, Dict, str, str]] = []
+    for key, jobs in sorted(clusters.items(), key=lambda kv: (-len(kv[1]), kv[0])):
+        rep = sorted(jobs, key=lambda j: j["name"])[0]
+        try:
+            torch_nightly_body = _fetch_job_log(rep["url"], token)
+            baseline_body = _fetch_job_log(rep.get("baseline_url"), token)
+        except urllib.error.HTTPError as exc:
+            print(
+                f"skip {key} diff: HTTP {exc.code} {exc.reason}{_http_error_hint(exc)}",
+                file=sys.stderr,
+            )
+            continue
+        except urllib.error.URLError as exc:
+            print(f"skip {key} diff: {exc}", file=sys.stderr)
+            continue
+        if torch_nightly_body is None or baseline_body is None:
+            continue
+        fetched.append((key, rep, torch_nightly_body, baseline_body))
+    return fetched
+
+
+def diff_both_clusters(
+    fetched: List[Tuple[str, Dict, str, str]]
+) -> List[BothClusterDiff]:
+    """Diff each fetched `both`-cluster; keep only those with new failures.
+
+    Red-on-both jobs are dropped by the metadata layer, but a larger
+    failing-test set on nightly is a real torch regression. A cluster is dropped
+    when its diff is unusable (parse failure, no pytest session) or when nightly
+    adds no new failure.
+
+    Args:
+        fetched: (cluster, rep, torch_nightly_body, baseline_body) tuples.
+
+    Returns:
+        One BothClusterDiff per surfaced cluster (>=1 new failure).
+    """
+    surfaced: List[BothClusterDiff] = []
+    for cluster, rep, torch_nightly_body, baseline_body in fetched:
+        diff = diff_failing_tests(torch_nightly_body, baseline_body)
+        if diff.skipped:
+            print(f"skip {cluster} diff: {diff.skipped}", file=sys.stderr)
+            continue
+        if not diff.new_failures:
+            continue
+        surfaced.append(BothClusterDiff(cluster, rep, torch_nightly_body, diff))
+    return surfaced
+
+
+def _write_both_artifacts(
+    cluster_diffs: List[BothClusterDiff], pathlib_dir: Any, tail_lines: int
+) -> List[str]:
+    """Write one `both_*.log` artifact per surfaced cluster.
+
+    Args:
+        cluster_diffs: Surfaced both-cluster diffs.
+        pathlib_dir: Directory to write artifacts into.
+        tail_lines: Lines of raw tail kept in the fallback.
+
+    Returns:
+        Paths of the artifacts written.
+    """
+    written: List[str] = []
+    for cluster_diff in cluster_diffs:
+        artifact = _render_cluster_artifact(
+            cluster_diff.torch_nightly_body,
+            cluster_diff.cluster,
+            cluster_diff.rep,
+            tail_lines,
+            shared_failures=cluster_diff.diff.shared_failures,
+        )
+        safe = re.sub(r"[^A-Za-z0-9._-]+", "_", cluster_diff.cluster)[:80]
+        dest = pathlib_dir / f"both_{safe}.log"
+        with open(dest, "w") as f:
+            f.write(artifact)
+        written.append(str(dest))
+    return written
+
+
 def fetch_cluster_logs(
     buckets: Dict[str, List[Dict]],
     logs_dir: str,
     token: str,
     tail_lines: int,
     torch_versions: Optional[List[str]] = None,
+    regressed_tests: Optional[List[Dict]] = None,
 ) -> List[str]:
     """Download one representative log per cluster, cleaned and tail-trimmed.
 
     One per cluster rather than one per job: a cluster is most likely a single root
-    cause, and 28 full logs is both slow and far more context than the analysis needs.
-    Only the tail is kept -- the failure and traceback are at the end, while the head
-    is install and setup noise.
-    """
-    import urllib.error
-    import urllib.request
+    cause, and only the tail is kept since the failure and traceback are at the end.
 
+    Args:
+        buckets: The compare() buckets.
+        logs_dir: Directory to write artifacts into.
+        token: Buildkite API token.
+        tail_lines: Lines of raw tail kept in the fallback.
+        torch_versions: Optional output list; a detected torch version per log is
+            appended here.
+        regressed_tests: Optional output list; when provided, the `both`-bucket
+            clusters are diffed and surfaced entries are appended here.
+
+    Returns:
+        Paths of the artifacts written.
+    """
     clusters: Dict[str, List[Dict]] = defaultdict(list)
     for job in buckets["regressed"]:
         clusters[cluster_key(job["name"])].append(job)
@@ -384,32 +753,19 @@ def fetch_cluster_logs(
 
     for key, jobs in sorted(clusters.items(), key=lambda kv: (-len(kv[1]), kv[0])):
         rep = sorted(jobs, key=lambda j: j["name"])[0]
-        # job["url"] is .../builds/<n>#<job-uuid>; the log endpoint needs both parts.
-        m = re.search(r"/builds/(\d+)#([0-9a-f-]+)$", rep["url"] or "")
-        if not m:
-            print(f"skip {key}: cannot parse job url {rep['url']!r}", file=sys.stderr)
-            continue
-        build_number, job_id = m.group(1), m.group(2)
-        url = (
-            "https://api.buildkite.com/v2/organizations/vllm/pipelines/"
-            f"{PIPELINE.lower()}/builds/{build_number}/jobs/{job_id}/log.txt"
-        )
-        req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
         try:
-            with urllib.request.urlopen(req, timeout=120) as resp:
-                body = resp.read().decode("utf-8", errors="replace")
+            body = _fetch_job_log(rep["url"], token)
         except urllib.error.HTTPError as exc:
-            hint = ""
-            if exc.code == 401:
-                hint = (
-                    "  (401 => token invalid for this org. Check it has read_builds "
-                    "and read_build_logs, that the vllm organization is selected, and "
-                    "that the value has no trailing newline.)"
-                )
-            print(f"skip {key}: HTTP {exc.code} {exc.reason}{hint}", file=sys.stderr)
+            print(
+                f"skip {key}: HTTP {exc.code} {exc.reason}{_http_error_hint(exc)}",
+                file=sys.stderr,
+            )
             continue
         except urllib.error.URLError as exc:
             print(f"skip {key}: {exc}", file=sys.stderr)
+            continue
+        if body is None:
+            print(f"skip {key}: cannot parse job url {rep['url']!r}", file=sys.stderr)
             continue
 
         if torch_versions is not None:
@@ -423,6 +779,14 @@ def fetch_cluster_logs(
         with open(dest, "w") as f:
             f.write(artifact)
         written.append(str(dest))
+
+    if regressed_tests is not None:
+        cluster_diffs = diff_both_clusters(_fetch_both_clusters(buckets, token))
+        regressed_tests.extend(
+            _build_regressed_entry(cd.cluster, cd.rep, cd.diff) for cd in cluster_diffs
+        )
+        written.extend(_write_both_artifacts(cluster_diffs, pathlib_dir, tail_lines))
+
     return written
 
 
@@ -451,18 +815,15 @@ def main() -> int:
 
     tn, base = pair
     buckets = compare(client, tn["number"], base["number"])
-    report = render(tn, base, buckets)
 
-    if args.output:
-        with open(args.output, "w") as f:
-            f.write(report)
-    else:
-        print(report)
-
-    # Logs are fetched before the JSON is written: the torch version is only
-    # observable in a log body, and report.json is what carries it downstream.
+    # Logs are fetched before the report is rendered/written: the torch version and
+    # the red-on-both test-set regressions are only observable in the log bodies, and
+    # both feed the rendered report and report.json downstream.
     torch_versions: List[str] = []
-    if args.logs_dir and buckets["regressed"]:
+    regressed_tests: List[Dict] = []
+    # `both` clusters are diffed for hidden test-set regressions even when nothing
+    # flipped green->red, so fetch whenever either bucket is non-empty.
+    if args.logs_dir and (buckets["regressed"] or buckets["both"]):
         import os as _os
 
         # .strip() matters: a trailing newline in the value (easy to introduce when
@@ -474,9 +835,21 @@ def main() -> int:
             print("BUILDKITE_TOKEN unset; skipping log fetch", file=sys.stderr)
         else:
             written = fetch_cluster_logs(
-                buckets, args.logs_dir, token, args.log_tail_lines, torch_versions
+                buckets,
+                args.logs_dir,
+                token,
+                args.log_tail_lines,
+                torch_versions,
+                regressed_tests,
             )
             print(f"fetched {len(written)} cluster log(s)", file=sys.stderr)
+
+    report = render(tn, base, buckets, regressed_tests)
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(report)
+    else:
+        print(report)
 
     # Most common wins: a stray version from some other wheel in one log should not
     # outvote the torch build the rest of the jobs installed.
@@ -505,6 +878,7 @@ def main() -> int:
                     "torch_version_minor": torch_version_minor,
                     "regressed": buckets["regressed"],
                     "both": buckets["both"],
+                    "regressed_tests": regressed_tests,
                 },
                 f,
                 indent=2,


### PR DESCRIPTION
This PR fills a gap in the new error detection

The following will now be covered with the following behavior:
If Job A fails in vllm pytorch nightly with tests 1/2 failing and Job A fails in vllm full ci with test 1, then new error (test 2) is never detected and nothing is pulled. 

Now Job A test 2 will come up with as a new failure. We know this without looking at the exception chain.

In addition if a new failure from the above is detected. We record the exception chains of the shared test failures for that job test 1 and will let the agent determine if there are any additional failures for that job. 