### PR TITLE
Stop chowning all of ${RUNNER_TEMP} in linux_job/linux_job_v2

### DIFF
--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -137,6 +137,7 @@ jobs:
       # Will be blank outside of this
       PR_NUMBER: ${{ github.event.pull_request.number }}
       SCRIPT: ${{ inputs.script }}
+      ALPINE_IMAGE: ${{ startsWith(inputs.runner, 'linux.arm64') && 'arm64v8/alpine' || startsWith(inputs.runner, 'linux.idc') && 'alpine' || '308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine' }}
       filter: ${{ inputs.checkout-mode == 'blobless' && 'blob:none' || inputs.checkout-mode == 'treeless' && 'tree:0' || null }}
     runs-on: ${{ inputs.runner }}
     # TODO: Eventually this should run in a container, we need to make a container that matches up
@@ -311,13 +312,27 @@ jobs:
         uses: ./test-infra/.github/actions/chown-directory
         with:
           directory: ${{ github.workspace }}/${{ env.repository }}
-          ALPINE_IMAGE: ${{ startsWith(inputs.runner, 'linux.arm64') && 'arm64v8/alpine' || startsWith(inputs.runner, 'linux.idc') && 'alpine' || '308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine' }}
+          ALPINE_IMAGE: ${{ env.ALPINE_IMAGE }}
 
-      - name: Chown runner temp
+      # Not all of ${RUNNER_TEMP} — a container-issued chown lands on a subordinate
+      # UID under rootless docker, locking the runner out of _github_workflow/.
+      - name: Chown runner artifacts dir
         uses: ./test-infra/.github/actions/chown-directory
         with:
-          directory: ${{ runner.temp }}
-          ALPINE_IMAGE: ${{ startsWith(inputs.runner, 'linux.arm64') && 'arm64v8/alpine' || startsWith(inputs.runner, 'linux.idc') && 'alpine' || '308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine' }}
+          directory: ${{ env.RUNNER_ARTIFACT_DIR }}
+          ALPINE_IMAGE: ${{ env.ALPINE_IMAGE }}
+
+      - name: Chown runner docs dir
+        uses: ./test-infra/.github/actions/chown-directory
+        with:
+          directory: ${{ env.RUNNER_DOCS_DIR }}
+          ALPINE_IMAGE: ${{ env.ALPINE_IMAGE }}
+
+      - name: Chown runner test results dir
+        uses: ./test-infra/.github/actions/chown-directory
+        with:
+          directory: ${{ env.RUNNER_TEST_RESULTS_DIR }}
+          ALPINE_IMAGE: ${{ env.ALPINE_IMAGE }}
 
       - name: Prepare artifacts for upload
         if: always()


### PR DESCRIPTION
On the gfx1100 ROCm runners docker is rootless, so a `chown -R $(id -u)` issued from inside a container lands on a subordinate UID. Chowning all of `${RUNNER_TEMP}` therefore takes `_github_workflow/event.json` away from the runner, and every step after it fails with `Access to the path ... is denied` — see [executorch#21977](https://github.com/pytorch/executorch/actions/runs/32396259928/job/96514005971?pr=21977), where the test passed and 6 post-steps failed.

Chown only the three dirs we mount into the container instead.
