### PR TITLE
Honor greenlight App bot approvals in pytorchbot merge gate

### DIFF
--- a/torchci/lib/bot/pytorchBotHandler.ts
+++ b/torchci/lib/bot/pytorchBotHandler.ts
@@ -187,6 +187,14 @@ The explanation needs to be clear on why this is needed. Here are some good exam
       "OWNER",
     ];
 
+    // GitHub App bots authenticate via installations rather than as repo
+    // collaborators, so their reviews always carry author_association=NONE.
+    // Allowlist trusted App identities so their approvals are still honored,
+    // but only on pytorch/pytorch since that is the sole repo these bots
+    // review -- other supported orgs/repos must not honor the exemption.
+    const ALLOWED_APPROVER_BOT_LOGINS = ["pytorchgreenlight[bot]"];
+    const isPyTorchPyTorchRepo = isPyTorchPyTorch(this.owner, this.repo);
+
     // Find the latest review offered by each authroized reviewer
     // But first sort them in case Github ever returns the list unsorted
     var latest_reviews: { [user: string]: string } = reviews
@@ -203,6 +211,12 @@ The explanation needs to be clear on why this is needed. Here are some good exam
           if (
             !ALLOWED_APPROVER_ASSOCIATIONS.includes(
               curr_review.author_association
+            ) &&
+            !(
+              isPyTorchPyTorchRepo &&
+              ALLOWED_APPROVER_BOT_LOGINS.includes(
+                curr_review.user?.login ?? ""
+              )
             )
           ) {
             // Not an authorized approver

--- a/torchci/test/mergeCommands.test.ts
+++ b/torchci/test/mergeCommands.test.ts
@@ -2,6 +2,9 @@ import { getFailureMessage, getMessage } from "lib/GeneralUtils";
 import nock from "nock";
 import * as probot from "probot";
 import pytorchBot from "../lib/bot/pytorchBot";
+import PytorchBotHandler, {
+  PytorchbotParams,
+} from "../lib/bot/pytorchBotHandler";
 import * as clickhouse from "../lib/clickhouse";
 import { handleScope, requireDeepCopy } from "./common";
 import * as utils from "./utils";
@@ -1612,6 +1615,80 @@ some other text lol
     await probot.receive(event);
 
     handleScope(scope);
+  });
+
+  // The greenlight App bot posts reviews with author_association=NONE, so it is
+  // only honored as an approver on pytorch/pytorch (see getApprovalStatus).
+  const greenlightApprovedReview = {
+    user: { login: "pytorchgreenlight[bot]" },
+    state: "APPROVED",
+    author_association: "NONE",
+    submitted_at: "2024-01-01T00:00:00Z",
+  };
+
+  function makeApprovalHandler(
+    owner: string,
+    repo: string,
+    reviews: any[]
+  ): PytorchBotHandler {
+    const params: PytorchbotParams = {
+      owner,
+      repo,
+      prNum: 42,
+      ctx: {
+        octokit: {
+          paginate: jest.fn().mockResolvedValue(reviews),
+          pulls: { listReviews: jest.fn() },
+        },
+        log: jest.fn(),
+      },
+      url: "https://github.com/pytorch/pytorch/pull/42#issuecomment-123",
+      login: "test-user",
+      commentId: 123,
+      commentBody: "@pytorchbot merge",
+      useReactions: false,
+      cachedConfigTracker: {} as any,
+    };
+    return new PytorchBotHandler(params);
+  }
+
+  test("greenlight bot approval (author_association NONE) counts as approved on pytorch/pytorch", async () => {
+    const handler = makeApprovalHandler("pytorch", "pytorch", [
+      greenlightApprovedReview,
+    ]);
+    expect(await handler.getApprovalStatus()).toBe("approved");
+  });
+
+  test("greenlight bot approval is not honored on a supported-org repo that is not pytorch/pytorch", async () => {
+    const handler = makeApprovalHandler("pytorch", "gha-ci-playground", [
+      greenlightApprovedReview,
+    ]);
+    expect(await handler.getApprovalStatus()).toBe("");
+  });
+
+  test("non-greenlight approval with author_association NONE is not honored on pytorch/pytorch", async () => {
+    const handler = makeApprovalHandler("pytorch", "pytorch", [
+      {
+        user: { login: "some-random-bot[bot]" },
+        state: "APPROVED",
+        author_association: "NONE",
+        submitted_at: "2024-01-01T00:00:00Z",
+      },
+    ]);
+    expect(await handler.getApprovalStatus()).toBe("");
+  });
+
+  test("greenlight bot review dismissed after approval is not honored on pytorch/pytorch", async () => {
+    const handler = makeApprovalHandler("pytorch", "pytorch", [
+      greenlightApprovedReview,
+      {
+        user: { login: "pytorchgreenlight[bot]" },
+        state: "DISMISSED",
+        author_association: "NONE",
+        submitted_at: "2024-01-02T00:00:00Z",
+      },
+    ]);
+    expect(await handler.getApprovalStatus()).toBe("");
   });
 
   test("pytorchmergebot -h rebase command on pull request prints help message and does not execute rebase", async () => {


### PR DESCRIPTION
**Impact:** pytorch/pytorch merge flow
**Risk:** low

## What
`getApprovalStatus` now honors approvals from an allowlisted set of GitHub App bots (currently `pytorchgreenlight[bot]`), scoped strictly to pytorch/pytorch. All other approver logic is unchanged.

## Why
GitHub App bots authenticate via installations, not as repo collaborators, so their reviews always carry `author_association=NONE` and were silently dropped by the existing `ALLOWED_APPROVER_ASSOCIATIONS` filter. The greenlight auto-land bot posts real APPROVED reviews that need to count toward the merge gate. The exemption is gated on `isPyTorchPyTorch(owner, repo)` so the same bot login cannot be honored on any other supported org/repo.

# Notes
- Dismissed reviews from the bot still correctly revoke the approval (covered by tests).
- Adding a new trusted App means appending to `ALLOWED_APPROVER_BOT_LOGINS`.