### PR TITLE
[CRCR] Split summary description with separate PR and Nightly HUD links

### DIFF
--- a/torchci/pages/crcr/index.tsx
+++ b/torchci/pages/crcr/index.tsx
@@ -826,7 +826,7 @@ export default function CrcrSummaryPage() {
           >
             pytorch/crcr-test
           </Link>{" "}
-          probes. To know more, check the HUD dashboard for{" "}
+          probes. To know more, check the HUD dashboard —{" "}
           <Link
             href="https://hud.pytorch.org/crcr/pytorch/crcr-test"
             target="_blank"
@@ -841,8 +841,8 @@ export default function CrcrSummaryPage() {
             rel="noreferrer"
           >
             Nightly
-          </Link>
-          , or view{" "}
+          </Link>{" "}
+          — or view{" "}
           <NextLink href="/crcr/metrics" passHref legacyBehavior>
             <Link underline="hover">success-rate trends</Link>
           </NextLink>

--- a/torchci/pages/crcr/index.tsx
+++ b/torchci/pages/crcr/index.tsx
@@ -827,21 +827,17 @@ export default function CrcrSummaryPage() {
             pytorch/crcr-test
           </Link>{" "}
           probes. To know more, check the HUD dashboard —{" "}
-          <Link
-            href="https://hud.pytorch.org/crcr/pytorch/crcr-test"
-            target="_blank"
-            rel="noreferrer"
-          >
-            Pull Requests
-          </Link>{" "}
+          <NextLink href="/crcr/pytorch/crcr-test" passHref legacyBehavior>
+            <Link underline="hover">Pull Requests</Link>
+          </NextLink>{" "}
           and{" "}
-          <Link
-            href="https://hud.pytorch.org/crcr/pytorch/crcr-test?event=nightly"
-            target="_blank"
-            rel="noreferrer"
+          <NextLink
+            href="/crcr/pytorch/crcr-test?event=nightly"
+            passHref
+            legacyBehavior
           >
-            Nightly
-          </Link>{" "}
+            <Link underline="hover">Nightly</Link>
+          </NextLink>{" "}
           — or view{" "}
           <NextLink href="/crcr/metrics" passHref legacyBehavior>
             <Link underline="hover">success-rate trends</Link>

--- a/torchci/pages/crcr/index.tsx
+++ b/torchci/pages/crcr/index.tsx
@@ -826,15 +826,23 @@ export default function CrcrSummaryPage() {
           >
             pytorch/crcr-test
           </Link>{" "}
-          probes. To know more, check the{" "}
+          probes. To know more, check the HUD dashboard for{" "}
           <Link
             href="https://hud.pytorch.org/crcr/pytorch/crcr-test"
             target="_blank"
             rel="noreferrer"
           >
-            HUD dashboard
+            Pull Requests
           </Link>{" "}
-          or view{" "}
+          and{" "}
+          <Link
+            href="https://hud.pytorch.org/crcr/pytorch/crcr-test?event=nightly"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Nightly
+          </Link>
+          , or view{" "}
           <NextLink href="/crcr/metrics" passHref legacyBehavior>
             <Link underline="hover">success-rate trends</Link>
           </NextLink>


### PR DESCRIPTION
## Summary
- The description sentence on the CRCR summary page previously had a single "HUD dashboard" link that always pointed to the PR view
- Update it to include separate links for the Pull Requests and Nightly dashboards so users can navigate directly to the relevant view
- The sentence is common to both tabs, providing quick access to either dashboard regardless of which tab is active

**Before:** "...check the [HUD dashboard](...) or view..."
**After:** "...check the HUD dashboard — [Pull Requests](...) and [Nightly](...?event=nightly) — or view..."

## Mockup
https://subinz1.github.io/CRCR/mockups/crcr-summary-sentence-mockup.html

## Test plan
- [ ] Verify the sentence renders correctly on the CRCR summary page
- [ ] Verify the Pull Requests link opens the PR view of crcr-test
- [ ] Verify the Nightly link opens the nightly view (?event=nightly)
- [ ] Confirm the sentence is visible in both PR and Nightly tabs