### PR TITLE
Point aarch64 CUDA wheel builds at manylinux2_28_aarch64-builder

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -216,7 +216,7 @@ def initialize_globals(
             for gpu_arch in CUDA_ARCHES
         },
         **{
-            gpu_arch: f"pytorch/manylinuxaarch64-builder:cuda{gpu_arch.replace('-aarch64', '')}"
+            gpu_arch: f"pytorch/manylinux2_28_aarch64-builder:cuda{gpu_arch.replace('-aarch64', '')}"
             for gpu_arch in CUDA_AARCH64_ARCHES
         },
         **{


### PR DESCRIPTION
Follow-up to pytorch/pytorch#191486, which consolidates the aarch64 CUDA builder image. One line:

```diff
-            gpu_arch: f"pytorch/manylinuxaarch64-builder:cuda{gpu_arch.replace('-aarch64', '')}"
+            gpu_arch: f"pytorch/manylinux2_28_aarch64-builder:cuda{gpu_arch.replace('-aarch64', '')}"
```

This makes aarch64 CUDA match aarch64 CPU, which already uses `manylinux2_28_aarch64-builder:cpu-aarch64`, and matches x86 naming.

## DRAFT — blocked, do not land yet

`pytorch/manylinux2_28_aarch64-builder` currently has **no cuda tags at all** (only `cpu-aarch64`), while `pytorch/manylinuxaarch64-builder` has `cuda12.6`, `cuda13.0`, `cuda13.2`, `cuda13.4`. Landing this now would point every aarch64 CUDA build at tags that do not exist.

Blocked on:

1. pytorch/pytorch#191486 merging, which starts publishing the new name, **and**
2. that PR gaining a `cuda13.4` entry — it currently adds only 13.2 / 13.0 / 12.6, but `CUDA_AARCH64_ARCHES` here is `["12.6-aarch64", "13.0-aarch64", "13.2-aarch64", "13.4-aarch64"]`, so 13.4 is required. Raised on that PR.

Land only once all four tags are visible in the registry.

## Generated output with this change

```
   cpu-aarch64            cpu -> pytorch/manylinux2_28_aarch64-builder:cpu-aarch64
  cuda-aarch64          cu126 -> pytorch/manylinux2_28_aarch64-builder:cuda12.6
  cuda-aarch64          cu130 -> pytorch/manylinux2_28_aarch64-builder:cuda13.0
  cuda-aarch64          cu132 -> pytorch/manylinux2_28_aarch64-builder:cuda13.2
  cuda-aarch64          cu134 -> pytorch/manylinux2_28_aarch64-builder:cuda13.4
```

x86, ROCm and XPU are untouched. No test assets reference the old name — `update_test_assets.sh` generates no `linux-aarch64` matrix — so nothing else changes. 15 tests pass.

After this lands, the legacy `manylinuxaarch64-builder` entries can be dropped from `build-manywheel-images.yml` in a third PR.