### PR TITLE
[treehugger] Harden upload-claude-usage against malformed metrics

### DIFF
--- a/.github/actions/upload-claude-usage/action.yml
+++ b/.github/actions/upload-claude-usage/action.yml
@@ -21,14 +21,32 @@ runs:
       run: |
         METRICS_FILE="${{ inputs.metrics-file }}"
         if [ ! -f "$METRICS_FILE" ]; then
-          echo "Metrics file not found: $METRICS_FILE"
+          echo "::notice::Claude usage metrics file not found: $METRICS_FILE; skipping upload"
           exit 0
         fi
 
-        # File is a JSON array, extract the "result" entry
-        RESULT=$(jq '.[] | select(.type == "result")' "$METRICS_FILE")
-        if [ -z "$RESULT" ]; then
-          echo "No result entry found in metrics file"
+        # The producer (claude-code-action) writes a JSON array of SDK message
+        # objects, one of which has type "result". Extract only the metric fields
+        # from that entry, defensively: a non-array, unparseable, or truncated
+        # file yields no match, and if more than one result object is ever
+        # emitted the last one wins. Projecting to just these fields here (rather
+        # than carrying the whole result, whose .result text can be large) keeps
+        # the value small for the payload step below.
+        METRICS=$(jq -s -c '
+          [ .. | objects | select(.type == "result") ] | last
+          | if . == null then empty else {
+              duration_ms: (.duration_ms? // 0),
+              num_turns: (.num_turns? // 0),
+              total_cost_usd: (.total_cost_usd? // 0),
+              input_tokens: (.usage.input_tokens? // 0),
+              output_tokens: (.usage.output_tokens? // 0),
+              cache_read_input_tokens: (.usage.cache_read_input_tokens? // 0),
+              cache_creation_input_tokens: (.usage.cache_creation_input_tokens? // 0),
+              model: (.modelUsage | if type == "object" then (keys[0] // "") else "" end)
+            } end
+        ' "$METRICS_FILE" 2>/dev/null || true)
+        if [ -z "$METRICS" ]; then
+          echo "::warning::No usable Claude result entry in $METRICS_FILE; skipping usage upload"
           exit 0
         fi
 
@@ -44,40 +62,36 @@ runs:
           ACTOR="${{ github.workflow }} (scheduled)"
         fi
 
-        # Extract fields and add context
-        jq -n \
+        # Merge GitHub context with the extracted metrics. Context ids arrive as
+        # strings and are coerced with tonumber (never --argjson, which aborts
+        # the step on an empty or malformed value).
+        PAYLOAD=$(jq -n \
+          --argjson metrics "$METRICS" \
           --arg repo "${{ github.repository }}" \
-          --argjson run_id "${{ github.run_id }}" \
-          --argjson run_attempt "${{ github.run_attempt }}" \
+          --arg run_id "${{ github.run_id }}" \
+          --arg run_attempt "${{ github.run_attempt }}" \
           --arg actor "$ACTOR" \
           --arg event_name "${{ github.event_name }}" \
-          --argjson pr_number "${{ github.event.issue.number || github.event.pull_request.number || 0 }}" \
+          --arg pr_number "${{ github.event.issue.number || github.event.pull_request.number || 0 }}" \
           --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%S.000)" \
-          --argjson duration_ms "$(echo "$RESULT" | jq -r '.duration_ms // 0')" \
-          --argjson num_turns "$(echo "$RESULT" | jq -r '.num_turns // 0')" \
-          --argjson total_cost_usd "$(echo "$RESULT" | jq -r '.total_cost_usd // 0')" \
-          --argjson input_tokens "$(echo "$RESULT" | jq -r '.usage.input_tokens // 0')" \
-          --argjson output_tokens "$(echo "$RESULT" | jq -r '.usage.output_tokens // 0')" \
-          --argjson cache_read_input_tokens "$(echo "$RESULT" | jq -r '.usage.cache_read_input_tokens // 0')" \
-          --argjson cache_creation_input_tokens "$(echo "$RESULT" | jq -r '.usage.cache_creation_input_tokens // 0')" \
-          --arg model "$(echo "$RESULT" | jq -r '.modelUsage | keys[0] // ""')" \
           '{
             repo: $repo,
-            run_id: $run_id,
-            run_attempt: $run_attempt,
+            run_id: ($run_id | tonumber? // 0),
+            run_attempt: ($run_attempt | tonumber? // 0),
             actor: $actor,
             event_name: $event_name,
-            pr_number: $pr_number,
-            timestamp: $timestamp,
-            duration_ms: $duration_ms,
-            num_turns: $num_turns,
-            total_cost_usd: $total_cost_usd,
-            input_tokens: $input_tokens,
-            output_tokens: $output_tokens,
-            cache_read_input_tokens: $cache_read_input_tokens,
-            cache_creation_input_tokens: $cache_creation_input_tokens,
-            model: $model
-          }' > /tmp/claude_usage.json
+            pr_number: ($pr_number | tonumber? // 0),
+            timestamp: $timestamp
+          } + $metrics' || true)
+        if [ -z "$PAYLOAD" ]; then
+          echo "::warning::Failed to build Claude usage payload; skipping usage upload"
+          exit 0
+        fi
 
-        aws s3 cp /tmp/claude_usage.json \
-          "s3://${{ inputs.s3-bucket }}/${{ inputs.s3-prefix }}/${{ github.repository }}/${{ github.run_id }}_${{ github.run_attempt }}.json"
+        echo "$PAYLOAD" > /tmp/claude_usage.json
+
+        if ! aws s3 cp /tmp/claude_usage.json \
+          "s3://${{ inputs.s3-bucket }}/${{ inputs.s3-prefix }}/${{ github.repository }}/${{ github.run_id }}_${{ github.run_attempt }}.json"; then
+          echo "::warning::Failed to upload Claude usage metrics to S3 (best-effort telemetry)"
+          exit 0
+        fi


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #8542
* #8541
* __->__ #8540

The action parsed the Claude execution-output JSON with
`jq '.[] | select(.type=="result")'` and fed the extracted fields to a
second jq via --argjson. Under the composite shell's `bash -eo pipefail`
this aborted the step (and, on the callers without continue-on-error,
the whole job) on inputs it should tolerate:
- a non-array, unparseable, or truncated file made the top-level `.[]`
  iteration throw (exit 5);
- more than one `result` entry made the per-field command-subs emit
  multiple lines, so `--argjson` received invalid JSON (exit 2).

Rewrite the parse to be defensive and best-effort:
- Select exactly one result entry (last wins), projecting only the
  needed fields, and bail to a warning + exit 0 when the file is
  missing, unparseable, or has no result -- telemetry upload must never
  fail the job.
- Build the payload in a single jq program; pass context ids as strings
  coerced with tonumber instead of --argjson; default every field.
- Treat an S3 upload failure as a warning, not a step failure (the
  Bedrock-scoped caller's role may legitimately lack S3 write).

The output payload schema is unchanged (same 15 fields), so the
ClickHouse table misc.claude_code_usage and its consumers are
unaffected.