### PR TITLE
Re-add nvidia-cudnn-cu12 9.1.0.70 to the mirrored cudnn index

### DIFF
--- a/s3_management/update_dependencies.py
+++ b/s3_management/update_dependencies.py
@@ -1,7 +1,7 @@
 import os
 import re
 import time
-from typing import Dict, List
+from typing import Dict, List, NamedTuple
 from urllib.parse import urljoin
 
 import boto3  # type: ignore[import-untyped]
@@ -919,6 +919,40 @@ PYPI_HOSTED_NVIDIA_PACKAGES = {
 }
 
 
+class RetainedWheel(NamedTuple):
+    filename: str
+    # Root-relative path to the wheel, so it resolves against whichever host
+    # serves the index (download.pytorch.org or download-r2.pytorch.org) and
+    # stays valid when the index is copied into subdirectories.
+    path: str
+    sha256: str
+
+
+# Wheels that we still host but the upstream simple index has stopped
+# publishing, so mirroring alone drops them and pinned installs stop resolving.
+# Keyed by normalised package name.
+#
+# Only the channel root is injected: manage_v2.py copies a root package index
+# down into every accepted subdirectory for packages in its
+# PACKAGE_LINKS_ALLOW_LIST, so the CUDA targets inherit these links without
+# their conserved indexes being re-mirrored from upstream.
+RETAINED_WHEEL_PREFIXES = {"whl/nightly", "whl/test", "whl"}
+RETAINED_WHEELS: Dict[str, List[RetainedWheel]] = {
+    "nvidia_cudnn_cu12": [
+        # Pinned by every torch 2.4.0-2.6.0 build; removed from pypi.nvidia.com
+        # around 2026-08-12. See pytorch/pytorch#193491.
+        RetainedWheel(
+            filename="nvidia_cudnn_cu12-9.1.0.70-py3-none-manylinux2014_x86_64.whl",
+            path=(
+                "/whl/cu124/"
+                "nvidia_cudnn_cu12-9.1.0.70-py3-none-manylinux2014_x86_64.whl"
+            ),
+            sha256="165764f44ef8c61fcdfdfdbe769d687e06374059fbb388b6c89ecb0e28793a6f",
+        ),
+    ],
+}
+
+
 def is_nvidia_package(pkg_name: str) -> bool:
     """Check if a package is from NVIDIA and is therefore CUDA-target only"""
     return pkg_name.startswith("nvidia-") or pkg_name.startswith("cuda-")
@@ -1028,6 +1062,10 @@ def upload_index_html(
         html, base_url, resolve_relative_paths=is_amd_package(pkg_name)
     )
 
+    # Re-add wheels we still host that upstream has stopped publishing. Runs
+    # after the rewrite above so the root-relative paths are left intact.
+    modified_html = append_retained_wheels(modified_html, pkg_name, prefix)
+
     index_key = f"{prefix}/{pkg_name}/index.html"
 
     if dry_run:
@@ -1128,6 +1166,39 @@ def append_preview_numpy_wheels(html: str, pkg_name: str, prefix: str) -> str:
 
     print(
         f"INFO: Merging {len(additions)} preview numpy wheel link(s) "
+        f"for {pkg_name} under {prefix}"
+    )
+    block = "\n".join(additions)
+    if "</body>" in html:
+        return html.replace("</body>", f"{block}\n  </body>", 1)
+    return f"{html}\n{block}\n"
+
+
+def append_retained_wheels(html: str, pkg_name: str, prefix: str) -> str:
+    """Merge :data:`RETAINED_WHEELS` links for *pkg_name* into *html*.
+
+    Limited to the channel roots in :data:`RETAINED_WHEEL_PREFIXES`. Wheels the
+    upstream index still lists are skipped, so this becomes a no-op if a version
+    is ever restored upstream.
+
+    Must run after :func:`replace_relative_links_with_absolute`, which would
+    otherwise resolve these root-relative paths against the upstream index.
+    """
+    entries = RETAINED_WHEELS.get(normalize_pkg_name(pkg_name))
+    if not entries or prefix not in RETAINED_WHEEL_PREFIXES:
+        return html
+
+    additions = [
+        f'    <a href="{entry.path}#sha256={entry.sha256}">{entry.filename}</a><br/>'
+        for entry in entries
+        if entry.filename not in html
+    ]
+
+    if not additions:
+        return html
+
+    print(
+        f"INFO: Merging {len(additions)} retained wheel link(s) "
         f"for {pkg_name} under {prefix}"
     )
     block = "\n".join(additions)


### PR DESCRIPTION
Fixes #193491

`nvidia-cudnn-cu12==9.1.0.70` disappeared from the cudnn index around 2026-08-12, which breaks every `pip install torch --index-url https://download.pytorch.org/whl/cu124` on Linux x86_64 with `ResolutionImpossible`. Every torch 2.4.0-2.6.0 build pins that exact version.

**Cause:** NVIDIA stopped publishing 9.1.0.70 on `pypi.nvidia.com/nvidia-cudnn-cu12/` (the listing now jumps `9.0.0.312` -> `9.1.1.17`). `upload_package_using_simple_index` mirrors that index verbatim, so the next run silently dropped the entry even though the wheel itself is still served fine from S3/R2.

**Fix:** a `RETAINED_WHEELS` table plus `append_retained_wheels()`, following the existing `append_preview_numpy_wheels()` idiom, re-injects links for wheels we still host but upstream no longer lists. Skipped if upstream ever restores the version, so there are no duplicate links.

The injected href is a **root-relative path** (`/whl/cu124/nvidia_cudnn_cu12-9.1.0.70-...whl`), matching the form `manage_v2.py` already uses for its libtorch and source-code indexes. It therefore resolves against whichever host serves the index -- the wheel is present and identical on both `download.pytorch.org` and `download-r2.pytorch.org` -- and, being root-relative rather than directory-relative, stays correct wherever the index is copied. Injection consequently runs *after* `replace_relative_links_with_absolute`, which would otherwise resolve the path against `pypi.nvidia.com`.

**Injection is limited to the channel roots** (`whl/nightly`, `whl/test`, `whl`). `manage_v2.py` copies a root package index down into every accepted subdirectory (`cu[0-9]+`, `rocm*`, `cpu`, `xpu`) for packages in its `PACKAGE_LINKS_ALLOW_LIST`, which includes `nvidia-cudnn-cu12`, so the CUDA targets inherit the link automatically. That keeps `cu124` and the other conserved targets conserved -- nothing re-mirrors them from upstream, so no other version NVIDIA removes can be dropped from them either. `PACKAGES_PER_PROJECT` and `manage_v2.py` are both unchanged.

`cu118` is unaffected: torch 2.6.0+cu118 pins `nvidia-cudnn-cu11==9.1.0.70`, and `nvidia_cudnn_cu11` is deliberately absent from `PACKAGE_LINKS_ALLOW_LIST` -- `whl/cu118/nvidia-cudnn-cu11/index.html` is a hand-curated 4-link index that still lists the version and is untouched here.

## Verification

- sha256 `165764f4...` is PyPI's. Confirmed the hosted file is byte-identical without downloading 664 MB: the S3 ETag on `whl/cu124` and `whl/nightly/cu124` is `97a2573180f8d6968a8068086339ff75`, exactly PyPI's published md5, and content-length matches at `664752741` on both `download.pytorch.org` and `download-r2.pytorch.org`.
- Ran the full `upload_package_using_simple_index` path with a stubbed S3: the link lands in the three channel-root indexes with the href intact as `/whl/cu124/...`, is absent from `whl/nightly/cu126`, and no href anywhere was mangled into a `pypi.nvidia.com/.../whl/` URL.
- Fed the result through pip's own `parse_links` collector, both as the root index and as the same bytes copied into a `cu124/` subdirectory (what `manage_v2.py` does): 151 links in each, both resolving to the same absolute wheel URL against the serving host, sha256 recognised as the link hash.
- The patched root index still satisfies `manage_v2.index_has_external_links()` (the 150 mirrored `pypi.nvidia.com` links), so the copy-to-subdirectory step is not skipped.
- Confirmed via AST extraction that `nvidia_cudnn_cu12` is in `PACKAGE_LINKS_ALLOW_LIST` and that `cu124` matches `ACCEPTED_SUBDIR_PATTERNS`. This also matches observed state: every `cu*` subdir index currently has an ETag byte-identical to its channel root.

Not exercised: the S3/R2 `put` calls themselves (no boto3 or usable pip on the machine this was written on), so a `dryrun: enabled` run is worth doing first.

## Rollout

`mode=update-packages, package=torch` covers nightly + test; prod needs a second run with `include-prod=enabled` (the `promote-env`-gated `update-prod` job). The cu\* subdirectories pick the link up on the next `manage_v2.py` run.
