### PR TITLE
Install torchvision before torch for ROCm

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -130,6 +130,7 @@ MACOS_M1_RUNNER = "macos-m1-stable"
 
 PACKAGES_TO_INSTALL_WHL = "torch torchvision"
 PACKAGES_TO_INSTALL_GETTING_STARTED_WHL = "torch torchvision"
+PACKAGES_TO_INSTALL_ROCM_WHL = "torchvision torch"
 PACKAGES_TO_INSTALL_WHL_WIN_ARM64 = "torch"
 WHL_INSTALL_BASE = "pip3 install"
 DOWNLOAD_URL_BASE = "https://download.pytorch.org"
@@ -323,6 +324,9 @@ def get_wheel_install_command(
         if getting_started
         else PACKAGES_TO_INSTALL_WHL
     )
+
+    if gpu_arch_type == ROCM:
+        PACKAGES_TO_INSTALL = PACKAGES_TO_INSTALL_ROCM_WHL
 
     # Validate torch only (no torchvision) for versions without published
     # torchvision wheels, e.g. 3.15 / 3.15t.

--- a/tools/tests/assets/build_matrix_linux_wheel_cuda.json
+++ b/tools/tests/assets/build_matrix_linux_wheel_cuda.json
@@ -79,7 +79,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_10-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torchvision torch --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.13.0"
@@ -93,7 +93,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_10-rocm7_14",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.14",
+      "installation": "pip3 install --pre torchvision torch --index-url https://download.pytorch.org/whl/nightly/rocm7.14",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.13.0"
@@ -177,7 +177,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_11-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torchvision torch --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.13.0"
@@ -191,7 +191,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_11-rocm7_14",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.14",
+      "installation": "pip3 install --pre torchvision torch --index-url https://download.pytorch.org/whl/nightly/rocm7.14",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.13.0"
@@ -275,7 +275,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_12-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torchvision torch --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.13.0"
@@ -289,7 +289,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_12-rocm7_14",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.14",
+      "installation": "pip3 install --pre torchvision torch --index-url https://download.pytorch.org/whl/nightly/rocm7.14",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.13.0"
@@ -373,7 +373,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torchvision torch --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.13.0"
@@ -387,7 +387,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13-rocm7_14",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.14",
+      "installation": "pip3 install --pre torchvision torch --index-url https://download.pytorch.org/whl/nightly/rocm7.14",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.13.0"
@@ -471,7 +471,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torchvision torch --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.13.0"
@@ -485,7 +485,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14-rocm7_14",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.14",
+      "installation": "pip3 install --pre torchvision torch --index-url https://download.pytorch.org/whl/nightly/rocm7.14",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.13.0"
@@ -569,7 +569,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14t-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torchvision torch --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.13.0"
@@ -583,7 +583,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14t-rocm7_14",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.14",
+      "installation": "pip3 install --pre torchvision torch --index-url https://download.pytorch.org/whl/nightly/rocm7.14",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.13.0"

--- a/tools/tests/assets/build_matrix_linux_wheel_nocpu.json
+++ b/tools/tests/assets/build_matrix_linux_wheel_nocpu.json
@@ -65,7 +65,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_10-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torchvision torch --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.13.0"
@@ -79,7 +79,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_10-rocm7_14",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.14",
+      "installation": "pip3 install --pre torchvision torch --index-url https://download.pytorch.org/whl/nightly/rocm7.14",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.13.0"
@@ -149,7 +149,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_11-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torchvision torch --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.13.0"
@@ -163,7 +163,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_11-rocm7_14",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.14",
+      "installation": "pip3 install --pre torchvision torch --index-url https://download.pytorch.org/whl/nightly/rocm7.14",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.13.0"
@@ -233,7 +233,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_12-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torchvision torch --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.13.0"
@@ -247,7 +247,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_12-rocm7_14",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.14",
+      "installation": "pip3 install --pre torchvision torch --index-url https://download.pytorch.org/whl/nightly/rocm7.14",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.13.0"
@@ -317,7 +317,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torchvision torch --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.13.0"
@@ -331,7 +331,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_13-rocm7_14",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.14",
+      "installation": "pip3 install --pre torchvision torch --index-url https://download.pytorch.org/whl/nightly/rocm7.14",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.13.0"
@@ -401,7 +401,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torchvision torch --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.13.0"
@@ -415,7 +415,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14-rocm7_14",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.14",
+      "installation": "pip3 install --pre torchvision torch --index-url https://download.pytorch.org/whl/nightly/rocm7.14",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.13.0"
@@ -485,7 +485,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14t-rocm7_2",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
+      "installation": "pip3 install --pre torchvision torch --index-url https://download.pytorch.org/whl/nightly/rocm7.2",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.13.0"
@@ -499,7 +499,7 @@
       "package_type": "manywheel",
       "build_name": "manywheel-py3_14t-rocm7_14",
       "validation_runner": "linux.2xlarge",
-      "installation": "pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.14",
+      "installation": "pip3 install --pre torchvision torch --index-url https://download.pytorch.org/whl/nightly/rocm7.14",
       "channel": "nightly",
       "upload_to_base_bucket": "no",
       "stable_version": "2.13.0"


### PR DESCRIPTION
ROCm install commands now list `torchvision` first:

```
pip3 install torchvision torch --index-url https://download.pytorch.org/whl/test/rocm7.14
```

Scoped to ROCm — CPU, CUDA and XPU are unchanged. The swap is applied in `get_wheel_install_command()` after the getting-started/validation selection, so it covers both the validation matrix and the command shown on the getting-started page, and it stays behind the `TORCH_ONLY_PYTHON_ARCHES` override so 3.15 / 3.15t still install `torch` alone.

## Generated output

```
   cpu      cpu : pip3 install torch torchvision --index-url .../whl/test/cpu
  cuda    cu126 : pip3 install torch torchvision --index-url .../whl/test/cu126
  cuda    cu134 : pip3 install torch torchvision --index-url .../whl/test/cu134
  rocm  rocm7.2 : pip3 install torchvision torch --index-url .../whl/test/rocm7.2
  rocm rocm7.14 : pip3 install torchvision torch --index-url .../whl/test/rocm7.14
   xpu      xpu : pip3 install torch torchvision --index-url .../whl/test/xpu
```

## Downstream string rewriting still works

`validate_binaries.sh` rewrites the generated command by substring, so the order matters there. Checked all three against the new string:

| option | result |
|---|---|
| `TORCH_ONLY` | `pip3 install torch` — unchanged |
| `INCLUDE_TORCHAUDIO` | `pip3 install torchvision torchaudio torch` |
| `RELEASE_VERSION` | `pip3 install torchvision torch==2.14.0` |

The pin is the one worth noting: `${installation/"torch "/...}` replaces the first match only, and `"torch "` cannot match inside `torchvision` (the next char is `v`), so it still lands on `torch` rather than on `torchvision`.

## Test assets

`tools/tests/test_generate_binary_build_matrix.py` compares against JSON assets, so the 12 ROCm `installation` lines in `build_matrix_linux_wheel_cuda.json` and `build_matrix_linux_wheel_nocpu.json` are updated. All 14 tests pass; baseline was green before the change.

Edited those two files with a targeted substitution rather than running `tools/tests/update_test_assets.sh` — that script is stale (it still generates `--package-type conda`, which now raises `KeyError: 'conda'` and truncates four asset files). Worth a separate cleanup.