### PR TITLE
Fix rendering of injected retained-wheel links

### DIFF
--- a/s3_management/update_dependencies.py
+++ b/s3_management/update_dependencies.py
@@ -1202,8 +1202,18 @@ def append_retained_wheels(html: str, pkg_name: str, prefix: str) -> str:
         f"for {pkg_name} under {prefix}"
     )
     block = "\n".join(additions)
-    if "</body>" in html:
-        return html.replace("</body>", f"{block}\n  </body>", 1)
+
+    # pypi.nvidia.com does not terminate its final anchor with a <br>, which
+    # would leave the first injected link on the same rendered line.
+    head, anchor_end, tail = html.rpartition("</a>")
+    if anchor_end and "<br" not in tail:
+        html = f"{head}{anchor_end}<br/>{tail}"
+
+    # Match on the indented closing tag: replacing the bare tag would leave its
+    # leading whitespace in front of the injected block.
+    for marker in ("  </body>", "</body>"):
+        if marker in html:
+            return html.replace(marker, f"{block}\n{marker}", 1)
     return f"{html}\n{block}\n"
 
 


### PR DESCRIPTION
Follow-up to #8532, which is live on the nightly index: https://download.pytorch.org/whl/nightly/nvidia-cudnn-cu12/

Two rendering defects in the injected link:

1. **Missing separator.** `pypi.nvidia.com` does not terminate its final anchor with a `<br>`, so the injected link rendered on the same line as the last upstream wheel:
   ```
   nvidia_cudnn_cu12-9.9.0.52-py3-none-win_amd64.whl nvidia_cudnn_cu12-9.1.0.70-py3-none-manylinux2014_x86_64.whl
   ```
   Fixed by appending the missing `<br/>` after the final upstream `</a>` before injecting, only when one is not already there.

2. **Wrong indentation.** The block was spliced in with `html.replace("</body>", ...)`, which left the closing tag's two leading spaces in front of the block, so the injected anchor came out at six spaces instead of four. Now matched against the indented tag.

Both are specific to the NVIDIA index. `append_preview_numpy_wheels()` is unaffected and untouched: the PyPI simple index puts its anchors at indent 0, has `</body>` at column 0, and does terminate its last anchor with a `<br/>` -- confirmed against the live https://download.pytorch.org/whl/nightly/numpy/ index, whose injected links are correctly indented and separated.

## Verification

Ran the full `upload_package_using_simple_index` path against the live upstream index with a stubbed S3:

- injected anchor indent is 4 (was 6), and the preceding upstream anchor now ends with `<br/>`
- exactly one `<br/>` added, no `<br/><br/>`, and re-running on already-patched HTML is a no-op
- pip's `parse_links` still returns 151 links, with the root-relative href resolving against the serving host and the sha256 recognised
- stripping tags and expanding `<br>` puts the last two wheels on separate rendered lines
