### PR TITLE
Invalidate bot config caches on push to main instead of eagerly reloading

### DIFF
--- a/torchci/lib/bot/utils.ts
+++ b/torchci/lib/bot/utils.ts
@@ -59,7 +59,7 @@ export class CachedConfigTracker {
         context.payload.ref === "refs/heads/master" ||
         context.payload.ref === "refs/heads/main"
       ) {
-        await this.loadConfig(context, /* force */ true);
+        delete this.repoConfigs[repoKey(context)];
       }
     });
   }
@@ -130,7 +130,9 @@ export class CachedLabelerConfigTracker extends CachedConfigTracker {
         context.payload.ref === "refs/heads/master" ||
         context.payload.ref === "refs/heads/main"
       ) {
-        await this.loadLabelsConfig(context, /* force */ true);
+        const key = repoKey(context);
+        delete this.repoConfigs[key];
+        delete this.repoLabels[key];
       }
     });
   }
@@ -159,7 +161,9 @@ export class LabelToLabelConfigTracker extends CachedConfigTracker {
         context.payload.ref === "refs/heads/master" ||
         context.payload.ref === "refs/heads/main"
       ) {
-        await this.loadLabelsConfig(context, /* force */ true);
+        const key = repoKey(context);
+        delete this.repoConfigs[key];
+        delete this.repoLabels[key];
       }
     });
   }

--- a/torchci/lib/bot/utils.ts
+++ b/torchci/lib/bot/utils.ts
@@ -50,8 +50,27 @@ export function isDrCIEnabled(owner: string, repo: string): boolean {
   );
 }
 
+function retainLastKnownGood(
+  context: Context,
+  lastKnownGood: any,
+  key: string,
+  error: unknown
+): any {
+  // A repo with no config file resolves to null, so membership rather than
+  // truthiness decides whether an earlier fetch ever succeeded.
+  if (!(key in lastKnownGood)) {
+    throw error;
+  }
+  context.log.error(
+    { key, err: error },
+    "config fetch failed, serving the last known good value"
+  );
+  return lastKnownGood[key];
+}
+
 export class CachedConfigTracker {
   repoConfigs: any = {};
+  lastKnownGoodConfigs: any = {};
 
   constructor(app: Probot) {
     app.on("push", async (context) => {
@@ -68,7 +87,20 @@ export class CachedConfigTracker {
     const key = repoKey(context);
     if (!(key in this.repoConfigs) || force) {
       context.log({ key }, "loadConfig");
-      this.repoConfigs[key] = await context.config("pytorch-probot.yml");
+      try {
+        this.repoConfigs[key] = await context.config("pytorch-probot.yml");
+        this.lastKnownGoodConfigs[key] = this.repoConfigs[key];
+      } catch (error) {
+        // A forced read leaves the previous value in place; dropping it keeps
+        // the key stale so the next read retries the fetch.
+        delete this.repoConfigs[key];
+        return retainLastKnownGood(
+          context,
+          this.lastKnownGoodConfigs,
+          key,
+          error
+        );
+      }
     }
     return this.repoConfigs[key];
   }
@@ -123,6 +155,7 @@ export class CachedIssueTracker extends CachedConfigTracker {
 
 export class CachedLabelerConfigTracker extends CachedConfigTracker {
   repoLabels: any = {};
+  lastKnownGoodLabels: any = {};
   constructor(app: Probot) {
     super(app);
     app.on("push", async (context) => {
@@ -140,7 +173,17 @@ export class CachedLabelerConfigTracker extends CachedConfigTracker {
   async loadLabelsConfig(context: Context, force = false): Promise<object> {
     const key = repoKey(context);
     if (!(key in this.repoLabels) || force) {
-      const config: any = await this.loadConfig(context, force);
+      let config: any;
+      try {
+        config = await this.loadConfig(context, force);
+      } catch (error) {
+        return retainLastKnownGood(
+          context,
+          this.lastKnownGoodLabels,
+          key,
+          error
+        );
+      }
 
       if (config != null && "labeler_config" in config) {
         this.repoLabels[key] = context.config(config["labeler_config"]);
@@ -148,12 +191,24 @@ export class CachedLabelerConfigTracker extends CachedConfigTracker {
         this.repoLabels[key] = {};
       }
     }
-    return this.repoLabels[key];
+    // The cache holds the unsettled fetch itself so concurrent readers share it.
+    const pending = this.repoLabels[key];
+    try {
+      const labels = await pending;
+      this.lastKnownGoodLabels[key] = labels;
+      return labels;
+    } catch (error) {
+      if (this.repoLabels[key] === pending) {
+        delete this.repoLabels[key];
+      }
+      return retainLastKnownGood(context, this.lastKnownGoodLabels, key, error);
+    }
   }
 }
 
 export class LabelToLabelConfigTracker extends CachedConfigTracker {
   repoLabels: any = {};
+  lastKnownGoodLabels: any = {};
   constructor(app: Probot) {
     super(app);
     app.on("push", async (context) => {
@@ -171,7 +226,17 @@ export class LabelToLabelConfigTracker extends CachedConfigTracker {
   async loadLabelsConfig(context: Context, force = false): Promise<object> {
     const key = repoKey(context);
     if (!(key in this.repoLabels) || force) {
-      const config: any = await this.loadConfig(context, force);
+      let config: any;
+      try {
+        config = await this.loadConfig(context, force);
+      } catch (error) {
+        return retainLastKnownGood(
+          context,
+          this.lastKnownGoodLabels,
+          key,
+          error
+        );
+      }
 
       if (config != null && "label_to_label_config" in config) {
         this.repoLabels[key] = context.config(config["label_to_label_config"]);
@@ -179,7 +244,18 @@ export class LabelToLabelConfigTracker extends CachedConfigTracker {
         this.repoLabels[key] = {};
       }
     }
-    return this.repoLabels[key];
+    // The cache holds the unsettled fetch itself so concurrent readers share it.
+    const pending = this.repoLabels[key];
+    try {
+      const labels = await pending;
+      this.lastKnownGoodLabels[key] = labels;
+      return labels;
+    } catch (error) {
+      if (this.repoLabels[key] === pending) {
+        delete this.repoLabels[key];
+      }
+      return retainLastKnownGood(context, this.lastKnownGoodLabels, key, error);
+    }
   }
 }
 

--- a/torchci/lib/fetchPR.ts
+++ b/torchci/lib/fetchPR.ts
@@ -1,5 +1,5 @@
 import { Octokit } from "octokit";
-import { queryClickhouseSaved } from "./clickhouse";
+import { queryClickhouse, queryClickhouseSaved } from "./clickhouse";
 import { PRData } from "./types";
 
 async function fetchHistoricalCommits(
@@ -14,35 +14,129 @@ async function fetchHistoricalCommits(
   });
 }
 
+interface PRTitleBody {
+  title: string;
+  body: string;
+  headSha: string;
+}
+
+async function fetchPRTitleBody(
+  owner: string,
+  repo: string,
+  prNumber: string
+): Promise<PRTitleBody | undefined> {
+  // Read the PR's title/body/head sha from the default.pull_request mirror
+  // instead of the GitHub API. Filter on `number` (the table's sorting key) for
+  // an indexed lookup; html_url pins the repo since PR numbers are not unique
+  // across repos. FINAL collapses the ReplacingMergeTree to the latest row.
+  const query = `
+SELECT
+    title,
+    body,
+    head.'sha' AS head_sha
+FROM default.pull_request FINAL
+WHERE
+    number = {prNumber: Int64}
+    AND html_url = {htmlUrl: String}
+  `;
+  const rows = await queryClickhouse(query, {
+    prNumber,
+    htmlUrl: `https://github.com/${owner}/${repo}/pull/${prNumber}`,
+  });
+  if (rows.length !== 1) {
+    return undefined;
+  }
+  return {
+    title: rows[0].title,
+    body: rows[0].body ?? "",
+    headSha: rows[0].head_sha,
+  };
+}
+
 export default async function fetchPR(
   owner: string,
   repo: string,
   prNumber: string,
-  octokit: Octokit
+  octokit: Octokit,
+  knownHeadSha?: string
 ): Promise<PRData> {
   // We pull data from both our database and Github to get all commits,
   // including the ones that have been force merged out of the git history.  Our
   // database is the primary source, GitHub covers anything newer that might
   // have been missed.
-  const [pull, commits, historicalCommits] = await Promise.all([
-    octokit.rest.pulls.get({
+  //
+  // Both ClickHouse reads run in parallel so a covered PR resolves in a single
+  // round trip and never touches the GitHub REST API. Each read independently
+  // falls back to GitHub on an empty result OR on error, so a ClickHouse outage
+  // degrades to GitHub-only behaviour instead of failing the refresh.
+  const [titleBodySettled, historicalCommitsSettled] = await Promise.allSettled(
+    [
+      fetchPRTitleBody(owner, repo, prNumber),
+      fetchHistoricalCommits(owner, repo, prNumber),
+    ]
+  );
+
+  let titleBody: PRTitleBody | undefined;
+  if (titleBodySettled.status === "fulfilled") {
+    titleBody = titleBodySettled.value;
+  } else {
+    console.warn(
+      `fetchPR: ClickHouse title/body query failed for ${owner}/${repo}#${prNumber}, falling back to GitHub`,
+      titleBodySettled.reason
+    );
+  }
+
+  let title: string;
+  let body: string;
+  if (titleBody !== undefined) {
+    title = titleBody.title;
+    body = titleBody.body;
+  } else {
+    // No ClickHouse row (or the query errored): fall back to the GitHub API.
+    const pull = await octokit.rest.pulls.get({
       owner,
       repo,
       pull_number: parseInt(prNumber),
-    }),
-    octokit.paginate(octokit.rest.pulls.listCommits, {
-      owner,
-      repo,
-      pull_number: parseInt(prNumber),
-      per_page: 100,
-    }),
-    fetchHistoricalCommits(owner, repo, prNumber),
-  ]);
-  const title = pull.data.title;
-  const body = pull.data.body ?? "";
+    });
+    title = pull.data.title;
+    body = pull.data.body ?? "";
+  }
+
+  let historicalCommits: any[] = [];
+  if (historicalCommitsSettled.status === "fulfilled") {
+    historicalCommits = historicalCommitsSettled.value;
+  } else {
+    console.warn(
+      `fetchPR: ClickHouse pr_commits query failed for ${owner}/${repo}#${prNumber}, falling back to GitHub`,
+      historicalCommitsSettled.reason
+    );
+  }
 
   let shas = historicalCommits.map((commit) => {
     return { sha: commit.sha, title: commit.message.split("\n")[0] };
+  });
+
+  // The reference head sha is the caller-supplied head (Dr. CI already knows it)
+  // or, failing that, the head sha from the ClickHouse pull_request row. When it
+  // is undefined (e.g. the /pull page with a ClickHouse miss) we can't prove our
+  // commit list is current, so we fall through to GitHub exactly like before.
+  const referenceHeadSha = knownHeadSha ?? titleBody?.headSha;
+  const newestHistoricalSha =
+    shas.length > 0 ? shas[shas.length - 1].sha : undefined;
+
+  // Skip the GitHub listCommits call when our database already has the tip:
+  // there are commits AND the newest one matches the known PR head. Otherwise
+  // (empty list, or newest sha differs) hit GitHub and reconcile below. Fork PRs
+  // return empty from pr_commits, so they naturally fall back.
+  if (shas.length !== 0 && newestHistoricalSha === referenceHeadSha) {
+    return { title, body, shas };
+  }
+
+  const commits = await octokit.paginate(octokit.rest.pulls.listCommits, {
+    owner,
+    repo,
+    pull_number: parseInt(prNumber),
+    per_page: 100,
   });
 
   // Ideally historicalCommits will be a superset of commits, but if there's a propagation delay with

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -1448,7 +1448,13 @@ export async function reorganizeWorkflows(
         let prShas: { sha: string; title: string }[] = [];
         // Gate this to PyTorch as disabled tests feature is only available there
         if (octokit && repo === "pytorch") {
-          const prData = await fetchPR(owner, repo, `${prNumber}`, octokit);
+          const prData = await fetchPR(
+            owner,
+            repo,
+            `${prNumber}`,
+            octokit,
+            workflows[0].head_sha
+          );
           prTitle = prData.title;
           prBody = prData.body;
           prShas = prData.shas;

--- a/torchci/test/configTracker.test.ts
+++ b/torchci/test/configTracker.test.ts
@@ -1,0 +1,99 @@
+import {
+  CachedConfigTracker,
+  CachedLabelerConfigTracker,
+  LabelToLabelConfigTracker,
+} from "lib/bot/utils";
+import nock from "nock";
+import { Probot } from "probot";
+import * as utils from "./utils";
+
+nock.disableNetConnect();
+
+const OWNER = "pytorch";
+const REPO = "pytorch";
+const KEY = `${OWNER}/${REPO}`;
+
+function pushToMain() {
+  return {
+    ref: "refs/heads/main",
+    repository: {
+      name: REPO,
+      full_name: KEY,
+      owner: { login: OWNER, name: OWNER },
+    },
+    installation: { id: 2 },
+  };
+}
+
+function loadTracker<T extends CachedConfigTracker>(
+  make: (app: Probot) => T
+): { probot: Probot; tracker: T } {
+  const probot = utils.testProbot();
+  let tracker!: T;
+  probot.load((app) => {
+    tracker = make(app);
+  });
+  return { probot, tracker };
+}
+
+describe("CachedConfigTracker push-driven cache invalidation", () => {
+  afterEach(() => {
+    nock.cleanAll();
+    jest.restoreAllMocks();
+  });
+
+  test("push to main invalidates the config cache without an eager fetch, next access re-fetches lazily", async () => {
+    const { probot, tracker } = loadTracker(
+      (app) => new CachedConfigTracker(app)
+    );
+    tracker.repoConfigs[KEY] = { cached: "stale" };
+
+    // Net connections are disabled and no config interceptor is registered, so an
+    // eager getContent fetch would throw; a clean resolve proves none happened.
+    await probot.receive({
+      name: "push",
+      payload: pushToMain() as any,
+      id: "1",
+    });
+    expect(KEY in tracker.repoConfigs).toBe(false);
+
+    const ctx = {
+      repo: () => ({ owner: OWNER, repo: REPO }),
+      log: jest.fn(),
+      config: jest.fn().mockResolvedValue({ fresh: true }),
+    } as any;
+    expect(await tracker.loadConfig(ctx)).toEqual({ fresh: true });
+    expect(ctx.config).toHaveBeenCalledTimes(1);
+    // Now re-cached: a subsequent access does not fetch again.
+    await tracker.loadConfig(ctx);
+    expect(ctx.config).toHaveBeenCalledTimes(1);
+  });
+
+  const labelerTrackers: [
+    string,
+    new (app: Probot) => CachedLabelerConfigTracker | LabelToLabelConfigTracker
+  ][] = [
+    ["CachedLabelerConfigTracker", CachedLabelerConfigTracker],
+    ["LabelToLabelConfigTracker", LabelToLabelConfigTracker],
+  ];
+
+  test.each(labelerTrackers)(
+    "%s push to main invalidates both the config and labels caches without an eager fetch",
+    async (_name, Tracker) => {
+      const { probot, tracker } = loadTracker((app) => new Tracker(app));
+      tracker.repoConfigs[KEY] = { cached: "stale" };
+      tracker.repoLabels[KEY] = { cached: "stale-labels" };
+
+      await probot.receive({
+        name: "push",
+        payload: pushToMain() as any,
+        id: "1",
+      });
+
+      // Both must be cleared: repoConfigs holds the labeler-file pointer, repoLabels
+      // holds the parsed labeler data; keeping either serves stale results.
+      expect(KEY in tracker.repoConfigs).toBe(false);
+      expect(KEY in tracker.repoLabels).toBe(false);
+    }
+  );
+});

--- a/torchci/test/configTracker.test.ts
+++ b/torchci/test/configTracker.test.ts
@@ -12,6 +12,31 @@ nock.disableNetConnect();
 const OWNER = "pytorch";
 const REPO = "pytorch";
 const KEY = `${OWNER}/${REPO}`;
+const PROBOT_CONFIG = "pytorch-probot.yml";
+const LABELS_FILE = "labeler.yml";
+const RATE_LIMITED = new Error("secondary rate limit");
+
+function throwRateLimited(): any {
+  throw RATE_LIMITED;
+}
+
+// Each entry is re-read per fetch so a test can swap a repo's reply mid-run.
+function testContext(replies: { [fileName: string]: () => any }) {
+  const log: any = jest.fn();
+  log.error = jest.fn();
+  return {
+    repo: () => ({ owner: OWNER, repo: REPO }),
+    log,
+    config: jest.fn(async (fileName: string) => replies[fileName]()),
+  } as any;
+}
+
+function expectRetainLogged(ctx: any) {
+  expect(ctx.log.error).toHaveBeenCalledWith(
+    expect.objectContaining({ key: KEY, err: RATE_LIMITED }),
+    expect.any(String)
+  );
+}
 
 function pushToMain() {
   return {
@@ -34,6 +59,45 @@ function loadTracker<T extends CachedConfigTracker>(
     tracker = make(app);
   });
   return { probot, tracker };
+}
+
+type LabelerTrackerCtor = new (app: Probot) =>
+  | CachedLabelerConfigTracker
+  | LabelToLabelConfigTracker;
+
+async function invalidate(probot: Probot) {
+  await probot.receive({ name: "push", payload: pushToMain() as any, id: "1" });
+}
+
+// A tracker that has cached one good config and has since been invalidated by a
+// push, i.e. the state in which the next read has to re-fetch.
+async function primedConfigTracker() {
+  const { probot, tracker } = loadTracker(
+    (app) => new CachedConfigTracker(app)
+  );
+  const reply = { config: () => ({ generation: 1 } as any) };
+  const ctx = testContext({ [PROBOT_CONFIG]: () => reply.config() });
+  await tracker.loadConfig(ctx);
+  await invalidate(probot);
+  return { tracker, ctx, reply };
+}
+
+async function primedLabelsTracker(
+  Tracker: LabelerTrackerCtor,
+  configKey: string
+) {
+  const { probot, tracker } = loadTracker((app) => new Tracker(app));
+  const reply = {
+    config: () => ({ [configKey]: LABELS_FILE } as any),
+    labels: () => ({ generation: 1 } as any),
+  };
+  const ctx = testContext({
+    [PROBOT_CONFIG]: () => reply.config(),
+    [LABELS_FILE]: () => reply.labels(),
+  });
+  await tracker.loadLabelsConfig(ctx);
+  await invalidate(probot);
+  return { tracker, ctx, reply };
 }
 
 describe("CachedConfigTracker push-driven cache invalidation", () => {
@@ -69,12 +133,95 @@ describe("CachedConfigTracker push-driven cache invalidation", () => {
     expect(ctx.config).toHaveBeenCalledTimes(1);
   });
 
-  const labelerTrackers: [
-    string,
-    new (app: Probot) => CachedLabelerConfigTracker | LabelToLabelConfigTracker
-  ][] = [
-    ["CachedLabelerConfigTracker", CachedLabelerConfigTracker],
-    ["LabelToLabelConfigTracker", LabelToLabelConfigTracker],
+  test("serves the retained config when the lazy re-fetch fails", async () => {
+    const { tracker, ctx, reply } = await primedConfigTracker();
+    reply.config = throwRateLimited;
+
+    expect(await tracker.loadConfig(ctx)).toEqual({ generation: 1 });
+    expect(ctx.config).toHaveBeenCalledTimes(2);
+    expectRetainLogged(ctx);
+  });
+
+  test("keeps the key stale after a failed re-fetch so the next read tries again", async () => {
+    const { tracker, ctx, reply } = await primedConfigTracker();
+    reply.config = throwRateLimited;
+    await tracker.loadConfig(ctx);
+
+    reply.config = () => ({ generation: 2 });
+    expect(await tracker.loadConfig(ctx)).toEqual({ generation: 2 });
+    expect(ctx.config).toHaveBeenCalledTimes(3);
+    // The fresh value is now the cached one.
+    await tracker.loadConfig(ctx);
+    expect(ctx.config).toHaveBeenCalledTimes(3);
+  });
+
+  test("throws when the fetch fails and nothing was ever cached", async () => {
+    const { tracker } = loadTracker((app) => new CachedConfigTracker(app));
+    const ctx = testContext({ [PROBOT_CONFIG]: throwRateLimited });
+
+    await expect(tracker.loadConfig(ctx)).rejects.toThrow(
+      "secondary rate limit"
+    );
+    expect(ctx.log.error).not.toHaveBeenCalled();
+  });
+
+  test("a null config is a cache hit and is retained across a failing re-fetch", async () => {
+    const { probot, tracker } = loadTracker(
+      (app) => new CachedConfigTracker(app)
+    );
+    const reply = { config: () => null as any };
+    const ctx = testContext({ [PROBOT_CONFIG]: () => reply.config() });
+
+    expect(await tracker.loadConfig(ctx)).toBeNull();
+    expect(await tracker.loadConfig(ctx)).toBeNull();
+    expect(ctx.config).toHaveBeenCalledTimes(1);
+
+    await invalidate(probot);
+    reply.config = throwRateLimited;
+    expect(await tracker.loadConfig(ctx)).toBeNull();
+    expect(ctx.config).toHaveBeenCalledTimes(2);
+    expectRetainLogged(ctx);
+  });
+
+  test("force re-reads the config even on a cache hit", async () => {
+    const { tracker } = loadTracker((app) => new CachedConfigTracker(app));
+    const reply = { config: () => ({ generation: 1 } as any) };
+    const ctx = testContext({ [PROBOT_CONFIG]: () => reply.config() });
+
+    await tracker.loadConfig(ctx);
+    await tracker.loadConfig(ctx);
+    expect(ctx.config).toHaveBeenCalledTimes(1);
+
+    reply.config = () => ({ generation: 2 });
+    expect(await tracker.loadConfig(ctx, true)).toEqual({ generation: 2 });
+    expect(ctx.config).toHaveBeenCalledTimes(2);
+  });
+
+  test("a forced re-read that fails serves the retained config and leaves the key stale", async () => {
+    const { tracker } = loadTracker((app) => new CachedConfigTracker(app));
+    const reply = { config: () => ({ generation: 1 } as any) };
+    const ctx = testContext({ [PROBOT_CONFIG]: () => reply.config() });
+
+    await tracker.loadConfig(ctx);
+    reply.config = throwRateLimited;
+    expect(await tracker.loadConfig(ctx, true)).toEqual({ generation: 1 });
+
+    reply.config = () => ({ generation: 2 });
+    expect(await tracker.loadConfig(ctx)).toEqual({ generation: 2 });
+    expect(ctx.config).toHaveBeenCalledTimes(3);
+  });
+
+  const labelerTrackers: [string, LabelerTrackerCtor, string][] = [
+    [
+      "CachedLabelerConfigTracker",
+      CachedLabelerConfigTracker,
+      "labeler_config",
+    ],
+    [
+      "LabelToLabelConfigTracker",
+      LabelToLabelConfigTracker,
+      "label_to_label_config",
+    ],
   ];
 
   test.each(labelerTrackers)(
@@ -94,6 +241,131 @@ describe("CachedConfigTracker push-driven cache invalidation", () => {
       // holds the parsed labeler data; keeping either serves stale results.
       expect(KEY in tracker.repoConfigs).toBe(false);
       expect(KEY in tracker.repoLabels).toBe(false);
+    }
+  );
+
+  test.each(labelerTrackers)(
+    "%s serves the retained labels when the lazy re-fetch fails",
+    async (_name, Tracker, configKey) => {
+      const { tracker, ctx, reply } = await primedLabelsTracker(
+        Tracker,
+        configKey
+      );
+      reply.labels = throwRateLimited;
+
+      expect(await tracker.loadLabelsConfig(ctx)).toEqual({ generation: 1 });
+      expectRetainLogged(ctx);
+    }
+  );
+
+  test.each(labelerTrackers)(
+    "%s serves the retained labels when the config read itself fails",
+    async (_name, Tracker) => {
+      const { tracker } = loadTracker((app) => new Tracker(app));
+      tracker.lastKnownGoodLabels[KEY] = { generation: 1 };
+      const ctx = testContext({ [PROBOT_CONFIG]: throwRateLimited });
+
+      expect(await tracker.loadLabelsConfig(ctx)).toEqual({ generation: 1 });
+      expectRetainLogged(ctx);
+    }
+  );
+
+  test.each(labelerTrackers)(
+    "%s keeps the labels key stale after a failed re-fetch so the next read tries again",
+    async (_name, Tracker, configKey) => {
+      const { tracker, ctx, reply } = await primedLabelsTracker(
+        Tracker,
+        configKey
+      );
+      reply.labels = throwRateLimited;
+      await tracker.loadLabelsConfig(ctx);
+
+      reply.labels = () => ({ generation: 2 });
+      expect(await tracker.loadLabelsConfig(ctx)).toEqual({ generation: 2 });
+    }
+  );
+
+  test.each(labelerTrackers)(
+    "%s throws when the labels fetch fails and nothing was ever cached",
+    async (_name, Tracker, configKey) => {
+      const { tracker } = loadTracker((app) => new Tracker(app));
+      const ctx = testContext({
+        [PROBOT_CONFIG]: () => ({ [configKey]: LABELS_FILE }),
+        [LABELS_FILE]: throwRateLimited,
+      });
+
+      await expect(tracker.loadLabelsConfig(ctx)).rejects.toThrow(
+        "secondary rate limit"
+      );
+      expect(ctx.log.error).not.toHaveBeenCalled();
+    }
+  );
+
+  test.each(labelerTrackers)(
+    "%s null labels are a cache hit and are retained across a failing re-fetch",
+    async (_name, Tracker, configKey) => {
+      const { probot, tracker } = loadTracker((app) => new Tracker(app));
+      const reply = { labels: () => null as any };
+      const ctx = testContext({
+        [PROBOT_CONFIG]: () => ({ [configKey]: LABELS_FILE }),
+        [LABELS_FILE]: () => reply.labels(),
+      });
+
+      expect(await tracker.loadLabelsConfig(ctx)).toBeNull();
+      expect(await tracker.loadLabelsConfig(ctx)).toBeNull();
+      // One config read plus one labels read; neither repeated on the cache hit.
+      expect(ctx.config).toHaveBeenCalledTimes(2);
+
+      await invalidate(probot);
+      reply.labels = throwRateLimited;
+      expect(await tracker.loadLabelsConfig(ctx)).toBeNull();
+      expectRetainLogged(ctx);
+    }
+  );
+
+  test.each(labelerTrackers)(
+    "%s force re-reads both the config and the labels file",
+    async (_name, Tracker, configKey) => {
+      const { tracker } = loadTracker((app) => new Tracker(app));
+      const reply = { labels: () => ({ generation: 1 } as any) };
+      const ctx = testContext({
+        [PROBOT_CONFIG]: () => ({ [configKey]: LABELS_FILE }),
+        [LABELS_FILE]: () => reply.labels(),
+      });
+
+      await tracker.loadLabelsConfig(ctx);
+      await tracker.loadLabelsConfig(ctx);
+      expect(ctx.config).toHaveBeenCalledTimes(2);
+
+      reply.labels = () => ({ generation: 2 });
+      expect(await tracker.loadLabelsConfig(ctx, true)).toEqual({
+        generation: 2,
+      });
+      expect(ctx.config).toHaveBeenCalledTimes(4);
+    }
+  );
+
+  test.each(labelerTrackers)(
+    "%s concurrent readers share a single in-flight labels fetch",
+    async (_name, Tracker, configKey) => {
+      const { tracker } = loadTracker((app) => new Tracker(app));
+      let release!: (_labels: any) => void;
+      const inFlight = new Promise((resolve) => {
+        release = resolve;
+      });
+      const ctx = testContext({
+        [PROBOT_CONFIG]: () => ({ [configKey]: LABELS_FILE }),
+        [LABELS_FILE]: () => inFlight,
+      });
+
+      const first = tracker.loadLabelsConfig(ctx);
+      await new Promise((resolve) => setImmediate(resolve));
+      const second = tracker.loadLabelsConfig(ctx);
+      release({ generation: 1 });
+
+      expect(await first).toEqual({ generation: 1 });
+      expect(await second).toEqual({ generation: 1 });
+      expect(ctx.config).toHaveBeenCalledTimes(2);
     }
   );
 });

--- a/torchci/test/fetchPR.test.ts
+++ b/torchci/test/fetchPR.test.ts
@@ -1,0 +1,167 @@
+import * as clickhouse from "lib/clickhouse";
+import fetchPR from "lib/fetchPR";
+import { Octokit } from "octokit";
+
+function makeOctokit(opts: { getResult?: any; paginateResult?: any[] }) {
+  const get = jest.fn().mockResolvedValue(opts.getResult ?? { data: {} });
+  // listCommits is only passed to paginate as an endpoint reference; the fake
+  // paginate ignores it, so it is never actually invoked by fetchPR.
+  const listCommits = jest.fn();
+  const paginate = jest.fn().mockResolvedValue(opts.paginateResult ?? []);
+  const octokit = {
+    rest: { pulls: { get, listCommits } },
+    paginate,
+  } as unknown as Octokit;
+  return { octokit, get, listCommits, paginate };
+}
+
+describe("fetchPR", () => {
+  let queryClickhouse: jest.SpyInstance;
+  let queryClickhouseSaved: jest.SpyInstance;
+
+  beforeEach(() => {
+    queryClickhouse = jest.spyOn(clickhouse, "queryClickhouse");
+    queryClickhouseSaved = jest.spyOn(clickhouse, "queryClickhouseSaved");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("(a) ClickHouse hit uses CH title/body and does not call pulls.get", async () => {
+    queryClickhouse.mockResolvedValue([
+      { title: "CH title", body: "CH body", head_sha: "shaA" },
+    ]);
+    queryClickhouseSaved.mockResolvedValue([
+      { sha: "shaA", message: "commit a\nsecond line" },
+    ]);
+    const { octokit, get, paginate } = makeOctokit({});
+
+    const result = await fetchPR("pytorch", "pytorch", "123", octokit);
+
+    expect(result).toEqual({
+      title: "CH title",
+      body: "CH body",
+      shas: [{ sha: "shaA", title: "commit a" }],
+    });
+    expect(get).not.toHaveBeenCalled();
+    // CH already has the tip (newest sha === head sha), so no GitHub commits call.
+    expect(paginate).not.toHaveBeenCalled();
+    // Title/body query is pinned by the exact html_url + PR number.
+    expect(queryClickhouse.mock.calls[0][1]).toEqual({
+      prNumber: "123",
+      htmlUrl: "https://github.com/pytorch/pytorch/pull/123",
+    });
+  });
+
+  test("(b) ClickHouse miss (empty) falls back to pulls.get", async () => {
+    queryClickhouse.mockResolvedValue([]);
+    queryClickhouseSaved.mockResolvedValue([]);
+    const { octokit, get, paginate } = makeOctokit({
+      getResult: {
+        data: { title: "GH title", body: "GH body", head: { sha: "shaGH" } },
+      },
+      paginateResult: [{ sha: "shaGH", commit: { message: "gh commit" } }],
+    });
+
+    const result = await fetchPR("pytorch", "pytorch", "123", octokit);
+
+    expect(result).toEqual({
+      title: "GH title",
+      body: "GH body",
+      shas: [{ sha: "shaGH", title: "gh commit" }],
+    });
+    expect(get).toHaveBeenCalledTimes(1);
+    // No CH commits at all, so GitHub commits are fetched.
+    expect(paginate).toHaveBeenCalledTimes(1);
+  });
+
+  test("(c) ClickHouse error falls back to GitHub without crashing", async () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    queryClickhouse.mockRejectedValue(new Error("clickhouse down"));
+    queryClickhouseSaved.mockRejectedValue(new Error("clickhouse down"));
+    const { octokit, get, paginate } = makeOctokit({
+      getResult: {
+        data: { title: "GH title", body: "GH body", head: { sha: "shaGH" } },
+      },
+      paginateResult: [{ sha: "shaGH", commit: { message: "gh commit" } }],
+    });
+
+    const result = await fetchPR("pytorch", "pytorch", "123", octokit);
+
+    expect(result).toEqual({
+      title: "GH title",
+      body: "GH body",
+      shas: [{ sha: "shaGH", title: "gh commit" }],
+    });
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(paginate).toHaveBeenCalledTimes(1);
+    // Both failing reads are logged with detail, not silently swallowed.
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  test("(d) newest CH sha === knownHeadSha skips listCommits", async () => {
+    queryClickhouse.mockResolvedValue([
+      { title: "CH title", body: "CH body", head_sha: "ignored" },
+    ]);
+    queryClickhouseSaved.mockResolvedValue([
+      { sha: "old", message: "m1" },
+      { sha: "shaHead", message: "tip" },
+    ]);
+    const { octokit, get, paginate } = makeOctokit({});
+
+    const result = await fetchPR(
+      "pytorch",
+      "pytorch",
+      "123",
+      octokit,
+      "shaHead"
+    );
+
+    expect(result).toEqual({
+      title: "CH title",
+      body: "CH body",
+      shas: [
+        { sha: "old", title: "m1" },
+        { sha: "shaHead", title: "tip" },
+      ],
+    });
+    expect(get).not.toHaveBeenCalled();
+    expect(paginate).not.toHaveBeenCalled();
+  });
+
+  test("(e) newest CH sha !== knownHeadSha calls listCommits and reconciles the tip", async () => {
+    queryClickhouse.mockResolvedValue([
+      { title: "CH title", body: "CH body", head_sha: "ignored" },
+    ]);
+    queryClickhouseSaved.mockResolvedValue([
+      { sha: "old1", message: "m1" },
+      { sha: "old2", message: "m2" },
+    ]);
+    const { octokit, get, paginate } = makeOctokit({
+      paginateResult: [
+        { sha: "old1", commit: { message: "m1" } },
+        { sha: "old2", commit: { message: "m2" } },
+        { sha: "shaHead", commit: { message: "tip msg" } },
+      ],
+    });
+
+    const result = await fetchPR(
+      "pytorch",
+      "pytorch",
+      "123",
+      octokit,
+      "shaHead"
+    );
+
+    expect(paginate).toHaveBeenCalledTimes(1);
+    expect(get).not.toHaveBeenCalled();
+    expect(result.title).toBe("CH title");
+    expect(result.body).toBe("CH body");
+    expect(result.shas).toEqual([
+      { sha: "old1", title: "m1" },
+      { sha: "old2", title: "m2" },
+      { sha: "shaHead", title: "tip msg" },
+    ]);
+  });
+});


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #8584
* #8582
* #8580
* #8579
* __->__ #8578
* #8576

**Impact:** PyTorchBot webhook handlers (config/labeler trackers)
**Risk:** low

## What
On every push to `main`/`master`, the config trackers now just drop their cached
entries instead of immediately re-fetching the config (and labeler) files. The
config is re-read lazily the next time a handler actually needs it.

## Why
Each push to the default branch fires across several tracker instances, and every
one of them was force-reloading its config through the GitHub App installation
token. That produced a burst of redundant `getContent` calls per push against a
shared, already-strained hourly rate limit. Swapping the eager force-reload for
cache invalidation removes the storm while keeping configs fresh — the next access
repopulates the cache with current data.

# Notes
`CachedLabelerConfigTracker` and `LabelToLabelConfigTracker` clear both
`repoConfigs` (the labeler-file pointer) and `repoLabels` (the parsed data), since
serving either stale would return outdated labels. Covered by
`test/configTracker.test.ts`.

Signed-off-by: Jean Schmidt <contato@jschmidt.me>