### PR TITLE
Show ROCm 7.2 on the preview getting-started page

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -55,6 +55,8 @@ ROCM_ARCHES_DICT = {
     "release": ["7.1", "7.2"],
 }
 
+GETTING_STARTED_ROCM_ARCH = "7.2"
+
 CUDA_CUDNN_VERSIONS = {
     "12.6": {"cuda": "12.6.3", "cudnn": "9"},
     "12.8": {"cuda": "12.8.0", "cudnn": "9"},
@@ -198,7 +200,11 @@ def initialize_globals(
         ]
     ROCM_ARCHES = ROCM_ARCHES_DICT[channel]
     if getting_started and channel == NIGHTLY:
-        ROCM_ARCHES = [max(ROCM_ARCHES, key=parse_version)]
+        ROCM_ARCHES = [
+            GETTING_STARTED_ROCM_ARCH
+            if GETTING_STARTED_ROCM_ARCH in ROCM_ARCHES
+            else max(ROCM_ARCHES, key=parse_version)
+        ]
     if build_python_only:
         # Only select the oldest version of python if building a python only package
         PYTHON_ARCHES = [PYTHON_ARCHES_DICT[channel][0]]

--- a/tools/tests/test_generate_binary_build_matrix.py
+++ b/tools/tests/test_generate_binary_build_matrix.py
@@ -241,9 +241,7 @@ class GenerateBuildMatrixTest(TestCase):
         self.assertIn(GETTING_STARTED_ROCM_ARCH, ROCM_ARCHES_DICT["nightly"])
 
     def test_getting_started_falls_back_to_newest_rocm(self):
-        with patch.dict(
-            ROCM_ARCHES_DICT, {"nightly": ["7.14", "8.0"]}, clear=False
-        ):
+        with patch.dict(ROCM_ARCHES_DICT, {"nightly": ["7.14", "8.0"]}, clear=False):
             versions = self._rocm_versions("nightly", "true")
         self.assertEqual(versions, {"8.0"})
 

--- a/tools/tests/test_generate_binary_build_matrix.py
+++ b/tools/tests/test_generate_binary_build_matrix.py
@@ -3,9 +3,11 @@ import json
 import os
 import sys
 from unittest import main, TestCase
+from unittest.mock import patch
 
 from tools.scripts.generate_binary_build_matrix import (
     generate_build_matrix,
+    GETTING_STARTED_ROCM_ARCH,
     parse_version,
     ROCM_ARCHES_DICT,
 )
@@ -235,9 +237,15 @@ class GenerateBuildMatrixTest(TestCase):
     def test_getting_started_nightly_ships_one_rocm(self):
         versions = self._rocm_versions("nightly", "true")
         self.assertEqual(len(versions), 1)
-        self.assertEqual(
-            versions, {max(ROCM_ARCHES_DICT["nightly"], key=parse_version)}
-        )
+        self.assertEqual(versions, {GETTING_STARTED_ROCM_ARCH})
+        self.assertIn(GETTING_STARTED_ROCM_ARCH, ROCM_ARCHES_DICT["nightly"])
+
+    def test_getting_started_falls_back_to_newest_rocm(self):
+        with patch.dict(
+            ROCM_ARCHES_DICT, {"nightly": ["7.14", "8.0"]}, clear=False
+        ):
+            versions = self._rocm_versions("nightly", "true")
+        self.assertEqual(versions, {"8.0"})
 
     def test_nightly_builds_keep_every_rocm(self):
         versions = self._rocm_versions("nightly", "false")


### PR DESCRIPTION
#8503 made the nightly (preview) getting-started page advertise a single ROCm version, chosen as the newest in the channel — which is now **7.14**. This rolls that back to **7.2** by naming the advertised version explicitly instead of deriving it from `max()`.

```python
GETTING_STARTED_ROCM_ARCH = "7.2"
...
if getting_started and channel == NIGHTLY:
    ROCM_ARCHES = [
        GETTING_STARTED_ROCM_ARCH
        if GETTING_STARTED_ROCM_ARCH in ROCM_ARCHES
        else max(ROCM_ARCHES, key=parse_version)
    ]
```

Explicit rather than `min()` so the advertised version is a deliberate choice: bumping the preview page to 7.14 later is a one-line change, and it does not silently move when the ROCm set rolls forward. The `max()` fallback keeps the page working if `7.2` is ever dropped from the nightly arches, so we can't end up advertising an index that doesn't exist.

## Effect

| matrix | before | after |
|---|---|---|
| nightly getting-started (preview page) | `rocm7.14` | **`rocm7.2`** |
| nightly builds | `rocm7.2`, `rocm7.14` | unchanged |
| test / release channels | unchanged | unchanged |

Only the getting-started matrix is affected — ROCm 7.14 nightlies are still built, tested and published, just not the version the preview tab hands to users.

Verified `https://download.pytorch.org/whl/nightly/rocm7.2/torch/` returns 200, so the advertised command resolves.

## Tests

- `test_getting_started_nightly_ships_one_rocm` now asserts the pinned version, plus that it is actually present in the nightly arches.
- New `test_getting_started_falls_back_to_newest_rocm` patches the nightly arches to `["7.14", "8.0"]` and asserts the fallback yields `8.0`, so the guard branch is covered rather than assumed.

15 passed.