### PR TITLE
Skip offline pet runners during scale-down offline sweep

### DIFF
--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/metrics.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/metrics.ts
@@ -1575,6 +1575,12 @@ export class ScaleDownMetrics extends Metrics {
   }
 
   /* istanbul ignore next */
+  runnerGhOfflineSkippedPetRepo(repo: Repo) {
+    const dimensions = this.getRepoDim(repo);
+    this.countEntry('run.ghRunner.perRepo.offline.skipped.pet', 1, dimensions);
+  }
+
+  /* istanbul ignore next */
   runnerGhOfflineFoundOrg(org: string, total: number) {
     const dimensions = new Map([['Org', org]]);
     this.addEntry('run.ghRunner.perOrg.offline.found', total, dimensions);
@@ -1590,6 +1596,12 @@ export class ScaleDownMetrics extends Metrics {
   runnerGhOfflineRemovedFailureOrg(org: string) {
     const dimensions = new Map([['Org', org]]);
     this.countEntry('run.ghRunner.perOrg.offline.removed.failure', 1, dimensions);
+  }
+
+  /* istanbul ignore next */
+  runnerGhOfflineSkippedPetOrg(org: string) {
+    const dimensions = new Map([['Org', org]]);
+    this.countEntry('run.ghRunner.perOrg.offline.skipped.pet', 1, dimensions);
   }
 
   /* istanbul ignore next */

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.test.ts
@@ -58,7 +58,7 @@ jest.mock('./gh-auth', () => ({
 
 beforeEach(() => {
   jest.resetModules();
-  jest.clearAllMocks();
+  jest.resetAllMocks();
   jest.restoreAllMocks();
   nock.disableNetConnect();
 });
@@ -501,6 +501,45 @@ describe('scale-down', () => {
         expect(mockedTerminateRunner).toBeCalledWith(awsR, metrics);
       }
     });
+
+    it('does not deregister an offline pet runner (org)', async () => {
+      const petEc2Runner = {
+        awsRegion: baseConfig.awsRegion,
+        runnerType: 'keep-all-4',
+        instanceId: 'pet-offline-01',
+        org: theOrg,
+        instanceManagement: 'pet',
+        launchTime: dateRef
+          .clone()
+          .subtract(minimumRunningTimeInMinutes + 5, 'minutes')
+          .toDate(),
+      };
+      const petGhRunner = mockRunner({ id: '01XX', name: 'pet-offline-01', busy: false, status: 'offline' });
+
+      const mockedListRunners = mocked(listRunners);
+      const mockedListGithubRunnersOrg = mocked(listGithubRunnersOrg);
+      const mockedGetRunnerTypes = mocked(getRunnerTypes);
+      const mockedRemoveGithubRunnerOrg = mocked(removeGithubRunnerOrg);
+      const mockedTerminateRunner = mocked(terminateRunner);
+
+      mockedListRunners.mockResolvedValueOnce([...listRunnersRet, petEc2Runner]);
+      mockedListGithubRunnersOrg.mockResolvedValue([...ghRunners, petGhRunner] as GhRunners);
+      mockedGetRunnerTypes.mockResolvedValue(runnerTypes);
+
+      await scaleDown();
+
+      expect(mockedRemoveGithubRunnerOrg).not.toBeCalledWith(petGhRunner.id, theOrg, metrics);
+      expect(mockedTerminateRunner).not.toBeCalledWith(petEc2Runner, metrics);
+
+      {
+        const { ghR } = getRunnerPair('remove-offline-01');
+        expect(mockedRemoveGithubRunnerOrg).toBeCalledWith(ghR.id, theOrg, metrics);
+      }
+      {
+        const { ghR } = getRunnerPair('remove-offline-02');
+        expect(mockedRemoveGithubRunnerOrg).toBeCalledWith(ghR.id, theOrg, metrics);
+      }
+    });
   });
 
   describe('repo', () => {
@@ -841,6 +880,45 @@ describe('scale-down', () => {
       {
         const { awsR } = getRunnerPair('remove-ephemeral-02');
         expect(mockedTerminateRunner).toBeCalledWith(awsR, metrics);
+      }
+    });
+
+    it('does not deregister an offline pet runner (repo)', async () => {
+      const petEc2Runner = {
+        awsRegion: baseConfig.awsRegion,
+        runnerType: 'keep-all-4',
+        instanceId: 'pet-offline-01',
+        repo: theRepo,
+        instanceManagement: 'pet',
+        launchTime: dateRef
+          .clone()
+          .subtract(minimumRunningTimeInMinutes + 5, 'minutes')
+          .toDate(),
+      };
+      const petGhRunner = mockRunner({ id: '01XX', name: 'pet-offline-01', busy: false, status: 'offline' });
+
+      const mockedListRunners = mocked(listRunners);
+      const mockedListGithubRunnersRepo = mocked(listGithubRunnersRepo);
+      const mockedGetRunnerTypes = mocked(getRunnerTypes);
+      const mockedRemoveGithubRunnerRepo = mocked(removeGithubRunnerRepo);
+      const mockedTerminateRunner = mocked(terminateRunner);
+
+      mockedListRunners.mockResolvedValueOnce([...listRunnersRet, petEc2Runner]);
+      mockedListGithubRunnersRepo.mockResolvedValue([...ghRunners, petGhRunner] as GhRunners);
+      mockedGetRunnerTypes.mockResolvedValue(runnerTypes);
+
+      await scaleDown();
+
+      expect(mockedRemoveGithubRunnerRepo).not.toBeCalledWith(petGhRunner.id, repo, metrics);
+      expect(mockedTerminateRunner).not.toBeCalledWith(petEc2Runner, metrics);
+
+      {
+        const { ghR } = getRunnerPair('remove-offline-01');
+        expect(mockedRemoveGithubRunnerRepo).toBeCalledWith(ghR.id, repo, metrics);
+      }
+      {
+        const { ghR } = getRunnerPair('remove-offline-02');
+        expect(mockedRemoveGithubRunnerRepo).toBeCalledWith(ghR.id, repo, metrics);
       }
     });
   });

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.test.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.test.ts
@@ -526,7 +526,14 @@ describe('scale-down', () => {
       mockedListGithubRunnersOrg.mockResolvedValue([...ghRunners, petGhRunner] as GhRunners);
       mockedGetRunnerTypes.mockResolvedValue(runnerTypes);
 
+      const spyOfflineFound = jest.spyOn(metrics, 'runnerGhOfflineFoundOrg');
+      const spyOfflineSkippedPet = jest.spyOn(metrics, 'runnerGhOfflineSkippedPetOrg');
+
       await scaleDown();
+
+      expect(spyOfflineFound).toBeCalledWith(theOrg, 3);
+      expect(spyOfflineSkippedPet).toBeCalledTimes(1);
+      expect(spyOfflineSkippedPet).toBeCalledWith(theOrg);
 
       expect(mockedRemoveGithubRunnerOrg).not.toBeCalledWith(petGhRunner.id, theOrg, metrics);
       expect(mockedTerminateRunner).not.toBeCalledWith(petEc2Runner, metrics);
@@ -907,7 +914,14 @@ describe('scale-down', () => {
       mockedListGithubRunnersRepo.mockResolvedValue([...ghRunners, petGhRunner] as GhRunners);
       mockedGetRunnerTypes.mockResolvedValue(runnerTypes);
 
+      const spyOfflineFound = jest.spyOn(metrics, 'runnerGhOfflineFoundRepo');
+      const spyOfflineSkippedPet = jest.spyOn(metrics, 'runnerGhOfflineSkippedPetRepo');
+
       await scaleDown();
+
+      expect(spyOfflineFound).toBeCalledWith(repo, 3);
+      expect(spyOfflineSkippedPet).toBeCalledTimes(1);
+      expect(spyOfflineSkippedPet).toBeCalledWith(repo);
 
       expect(mockedRemoveGithubRunnerRepo).not.toBeCalledWith(petGhRunner.id, repo, metrics);
       expect(mockedTerminateRunner).not.toBeCalledWith(petEc2Runner, metrics);

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
@@ -36,13 +36,13 @@ export async function scaleDown(): Promise<void> {
 
     metrics.run();
 
-    const runnersDict = groupBy(
-      sortRunnersByLaunchTime(await listRunners(metrics, { environment: Config.Instance.environment })),
-      (itm) => {
-        if (Config.Instance.enableOrganizationRunners) return itm.runnerType;
-        return `${itm.runnerType}#${itm.repo}`;
-      },
+    const ec2Runners = sortRunnersByLaunchTime(
+      await listRunners(metrics, { environment: Config.Instance.environment }),
     );
+    const runnersDict = groupBy(ec2Runners, (itm) => {
+      if (Config.Instance.enableOrganizationRunners) return itm.runnerType;
+      return `${itm.runnerType}#${itm.repo}`;
+    });
 
     if (runnersDict.size === 0) {
       console.info(`No active runners found for environment: '${Config.Instance.environment}'`);
@@ -100,10 +100,18 @@ export async function scaleDown(): Promise<void> {
       }
     }
 
+    // Pet instances register one-shot, so deregistering a live-but-offline pet orphans it permanently;
+    // skip pets still backed by a live EC2 instance when sweeping offline runners.
+    const petInstanceIds = new Set(
+      ec2Runners
+        .filter((runner) => runner.instanceManagement?.toLowerCase() === 'pet')
+        .map((runner) => runner.instanceId),
+    );
+
     if (Config.Instance.enableOrganizationRunners) {
       for (const org of foundOrgs) {
         const offlineGhRunners = (await listGithubRunnersOrg(org, metrics)).filter(
-          (r) => r.status.toLowerCase() === 'offline',
+          (r) => r.status.toLowerCase() === 'offline' && !petInstanceIds.has(r.name),
         );
         metrics.runnerGhOfflineFoundOrg(org, offlineGhRunners.length);
 
@@ -123,7 +131,7 @@ export async function scaleDown(): Promise<void> {
       for (const repoString of foundRepos) {
         const repo = getRepo(repoString);
         const offlineGhRunners = (await listGithubRunnersRepo(repo, metrics)).filter(
-          (r) => r.status.toLowerCase() === 'offline',
+          (r) => r.status.toLowerCase() === 'offline' && !petInstanceIds.has(r.name),
         );
         metrics.runnerGhOfflineFoundRepo(repo, offlineGhRunners.length);
 

--- a/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
+++ b/terraform-aws-github-runner/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
@@ -111,11 +111,15 @@ export async function scaleDown(): Promise<void> {
     if (Config.Instance.enableOrganizationRunners) {
       for (const org of foundOrgs) {
         const offlineGhRunners = (await listGithubRunnersOrg(org, metrics)).filter(
-          (r) => r.status.toLowerCase() === 'offline' && !petInstanceIds.has(r.name),
+          (r) => r.status.toLowerCase() === 'offline',
         );
         metrics.runnerGhOfflineFoundOrg(org, offlineGhRunners.length);
 
         for (const ghRunner of offlineGhRunners) {
+          if (petInstanceIds.has(ghRunner.name)) {
+            metrics.runnerGhOfflineSkippedPetOrg(org);
+            continue;
+          }
           try {
             await removeGithubRunnerOrg(ghRunner.id, org, metrics);
             metrics.runnerGhOfflineRemovedOrg(org);
@@ -131,11 +135,15 @@ export async function scaleDown(): Promise<void> {
       for (const repoString of foundRepos) {
         const repo = getRepo(repoString);
         const offlineGhRunners = (await listGithubRunnersRepo(repo, metrics)).filter(
-          (r) => r.status.toLowerCase() === 'offline' && !petInstanceIds.has(r.name),
+          (r) => r.status.toLowerCase() === 'offline',
         );
         metrics.runnerGhOfflineFoundRepo(repo, offlineGhRunners.length);
 
         for (const ghRunner of offlineGhRunners) {
+          if (petInstanceIds.has(ghRunner.name)) {
+            metrics.runnerGhOfflineSkippedPetRepo(repo);
+            continue;
+          }
           try {
             await removeGithubRunnerRepo(ghRunner.id, repo, metrics);
             metrics.runnerGhOfflineRemovedRepo(repo);


### PR DESCRIPTION
**Impact:** self-hosted runner scale-down Lambda (pet/Mac instances)
**Risk:** low

## What
The scale-down offline sweep no longer deregisters GitHub runners whose backing EC2 instance is a live "pet" instance. Pet instance IDs are collected up front and excluded from the org/repo offline-runner filters.

## Why
Pet instances (e.g. Mac runners) register with GitHub one-shot. When such a runner briefly reports `offline` while its EC2 instance is still alive, the offline sweep would deregister it — permanently orphaning the instance since it never re-registers. Guarding the sweep against pets still backed by a running instance prevents that.

# Notes
- Adds org and repo test cases asserting a live-but-offline pet is left registered while regular offline runners are still cleaned up.
- `beforeEach` switched from `jest.clearAllMocks()` to `jest.resetAllMocks()` so the per-test `mockResolvedValueOnce`/`mockResolvedValue` setups don't leak between the new and existing tests.