### PR TITLE
[CRCR] Fix query double-counting: use run_id partition for retry deduplication

### DIFF
--- a/torchci/clickhouse_queries/crcr_backend_summary/query.sql
+++ b/torchci/clickhouse_queries/crcr_backend_summary/query.sql
@@ -6,7 +6,7 @@ WITH deduped AS (
         queue_time,
         execution_time,
         ROW_NUMBER() OVER (
-            PARTITION BY pr_number, job_name
+            PARTITION BY run_id, job_name
             ORDER BY run_attempt DESC
         ) AS rn
     FROM

--- a/torchci/clickhouse_queries/crcr_backend_summary/query.sql
+++ b/torchci/clickhouse_queries/crcr_backend_summary/query.sql
@@ -1,3 +1,22 @@
+WITH deduped AS (
+    SELECT
+        pr_number,
+        job_name,
+        conclusion,
+        queue_time,
+        execution_time,
+        ROW_NUMBER() OVER (
+            PARTITION BY pr_number, job_name
+            ORDER BY run_attempt DESC
+        ) AS rn
+    FROM
+        default.crcr_workflow_job FINAL
+    WHERE
+        downstream_repo = {repo: String}
+        AND started_at > now() - INTERVAL {days: UInt64} DAY
+        AND status = 'completed'
+        AND pr_number > 0
+)
 SELECT
     countIf(
         conclusion = 'success'
@@ -37,9 +56,6 @@ SELECT
         0
     ) AS timeout_rate
 FROM
-    default.crcr_workflow_job FINAL
+    deduped
 WHERE
-    downstream_repo = {repo: String}
-    AND started_at > now() - INTERVAL {days: UInt64} DAY
-    AND status = 'completed'
-    AND pr_number > 0
+    rn = 1

--- a/torchci/clickhouse_queries/crcr_backend_summary/query.sql
+++ b/torchci/clickhouse_queries/crcr_backend_summary/query.sql
@@ -17,6 +17,7 @@ WITH deduped AS (
         AND status = 'completed'
         AND pr_number > 0
 )
+
 SELECT
     countIf(
         conclusion = 'success'

--- a/torchci/clickhouse_queries/crcr_health_last_prs/query.sql
+++ b/torchci/clickhouse_queries/crcr_health_last_prs/query.sql
@@ -10,25 +10,39 @@ SELECT
     count() AS total,
     if(total > 0, successes / total, 0) AS pass_rate
 FROM
-    default.crcr_workflow_job FINAL
-WHERE
-    downstream_repo = 'pytorch/crcr-test'
-    AND status = 'completed'
-    AND pr_number > 0
-    AND pr_number IN (
-        SELECT pr_number
+    (
+        SELECT
+            pr_number,
+            job_name,
+            started_at,
+            conclusion,
+            ROW_NUMBER() OVER (
+                PARTITION BY pr_number, job_name
+                ORDER BY run_attempt DESC
+            ) AS rn
         FROM
             default.crcr_workflow_job FINAL
         WHERE
             downstream_repo = 'pytorch/crcr-test'
             AND status = 'completed'
             AND pr_number > 0
-        GROUP BY
-            pr_number
-        ORDER BY
-            max(started_at) DESC
-        LIMIT {count: UInt64}
+            AND pr_number IN (
+                SELECT pr_number
+                FROM
+                    default.crcr_workflow_job FINAL
+                WHERE
+                    downstream_repo = 'pytorch/crcr-test'
+                    AND status = 'completed'
+                    AND pr_number > 0
+                GROUP BY
+                    pr_number
+                ORDER BY
+                    max(started_at) DESC
+                LIMIT {count: UInt64}
+            )
     )
+WHERE
+    rn = 1
 GROUP BY
     pr_number
 ORDER BY

--- a/torchci/clickhouse_queries/crcr_health_last_prs/query.sql
+++ b/torchci/clickhouse_queries/crcr_health_last_prs/query.sql
@@ -25,11 +25,12 @@ FROM
     (
         SELECT
             pr_number,
+            run_id,
             job_name,
             started_at,
             conclusion,
             ROW_NUMBER() OVER (
-                PARTITION BY pr_number, job_name
+                PARTITION BY run_id, job_name
                 ORDER BY run_attempt DESC
             ) AS rn
         FROM

--- a/torchci/clickhouse_queries/crcr_health_last_prs/query.sql
+++ b/torchci/clickhouse_queries/crcr_health_last_prs/query.sql
@@ -1,3 +1,14 @@
+WITH recent_prs AS (
+    SELECT pr_number
+    FROM default.crcr_workflow_job FINAL
+    WHERE
+        downstream_repo = 'pytorch/crcr-test'
+        AND status = 'completed'
+        AND pr_number > 0
+    GROUP BY pr_number
+    ORDER BY max(started_at) DESC
+    LIMIT {count: UInt64}
+)
 SELECT
     pr_number,
     max(started_at) AS last_run,
@@ -26,20 +37,7 @@ FROM
             downstream_repo = 'pytorch/crcr-test'
             AND status = 'completed'
             AND pr_number > 0
-            AND pr_number IN (
-                SELECT pr_number
-                FROM
-                    default.crcr_workflow_job FINAL
-                WHERE
-                    downstream_repo = 'pytorch/crcr-test'
-                    AND status = 'completed'
-                    AND pr_number > 0
-                GROUP BY
-                    pr_number
-                ORDER BY
-                    max(started_at) DESC
-                LIMIT {count: UInt64}
-            )
+            AND pr_number IN (SELECT pr_number FROM recent_prs)
     )
 WHERE
     rn = 1

--- a/torchci/clickhouse_queries/crcr_health_last_prs/query.sql
+++ b/torchci/clickhouse_queries/crcr_health_last_prs/query.sql
@@ -9,6 +9,7 @@ WITH recent_prs AS (
     ORDER BY max(started_at) DESC
     LIMIT {count: UInt64}
 )
+
 SELECT
     pr_number,
     max(started_at) AS last_run,

--- a/torchci/clickhouse_queries/crcr_summary/query.sql
+++ b/torchci/clickhouse_queries/crcr_summary/query.sql
@@ -1,3 +1,22 @@
+WITH deduped AS (
+    SELECT
+        downstream_repo,
+        downstream_repo_level,
+        job_name,
+        conclusion,
+        duration_seconds,
+        started_at,
+        ROW_NUMBER() OVER (
+            PARTITION BY downstream_repo, pr_number, job_name
+            ORDER BY run_attempt DESC
+        ) AS rn
+    FROM
+        default.crcr_workflow_job FINAL
+    WHERE
+        started_at > now() - INTERVAL {days: UInt64} DAY
+        AND status = 'completed'
+        AND pr_number > 0
+)
 SELECT
     downstream_repo AS repo,
     anyLast(downstream_repo_level) AS downstream_repo_level,
@@ -33,11 +52,9 @@ SELECT
     avg(duration_seconds) AS avg_duration_s,
     max(started_at) AS last_run
 FROM
-    default.crcr_workflow_job FINAL
+    deduped
 WHERE
-    started_at > now() - INTERVAL {days: UInt64} DAY
-    AND status = 'completed'
-    AND pr_number > 0
+    rn = 1
 GROUP BY
     repo
 ORDER BY

--- a/torchci/clickhouse_queries/crcr_summary/query.sql
+++ b/torchci/clickhouse_queries/crcr_summary/query.sql
@@ -17,6 +17,7 @@ WITH deduped AS (
         AND status = 'completed'
         AND pr_number > 0
 )
+
 SELECT
     downstream_repo AS repo,
     anyLast(downstream_repo_level) AS downstream_repo_level,

--- a/torchci/clickhouse_queries/crcr_summary/query.sql
+++ b/torchci/clickhouse_queries/crcr_summary/query.sql
@@ -7,7 +7,7 @@ WITH deduped AS (
         duration_seconds,
         started_at,
         ROW_NUMBER() OVER (
-            PARTITION BY downstream_repo, pr_number, job_name
+            PARTITION BY run_id, job_name
             ORDER BY run_attempt DESC
         ) AS rn
     FROM

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -351,7 +351,7 @@ function RelayHealthCard({
         borderTop: `3px solid ${borderColor}`,
         textAlign: "center",
         minWidth: 200,
-        flex: 1,
+        maxWidth: 280,
       }}
     >
       <Typography variant="caption" color="text.secondary">
@@ -361,7 +361,7 @@ function RelayHealthCard({
         {label}
       </Typography>
       <Typography variant="caption" color="text.secondary">
-        {passedCount}/{healthPrs.length} recent PRs passed
+        {passedCount}/{healthPrs.length} recent PRs passed (all time)
       </Typography>
     </Paper>
   );
@@ -1426,11 +1426,7 @@ export default function CrcrBackendPage() {
 
             {!isNightly && (
               <>
-                {isCrcrTest && (
-                  <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
-                    <RelayHealthCard healthPrs={healthPrs} />
-                  </Box>
-                )}
+                {isCrcrTest && <RelayHealthCard healthPrs={healthPrs} />}
                 {stats ? (
                   <SummaryCards stats={stats} />
                 ) : (

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -361,7 +361,7 @@ function RelayHealthCard({
         {label}
       </Typography>
       <Typography variant="caption" color="text.secondary">
-        {passedCount}/{healthPrs.length} recent PRs passed (all time)
+        {passedCount}/{healthPrs.length} of last {HEALTH_COUNT} PRs passed
       </Typography>
     </Paper>
   );

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -351,7 +351,7 @@ function RelayHealthCard({
         borderTop: `3px solid ${borderColor}`,
         textAlign: "center",
         minWidth: 200,
-        maxWidth: 280,
+        flex: 1,
       }}
     >
       <Typography variant="caption" color="text.secondary">
@@ -361,7 +361,7 @@ function RelayHealthCard({
         {label}
       </Typography>
       <Typography variant="caption" color="text.secondary">
-        {passedCount}/{healthPrs.length} of last {HEALTH_COUNT} PRs passed
+        {passedCount}/{healthPrs.length} recent PRs passed
       </Typography>
     </Paper>
   );
@@ -1426,7 +1426,11 @@ export default function CrcrBackendPage() {
 
             {!isNightly && (
               <>
-                {isCrcrTest && <RelayHealthCard healthPrs={healthPrs} />}
+                {isCrcrTest && (
+                  <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+                    <RelayHealthCard healthPrs={healthPrs} />
+                  </Box>
+                )}
                 {stats ? (
                   <SummaryCards stats={stats} />
                 ) : (


### PR DESCRIPTION
## Summary

Addresses review feedback from @atalman on #8520 — fixes the retry deduplication logic in all three CRCR summary queries.

**Problem**: The original `PARTITION BY pr_number, job_name` incorrectly collapses separate dispatches (from different pushes to the same PR) into a single row. Since `run_attempt` restarts at 1 for each new `run_id`, comparing it across runs is meaningless — it can keep a stale result from an older push while discarding a newer one.

**Fix**: Change partition key to `(run_id, job_name)` in all three queries, matching the precedent in `crcr_nightly_dashboard`. This correctly deduplicates retries within a single run while preserving all distinct dispatches.

Queries fixed:
- `crcr_health_last_prs` — health card on per-repo page
- `crcr_backend_summary` — per-repo stats (pass rate, total PRs, etc.)
- `crcr_summary` — main summary table on CRCR index page

Additionally extracts the PR-selection subquery into a CTE for readability in the health query.

**UI changes have been moved to separate PRs** to keep this focused on the data correctness fix.

## Test plan

- Verify summary table pass rates are not inflated by retry attempts
- Verify per-repo backend stats correctly deduplicate retries within a run
- Verify separate dispatches from different pushes to the same PR are all preserved