### PR TITLE
Harden upload-claude-usage against script injection and malformed metrics

### DIFF
--- a/.github/actions/upload-claude-usage/action.yml
+++ b/.github/actions/upload-claude-usage/action.yml
@@ -18,8 +18,18 @@ runs:
   steps:
     - name: Upload usage metrics
       shell: bash
+      env:
+        METRICS_FILE: ${{ inputs.metrics-file }}
+        GH_REPOSITORY: ${{ github.repository }}
+        GH_RUN_ID: ${{ github.run_id }}
+        GH_RUN_ATTEMPT: ${{ github.run_attempt }}
+        GH_ACTOR: ${{ github.actor }}
+        GH_EVENT_NAME: ${{ github.event_name }}
+        GH_WORKFLOW: ${{ github.workflow }}
+        GH_PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number || 0 }}
+        S3_BUCKET: ${{ inputs.s3-bucket }}
+        S3_PREFIX: ${{ inputs.s3-prefix }}
       run: |
-        METRICS_FILE="${{ inputs.metrics-file }}"
         if [ ! -f "$METRICS_FILE" ]; then
           echo "::notice::Claude usage metrics file not found: $METRICS_FILE; skipping upload"
           exit 0
@@ -57,9 +67,9 @@ runs:
         # workflow name instead so these rows are clearly automated and remain
         # distinguishable per-workflow. github.event_name is still stored, so
         # the original signal isn't lost.
-        ACTOR="${{ github.actor }}"
-        if [ "${{ github.event_name }}" = "schedule" ]; then
-          ACTOR="${{ github.workflow }} (scheduled)"
+        ACTOR="$GH_ACTOR"
+        if [ "$GH_EVENT_NAME" = "schedule" ]; then
+          ACTOR="$GH_WORKFLOW (scheduled)"
         fi
 
         # Merge GitHub context with the extracted metrics. Context ids arrive as
@@ -67,12 +77,12 @@ runs:
         # the step on an empty or malformed value).
         PAYLOAD=$(jq -n \
           --argjson metrics "$METRICS" \
-          --arg repo "${{ github.repository }}" \
-          --arg run_id "${{ github.run_id }}" \
-          --arg run_attempt "${{ github.run_attempt }}" \
+          --arg repo "$GH_REPOSITORY" \
+          --arg run_id "$GH_RUN_ID" \
+          --arg run_attempt "$GH_RUN_ATTEMPT" \
           --arg actor "$ACTOR" \
-          --arg event_name "${{ github.event_name }}" \
-          --arg pr_number "${{ github.event.issue.number || github.event.pull_request.number || 0 }}" \
+          --arg event_name "$GH_EVENT_NAME" \
+          --arg pr_number "$GH_PR_NUMBER" \
           --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%S.000)" \
           '{
             repo: $repo,
@@ -94,7 +104,7 @@ runs:
         fi
 
         if ! aws s3 cp /tmp/claude_usage.json \
-          "s3://${{ inputs.s3-bucket }}/${{ inputs.s3-prefix }}/${{ github.repository }}/${{ github.run_id }}_${{ github.run_attempt }}.json"; then
+          "s3://$S3_BUCKET/$S3_PREFIX/$GH_REPOSITORY/${GH_RUN_ID}_${GH_RUN_ATTEMPT}.json"; then
           echo "::warning::Failed to upload Claude usage metrics to S3 (best-effort telemetry)"
           exit 0
         fi

--- a/.github/actions/upload-claude-usage/action.yml
+++ b/.github/actions/upload-claude-usage/action.yml
@@ -33,15 +33,15 @@ runs:
         # than carrying the whole result, whose .result text can be large) keeps
         # the value small for the payload step below.
         METRICS=$(jq -s -c '
-          [ .. | objects | select(.type == "result") ] | last
+          [ .[] | (if type == "array" then .[] else empty end) | select(type == "object" and .type == "result") ] | last
           | if . == null then empty else {
-              duration_ms: (.duration_ms? // 0),
-              num_turns: (.num_turns? // 0),
-              total_cost_usd: (.total_cost_usd? // 0),
-              input_tokens: (.usage.input_tokens? // 0),
-              output_tokens: (.usage.output_tokens? // 0),
-              cache_read_input_tokens: (.usage.cache_read_input_tokens? // 0),
-              cache_creation_input_tokens: (.usage.cache_creation_input_tokens? // 0),
+              duration_ms: ((.duration_ms? | tonumber?) // 0),
+              num_turns: ((.num_turns? | tonumber?) // 0),
+              total_cost_usd: ((.total_cost_usd? | tonumber?) // 0),
+              input_tokens: ((.usage.input_tokens? | tonumber?) // 0),
+              output_tokens: ((.usage.output_tokens? | tonumber?) // 0),
+              cache_read_input_tokens: ((.usage.cache_read_input_tokens? | tonumber?) // 0),
+              cache_creation_input_tokens: ((.usage.cache_creation_input_tokens? | tonumber?) // 0),
               model: (.modelUsage | if type == "object" then (keys[0] // "") else "" end)
             } end
         ' "$METRICS_FILE" 2>/dev/null || true)
@@ -88,7 +88,10 @@ runs:
           exit 0
         fi
 
-        echo "$PAYLOAD" > /tmp/claude_usage.json
+        if ! echo "$PAYLOAD" > /tmp/claude_usage.json; then
+          echo "::warning::Failed to write Claude usage payload to disk; skipping usage upload"
+          exit 0
+        fi
 
         if ! aws s3 cp /tmp/claude_usage.json \
           "s3://${{ inputs.s3-bucket }}/${{ inputs.s3-prefix }}/${{ github.repository }}/${{ github.run_id }}_${{ github.run_attempt }}.json"; then

--- a/.github/actions/upload-claude-usage/action.yml
+++ b/.github/actions/upload-claude-usage/action.yml
@@ -21,14 +21,32 @@ runs:
       run: |
         METRICS_FILE="${{ inputs.metrics-file }}"
         if [ ! -f "$METRICS_FILE" ]; then
-          echo "Metrics file not found: $METRICS_FILE"
+          echo "::notice::Claude usage metrics file not found: $METRICS_FILE; skipping upload"
           exit 0
         fi
 
-        # File is a JSON array, extract the "result" entry
-        RESULT=$(jq '.[] | select(.type == "result")' "$METRICS_FILE")
-        if [ -z "$RESULT" ]; then
-          echo "No result entry found in metrics file"
+        # The producer (claude-code-action) writes a JSON array of SDK message
+        # objects, one of which has type "result". Extract only the metric fields
+        # from that entry, defensively: a non-array, unparseable, or truncated
+        # file yields no match, and if more than one result object is ever
+        # emitted the last one wins. Projecting to just these fields here (rather
+        # than carrying the whole result, whose .result text can be large) keeps
+        # the value small for the payload step below.
+        METRICS=$(jq -s -c '
+          [ .. | objects | select(.type == "result") ] | last
+          | if . == null then empty else {
+              duration_ms: (.duration_ms? // 0),
+              num_turns: (.num_turns? // 0),
+              total_cost_usd: (.total_cost_usd? // 0),
+              input_tokens: (.usage.input_tokens? // 0),
+              output_tokens: (.usage.output_tokens? // 0),
+              cache_read_input_tokens: (.usage.cache_read_input_tokens? // 0),
+              cache_creation_input_tokens: (.usage.cache_creation_input_tokens? // 0),
+              model: (.modelUsage | if type == "object" then (keys[0] // "") else "" end)
+            } end
+        ' "$METRICS_FILE" 2>/dev/null || true)
+        if [ -z "$METRICS" ]; then
+          echo "::warning::No usable Claude result entry in $METRICS_FILE; skipping usage upload"
           exit 0
         fi
 
@@ -44,40 +62,36 @@ runs:
           ACTOR="${{ github.workflow }} (scheduled)"
         fi
 
-        # Extract fields and add context
-        jq -n \
+        # Merge GitHub context with the extracted metrics. Context ids arrive as
+        # strings and are coerced with tonumber (never --argjson, which aborts
+        # the step on an empty or malformed value).
+        PAYLOAD=$(jq -n \
+          --argjson metrics "$METRICS" \
           --arg repo "${{ github.repository }}" \
-          --argjson run_id "${{ github.run_id }}" \
-          --argjson run_attempt "${{ github.run_attempt }}" \
+          --arg run_id "${{ github.run_id }}" \
+          --arg run_attempt "${{ github.run_attempt }}" \
           --arg actor "$ACTOR" \
           --arg event_name "${{ github.event_name }}" \
-          --argjson pr_number "${{ github.event.issue.number || github.event.pull_request.number || 0 }}" \
+          --arg pr_number "${{ github.event.issue.number || github.event.pull_request.number || 0 }}" \
           --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%S.000)" \
-          --argjson duration_ms "$(echo "$RESULT" | jq -r '.duration_ms // 0')" \
-          --argjson num_turns "$(echo "$RESULT" | jq -r '.num_turns // 0')" \
-          --argjson total_cost_usd "$(echo "$RESULT" | jq -r '.total_cost_usd // 0')" \
-          --argjson input_tokens "$(echo "$RESULT" | jq -r '.usage.input_tokens // 0')" \
-          --argjson output_tokens "$(echo "$RESULT" | jq -r '.usage.output_tokens // 0')" \
-          --argjson cache_read_input_tokens "$(echo "$RESULT" | jq -r '.usage.cache_read_input_tokens // 0')" \
-          --argjson cache_creation_input_tokens "$(echo "$RESULT" | jq -r '.usage.cache_creation_input_tokens // 0')" \
-          --arg model "$(echo "$RESULT" | jq -r '.modelUsage | keys[0] // ""')" \
           '{
             repo: $repo,
-            run_id: $run_id,
-            run_attempt: $run_attempt,
+            run_id: ($run_id | tonumber? // 0),
+            run_attempt: ($run_attempt | tonumber? // 0),
             actor: $actor,
             event_name: $event_name,
-            pr_number: $pr_number,
-            timestamp: $timestamp,
-            duration_ms: $duration_ms,
-            num_turns: $num_turns,
-            total_cost_usd: $total_cost_usd,
-            input_tokens: $input_tokens,
-            output_tokens: $output_tokens,
-            cache_read_input_tokens: $cache_read_input_tokens,
-            cache_creation_input_tokens: $cache_creation_input_tokens,
-            model: $model
-          }' > /tmp/claude_usage.json
+            pr_number: ($pr_number | tonumber? // 0),
+            timestamp: $timestamp
+          } + $metrics' || true)
+        if [ -z "$PAYLOAD" ]; then
+          echo "::warning::Failed to build Claude usage payload; skipping usage upload"
+          exit 0
+        fi
 
-        aws s3 cp /tmp/claude_usage.json \
-          "s3://${{ inputs.s3-bucket }}/${{ inputs.s3-prefix }}/${{ github.repository }}/${{ github.run_id }}_${{ github.run_attempt }}.json"
+        echo "$PAYLOAD" > /tmp/claude_usage.json
+
+        if ! aws s3 cp /tmp/claude_usage.json \
+          "s3://${{ inputs.s3-bucket }}/${{ inputs.s3-prefix }}/${{ github.repository }}/${{ github.run_id }}_${{ github.run_attempt }}.json"; then
+          echo "::warning::Failed to upload Claude usage metrics to S3 (best-effort telemetry)"
+          exit 0
+        fi


### PR DESCRIPTION
**Impact:** CI only — the `upload-claude-usage`
**Risk:** low

## What
Moves all GitHub context (`github.*`) and action inputs out of inline `${{ }}` interpolation and into `env:` vars, and rewrites the metrics-extraction/payload jq so that a missing, truncated, non-array, or otherwise malformed metrics file degrades gracefully to a skipped upload instead of failing the step.

1. **Silent loss of agent memory + issue-filing (primary).** The action parsed the
   Claude execution-output JSON with brittle `jq`: a non-array/malformed file threw
   (exit 5) and multiple `result` entries broke `--argjson` (exit 2). Under the
   composite shell's `bash -eo pipefail` that aborted the step, and on the callers
   without `continue-on-error` it failed the whole job. In the treehugger
   investigation workflow the failed job gated the downstream `persist-memory` job —
   so a *billing-telemetry* step was discarding the run's built-up memory and
   skipping issue-filing. Observed on real runs (gha-infra 3021/3028 and the
   surrounding cadence). This fixes the root cause upstream of the per-caller
   `continue-on-error` band-aid.
2. **Corrupt/rejected telemetry rows.** Numeric fields could pass through as strings
   or objects on odd input, which ClickHouse then rejects. Now coerced to numbers.
3. **Best-effort uploads.** An S3 upload error (e.g. a Bedrock-scoped role with no S3
   write) no longer fails the step — telemetry is best-effort.
4. **Script injection.** `${{ github.workflow }}` was interpolated straight into the
   bash source: a workflow name containing `$(...)`/backticks would execute on the
   runner, and a stray quote would abort the step (notably on scheduled runs).
   Context now flows through the step `env:` and is never parsed as code.

## Why
Interpolating `${{ github.actor }}`, `${{ github.workflow }}`, etc. directly into a `run:` script is a script-injection vector (attacker-controlled fields land in the shell). Passing them via `env` closes that hole. Separately, the previous `--argjson` usage aborted the whole step whenever a field was empty or non-numeric; since this is best-effort telemetry, every failure path (no file, no result entry, bad JSON, S3 upload failure) now emits a notice/warning and exits 0 rather than turning a build red.

# Notes
Behavior on the happy path is unchanged — same payload shape and same S3 destination key. The extraction now projects only the metric fields it needs (dropping the potentially large `.result` text) and coerces all numeric context ids with `tonumber` defaults.
