### PR TITLE
Serve the HUD commit list from ClickHouse with a GitHub fallback

### DIFF
--- a/torchci/clickhouse_queries/hud_commits/params.json
+++ b/torchci/clickhouse_queries/hud_commits/params.json
@@ -1,0 +1,16 @@
+{
+  "params": {
+    "repo": "String",
+    "branch": "String",
+    "per_page": "Int32",
+    "offset": "Int32"
+  },
+  "tests": [
+    {
+      "repo": "pytorch/pytorch",
+      "branch": "main",
+      "per_page": 50,
+      "offset": 0
+    }
+  ]
+}

--- a/torchci/clickhouse_queries/hud_commits/query.sql
+++ b/torchci/clickhouse_queries/hud_commits/query.sql
@@ -1,0 +1,46 @@
+-- Commit list for the HUD landing-page grid, read from default.push instead of
+-- the GitHub REST API.
+--
+-- arrayJoin over `commits` rather than head_commit: a ghstack land pushes the
+-- whole stack in one event, so head_commit alone omits the non-tip commits.
+-- head_commit is always the last element of `commits`, so array position DESC
+-- orders the commits of a single push head/newest-first.
+--
+-- No FINAL, and the two-stage shape, are deliberate: FINAL forces a full merge
+-- that defeats the read-in-order tail scan (~25x slower here) and push has no
+-- duplicate rows in practice; the inner query keeps the wide scan on the cheap
+-- sort-key columns so only the projected commit subcolumns are decompressed
+-- (never the large added/modified/removed file lists).
+SELECT
+    sha,
+    message,
+    url,
+    formatDateTime(ts, '%Y-%m-%dT%H:%i:%SZ', 'UTC') AS timestamp,
+    author_username,
+    author_name
+FROM (
+    SELECT
+        commits.id AS ids,
+        commits.message AS messages,
+        commits.url AS urls,
+        commits.timestamp AS tss,
+        commits.author.username AS author_usernames,
+        commits.author.name AS author_names,
+        head_commit.timestamp AS push_ts
+    FROM default.push
+    PREWHERE
+        repository.full_name = {repo: String}
+        AND ref = concat('refs/heads/', {branch: String})
+    ORDER BY head_commit.timestamp DESC
+    LIMIT {per_page: Int32} + {offset: Int32}
+)
+ARRAY JOIN
+    ids AS sha,
+    messages AS message,
+    urls AS url,
+    tss AS ts,
+    author_usernames AS author_username,
+    author_names AS author_name,
+    arrayEnumerate(ids) AS commit_pos
+ORDER BY push_ts DESC, commit_pos DESC
+LIMIT {per_page: Int32} OFFSET {offset: Int32}

--- a/torchci/clickhouse_queries/hud_commits/query.sql
+++ b/torchci/clickhouse_queries/hud_commits/query.sql
@@ -6,11 +6,19 @@
 -- head_commit is always the last element of `commits`, so array position DESC
 -- orders the commits of a single push head/newest-first.
 --
--- No FINAL, and the two-stage shape, are deliberate: FINAL forces a full merge
--- that defeats the read-in-order tail scan (~25x slower here) and push has no
--- duplicate rows in practice; the inner query keeps the wide scan on the cheap
--- sort-key columns so only the projected commit subcolumns are decompressed
--- (never the large added/modified/removed file lists).
+-- The inner ORDER BY uses the tupleElement(head_commit, ...) sort-key expression
+-- rather than head_commit.<field> dot syntax: only the exact sort-key expression
+-- lets ClickHouse read in sort-key order and stop after LIMIT rows instead of
+-- scanning the whole table. The head_commit.id term also makes the LIMIT cutoff
+-- deterministic when pushes share a timestamp.
+--
+-- No FINAL: default.push can hold several rows for one head_commit.id (the same
+-- push stored under different dynamoKey), but dynamoKey is part of the sort key,
+-- so ReplacingMergeTree treats those rows as distinct and FINAL would not merge
+-- them. `LIMIT 1 BY` dedups by head sha before the ARRAY JOIN (with the downstream
+-- keyBy(sha) as backstop). The two-stage shape keeps the scan on the small
+-- sort-key columns so only the projected commit subcolumns are decompressed,
+-- never the large added/modified/removed file lists.
 SELECT
     sha,
     message,
@@ -31,7 +39,8 @@ FROM (
     PREWHERE
         repository.full_name = {repo: String}
         AND ref = concat('refs/heads/', {branch: String})
-    ORDER BY head_commit.timestamp DESC
+    ORDER BY tupleElement(head_commit, 'timestamp') DESC, tupleElement(head_commit, 'id') DESC
+    LIMIT 1 BY tupleElement(head_commit, 'id')
     LIMIT {per_page: Int32} + {offset: Int32}
 )
 ARRAY JOIN

--- a/torchci/lib/fetchHud.ts
+++ b/torchci/lib/fetchHud.ts
@@ -59,11 +59,12 @@ function commitDataFromPushRow(row: any): CommitData {
 }
 
 // Commit list for the HUD grid, read from the push mirror first so a normal page
-// load never calls GitHub (this listCommits was the highest-volume GitHub read on
-// the PyTorchBot app). Falls back to GitHub's listCommits when the mirror can't
-// answer authoritatively: a raw-sha ref it isn't keyed by, a ClickHouse failure,
-// or fewer rows than a full page (empty branch, deep page beyond the mirror, or a
-// just-landed tip not yet ingested).
+// load never calls GitHub. Falls back to GitHub's listCommits only when the
+// mirror can't answer authoritatively: a raw-sha branch (the mirror isn't keyed
+// by sha), a ClickHouse error, or fewer than per_page rows returned (empty branch
+// or a deep page past what the mirror holds). The guard is count-only: a full
+// page never triggers fallback, so a just-landed tip not yet ingested can briefly
+// be missing from page 1 until the next ingest (display-only, self-heals).
 async function fetchCommits(params: HudParams): Promise<CommitData[]> {
   const branch = decodeURIComponent(params.branch);
   const isRawSha = /^[0-9a-f]{40}$/i.test(branch);

--- a/torchci/lib/fetchHud.ts
+++ b/torchci/lib/fetchHud.ts
@@ -41,7 +41,7 @@ async function fetchDatabaseInfo(owner: string, repo: string, shas: string[]) {
 // Map a hud_commits row to the same CommitData shape commitDataFromResponse
 // produces. The push mirror stores author.username as "" (never null) when no
 // GitHub user was resolved, so "" means: use the git author name and no URL.
-function commitDataFromPushRow(row: any): CommitData {
+export function commitDataFromPushRow(row: any): CommitData {
   const message = row.message as string;
   const { prNum, diffNum } = parsePrAndDiffNumbers(message);
   const username = (row.author_username as string) ?? "";
@@ -60,17 +60,20 @@ function commitDataFromPushRow(row: any): CommitData {
 
 // Commit list for the HUD grid, read from the push mirror first so a normal page
 // load never calls GitHub. Falls back to GitHub's listCommits only when the
-// mirror can't answer authoritatively: a raw-sha branch (the mirror isn't keyed
-// by sha), a ClickHouse error, or fewer than per_page rows returned (empty branch
-// or a deep page past what the mirror holds). The guard is count-only: a full
-// page never triggers fallback, so a just-landed tip not yet ingested can briefly
-// be missing from page 1 until the next ingest (display-only, self-heals).
+// mirror can't answer authoritatively: params.requireLatestCommit, a raw-sha
+// branch (the mirror isn't keyed by sha), a ClickHouse error, or fewer than
+// per_page rows returned (empty branch or a deep page past what the mirror
+// holds). The count-only guard cannot see ingest lag — a full page still looks
+// complete while a just-landed tip is missing from it. For the grid that is
+// display-only staleness that self-heals on the next ingest, but a caller asking
+// which commit is the tip would silently get the one below it, so those callers
+// set requireLatestCommit and read through to GitHub.
 async function fetchCommits(params: HudParams): Promise<CommitData[]> {
   const branch = decodeURIComponent(params.branch);
   const isRawSha = /^[0-9a-f]{40}$/i.test(branch);
 
   let chCommits: CommitData[] | undefined;
-  if (!isRawSha) {
+  if (!isRawSha && !params.requireLatestCommit) {
     try {
       const rows = await queryClickhouseSaved("hud_commits", {
         repo: `${params.repoOwner}/${params.repoName}`,

--- a/torchci/lib/fetchHud.ts
+++ b/torchci/lib/fetchHud.ts
@@ -2,7 +2,11 @@ import { JobStatus } from "components/job/GroupJobConclusion";
 import fetchIssuesByLabel from "lib/fetchIssuesByLabel";
 import _ from "lodash";
 import { queryClickhouseSaved } from "./clickhouse";
-import { commitDataFromResponse, getOctokit } from "./github";
+import {
+  commitDataFromResponse,
+  getOctokit,
+  parsePrAndDiffNumbers,
+} from "./github";
 import {
   getNameWithoutLF,
   getNameWithoutOSDC,
@@ -10,6 +14,7 @@ import {
 } from "./JobClassifierUtil";
 import { isRerunDisabledTestsJob, isUnstableJob } from "./jobUtils";
 import {
+  CommitData,
   HudDataAPIResponse,
   HudParams,
   JobData,
@@ -33,19 +38,73 @@ async function fetchDatabaseInfo(owner: string, repo: string, shas: string[]) {
   return response;
 }
 
-export default async function fetchHud(
-  params: HudParams
-): Promise<HudDataAPIResponse> {
-  // Retrieve commit data from GitHub
+// Map a hud_commits row to the same CommitData shape commitDataFromResponse
+// produces. The push mirror stores author.username as "" (never null) when no
+// GitHub user was resolved, so "" means: use the git author name and no URL.
+function commitDataFromPushRow(row: any): CommitData {
+  const message = row.message as string;
+  const { prNum, diffNum } = parsePrAndDiffNumbers(message);
+  const username = (row.author_username as string) ?? "";
+  return {
+    author: username !== "" ? username : (row.author_name as string),
+    authorUrl: username !== "" ? `https://github.com/${username}` : null,
+    time: row.timestamp as string,
+    sha: row.sha as string,
+    commitUrl: row.url as string,
+    commitTitle: message.split("\n")[0],
+    commitMessageBody: message,
+    prNum,
+    diffNum,
+  };
+}
+
+// Commit list for the HUD grid, read from the push mirror first so a normal page
+// load never calls GitHub (this listCommits was the highest-volume GitHub read on
+// the PyTorchBot app). Falls back to GitHub's listCommits when the mirror can't
+// answer authoritatively: a raw-sha ref it isn't keyed by, a ClickHouse failure,
+// or fewer rows than a full page (empty branch, deep page beyond the mirror, or a
+// just-landed tip not yet ingested).
+async function fetchCommits(params: HudParams): Promise<CommitData[]> {
+  const branch = decodeURIComponent(params.branch);
+  const isRawSha = /^[0-9a-f]{40}$/i.test(branch);
+
+  let chCommits: CommitData[] | undefined;
+  if (!isRawSha) {
+    try {
+      const rows = await queryClickhouseSaved("hud_commits", {
+        repo: `${params.repoOwner}/${params.repoName}`,
+        branch,
+        per_page: params.per_page,
+        offset: (params.page - 1) * params.per_page,
+      });
+      chCommits = rows.map(commitDataFromPushRow);
+    } catch (e) {
+      console.warn(
+        `fetchHud: ClickHouse hud_commits query failed for ${params.repoOwner}/${params.repoName}@${branch}, falling back to GitHub`,
+        e
+      );
+    }
+  }
+
+  if (chCommits !== undefined && chCommits.length >= params.per_page) {
+    return chCommits;
+  }
+
   const octokit = await getOctokit(params.repoOwner, params.repoName);
-  const branch = await octokit.rest.repos.listCommits({
+  const githubCommits = await octokit.rest.repos.listCommits({
     owner: params.repoOwner,
     repo: params.repoName,
-    sha: decodeURIComponent(params.branch),
+    sha: branch,
     per_page: params.per_page,
     page: params.page,
   });
-  const commits = branch.data.map(commitDataFromResponse);
+  return githubCommits.data.map(commitDataFromResponse);
+}
+
+export default async function fetchHud(
+  params: HudParams
+): Promise<HudDataAPIResponse> {
+  const commits = await fetchCommits(params);
 
   // Retrieve job data from the database
   const shas = commits.map((commit) => commit.sha);

--- a/torchci/lib/github.ts
+++ b/torchci/lib/github.ts
@@ -49,9 +49,13 @@ const PR_REGEX = /Pull Request resolved: .*?(\d+)/;
 const PHAB_REGEX = /Differential Revision: (D.*)/;
 const EXPORTED_PHAB_REGEX = /Differential Revision: \[(.*)\]/;
 
-// Turns a JSON response from octokit into our CommitData type.
-export function commitDataFromResponse(data: any): CommitData {
-  const message = data.commit.message;
+// Parse the PR number and Phabricator diff number out of a commit message.
+// Shared by both the GitHub-sourced and ClickHouse-sourced commit paths so the
+// two stay in lockstep on how a commit is linked back to its PR/diff.
+export function parsePrAndDiffNumbers(message: string): {
+  prNum: number | null;
+  diffNum: string | null;
+} {
   const prMatch = message.match(PR_REGEX);
   let prNum = null;
   if (prMatch) {
@@ -70,6 +74,14 @@ export function commitDataFromResponse(data: any): CommitData {
       diffNum = exportedPhabMatch[1];
     }
   }
+
+  return { prNum, diffNum };
+}
+
+// Turns a JSON response from octokit into our CommitData type.
+export function commitDataFromResponse(data: any): CommitData {
+  const message = data.commit.message;
+  const { prNum, diffNum } = parsePrAndDiffNumbers(message);
 
   return {
     author: data.author?.login ?? data.commit.author.name,

--- a/torchci/lib/types.ts
+++ b/torchci/lib/types.ts
@@ -135,6 +135,9 @@ export interface HudParams {
   mergeEphemeralLF?: boolean;
   mergeOSDC?: boolean;
   useRegexFilter?: boolean;
+  // Set by callers that read the commit list to learn which commit is the tip
+  // rather than to render a page of it. See fetchCommits in lib/fetchHud.ts.
+  requireLatestCommit?: boolean;
 }
 
 export function isPyTorchPyTorchRepo(params: HudParams): boolean {
@@ -300,6 +303,7 @@ export function packHudParams(input: any) {
     mergeEphemeralLF: input.mergeEphemeralLF as boolean,
     mergeOSDC: input.mergeOSDC as boolean,
     useRegexFilter: input.useRegexFilter === "true",
+    requireLatestCommit: input.requireLatestCommit === "true",
   };
 }
 
@@ -350,6 +354,10 @@ function formatHudURL(
 
   if (params.mergeOSDC) {
     base += `&mergeOSDC=true`;
+  }
+
+  if (params.requireLatestCommit) {
+    base += `&requireLatestCommit=true`;
   }
 
   // Preserve autorevert view params so router.push doesn't strip them.

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -703,7 +703,12 @@ export default function Hud() {
 }
 
 function useLatestCommitSha(params: HudParams) {
-  const { data } = useHudData({ ...params, page: 1, per_page: 1 });
+  const { data } = useHudData({
+    ...params,
+    page: 1,
+    per_page: 1,
+    requireLatestCommit: true,
+  });
   if (data === undefined) {
     return null;
   }

--- a/torchci/test/fetchHud.test.ts
+++ b/torchci/test/fetchHud.test.ts
@@ -1,7 +1,7 @@
 import * as clickhouse from "lib/clickhouse";
-import fetchHud from "lib/fetchHud";
+import fetchHud, { commitDataFromPushRow } from "lib/fetchHud";
 import * as github from "lib/github";
-import { HudParams } from "lib/types";
+import { formatHudUrlForFetch, HudParams, packHudParams } from "lib/types";
 import { Octokit } from "octokit";
 
 function makeParams(overrides: Partial<HudParams> = {}): HudParams {
@@ -193,5 +193,155 @@ describe("fetchHud", () => {
 
     expect(listCommits).toHaveBeenCalledTimes(1);
     expect(shaGrid.map((r) => r.sha)).toEqual(["ghsha"]);
+  });
+
+  test("(e) requireLatestCommit skips ClickHouse and uses GitHub", async () => {
+    // ClickHouse returns a full page here, so the count-only guard would accept
+    // it and never reach GitHub. Only the explicit flag forces the authoritative
+    // read the caller asked for.
+    const saved = mockClickhouse({ hudCommits: [chRows[0]] });
+    const { listCommits } = mockOctokit([ghCommit]);
+
+    const { shaGrid } = await fetchHud(
+      makeParams({ per_page: 1, requireLatestCommit: true })
+    );
+
+    expect(listCommits).toHaveBeenCalledTimes(1);
+    const queriedNames = saved.mock.calls.map((c) => c[0]);
+    expect(queriedNames).not.toContain("hud_commits");
+    expect(shaGrid.map((r) => r.sha)).toEqual(["ghsha"]);
+  });
+
+  test("(f) requireLatestCommit survives the client fetch URL round trip", () => {
+    // The flag is set on the client and consumed on the server, so a mismatch
+    // across that hop would disable (e) in production with every test still green.
+    const url = formatHudUrlForFetch(
+      "api/hud",
+      makeParams({ per_page: 1, requireLatestCommit: true })
+    );
+    const query = Object.fromEntries(new URL(url, "https://hud").searchParams);
+    expect(packHudParams(query).requireLatestCommit).toBe(true);
+
+    // The grid request shares the same builder and must not opt in.
+    const gridUrl = formatHudUrlForFetch("api/hud", makeParams());
+    expect(gridUrl).not.toContain("requireLatestCommit");
+    const gridQuery = Object.fromEntries(
+      new URL(gridUrl, "https://hud").searchParams
+    );
+    expect(packHudParams(gridQuery).requireLatestCommit).toBe(false);
+  });
+});
+
+// One logical commit expressed in both source shapes, so a single fixture drives
+// both mappers and neither can drift without the other noticing.
+function bothShapesOf(opts: {
+  sha: string;
+  message: string;
+  timestamp: string;
+  authorLogin: string;
+  authorName: string;
+}) {
+  const commitUrl = `https://github.com/pytorch/pytorch/commit/${opts.sha}`;
+  return {
+    // hud_commits/query.sql renders timestamp with
+    // formatDateTime(ts, '%Y-%m-%dT%H:%i:%SZ', 'UTC'), which is byte-identical to
+    // the ISO-8601 Z string GitHub puts in commit.committer.date. It stores
+    // author.username as "" rather than null for an unresolved GitHub user.
+    chRow: {
+      sha: opts.sha,
+      message: opts.message,
+      url: commitUrl,
+      timestamp: opts.timestamp,
+      author_username: opts.authorLogin,
+      author_name: opts.authorName,
+    },
+    ghResponse: {
+      sha: opts.sha,
+      html_url: commitUrl,
+      author:
+        opts.authorLogin !== ""
+          ? {
+              login: opts.authorLogin,
+              html_url: `https://github.com/${opts.authorLogin}`,
+            }
+          : null,
+      commit: {
+        message: opts.message,
+        author: { name: opts.authorName },
+        committer: { date: opts.timestamp },
+      },
+    },
+  };
+}
+
+describe("commit mapping equivalence", () => {
+  const sha = "9f2e1c4b7a05d38e6c1b0f4a2d7e8c395b6a1d02";
+  const commitUrl = `https://github.com/pytorch/pytorch/commit/${sha}`;
+  const timestamp = "2026-08-19T14:32:07Z";
+
+  test("a resolved author maps identically from ClickHouse and GitHub", () => {
+    const message = [
+      "Fix the thing that broke",
+      "",
+      "A body spanning several lines, so commitTitle and commitMessageBody are",
+      "actually distinguishable.",
+      "",
+      "Pull Request resolved: https://github.com/pytorch/pytorch/pull/145678",
+      "Differential Revision: D65432109",
+    ].join("\n");
+    const { chRow, ghResponse } = bothShapesOf({
+      sha,
+      message,
+      timestamp,
+      authorLogin: "alice",
+      authorName: "Alice Anderson",
+    });
+
+    const fromCh = commitDataFromPushRow(chRow);
+
+    expect(fromCh).toEqual(github.commitDataFromResponse(ghResponse));
+    // Also spelled out: a field both mappers dropped would satisfy the
+    // comparison above while never reaching the UI from either source.
+    expect(fromCh).toEqual({
+      sha,
+      time: timestamp,
+      author: "alice",
+      authorUrl: "https://github.com/alice",
+      commitUrl,
+      commitTitle: "Fix the thing that broke",
+      commitMessageBody: message,
+      prNum: 145678,
+      diffNum: "D65432109",
+    });
+  });
+
+  test("an unresolved author falls back to the git name on both paths", () => {
+    const message = [
+      "Bump the pinned toolchain",
+      "",
+      "Landed without a PR trailer, so prNum and diffNum stay null.",
+    ].join("\n");
+    const { chRow, ghResponse } = bothShapesOf({
+      sha,
+      message,
+      timestamp,
+      authorLogin: "",
+      authorName: "Alice Anderson",
+    });
+
+    const fromCh = commitDataFromPushRow(chRow);
+
+    expect(fromCh).toEqual(github.commitDataFromResponse(ghResponse));
+    expect(fromCh).toEqual({
+      sha,
+      time: timestamp,
+      author: "Alice Anderson",
+      authorUrl: null,
+      commitUrl,
+      commitTitle: "Bump the pinned toolchain",
+      commitMessageBody: message,
+      prNum: null,
+      diffNum: null,
+    });
   });
 });

--- a/torchci/test/fetchHud.test.ts
+++ b/torchci/test/fetchHud.test.ts
@@ -1,0 +1,197 @@
+import * as clickhouse from "lib/clickhouse";
+import fetchHud from "lib/fetchHud";
+import * as github from "lib/github";
+import { HudParams } from "lib/types";
+import { Octokit } from "octokit";
+
+function makeParams(overrides: Partial<HudParams> = {}): HudParams {
+  return {
+    repoOwner: "pytorch",
+    repoName: "pytorch",
+    branch: "main",
+    page: 1,
+    per_page: 2,
+    filter_reruns: false,
+    filter_unstable: false,
+    ...overrides,
+  };
+}
+
+// A CH hud_commits row as returned by the saved query (subcolumns unnested).
+const chRows = [
+  {
+    sha: "sha1",
+    message:
+      "Title one\n\nbody\n\nPull Request resolved: https://github.com/pytorch/pytorch/pull/111",
+    url: "https://github.com/pytorch/pytorch/commit/sha1",
+    timestamp: "2026-01-02T00:00:01Z",
+    author_username: "alice",
+    author_name: "Alice A",
+  },
+  {
+    sha: "sha2",
+    message: "Title two",
+    url: "https://github.com/pytorch/pytorch/commit/sha2",
+    timestamp: "2026-01-02T00:00:00Z",
+    author_username: "",
+    author_name: "Bob B",
+  },
+];
+
+// A GitHub listCommits payload element in the shape commitDataFromResponse reads.
+const ghCommit = {
+  sha: "ghsha",
+  html_url: "https://github.com/pytorch/pytorch/commit/ghsha",
+  author: { login: "ghuser", html_url: "https://github.com/ghuser" },
+  commit: {
+    message: "GH title\n\nGH body",
+    author: { name: "GH Name" },
+    committer: { date: "2026-02-02T00:00:00Z" },
+  },
+};
+
+function mockClickhouse(opts: {
+  hudCommits?: any[];
+  hudCommitsReject?: boolean;
+  forcedMerge?: any[];
+  autorevert?: any[];
+  hudQuery?: any[];
+}) {
+  return jest
+    .spyOn(clickhouse, "queryClickhouseSaved")
+    .mockImplementation((queryName: string) => {
+      switch (queryName) {
+        case "hud_commits":
+          if (opts.hudCommitsReject) {
+            return Promise.reject(new Error("clickhouse down"));
+          }
+          return Promise.resolve(opts.hudCommits ?? []);
+        case "hud_query":
+          return Promise.resolve(opts.hudQuery ?? []);
+        case "filter_forced_merge_pr":
+          return Promise.resolve(opts.forcedMerge ?? []);
+        case "autorevert_commits":
+          return Promise.resolve(opts.autorevert ?? []);
+        default:
+          return Promise.resolve([]);
+      }
+    });
+}
+
+function mockOctokit(listCommitsData: any[]) {
+  const listCommits = jest.fn().mockResolvedValue({ data: listCommitsData });
+  const octokit = {
+    rest: { repos: { listCommits } },
+  } as unknown as Octokit;
+  const getOctokit = jest
+    .spyOn(github, "getOctokit")
+    .mockResolvedValue(octokit);
+  return { getOctokit, listCommits };
+}
+
+describe("fetchHud", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("(a) covered branch page 1 sources commits from ClickHouse, not GitHub", async () => {
+    mockClickhouse({
+      hudCommits: chRows,
+      forcedMerge: [{ merge_commit_sha: "sha1", force_merge_with_failures: 1 }],
+      autorevert: [
+        {
+          commit_sha: "sha2",
+          all_workflows: [["trunk"]],
+          all_source_signal_keys: [["sig1"]],
+        },
+      ],
+    });
+    const { listCommits } = mockOctokit([]);
+
+    const { shaGrid } = await fetchHud(makeParams());
+
+    // The full page came from ClickHouse, so GitHub is never touched.
+    expect(listCommits).not.toHaveBeenCalled();
+    expect(shaGrid.map((r) => r.sha)).toEqual(["sha1", "sha2"]);
+
+    // sha1: username present -> author + authorUrl from the login; PR parsed;
+    // forced-merge flags applied from filter_forced_merge_pr.
+    expect(shaGrid[0]).toMatchObject({
+      sha: "sha1",
+      author: "alice",
+      authorUrl: "https://github.com/alice",
+      commitTitle: "Title one",
+      commitUrl: "https://github.com/pytorch/pytorch/commit/sha1",
+      time: "2026-01-02T00:00:01Z",
+      prNum: 111,
+      isForcedMerge: true,
+      isForcedMergeWithFailures: true,
+      isAutoreverted: false,
+    });
+
+    // sha2: empty username -> git name and null URL; no PR; autorevert applied.
+    expect(shaGrid[1]).toMatchObject({
+      sha: "sha2",
+      author: "Bob B",
+      authorUrl: null,
+      commitTitle: "Title two",
+      prNum: null,
+      isForcedMerge: false,
+      isAutoreverted: true,
+      autorevertWorkflows: ["trunk"],
+      autorevertSignals: ["sig1"],
+    });
+  });
+
+  test("(b1) a raw-sha branch skips ClickHouse and uses GitHub", async () => {
+    const saved = mockClickhouse({ hudCommits: chRows });
+    const { listCommits } = mockOctokit([ghCommit]);
+
+    const { shaGrid } = await fetchHud(makeParams({ branch: "a".repeat(40) }));
+
+    expect(listCommits).toHaveBeenCalledTimes(1);
+    // hud_commits is never queried for a raw sha; the job/flag queries still run.
+    const queriedNames = saved.mock.calls.map((c) => c[0]);
+    expect(queriedNames).not.toContain("hud_commits");
+    expect(shaGrid.map((r) => r.sha)).toEqual(["ghsha"]);
+    expect(shaGrid[0]).toMatchObject({
+      author: "ghuser",
+      authorUrl: "https://github.com/ghuser",
+      commitTitle: "GH title",
+    });
+  });
+
+  test("(b2) an empty ClickHouse result falls back to GitHub", async () => {
+    mockClickhouse({ hudCommits: [] });
+    const { listCommits } = mockOctokit([ghCommit]);
+
+    const { shaGrid } = await fetchHud(makeParams());
+
+    expect(listCommits).toHaveBeenCalledTimes(1);
+    expect(shaGrid.map((r) => r.sha)).toEqual(["ghsha"]);
+  });
+
+  test("(c) a ClickHouse error falls back to GitHub without crashing", async () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    mockClickhouse({ hudCommitsReject: true });
+    const { listCommits } = mockOctokit([ghCommit]);
+
+    const { shaGrid } = await fetchHud(makeParams());
+
+    expect(listCommits).toHaveBeenCalledTimes(1);
+    expect(shaGrid.map((r) => r.sha)).toEqual(["ghsha"]);
+    // The failing read is logged with detail, not silently swallowed.
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  test("(d) fewer ClickHouse rows than a page falls back to GitHub", async () => {
+    // per_page is 2 but ClickHouse only has 1 row (deep page / ingest lag).
+    mockClickhouse({ hudCommits: [chRows[0]] });
+    const { listCommits } = mockOctokit([ghCommit]);
+
+    const { shaGrid } = await fetchHud(makeParams());
+
+    expect(listCommits).toHaveBeenCalledTimes(1);
+    expect(shaGrid.map((r) => r.sha)).toEqual(["ghsha"]);
+  });
+});


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #8584
* __->__ #8583
* #8582
* #8580
* #8579
* #8578
* #8576

**Impact:** HUD landing-page loads (torchci) and the shared PyTorchBot GitHub rate-limit budget
**Risk:** low

## What
Reads the HUD commit grid from a new `hud_commits` saved query against `default.push` instead of calling GitHub's `repos.listCommits` on every page load, falling back to GitHub only when ClickHouse can't answer a full page.

## Why
`repos.listCommits` for the HUD grid was the single highest-volume GitHub read on the PyTorchBot installation, which intermittently exhausts the shared hourly REST rate limit and 403s other torchci callers. The push mirror already holds this data, so a normal page load no longer spends a GitHub call.

# Notes
The GitHub path is kept for the cases the mirror can't serve authoritatively: a raw 40-char sha ref (not keyed by branch), a ClickHouse error, or fewer rows than a full page (empty branch, a page deeper than the mirror, or a just-landed tip not yet ingested — push ingest lag is ~25s p50 / ~56s p90).

A few things worth a reviewer's eye:
- The query does `arrayJoin` over `commits` (not `head_commit`) so a ghstack land, which pushes the whole stack in one event, contributes all its commits — ordered by push time then array position (head_commit is always the last element). The `query.sql` comment explains the deliberate no-`FINAL`/two-stage shape for scan performance.
- `commitDataFromPushRow` treats `author.username == ""` (the mirror's not-resolved sentinel, never null) as "use the git author name and no URL".
- PR/diff-number parsing was extracted into a shared `parsePrAndDiffNumbers` in `lib/github.ts` so the ClickHouse and GitHub commit paths stay in lockstep.

Signed-off-by: Jean Schmidt <contato@jschmidt.me>