### PR TITLE
[vllm-triage] Fix test regresssion

### DIFF
--- a/tools/torchci/tests/test_vllm_torch_nightly_triage.py
+++ b/tools/torchci/tests/test_vllm_torch_nightly_triage.py
@@ -315,7 +315,12 @@ class TestRenderRegressedTests(unittest.TestCase):
             "state": "failed",
             "commit": "b706fd1628b0abcdef",
         }
-        base = {"number": 82790, "url": "u_base", "state": "failed"}
+        base = {
+            "number": 82790,
+            "url": "u_base",
+            "state": "failed",
+            "commit": "b706fd1628b0abcdef",
+        }
         return tn, base
 
     def test_section_present_when_regressed_tests(self) -> None:
@@ -348,7 +353,12 @@ class TestReportJsonWiring(unittest.TestCase):
             "state": "failed",
             "commit": "b706fd1628b0abcdef",
         }
-        base = {"number": 82790, "url": "u_base", "state": "failed"}
+        base = {
+            "number": 82790,
+            "url": "u_base",
+            "state": "failed",
+            "commit": "b706fd1628b0abcdef",
+        }
         # A `both` job so main() decides to fetch logs (the diff path).
         buckets = {
             "regressed": [],


### PR DESCRIPTION
The following tests broke due to multiple different merges on main. 

The fixes are purely test side and won't effect actually using the workflow. Just had to add some additional data to the the fixture.

tests/test_vllm_torch_nightly_triage.py::TestRenderRegressedTests::test_no_section_when_empty
tests/test_vllm_torch_nightly_triage.py::TestRenderRegressedTests::test_section_present_when_regressed_tests tests/test_vllm_torch_nightly_triage.py::TestReportJsonWiring::test_json_has_regressed_tests_key