### PR TITLE
[hud] Match sole viable/strict blockers on full workflow name

### DIFF
--- a/torchci/clickhouse_queries/viable_strict_sole_blocker/query.sql
+++ b/torchci/clickhouse_queries/viable_strict_sole_blocker/query.sql
@@ -4,8 +4,9 @@
 -- Approximates the viable/strict gate for FAILURE ATTRIBUTION -- it is not a
 -- full reimplementation. It uses the same job-level red definition as
 -- pytorch/.github/scripts/fetch_latest_green_commit.py (via commit_jobs_batch_query):
---   * gating workflows are prefix-matched against ^(pull|trunk|lint|docs-build)
+--   * gating workflows are matched in FULL against ^(pull|trunk|lint|docs-build)$
 --     (case-insensitive), same as the `requires` list in update-viablestrict.yml
+--     and the gate's re.fullmatch
 --   * a job blocks if its latest run attempt (per workflow run) has a
 --     conclusion_kg other than success/skipped
 --   * jobs marked unstable (name contains "unstable", or the shard-folded name
@@ -84,10 +85,14 @@ raw_jobs AS (
             SELECT id FROM materialized_views.workflow_run_by_head_sha
             WHERE head_sha IN (SELECT sha FROM commits)
         )
-        -- Gating workflow prefixes; keep in sync with the `requires` list in
+        -- Gating workflows; keep in sync with the `requires` list in
         -- pytorch/pytorch .github/workflows/update-viablestrict.yml
         -- (["pull", "trunk", "lint", "docs-build"] as of 2026-07-27).
-        AND match(lower(j.workflow_name), '^(pull|trunk|lint|docs-build)')
+        -- Anchored at both ends to mirror the gate's re.fullmatch (test-infra
+        -- #8438): a prefix match would also pull in unrelated workflows that
+        -- merely share the prefix -- e.g. a `trunk-ci-sandbox` experiment or a
+        -- `Linter` -- and make them look like viable/strict blockers.
+        AND match(lower(j.workflow_name), '^(pull|trunk|lint|docs-build)$')
         -- Match the gate's job-level filtering (commit_jobs_batch_query), which
         -- only drops ciflow_should_run and generate-test-matrix. We additionally
         -- drop unstable and rerun_disabled_tests jobs: the gate ignores unstable

--- a/torchci/test/viableStrictSoleBlocker.test.ts
+++ b/torchci/test/viableStrictSoleBlocker.test.ts
@@ -91,21 +91,30 @@ describe("viable/strict sole blocker query.sql stays in sync with the fold + fil
   test("matches gating workflows in full, mirroring the gate's re.fullmatch", () => {
     // Anchored at both ends (test-infra #8438). A bare prefix would also match
     // sandbox/experiment workflows and linters that share the prefix but do
-    // not gate.
-    expect(sql).toContain("'^(pull|trunk|lint|docs-build)$'");
+    // not gate. Assert the whole predicate, not just the pattern: the pattern
+    // is all-lowercase only because lower() runs first, so dropping lower() as
+    // redundant-looking would silently un-gate the "Lint" workflow.
+    expect(sql).toContain(
+      "match(lower(j.workflow_name), '^(pull|trunk|lint|docs-build)$')"
+    );
 
-    const gating = /^(pull|trunk|lint|docs-build)$/;
-    for (const wf of ["pull", "trunk", "lint", "docs-build"]) {
-      expect(gating.test(wf)).toBe(true);
+    // Mirrors match(lower(j.workflow_name), ...): case-fold, then full-match.
+    const gates = (workflowName: string) =>
+      /^(pull|trunk|lint|docs-build)$/.test(workflowName.toLowerCase());
+
+    // Workflow names as they are actually spelled on main -- note "Lint",
+    // which a case-sensitive mirror would wrongly reject.
+    for (const wf of ["pull", "trunk", "Lint", "docs-build"]) {
+      expect(gates(wf)).toBe(true);
     }
     for (const wf of [
       "trunk-ci-sandbox",
       "trunk-tagging",
       "pull-test-sandbox",
-      "linter",
-      "lintrunner",
+      "Linter",
+      "Lintrunner",
     ]) {
-      expect(gating.test(wf)).toBe(false);
+      expect(gates(wf)).toBe(false);
     }
   });
 

--- a/torchci/test/viableStrictSoleBlocker.test.ts
+++ b/torchci/test/viableStrictSoleBlocker.test.ts
@@ -88,6 +88,27 @@ describe("viable/strict sole blocker query.sql stays in sync with the fold + fil
     expect(sql).not.toContain("splitByString(' / ', j.name), 2)");
   });
 
+  test("matches gating workflows in full, mirroring the gate's re.fullmatch", () => {
+    // Anchored at both ends (test-infra #8438). A bare prefix would also match
+    // sandbox/experiment workflows and linters that share the prefix but do
+    // not gate.
+    expect(sql).toContain("'^(pull|trunk|lint|docs-build)$'");
+
+    const gating = /^(pull|trunk|lint|docs-build)$/;
+    for (const wf of ["pull", "trunk", "lint", "docs-build"]) {
+      expect(gating.test(wf)).toBe(true);
+    }
+    for (const wf of [
+      "trunk-ci-sandbox",
+      "trunk-tagging",
+      "pull-test-sandbox",
+      "linter",
+      "lintrunner",
+    ]) {
+      expect(gating.test(wf)).toBe(false);
+    }
+  });
+
   test("keeps the gate's job filters + the fold-collision filters, drops the over-filters", () => {
     // gate parity
     expect(sql).toContain("j.name != 'ciflow_should_run'");


### PR DESCRIPTION
The sole-blocker query prefix-matched gating workflows, so unrelated workflows that merely share a prefix (sandbox/experiment workflows, linters) counted as viable/strict blockers. #8438 made the gate itself re.fullmatch; mirror that here so /reliability agrees with the gate (and with #8439 on the HUD grid).