### PR TITLE
Serve Dr. CI's fetchPR from ClickHouse with a GitHub fallback (R1)

### DIFF
--- a/torchci/lib/fetchPR.ts
+++ b/torchci/lib/fetchPR.ts
@@ -1,5 +1,5 @@
 import { Octokit } from "octokit";
-import { queryClickhouseSaved } from "./clickhouse";
+import { queryClickhouse, queryClickhouseSaved } from "./clickhouse";
 import { PRData } from "./types";
 
 async function fetchHistoricalCommits(
@@ -14,35 +14,129 @@ async function fetchHistoricalCommits(
   });
 }
 
+interface PRTitleBody {
+  title: string;
+  body: string;
+  headSha: string;
+}
+
+async function fetchPRTitleBody(
+  owner: string,
+  repo: string,
+  prNumber: string
+): Promise<PRTitleBody | undefined> {
+  // Read the PR's title/body/head sha from the default.pull_request mirror
+  // instead of the GitHub API. Filter on `number` (the table's sorting key) for
+  // an indexed lookup; html_url pins the repo since PR numbers are not unique
+  // across repos. FINAL collapses the ReplacingMergeTree to the latest row.
+  const query = `
+SELECT
+    title,
+    body,
+    head.'sha' AS head_sha
+FROM default.pull_request FINAL
+WHERE
+    number = {prNumber: Int64}
+    AND html_url = {htmlUrl: String}
+  `;
+  const rows = await queryClickhouse(query, {
+    prNumber,
+    htmlUrl: `https://github.com/${owner}/${repo}/pull/${prNumber}`,
+  });
+  if (rows.length !== 1) {
+    return undefined;
+  }
+  return {
+    title: rows[0].title,
+    body: rows[0].body ?? "",
+    headSha: rows[0].head_sha,
+  };
+}
+
 export default async function fetchPR(
   owner: string,
   repo: string,
   prNumber: string,
-  octokit: Octokit
+  octokit: Octokit,
+  knownHeadSha?: string
 ): Promise<PRData> {
   // We pull data from both our database and Github to get all commits,
   // including the ones that have been force merged out of the git history.  Our
   // database is the primary source, GitHub covers anything newer that might
   // have been missed.
-  const [pull, commits, historicalCommits] = await Promise.all([
-    octokit.rest.pulls.get({
+  //
+  // Both ClickHouse reads run in parallel so a covered PR resolves in a single
+  // round trip and never touches the GitHub REST API. Each read independently
+  // falls back to GitHub on an empty result OR on error, so a ClickHouse outage
+  // degrades to GitHub-only behaviour instead of failing the refresh.
+  const [titleBodySettled, historicalCommitsSettled] = await Promise.allSettled(
+    [
+      fetchPRTitleBody(owner, repo, prNumber),
+      fetchHistoricalCommits(owner, repo, prNumber),
+    ]
+  );
+
+  let titleBody: PRTitleBody | undefined;
+  if (titleBodySettled.status === "fulfilled") {
+    titleBody = titleBodySettled.value;
+  } else {
+    console.warn(
+      `fetchPR: ClickHouse title/body query failed for ${owner}/${repo}#${prNumber}, falling back to GitHub`,
+      titleBodySettled.reason
+    );
+  }
+
+  let title: string;
+  let body: string;
+  if (titleBody !== undefined) {
+    title = titleBody.title;
+    body = titleBody.body;
+  } else {
+    // No ClickHouse row (or the query errored): fall back to the GitHub API.
+    const pull = await octokit.rest.pulls.get({
       owner,
       repo,
       pull_number: parseInt(prNumber),
-    }),
-    octokit.paginate(octokit.rest.pulls.listCommits, {
-      owner,
-      repo,
-      pull_number: parseInt(prNumber),
-      per_page: 100,
-    }),
-    fetchHistoricalCommits(owner, repo, prNumber),
-  ]);
-  const title = pull.data.title;
-  const body = pull.data.body ?? "";
+    });
+    title = pull.data.title;
+    body = pull.data.body ?? "";
+  }
+
+  let historicalCommits: any[] = [];
+  if (historicalCommitsSettled.status === "fulfilled") {
+    historicalCommits = historicalCommitsSettled.value;
+  } else {
+    console.warn(
+      `fetchPR: ClickHouse pr_commits query failed for ${owner}/${repo}#${prNumber}, falling back to GitHub`,
+      historicalCommitsSettled.reason
+    );
+  }
 
   let shas = historicalCommits.map((commit) => {
     return { sha: commit.sha, title: commit.message.split("\n")[0] };
+  });
+
+  // The reference head sha is the caller-supplied head (Dr. CI already knows it)
+  // or, failing that, the head sha from the ClickHouse pull_request row. When it
+  // is undefined (e.g. the /pull page with a ClickHouse miss) we can't prove our
+  // commit list is current, so we fall through to GitHub exactly like before.
+  const referenceHeadSha = knownHeadSha ?? titleBody?.headSha;
+  const newestHistoricalSha =
+    shas.length > 0 ? shas[shas.length - 1].sha : undefined;
+
+  // Skip the GitHub listCommits call when our database already has the tip:
+  // there are commits AND the newest one matches the known PR head. Otherwise
+  // (empty list, or newest sha differs) hit GitHub and reconcile below. Fork PRs
+  // return empty from pr_commits, so they naturally fall back.
+  if (shas.length !== 0 && newestHistoricalSha === referenceHeadSha) {
+    return { title, body, shas };
+  }
+
+  const commits = await octokit.paginate(octokit.rest.pulls.listCommits, {
+    owner,
+    repo,
+    pull_number: parseInt(prNumber),
+    per_page: 100,
   });
 
   // Ideally historicalCommits will be a superset of commits, but if there's a propagation delay with

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -1448,7 +1448,13 @@ export async function reorganizeWorkflows(
         let prShas: { sha: string; title: string }[] = [];
         // Gate this to PyTorch as disabled tests feature is only available there
         if (octokit && repo === "pytorch") {
-          const prData = await fetchPR(owner, repo, `${prNumber}`, octokit);
+          const prData = await fetchPR(
+            owner,
+            repo,
+            `${prNumber}`,
+            octokit,
+            workflows[0].head_sha
+          );
           prTitle = prData.title;
           prBody = prData.body;
           prShas = prData.shas;

--- a/torchci/test/fetchPR.test.ts
+++ b/torchci/test/fetchPR.test.ts
@@ -1,0 +1,167 @@
+import * as clickhouse from "lib/clickhouse";
+import fetchPR from "lib/fetchPR";
+import { Octokit } from "octokit";
+
+function makeOctokit(opts: { getResult?: any; paginateResult?: any[] }) {
+  const get = jest.fn().mockResolvedValue(opts.getResult ?? { data: {} });
+  // listCommits is only passed to paginate as an endpoint reference; the fake
+  // paginate ignores it, so it is never actually invoked by fetchPR.
+  const listCommits = jest.fn();
+  const paginate = jest.fn().mockResolvedValue(opts.paginateResult ?? []);
+  const octokit = {
+    rest: { pulls: { get, listCommits } },
+    paginate,
+  } as unknown as Octokit;
+  return { octokit, get, listCommits, paginate };
+}
+
+describe("fetchPR", () => {
+  let queryClickhouse: jest.SpyInstance;
+  let queryClickhouseSaved: jest.SpyInstance;
+
+  beforeEach(() => {
+    queryClickhouse = jest.spyOn(clickhouse, "queryClickhouse");
+    queryClickhouseSaved = jest.spyOn(clickhouse, "queryClickhouseSaved");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("(a) ClickHouse hit uses CH title/body and does not call pulls.get", async () => {
+    queryClickhouse.mockResolvedValue([
+      { title: "CH title", body: "CH body", head_sha: "shaA" },
+    ]);
+    queryClickhouseSaved.mockResolvedValue([
+      { sha: "shaA", message: "commit a\nsecond line" },
+    ]);
+    const { octokit, get, paginate } = makeOctokit({});
+
+    const result = await fetchPR("pytorch", "pytorch", "123", octokit);
+
+    expect(result).toEqual({
+      title: "CH title",
+      body: "CH body",
+      shas: [{ sha: "shaA", title: "commit a" }],
+    });
+    expect(get).not.toHaveBeenCalled();
+    // CH already has the tip (newest sha === head sha), so no GitHub commits call.
+    expect(paginate).not.toHaveBeenCalled();
+    // Title/body query is pinned by the exact html_url + PR number.
+    expect(queryClickhouse.mock.calls[0][1]).toEqual({
+      prNumber: "123",
+      htmlUrl: "https://github.com/pytorch/pytorch/pull/123",
+    });
+  });
+
+  test("(b) ClickHouse miss (empty) falls back to pulls.get", async () => {
+    queryClickhouse.mockResolvedValue([]);
+    queryClickhouseSaved.mockResolvedValue([]);
+    const { octokit, get, paginate } = makeOctokit({
+      getResult: {
+        data: { title: "GH title", body: "GH body", head: { sha: "shaGH" } },
+      },
+      paginateResult: [{ sha: "shaGH", commit: { message: "gh commit" } }],
+    });
+
+    const result = await fetchPR("pytorch", "pytorch", "123", octokit);
+
+    expect(result).toEqual({
+      title: "GH title",
+      body: "GH body",
+      shas: [{ sha: "shaGH", title: "gh commit" }],
+    });
+    expect(get).toHaveBeenCalledTimes(1);
+    // No CH commits at all, so GitHub commits are fetched.
+    expect(paginate).toHaveBeenCalledTimes(1);
+  });
+
+  test("(c) ClickHouse error falls back to GitHub without crashing", async () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    queryClickhouse.mockRejectedValue(new Error("clickhouse down"));
+    queryClickhouseSaved.mockRejectedValue(new Error("clickhouse down"));
+    const { octokit, get, paginate } = makeOctokit({
+      getResult: {
+        data: { title: "GH title", body: "GH body", head: { sha: "shaGH" } },
+      },
+      paginateResult: [{ sha: "shaGH", commit: { message: "gh commit" } }],
+    });
+
+    const result = await fetchPR("pytorch", "pytorch", "123", octokit);
+
+    expect(result).toEqual({
+      title: "GH title",
+      body: "GH body",
+      shas: [{ sha: "shaGH", title: "gh commit" }],
+    });
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(paginate).toHaveBeenCalledTimes(1);
+    // Both failing reads are logged with detail, not silently swallowed.
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  test("(d) newest CH sha === knownHeadSha skips listCommits", async () => {
+    queryClickhouse.mockResolvedValue([
+      { title: "CH title", body: "CH body", head_sha: "ignored" },
+    ]);
+    queryClickhouseSaved.mockResolvedValue([
+      { sha: "old", message: "m1" },
+      { sha: "shaHead", message: "tip" },
+    ]);
+    const { octokit, get, paginate } = makeOctokit({});
+
+    const result = await fetchPR(
+      "pytorch",
+      "pytorch",
+      "123",
+      octokit,
+      "shaHead"
+    );
+
+    expect(result).toEqual({
+      title: "CH title",
+      body: "CH body",
+      shas: [
+        { sha: "old", title: "m1" },
+        { sha: "shaHead", title: "tip" },
+      ],
+    });
+    expect(get).not.toHaveBeenCalled();
+    expect(paginate).not.toHaveBeenCalled();
+  });
+
+  test("(e) newest CH sha !== knownHeadSha calls listCommits and reconciles the tip", async () => {
+    queryClickhouse.mockResolvedValue([
+      { title: "CH title", body: "CH body", head_sha: "ignored" },
+    ]);
+    queryClickhouseSaved.mockResolvedValue([
+      { sha: "old1", message: "m1" },
+      { sha: "old2", message: "m2" },
+    ]);
+    const { octokit, get, paginate } = makeOctokit({
+      paginateResult: [
+        { sha: "old1", commit: { message: "m1" } },
+        { sha: "old2", commit: { message: "m2" } },
+        { sha: "shaHead", commit: { message: "tip msg" } },
+      ],
+    });
+
+    const result = await fetchPR(
+      "pytorch",
+      "pytorch",
+      "123",
+      octokit,
+      "shaHead"
+    );
+
+    expect(paginate).toHaveBeenCalledTimes(1);
+    expect(get).not.toHaveBeenCalled();
+    expect(result.title).toBe("CH title");
+    expect(result.body).toBe("CH body");
+    expect(result.shas).toEqual([
+      { sha: "old1", title: "m1" },
+      { sha: "old2", title: "m2" },
+      { sha: "shaHead", title: "tip msg" },
+    ]);
+  });
+});


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #8584
* #8582
* #8580
* #8579
* #8578
* __->__ #8576

**Impact:** Dr. CI / drci refreshes and the `/pull` page (torchci)
**Risk:** low

## What
`fetchPR` now reads a PR's title, body, and commit list from the ClickHouse
mirrors (`default.pull_request` + `pr_commits`) instead of the GitHub REST API,
and only calls GitHub when ClickHouse misses, errors, or is stale.

## Why
The PyTorchBot GitHub App installation keeps hitting its shared hourly rate
limit and returning 403s. `fetchPR` runs unconditionally once per PR per Dr. CI
run and was one of the biggest steady drains (~600 calls/hr).

Key behaviours to check while reviewing:
- Both ClickHouse reads run under `Promise.allSettled`; each independently falls
  back to GitHub on an empty result **or** on error, so a ClickHouse outage
  degrades to today's GitHub-only path rather than failing the refresh.
- The `listCommits` call is skipped only when our commit list is non-empty *and*
  its newest sha matches a known head sha (caller-supplied by Dr. CI, else the
  head sha from the ClickHouse row). Fork PRs return empty from `pr_commits`, so
  they naturally fall back to GitHub.
- Dr. CI passes `workflows[0].head_sha` as the reference head; the `/pull` page
  passes nothing and relies on the ClickHouse head sha.

# Notes
GitHub is still the source of truth for anything the mirror can't cover (fork
PRs, ~31% of older PRs not mirrored, and the ~25–56s ingest lag on very recent
pushes). New `fetchPR.test.ts` covers the hit / miss / error / stale-tip paths.

Signed-off-by: Jean Schmidt <contato@jschmidt.me>