### PR TITLE
[CRCR] Add 100-day TTL to crcr_workflow_job

### DIFF
--- a/clickhouse_db_schema/default.crcr_workflow_job/schema.sql
+++ b/clickhouse_db_schema/default.crcr_workflow_job/schema.sql
@@ -38,4 +38,5 @@ CREATE TABLE default.crcr_workflow_job
 )
 ENGINE = SharedReplacingMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}')
 ORDER BY (downstream_repo, delivery_id, dynamoKey)
+TTL toDate(_inserted_at) + toIntervalDay(100)
 SETTINGS index_granularity = 8192


### PR DESCRIPTION
## Summary

Adds a 100-day TTL to `default.crcr_workflow_job`, addressing #8549. The table previously had no data retention, causing indefinite accumulation.

### Key decisions

| Decision | Choice | Rationale |
|---|---|---|
| TTL column | `_inserted_at` | Server-controlled (`MATERIALIZED now()`), immutable, avoids epoch-0 `started_at` bug |
| Retention | 100 days | 10-day buffer over the metrics page's "Last 90 days" view (TTL enforcement is async) |
| Partitioning | None added | `ReplacingMergeTree` only deduplicates within a partition; partitioning on a mutable column risks breaking `FINAL` correctness |

### Migration

```sql
ALTER TABLE default.crcr_workflow_job
    MODIFY TTL toDate(_inserted_at) + toIntervalDay(100);
```

No table recreation required — `ALTER TABLE ... MODIFY TTL` works on existing tables.

Closes #8549