### PR TITLE
Fix dependency CVEs in gha-artifacts and usage-log-aggregator lambdas

### DIFF
--- a/aws/lambda/gha-artifacts/requirements.txt
+++ b/aws/lambda/gha-artifacts/requirements.txt
@@ -1,2 +1,2 @@
-aioboto3==12.1.0
+aioboto3==15.5.0
 pytest==7.4.0

--- a/aws/lambda/usage-log-aggregator/lambda_function.py
+++ b/aws/lambda/usage-log-aggregator/lambda_function.py
@@ -24,7 +24,7 @@ JOB_NAME_REGEX = re.compile(
     r"^(?P<job>.+)\s/\s.+\((?P<s_name>[^,]+),\s(?P<s_id>[^,]+),\s(?P<s_count>[^,]+),\s(?P<platform>[^,]+)\)$"
 )
 # One minute according to the rule https://pandas.pydata.org/docs/reference/api/pandas.Series.resample.html
-RESAMPLING_WINDOW = "1T"
+RESAMPLING_WINDOW = "1min"
 DATETIME_FORMAT = "%Y-%m-%d %X"
 # NB: This is a work around to handle the case where requested job is retried
 MAX_RUN_ATTEMPT_TO_SCAN = 10

--- a/aws/lambda/usage-log-aggregator/requirements.txt
+++ b/aws/lambda/usage-log-aggregator/requirements.txt
@@ -9,7 +9,6 @@
 aioboto3
 aiobotocore
 aiofile
-# >=3.13.3 fixes CVE-2025-69223, CVE-2025-69224, CVE-2025-69228, CVE-2025-69229
 aiohttp>=3.13.3
 pandas
 python-dateutil

--- a/aws/lambda/usage-log-aggregator/requirements.txt
+++ b/aws/lambda/usage-log-aggregator/requirements.txt
@@ -9,7 +9,8 @@
 aioboto3
 aiobotocore
 aiofile
-aiohttp
+# >=3.13.3 fixes CVE-2025-69223, CVE-2025-69224, CVE-2025-69228, CVE-2025-69229
+aiohttp>=3.13.3
 pandas
 python-dateutil
 pytest


### PR DESCRIPTION
## 1. `gha-artifacts` — aiohttp 

    aioboto3==12.1.0  ->  aioboto3==15.5.0

## 2. `usage-log-aggregator` — same aiohttp

## 3. `usage-log-aggregator` — `"1T"` no longer parses under pandas 3

Verifying the above surfaced a pre-existing break unrelated to aiohttp. `RESAMPLING_WINDOW = "1T"` uses the single-letter `T` frequency alias, deprecated in pandas 2.2 and **removed in pandas 3.0**. pandas is unpinned too, so any rebuild now installs 3.x and `_process_raw_logs` raises:

    ValueError: Invalid frequency: 1T. Failed to parse with error message:
    ValueError("Invalid frequency: T. ... Did you mean min?")

This breaks any rebuild of this lambda from today onwards, independently of this PR — the only thing preventing a broken deploy is that the workflow runs pytest before `make deploy`. `"1min"` is accepted by both pandas 2.x and 3.x, so no version pin is needed.

*Verified:* `pytest test_lambda_function.py` against both resolutions —

| pandas | aiohttp | result |
| --- | --- | --- |
| 3.0.5 | 3.14.3 | 3 passed |
| 2.3.3 | 3.14.3 | 3 passed |

Before the `"1min"` change the pandas 3.0.5 run failed `test_process_raw_logs`.

## Deployment

Each lambda has its own path-filtered workflow, so merging redeploys both automatically — `gha-artifacts-lambda.yml` and `usage-log-aggregator-lambda.yml`.

Two things to check afterwards, neither included here:

1. `gha-artifacts` has **no tests** — its `test` job only runs `pip3 install`, so CI confirms the dependency set resolves but will not catch a behavioural regression before deploy. Worth invoking the deployed function with a recent `workflow_id` and confirming a non-empty response. Adding an import smoke check to that workflow would help; I could not include it here because it edits a workflow file.
2. `usage-log-aggregator`'s `requirements.txt` carries an older comment describing these packages being installed as a Lambda layer, while the `Makefile` bundles them into the function zip. If a layer with its own aiohttp copy is still attached, it needs rebuilding separately — `aws lambda get-function-configuration --function-name usage-log-aggregator --query Layers`.

## Follow-up

`usage-log-aggregator`'s fully unpinned `requirements.txt` is what produced both of its problems: the deployed dependency set is a function of when the workflow last ran rather than of anything reviewed. Worth pinning properly, or adding a lockfile, in a separate change.
