### PR TITLE
Fix flaky_trunk filter UX and clarify persistence comments

### DIFF
--- a/torchci/clickhouse_queries/flaky_trunk_entity_runs/query.sql
+++ b/torchci/clickhouse_queries/flaky_trunk_entity_runs/query.sql
@@ -167,7 +167,7 @@ final_jobs AS (
             adv_real,
             adv_infra,
             adv_testflake,
-            -- persistent: this hard-red has an adjacent hard-red on trunk (run of >= 2 consecutive reds).
+            -- persistent: this job's adjacent observed run is also hard-red (>= 2 of its runs in a row).
             toUInt8(
                 hard_red = 1
                 AND (

--- a/torchci/clickhouse_queries/flaky_trunk_jobs/query.sql
+++ b/torchci/clickhouse_queries/flaky_trunk_jobs/query.sql
@@ -17,9 +17,11 @@
 -- for test_flake, infra_issue for infra_flake), so the structural fallback yields only real_regression
 -- (persistent) or unclassified (non-persistent). Persistence
 -- discriminates: a hard-red (failed, no retry-green at this commit) is "persistent" when the SAME job is
--- also hard-red at the immediately previous OR next trunk commit; a hard-red with a clean green on BOTH
--- neighbors is an isolated green->red->green flake. real_regression is NOT gated on
--- later recovery, so an ongoing (still-red) break still counts.
+-- also hard-red at its immediately adjacent observed run -- its previous or next run ordered by
+-- commit_time. A job need not run on every commit, so "adjacent" means adjacent in this job's own run
+-- sequence, not the trunk-commit sequence, and that run may be several trunk commits away; a hard-red
+-- flanked by green on BOTH its neighbor runs is an isolated green->red->green flake. real_regression is
+-- NOT gated on later recovery, so an ongoing (still-red) break still counts.
 --
 -- Trunk filter: jobs whose head_sha is a real push to refs/heads/main for the repo param. The shared CTE
 -- chain (trunk_commits .. final_jobs) is identical across flaky_trunk_timeseries, flaky_trunk_jobs
@@ -167,7 +169,7 @@ final_jobs AS (
             adv_real,
             adv_infra,
             adv_testflake,
-            -- persistent: this hard-red has an adjacent hard-red on trunk (run of >= 2 consecutive reds).
+            -- persistent: this job's adjacent observed run is also hard-red (>= 2 of its runs in a row).
             toUInt8(
                 hard_red = 1
                 AND (

--- a/torchci/clickhouse_queries/flaky_trunk_runner_labels/query.sql
+++ b/torchci/clickhouse_queries/flaky_trunk_runner_labels/query.sql
@@ -158,7 +158,7 @@ final_jobs AS (
             adv_real,
             adv_infra,
             adv_testflake,
-            -- persistent: this hard-red has an adjacent hard-red on trunk (run of >= 2 consecutive reds).
+            -- persistent: this job's adjacent observed run is also hard-red (>= 2 of its runs in a row).
             toUInt8(
                 hard_red = 1
                 AND (

--- a/torchci/clickhouse_queries/flaky_trunk_timeseries/query.sql
+++ b/torchci/clickhouse_queries/flaky_trunk_timeseries/query.sql
@@ -16,9 +16,11 @@
 -- for test_flake, infra_issue for infra_flake), so the structural fallback yields only real_regression
 -- (persistent) or unclassified (non-persistent). Persistence
 -- discriminates: a hard-red (failed, no retry-green at this commit) is "persistent" when the SAME job is
--- also hard-red at the immediately previous OR next trunk commit; a hard-red with a clean green on BOTH
--- neighbors is an isolated green->red->green flake. real_regression is NOT gated on
--- later recovery, so an ongoing (still-red) break still counts.
+-- also hard-red at its immediately adjacent observed run -- its previous or next run ordered by
+-- commit_time. A job need not run on every commit, so "adjacent" means adjacent in this job's own run
+-- sequence, not the trunk-commit sequence, and that run may be several trunk commits away; a hard-red
+-- flanked by green on BOTH its neighbor runs is an isolated green->red->green flake. real_regression is
+-- NOT gated on later recovery, so an ongoing (still-red) break still counts.
 --
 -- Trunk filter: jobs whose head_sha is a real push to refs/heads/main for the repo param (join to
 -- default.push, which also yields the commit push timestamp used for bucketing + adjacency).
@@ -167,7 +169,7 @@ final_jobs AS (
             adv_real,
             adv_infra,
             adv_testflake,
-            -- persistent: this hard-red has an adjacent hard-red on trunk (run of >= 2 consecutive reds).
+            -- persistent: this job's adjacent observed run is also hard-red (>= 2 of its runs in a row).
             toUInt8(
                 hard_red = 1
                 AND (

--- a/torchci/components/flakyTrunk/FlakyTrunkControls.tsx
+++ b/torchci/components/flakyTrunk/FlakyTrunkControls.tsx
@@ -130,7 +130,7 @@ export default function FlakyTrunkControls({
             onChange={(e) => setViableStrictOnly(e.target.checked)}
           />
         }
-        label="Viable/strict jobs only"
+        label="Required workflows only"
       />
     </Stack>
   );

--- a/torchci/components/flakyTrunk/FlakyTrunkHelp.tsx
+++ b/torchci/components/flakyTrunk/FlakyTrunkHelp.tsx
@@ -54,9 +54,7 @@ export default function FlakyTrunkHelp() {
             </Typography>
             <Typography component="li" variant="body2" color="text.secondary">
               <Term>Unclassified</Term>
-              {
-                " — an isolated one-off red we can't yet attribute (~a few % of reds)."
-              }
+              {" — an isolated one-off red we can't yet attribute."}
             </Typography>
           </Box>
 

--- a/torchci/components/flakyTrunk/common.ts
+++ b/torchci/components/flakyTrunk/common.ts
@@ -2,8 +2,10 @@ import { GridColDef } from "@mui/x-data-grid";
 import { Granularity } from "components/metrics/panels/TimeSeriesPanel";
 import dayjs from "dayjs";
 import isoWeek from "dayjs/plugin/isoWeek";
+import utc from "dayjs/plugin/utc";
 
 dayjs.extend(isoWeek);
+dayjs.extend(utc);
 
 export const FLAKY_TRUNK_REPO = "pytorch/pytorch";
 
@@ -169,7 +171,7 @@ export function parseDate(value: unknown, fallback: dayjs.Dayjs): dayjs.Dayjs {
   if (typeof value !== "string") {
     return fallback;
   }
-  const parsed = dayjs(value);
+  const parsed = dayjs.utc(value);
   return parsed.isValid() ? parsed : fallback;
 }
 

--- a/torchci/pages/flaky_trunk.tsx
+++ b/torchci/pages/flaky_trunk.tsx
@@ -150,6 +150,13 @@ export default function Page() {
       clearSelections();
     }
   };
+  // Filtering can hide the drilled-in job, leaving the runs panel open over an
+  // empty grid, so drop the entity; the selected bucket's interval is still
+  // valid under the filter, so keep it.
+  const changeViableStrictOnly = (value: boolean) => {
+    setViableStrictOnly(value);
+    setSelectedEntity(null);
+  };
 
   const onBucketClick = useCallback(
     (bucketStart: dayjs.Dayjs) => {
@@ -228,7 +235,7 @@ export default function Page() {
         minRuns={minRuns}
         setMinRuns={setMinRuns}
         viableStrictOnly={viableStrictOnly}
-        setViableStrictOnly={setViableStrictOnly}
+        setViableStrictOnly={changeViableStrictOnly}
       />
 
       <Box sx={{ mt: 3 }}>


### PR DESCRIPTION
**Impact:** HUD flaky_trunk page users (dashboard only)
**Risk:** low

## What
Small UX/correctness cleanups on the flaky_trunk drill-down page: clearer filter label, drop the stale drill-in when the filter changes, parse URL dates as UTC, and clarify the SQL comments describing when a hard-red counts as "persistent".

## Why
The "Viable/strict jobs only" checkbox was confusingly named — it's really "Required workflows only". Toggling it could hide the job you'd drilled into, leaving the runs panel open over an empty grid, so the selected entity is now cleared on toggle (the bucket interval stays valid, so it's kept). The URL writes start/stop dates via `.utc().format(...)` but `parseDate` read them in local time, so round-tripping a shared link could shift the window by a day; parsing now uses `dayjs.utc`. The SQL persistence comments were misleading — "adjacent" means the job's own previous/next observed run (which may be several trunk commits away), not the adjacent trunk commit; the comments now say so, and a stale "~a few %" figure was removed from the help text.