### PR TITLE
Add Better Benchmark performance summary dashboard

### DIFF
--- a/torchci/components/benchmark_v3/configs/teams/compilers/BetterBenchmarkSummary.tsx
+++ b/torchci/components/benchmark_v3/configs/teams/compilers/BetterBenchmarkSummary.tsx
@@ -1,0 +1,864 @@
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import TrendingDownIcon from "@mui/icons-material/TrendingDown";
+import TrendingFlatIcon from "@mui/icons-material/TrendingFlat";
+import TrendingUpIcon from "@mui/icons-material/TrendingUp";
+import {
+  Alert,
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  Divider,
+  IconButton,
+  Paper,
+  Stack,
+  Tab,
+  Tabs,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { DataGrid, GridColDef, GridPaginationModel } from "@mui/x-data-grid";
+import type { AutoComponentProps } from "components/benchmark_v3/configs/utils/autoRegistration";
+import LoadingPage from "components/common/LoadingPage";
+import type {
+  BetterBenchmarkSummaryData,
+  RollupStats,
+} from "lib/benchmark/api_helper/backend/dataFetchers/queryBuilderUtils/betterBenchmarkSummary";
+import {
+  useBenchmarkCommittedContext,
+  useBenchmarkTimeSeriesData,
+} from "lib/benchmark/api_helper/fe/hooks";
+import { useMemo, useState } from "react";
+
+type Mover = BetterBenchmarkSummaryData["models"][number];
+type MoverTab = "gains" | "losses" | "neutral";
+
+const NEUTRAL_THRESHOLD_PCT = 5;
+
+function moverCategory(value: number): MoverTab {
+  if (value >= NEUTRAL_THRESHOLD_PCT) {
+    return "gains";
+  }
+  if (value <= -NEUTRAL_THRESHOLD_PCT) {
+    return "losses";
+  }
+  return "neutral";
+}
+
+function moverCounts(source: Mover[]) {
+  return source.reduce(
+    (counts, row) => {
+      counts[moverCategory(row.reductionPct)] += 1;
+      return counts;
+    },
+    { gains: 0, losses: 0, neutral: 0 }
+  );
+}
+
+function speedupPctToReductionPct(value: number) {
+  return (1 - 1 / (1 + value / 100)) * 100;
+}
+
+function formatDelta(value: number, digits = 2) {
+  return `${value >= 0 ? "+" : ""}${value.toFixed(digits)}%`;
+}
+
+function formatLatency(value: number, signed = false) {
+  const prefix = signed && value >= 0.005 ? "+" : "";
+  const absolute = Math.abs(value);
+  if (absolute >= 1000) {
+    return `${prefix}${(value / 1000).toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })} ms`;
+  }
+  return `${prefix}${value.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })} µs`;
+}
+
+function DeltaValue({
+  value,
+  large = false,
+  speedup = false,
+}: {
+  value: number;
+  large?: boolean;
+  speedup?: boolean;
+}) {
+  const classifiedValue = speedup ? speedupPctToReductionPct(value) : value;
+  const neutral = Math.abs(classifiedValue) < NEUTRAL_THRESHOLD_PCT;
+  const improving = classifiedValue >= NEUTRAL_THRESHOLD_PCT;
+  return (
+    <Stack
+      direction="row"
+      spacing={0.5}
+      alignItems="center"
+      sx={{
+        color: neutral
+          ? "text.secondary"
+          : improving
+          ? "success.main"
+          : "error.main",
+      }}
+    >
+      {neutral ? (
+        <TrendingFlatIcon fontSize={large ? "large" : "small"} />
+      ) : improving ? (
+        <TrendingUpIcon fontSize={large ? "large" : "small"} />
+      ) : (
+        <TrendingDownIcon fontSize={large ? "large" : "small"} />
+      )}
+      <Typography
+        component="span"
+        sx={{
+          fontSize: large ? { xs: "2.25rem", md: "3rem" } : "inherit",
+          fontWeight: large ? 700 : 600,
+          fontVariantNumeric: "tabular-nums",
+        }}
+      >
+        {formatDelta(value, large ? 3 : 2)}
+      </Typography>
+    </Stack>
+  );
+}
+
+function LatencySavedValue({ value }: { value: number }) {
+  return (
+    <Typography
+      component="span"
+      fontWeight={600}
+      sx={{
+        color:
+          value > 0
+            ? "success.main"
+            : value < 0
+            ? "error.main"
+            : "text.secondary",
+        fontVariantNumeric: "tabular-nums",
+      }}
+    >
+      {formatLatency(value, true)}
+    </Typography>
+  );
+}
+
+function SummaryCard({
+  title,
+  description,
+  stats,
+  projected = false,
+  unavailableReason = "",
+  distribution,
+}: {
+  title: string;
+  description: string;
+  stats: RollupStats | null;
+  projected?: boolean;
+  unavailableReason?: string;
+  distribution?: ReturnType<typeof moverCounts>;
+}) {
+  return (
+    <Card variant="outlined" sx={{ height: "100%" }}>
+      <CardContent>
+        <Stack direction="row" justifyContent="space-between" spacing={2}>
+          <Box>
+            <Stack direction="row" spacing={0.75} alignItems="center">
+              <Typography variant="h6" component="h3">
+                {title}
+              </Typography>
+              <Tooltip title={description}>
+                <IconButton
+                  size="small"
+                  aria-label={`How ${title.toLowerCase()} is calculated`}
+                >
+                  <InfoOutlinedIcon color="action" fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            </Stack>
+            {projected && (
+              <Typography variant="caption" color="text.secondary">
+                Projected end-to-end estimate
+              </Typography>
+            )}
+          </Box>
+          <Chip
+            size="small"
+            variant="outlined"
+            label={`n = ${stats?.n ?? 0}`}
+          />
+        </Stack>
+        {stats ? (
+          <>
+            <Box sx={{ my: 2 }}>
+              <Typography variant="overline" color="text.secondary">
+                Geometric-mean speedup
+              </Typography>
+              <DeltaValue value={stats.geomean} large speedup />
+              <Typography variant="caption" color="text.secondary">
+                Median and mean below are per-item latency changes. Positive is
+                faster; negative is slower.
+              </Typography>
+              {distribution && (
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ mt: 0.5 }}
+                >
+                  {distribution.gains} improved · {distribution.losses}{" "}
+                  regressed · {distribution.neutral} neutral
+                </Typography>
+              )}
+            </Box>
+            <Divider />
+            <Stack
+              direction="row"
+              spacing={3}
+              sx={{ mt: 2 }}
+              divider={<Divider orientation="vertical" flexItem />}
+            >
+              <Box>
+                <Typography variant="caption" color="text.secondary">
+                  Median latency change
+                </Typography>
+                <Typography fontWeight={600}>
+                  {formatDelta(stats.median, 3)}
+                </Typography>
+              </Box>
+              <Box>
+                <Typography variant="caption" color="text.secondary">
+                  Mean latency change
+                </Typography>
+                <Typography fontWeight={600}>
+                  {formatDelta(stats.mean, 3)}
+                </Typography>
+              </Box>
+            </Stack>
+          </>
+        ) : (
+          <Alert severity="warning" sx={{ mt: 2 }}>
+            {unavailableReason ||
+              "No exact points are shared by the selected workflows."}
+          </Alert>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function SectionHeader({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <Box sx={{ mb: 1.5 }}>
+      <Typography variant="h5" component="h3" fontWeight={650}>
+        {title}
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        {description}
+      </Typography>
+    </Box>
+  );
+}
+
+function SuiteBreakdown({
+  rows,
+}: {
+  rows: BetterBenchmarkSummaryData["suites"];
+}) {
+  const max = Math.max(
+    0,
+    ...rows.map((row) => Math.abs(row.stats?.geomean ?? 0))
+  );
+  const domain = Math.max(2, Math.ceil(max));
+  return (
+    <Paper variant="outlined" sx={{ p: { xs: 2, md: 2.5 } }}>
+      <SectionHeader
+        title="Performance by suite and mode"
+        description={`Each complete model receives equal weight. Bars use a centered, fixed ±${domain}% scale.`}
+      />
+      {rows.length === 0 ? (
+        <Typography color="text.secondary">
+          No complete model comparisons.
+        </Typography>
+      ) : (
+        <Stack spacing={1}>
+          {rows.map((row) => (
+            <Box
+              key={row.id}
+              sx={{
+                display: "grid",
+                gridTemplateColumns: {
+                  xs: "minmax(125px, 1fr) minmax(150px, auto)",
+                  md: "180px minmax(180px, 1fr) 100px 100px 180px",
+                },
+                gap: 2,
+                alignItems: "center",
+                px: 1.25,
+                py: 1,
+                borderRadius: 1,
+                "&:hover": { bgcolor: "action.hover" },
+              }}
+            >
+              <Typography fontWeight={600}>{row.suiteMode}</Typography>
+              <Tooltip
+                title={
+                  row.stats
+                    ? `${row.suiteMode}: ${formatDelta(
+                        row.stats.geomean,
+                        2
+                      )} geometric-mean speedup`
+                    : `${row.suiteMode}: no complete comparisons`
+                }
+              >
+                <Box
+                  role="img"
+                  aria-label={
+                    row.stats
+                      ? `${row.suiteMode} geometric-mean speedup ${formatDelta(
+                          row.stats.geomean,
+                          2
+                        )}`
+                      : `${row.suiteMode} has no complete comparisons`
+                  }
+                  sx={{
+                    display: { xs: "none", md: "block" },
+                    position: "relative",
+                    height: 8,
+                    borderRadius: 4,
+                    bgcolor: "action.hover",
+                    overflow: "hidden",
+                  }}
+                >
+                  <Box
+                    sx={{
+                      position: "absolute",
+                      left: "50%",
+                      top: 0,
+                      bottom: 0,
+                      width: "1px",
+                      bgcolor: "text.secondary",
+                      opacity: 0.65,
+                      zIndex: 1,
+                    }}
+                  />
+                  <Box
+                    sx={{
+                      position: "absolute",
+                      left:
+                        row.stats && row.stats.geomean < 0
+                          ? `${
+                              50 -
+                              Math.min(
+                                50,
+                                (Math.abs(row.stats.geomean) / domain) * 50
+                              )
+                            }%`
+                          : "50%",
+                      width: row.stats
+                        ? `${Math.min(
+                            50,
+                            (Math.abs(row.stats.geomean) / domain) * 50
+                          )}%`
+                        : 0,
+                      height: "100%",
+                      borderRadius: 4,
+                      bgcolor:
+                        row.stats == null
+                          ? "action.disabled"
+                          : Math.abs(
+                              speedupPctToReductionPct(row.stats.geomean)
+                            ) < NEUTRAL_THRESHOLD_PCT
+                          ? "text.disabled"
+                          : row.stats.geomean > 0
+                          ? "success.main"
+                          : "error.main",
+                    }}
+                  />
+                </Box>
+              </Tooltip>
+              <Box sx={{ display: { xs: "none", md: "block" } }}>
+                <Typography variant="caption" color="text.secondary">
+                  Median
+                </Typography>
+                <Typography variant="body2">
+                  {row.stats ? formatDelta(row.stats.median, 3) : "n/a"}
+                </Typography>
+              </Box>
+              <Box sx={{ display: { xs: "none", md: "block" } }}>
+                <Typography variant="caption" color="text.secondary">
+                  Mean
+                </Typography>
+                <Typography variant="body2">
+                  {row.stats ? formatDelta(row.stats.mean, 3) : "n/a"}
+                </Typography>
+              </Box>
+              <Stack
+                direction="row"
+                spacing={0.75}
+                alignItems="center"
+                justifySelf="end"
+                sx={{ whiteSpace: "nowrap" }}
+              >
+                {row.stats ? (
+                  <DeltaValue value={row.stats.geomean} speedup />
+                ) : (
+                  <Typography color="text.secondary">n/a</Typography>
+                )}
+                <Typography variant="caption" color="text.secondary">
+                  n={row.stats?.n ?? 0}
+                </Typography>
+              </Stack>
+            </Box>
+          ))}
+        </Stack>
+      )}
+    </Paper>
+  );
+}
+
+const latencyColumn = (
+  field: "baseUs" | "headUs" | "deltaUs",
+  headerName: string,
+  signed = false
+): GridColDef =>
+  signed
+    ? {
+        field,
+        headerName,
+        type: "number",
+        display: "flex",
+        minWidth: 140,
+        renderCell: (params) => (
+          <LatencySavedValue value={Number(params.value)} />
+        ),
+      }
+    : {
+        field,
+        headerName,
+        type: "number",
+        minWidth: 120,
+        valueFormatter: (value) => formatLatency(Number(value)),
+      };
+
+const modelColumns: GridColDef[] = [
+  {
+    field: "name",
+    headerName: "Model",
+    minWidth: 270,
+    flex: 1,
+    renderCell: (params) => (
+      <Typography noWrap title={params.value as string}>
+        {params.value as string}
+      </Typography>
+    ),
+  },
+  { field: "suite", headerName: "Suite", minWidth: 115 },
+  { field: "mode", headerName: "Mode", minWidth: 100 },
+  latencyColumn("baseUs", "Baseline"),
+  latencyColumn("headUs", "Candidate"),
+  latencyColumn("deltaUs", "Latency saved", true),
+  {
+    field: "reductionPct",
+    headerName: "Projected change",
+    type: "number",
+    display: "flex",
+    minWidth: 160,
+    renderCell: (params) => <DeltaValue value={params.value as number} />,
+  },
+];
+
+const kernelColumns: GridColDef[] = [
+  {
+    field: "name",
+    headerName: "Kernel shape",
+    minWidth: 245,
+    flex: 1,
+    renderCell: (params) => (
+      <Typography noWrap title={params.value as string} fontFamily="monospace">
+        {params.value as string}
+      </Typography>
+    ),
+  },
+  {
+    field: "exampleModel",
+    headerName: "Example model",
+    minWidth: 220,
+    flex: 0.8,
+  },
+  latencyColumn("baseUs", "Baseline"),
+  latencyColumn("headUs", "Candidate"),
+  latencyColumn("deltaUs", "Latency saved", true),
+  {
+    field: "reductionPct",
+    headerName: "Change",
+    type: "number",
+    display: "flex",
+    minWidth: 130,
+    renderHeader: () => (
+      <Tooltip title="Kernel latency change from baseline to candidate. Positive values mean latency decreased (faster); negative values mean latency increased (slower).">
+        <Stack direction="row" spacing={0.5} alignItems="center">
+          <Typography component="span" variant="body2" fontWeight={500}>
+            Change
+          </Typography>
+          <InfoOutlinedIcon color="action" fontSize="small" />
+        </Stack>
+      </Tooltip>
+    ),
+    renderCell: (params) => <DeltaValue value={params.value as number} />,
+  },
+  {
+    field: "headGapVsSol",
+    headerName: "Gap vs SOL",
+    type: "number",
+    minWidth: 175,
+    renderHeader: () => (
+      <Tooltip title="Measured kernel latency divided by the estimated hardware speed-of-light latency. 1× is ideal; lower is better.">
+        <Stack direction="row" spacing={0.5} alignItems="center">
+          <Typography component="span" variant="body2" fontWeight={500}>
+            Gap vs SOL
+          </Typography>
+          <InfoOutlinedIcon color="action" fontSize="small" />
+        </Stack>
+      </Tooltip>
+    ),
+    renderCell: (params) => {
+      const baseline = params.row.baseGapVsSol;
+      const candidate = params.row.headGapVsSol;
+      if (baseline == null || candidate == null) {
+        return <Typography color="text.secondary">n/a</Typography>;
+      }
+      return (
+        <Tooltip title="Baseline → candidate">
+          <Typography sx={{ fontVariantNumeric: "tabular-nums" }}>
+            {baseline.toFixed(2)}× → {candidate.toFixed(2)}×
+          </Typography>
+        </Tooltip>
+      );
+    },
+  },
+];
+
+function MoversTable({
+  kind,
+  source,
+}: {
+  kind: "models" | "kernels";
+  source: Mover[];
+}) {
+  const [tab, setTab] = useState<MoverTab>("gains");
+  const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
+    pageSize: 10,
+    page: 0,
+  });
+  const counts = useMemo(() => moverCounts(source), [source]);
+  const rows = useMemo(
+    () =>
+      source
+        .filter((row) => moverCategory(row.reductionPct) === tab)
+        .sort((a, b) => {
+          if (tab === "gains") {
+            return b.deltaUs - a.deltaUs;
+          }
+          if (tab === "losses") {
+            return a.deltaUs - b.deltaUs;
+          }
+          return Math.abs(b.reductionPct) - Math.abs(a.reductionPct);
+        }),
+    [source, tab]
+  );
+
+  return (
+    <Paper variant="outlined" sx={{ p: { xs: 2, md: 2.5 } }}>
+      <SectionHeader
+        title={kind === "models" ? "Model movers" : "Kernel movers"}
+        description={
+          kind === "models"
+            ? "Projected models ranked by absolute latency impact after occurrence weighting and unchanged extern dilution."
+            : "Exact kernel-shape matches ranked by absolute latency impact."
+        }
+      />
+      <Tabs
+        aria-label={`${
+          kind === "models" ? "Model" : "Kernel"
+        } mover categories`}
+        value={tab}
+        onChange={(_, value: MoverTab) => {
+          setTab(value);
+          setPaginationModel((current) => ({ ...current, page: 0 }));
+        }}
+        sx={{ mb: 1 }}
+      >
+        <Tab
+          value="gains"
+          label={
+            <Tooltip
+              title={`Latency reduction of ${NEUTRAL_THRESHOLD_PCT}% or more`}
+            >
+              <span>Gains ({counts.gains})</span>
+            </Tooltip>
+          }
+        />
+        <Tab
+          value="losses"
+          label={
+            <Tooltip
+              title={`Latency increase of ${NEUTRAL_THRESHOLD_PCT}% or more`}
+            >
+              <span>Losses ({counts.losses})</span>
+            </Tooltip>
+          }
+        />
+        <Tab
+          value="neutral"
+          label={
+            <Tooltip
+              title={`Latency change smaller than ${NEUTRAL_THRESHOLD_PCT}% in either direction`}
+            >
+              <span>Neutral ({counts.neutral})</span>
+            </Tooltip>
+          }
+        />
+      </Tabs>
+      <DataGrid
+        autoHeight
+        density="compact"
+        rows={rows}
+        columns={kind === "models" ? modelColumns : kernelColumns}
+        pageSizeOptions={[10, 25, 50, 100]}
+        paginationModel={paginationModel}
+        onPaginationModelChange={setPaginationModel}
+        localeText={{
+          noRowsLabel:
+            tab === "gains"
+              ? "No improvements above the noise threshold"
+              : tab === "losses"
+              ? "No regressions above the noise threshold"
+              : "No changes within the neutral band",
+        }}
+        showToolbar
+        disableRowSelectionOnClick
+        sx={{
+          border: 0,
+          "& .MuiDataGrid-columnHeaders": { bgcolor: "action.hover" },
+        }}
+      />
+    </Paper>
+  );
+}
+
+function BetterBenchmarkSummary({
+  data,
+  repo,
+}: {
+  data: BetterBenchmarkSummaryData;
+  repo: string;
+}) {
+  const workflowUrl = (workflow: string) =>
+    `https://github.com/${repo}/actions/runs/${workflow}`;
+  const hasRunQualityWarnings = [
+    data.coverage.baselineRun,
+    data.coverage.candidateRun,
+  ].some((run) =>
+    [
+      run.failedRepros,
+      run.invalidMeasurements,
+      run.missingShapeFiles,
+      run.unresolvedShapeMetadata,
+    ].some((value) => (value ?? 0) > 0)
+  );
+  const hasUnknownRunQuality =
+    !data.coverage.baselineRun.available ||
+    !data.coverage.candidateRun.available;
+
+  return (
+    <Box sx={{ width: "100%", maxWidth: 1500, mx: "auto", py: 2 }}>
+      {data.comparisonUnavailableReason && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          {data.comparisonUnavailableReason}
+        </Alert>
+      )}
+      {data.modelUnavailableReason &&
+        data.modelUnavailableReason !== data.comparisonUnavailableReason && (
+          <Alert severity="info" sx={{ mb: 2 }}>
+            {data.modelUnavailableReason}. Kernel results remain comparable.
+          </Alert>
+        )}
+      <Paper
+        variant="outlined"
+        sx={{
+          p: 2,
+          mb: 2.5,
+          display: "flex",
+          flexWrap: "wrap",
+          alignItems: "center",
+          gap: 1.25,
+        }}
+      >
+        <Typography variant="subtitle2" color="text.secondary">
+          Summary comparison
+        </Typography>
+        <Chip
+          component="a"
+          clickable
+          href={workflowUrl(data.comparison.leftWorkflow)}
+          target="_blank"
+          rel="noopener noreferrer"
+          label={`Baseline workflow: ${data.comparison.leftWorkflow}`}
+        />
+        <Typography color="text.secondary" aria-hidden>
+          →
+        </Typography>
+        <Chip
+          component="a"
+          clickable
+          color="primary"
+          href={workflowUrl(data.comparison.rightWorkflow)}
+          target="_blank"
+          rel="noopener noreferrer"
+          label={`Candidate workflow: ${data.comparison.rightWorkflow}`}
+        />
+        <Box sx={{ flexGrow: 1 }} />
+        <Typography variant="caption" color="text.secondary">
+          {data.coverage.matchedKernelPoints.toLocaleString()} matched kernel
+          points
+          {data.coverage.leftOnlyKernelPoints > 0
+            ? ` · ${data.coverage.leftOnlyKernelPoints.toLocaleString()} baseline-only`
+            : ""}
+          {data.coverage.rightOnlyKernelPoints > 0
+            ? ` · ${data.coverage.rightOnlyKernelPoints.toLocaleString()} candidate-only`
+            : ""}
+          {data.coverage.invalidBaselineKernelPoints > 0
+            ? ` · ${data.coverage.invalidBaselineKernelPoints.toLocaleString()} invalid baseline`
+            : ""}
+          {data.coverage.invalidCandidateKernelPoints > 0
+            ? ` · ${data.coverage.invalidCandidateKernelPoints.toLocaleString()} invalid candidate`
+            : ""}
+          {data.coverage.incompatibleModels > 0
+            ? ` · ${data.coverage.incompatibleModels.toLocaleString()} accounting-incompatible models`
+            : ""}
+          {" · "}
+          {data.coverage.includedModels}/{data.coverage.totalModels} paired
+          complete models
+        </Typography>
+      </Paper>
+      {hasUnknownRunQuality && (
+        <Alert severity="info" sx={{ mb: 2.5 }}>
+          Sweep-quality metadata is unavailable for one or both workflows.
+        </Alert>
+      )}
+      {hasRunQualityWarnings && (
+        <Alert severity="warning" sx={{ mb: 2.5 }}>
+          Partial sweep data detected. Baseline:{" "}
+          {data.coverage.baselineRun.failedRepros ?? "unknown"} failed repros,{" "}
+          {data.coverage.baselineRun.invalidMeasurements ?? "unknown"} invalid
+          measurements,{" "}
+          {data.coverage.baselineRun.missingShapeFiles ?? "unknown"} missing
+          shape files,{" "}
+          {data.coverage.baselineRun.unresolvedShapeMetadata ?? "unknown"}{" "}
+          unresolved shape points; candidate:{" "}
+          {data.coverage.candidateRun.failedRepros ?? "unknown"} failed repros,{" "}
+          {data.coverage.candidateRun.invalidMeasurements ?? "unknown"} invalid
+          measurements,{" "}
+          {data.coverage.candidateRun.missingShapeFiles ?? "unknown"} missing
+          shape files,{" "}
+          {data.coverage.candidateRun.unresolvedShapeMetadata ?? "unknown"}{" "}
+          unresolved shape points. Metrics include only valid exported points.
+        </Alert>
+      )}
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", md: "1fr 1fr" },
+          gap: 2.5,
+          mb: 2.5,
+        }}
+      >
+        <SummaryCard
+          title="Overall projected full-model performance"
+          description="Estimates each model's latency using measured kernel performance and how often each kernel occurs. External-operation latency is assumed unchanged. Each model contributes equally to the summary."
+          stats={data.model}
+          projected
+          unavailableReason={data.modelUnavailableReason}
+          distribution={moverCounts(data.models)}
+        />
+        <SummaryCard
+          title="Overall kernel performance"
+          description="Compares latency for the same kernel pattern and input shape in both runs. Each matched kernel measurement contributes once to the summary."
+          stats={data.kernel}
+          unavailableReason={data.comparisonUnavailableReason}
+          distribution={moverCounts(data.kernels)}
+        />
+      </Box>
+
+      <Stack spacing={2.5}>
+        <Alert severity="info" variant="outlined">
+          Changes smaller than {NEUTRAL_THRESHOLD_PCT}% are shown as neutral.
+        </Alert>
+        <SuiteBreakdown rows={data.suites} />
+        <MoversTable kind="models" source={data.models} />
+        <MoversTable kind="kernels" source={data.kernels} />
+      </Stack>
+    </Box>
+  );
+}
+
+export function AutoBetterBenchmarkSummary({ config }: AutoComponentProps) {
+  const ctx = useBenchmarkCommittedContext();
+  const leftWorkflow = ctx.lcommit?.workflow_id;
+  const rightWorkflow = ctx.rcommit?.workflow_id;
+  const ready =
+    !!ctx.committedTime?.start &&
+    !!ctx.committedTime?.end &&
+    leftWorkflow != null &&
+    rightWorkflow != null;
+
+  const params = ctx.configHandler.dataBinding.toQueryParams({
+    repo: ctx.repo,
+    branches: [
+      ...new Set([ctx.committedLbranch, ctx.committedRbranch].filter(Boolean)),
+    ],
+    workflows: [String(leftWorkflow ?? ""), String(rightWorkflow ?? "")],
+    benchmarkName: ctx.benchmarkName,
+    timeRange: ctx.committedTime,
+    filters: ctx.committedFilters,
+    maxSampling: ctx.committedMaxSampling,
+  });
+  const fetcherId = config?.config?.fetcherId ?? ctx.benchmarkId;
+  const {
+    data: response,
+    isLoading,
+    error,
+  } = useBenchmarkTimeSeriesData(fetcherId, ready ? params : null, [
+    "better_summary",
+  ]);
+
+  if (!ready) {
+    return (
+      <Alert severity="info">
+        Select both comparison commits to load the performance summary.
+      </Alert>
+    );
+  }
+  if (isLoading) {
+    return (
+      <LoadingPage height={400} content="Loading Better Benchmark summary..." />
+    );
+  }
+  if (error) {
+    return <Alert severity="error">{error.message}</Alert>;
+  }
+
+  const summary = response?.data?.data?.better_summary as
+    | BetterBenchmarkSummaryData
+    | undefined;
+  if (!summary) {
+    return <Alert severity="warning">No summary data found.</Alert>;
+  }
+  return <BetterBenchmarkSummary data={summary} repo={ctx.repo} />;
+}

--- a/torchci/components/benchmark_v3/configs/teams/compilers/inductor_kernel_benchmark_config.ts
+++ b/torchci/components/benchmark_v3/configs/teams/compilers/inductor_kernel_benchmark_config.ts
@@ -1,48 +1,17 @@
-import {
-  BenchmarkUIConfig,
-  SubSectionRenderConfig,
-  UIRenderConfig,
-} from "../../config_book_types";
-import { BenchmarkComparisonPolicyConfig } from "../../helpers/RegressionPolicy";
+import { BenchmarkUIConfig } from "../../config_book_types";
 import {
   DEFAULT_DASHBOARD_BENCHMARK_INITIAL,
   defaultDashboardBenchmarkUIConfig,
 } from "../defaults/default_dashboard_config";
 
 export const BETTER_BENCHMARK_ID = "better_benchmark";
-
-const LOWER_IS_BETTER_POLICY: BenchmarkComparisonPolicyConfig = {
-  target: "latency_us",
-  type: "ratio",
-  ratioPolicy: {
-    badRatio: 1.05,
-    goodRatio: 0.95,
-    direction: "down",
-  },
-};
-
-const COMPARISON_POLICY = {
-  latency_us: LOWER_IS_BETTER_POLICY,
-  gap_vs_sol: {
-    ...LOWER_IS_BETTER_POLICY,
-    target: "gap_vs_sol",
-  },
-};
-
-function withComparisonPolicy(render: UIRenderConfig): UIRenderConfig {
-  if (render.type !== "AutoBenchmarkTimeSeriesTable") {
-    return render;
-  }
-  return {
-    ...render,
-    config: {
-      ...render.config,
-      comparisonPolicy: COMPARISON_POLICY,
-    },
-  };
-}
+export const BETTER_BENCHMARK_SUMMARY_FETCHER_ID = "better_benchmark_summary";
 
 const defaultDataRender = defaultDashboardBenchmarkUIConfig.dataRender;
+const externalLinkRenders = (defaultDataRender.renders ?? []).filter(
+  (render: { type: string }) =>
+    render.type === "AutoBenchmarkComparisonGithubExternalLink"
+);
 
 export const BetterBenchmarkDashboardConfig: BenchmarkUIConfig = {
   ...defaultDashboardBenchmarkUIConfig,
@@ -64,20 +33,28 @@ export const BetterBenchmarkDashboardConfig: BenchmarkUIConfig = {
   },
   dataRender: {
     ...defaultDataRender,
-    renders: (defaultDataRender.renders ?? []).map(withComparisonPolicy),
-    subSectionRenders: Object.fromEntries(
-      (
-        Object.entries(defaultDataRender.subSectionRenders ?? {}) as [
-          string,
-          SubSectionRenderConfig
-        ][]
-      ).map(([name, section]) => [
-        name,
-        {
-          ...section,
-          renders: section.renders.map(withComparisonPolicy),
+    renders: [
+      {
+        type: "AutoBetterBenchmarkSummary",
+        title: "Full performance rollup",
+        config: {
+          fetcherId: BETTER_BENCHMARK_SUMMARY_FETCHER_ID,
         },
-      ])
-    ),
+      },
+      ...externalLinkRenders,
+    ],
+    subSectionRenders: {
+      main: {
+        filterConstraint: {
+          mode: {
+            disableOptions: ["inference"],
+          },
+          dtype: {
+            disableOptions: ["unknown"],
+          },
+        },
+        renders: [],
+      },
+    },
   },
 };

--- a/torchci/components/benchmark_v3/configs/utils/autoRegistration.tsx
+++ b/torchci/components/benchmark_v3/configs/utils/autoRegistration.tsx
@@ -10,6 +10,7 @@ import {
   AutoBenchmarkTimeSeriesChartGroup,
   AutoBenchmarkTimeSeriesTable,
 } from "components/benchmark_v3/components/dataRender/auto/autoComponents";
+import { AutoBetterBenchmarkSummary } from "components/benchmark_v3/configs/teams/compilers/BetterBenchmarkSummary";
 
 export type AutoComponentProps = {
   config?: any;
@@ -48,6 +49,9 @@ export class AutoComponentRegistry {
 
   private constructor() {
     const registry: Record<string, AutoComponentConfig> = {
+      AutoBetterBenchmarkSummary: {
+        Component: AutoBetterBenchmarkSummary,
+      },
       AutoBenchmarkTimeSeriesTable: {
         Component: AutoBenchmarkTimeSeriesTable,
       },

--- a/torchci/lib/benchmark/api_helper/backend/dataFetchers/fetchers.ts
+++ b/torchci/lib/benchmark/api_helper/backend/dataFetchers/fetchers.ts
@@ -1,5 +1,6 @@
 import {
   BenchmarkDataQuery,
+  BetterBenchmarkDataFetcher,
   PytorchAoMicroApiBenchmarkDataFetcher,
   PytorchHelionDataFetcher,
   PytorchOperatorMicroBenchmarkDataFetcher,
@@ -29,6 +30,7 @@ import {
 
 // Register benchmark data fetchers, this is mainly used in get_benchmark_data api and get_time_series api
 const dataCtors: Record<string, new () => BenchmarkDataFetcher> = {
+  better_benchmark_summary: BetterBenchmarkDataFetcher,
   pytorch_operator_microbenchmark: PytorchOperatorMicroBenchmarkDataFetcher,
   pytorch_helion: PytorchHelionDataFetcher,
   torchao_micro_api_benchmark: PytorchAoMicroApiBenchmarkDataFetcher,

--- a/torchci/lib/benchmark/api_helper/backend/dataFetchers/queryBuilderUtils/benchmarkDataQueryBuilder.ts
+++ b/torchci/lib/benchmark/api_helper/backend/dataFetchers/queryBuilderUtils/benchmarkDataQueryBuilder.ts
@@ -1,6 +1,10 @@
 import { deepClone } from "@mui/x-data-grid/internals";
 import { toBenchmarkTimeSeriesReponseFormat } from "../../common/utils";
 import { BenchmarkDataFetcher } from "../type";
+import {
+  buildBetterBenchmarkSummary,
+  RawBenchmarkRow,
+} from "./betterBenchmarkSummary";
 import { ExecutableQueryBase, QueryBuilder, SelectItem } from "./queryBuilder";
 
 const DEFAULT_TS_GROUP_KEY = [
@@ -115,6 +119,7 @@ export class BenchmarkDataQuery extends ExecutableQueryBase {
       SELECT
         replaceOne(o.head_branch, 'refs/heads/', '') AS branch,
         o.workflow_id AS workflow_id,
+        o.run_attempt AS run_attempt,
         o.job_id AS job_id,
         o.repo AS repo,
         o.head_sha AS commit,
@@ -193,6 +198,7 @@ export class BenchmarkDataQuery extends ExecutableQueryBase {
       `
            SELECT DISTINCT
             workflow_id,
+            run_attempt,
             repo,
             branch,
             commit,
@@ -377,6 +383,96 @@ export class BenchmarkDataQuery extends ExecutableQueryBase {
 
     console.log("[benchmarkDatQueryBuilder] query calls to db:", params);
     return params;
+  }
+}
+
+export class BetterBenchmarkDataFetcher extends BenchmarkDataQuery {
+  private workflowIds: Array<string | number> = [];
+
+  constructor() {
+    super();
+    this.replaceValueSelectStatement(
+      "toFloat64(arrayAvg(o.metric.'benchmark_values'))"
+    );
+    this.addExtraInfos(
+      new Map(
+        [
+          "record_type",
+          "pattern_hash",
+          "shape_hash",
+          "kernel_name",
+          "suite",
+          "source_mode",
+          "example_model",
+          "included",
+          "exclusion_reasons",
+          "timing_policy",
+          "accounting_digest",
+          "model_accounting_digest",
+          "sweep_total_repros",
+          "sweep_failed_repros",
+          "sweep_invalid_measurements",
+          "sweep_missing_shape_files",
+          "sweep_unresolved_shape_metadata",
+        ].map((key) => [
+          key,
+          `tupleElement(o.benchmark, 'extra_info')['${key}']`,
+        ])
+      )
+    );
+  }
+
+  toQueryParams(inputs: any, id?: string): Record<string, any> {
+    const params = super.toQueryParams(inputs, id);
+    this.workflowIds = params.workflows ?? [];
+    return params;
+  }
+
+  applyFormat(
+    data: RawBenchmarkRow[],
+    formats: string[],
+    includesAllExtraKey: boolean = true,
+    groupByFields?: string[]
+  ): any {
+    const kernelRows = data.filter(
+      (row) =>
+        !row.extra_key?.record_type || row.extra_key.record_type === "kernel"
+    );
+    const standardFormats = formats.filter(
+      (format) => format !== "better_summary"
+    );
+    const timestamps = data
+      .map((row) => Date.parse(row.metadata_info?.timestamp ?? ""))
+      .filter(Number.isFinite);
+    const start = timestamps.length
+      ? new Date(Math.min(...timestamps)).toISOString()
+      : null;
+    const end = timestamps.length
+      ? new Date(Math.max(...timestamps)).toISOString()
+      : null;
+    const standard: any =
+      standardFormats.length > 0
+        ? super.applyFormat(
+            kernelRows,
+            standardFormats,
+            includesAllExtraKey,
+            groupByFields
+          )
+        : {
+            total_raw_rows: data.length,
+            time_range: {
+              start,
+              end,
+            },
+            data: {},
+          };
+    if (formats.includes("better_summary")) {
+      standard.data.better_summary = buildBetterBenchmarkSummary(
+        data,
+        this.workflowIds
+      );
+    }
+    return standard;
   }
 }
 

--- a/torchci/lib/benchmark/api_helper/backend/dataFetchers/queryBuilderUtils/betterBenchmarkDataFetcher.test.ts
+++ b/torchci/lib/benchmark/api_helper/backend/dataFetchers/queryBuilderUtils/betterBenchmarkDataFetcher.test.ts
@@ -1,0 +1,452 @@
+/** @jest-environment node */
+
+import { BetterBenchmarkDashboardConfig } from "components/benchmark_v3/configs/teams/compilers/inductor_kernel_benchmark_config";
+
+import { getBenchmarkDataFetcher } from "../fetchers";
+import { buildBetterBenchmarkSummary } from "./betterBenchmarkSummary";
+
+function row(
+  workflow_id: number,
+  model: string,
+  metric: string,
+  value: number,
+  record_type: "kernel" | "model",
+  extra: Record<string, string> = {}
+) {
+  return {
+    workflow_id,
+    model,
+    metric,
+    value,
+    extra_key: { record_type, ...extra },
+  };
+}
+
+describe("buildBetterBenchmarkSummary", () => {
+  test("computes shape-aligned kernel and model reductions", () => {
+    const data = [
+      row(10, "kernel-a", "latency_us", 10, "kernel"),
+      row(20, "kernel-a", "latency_us", 5, "kernel"),
+      row(10, "kernel-a", "gap_vs_sol", 4, "kernel"),
+      row(20, "kernel-a", "gap_vs_sol", 2, "kernel"),
+      row(10, "kernel-base-only", "latency_us", 4, "kernel"),
+      row(
+        10,
+        "timm/infer/model-a",
+        "projected_model_latency_us",
+        100,
+        "model",
+        {
+          suite: "timm",
+          source_mode: "infer",
+        }
+      ),
+      row(20, "timm/infer/model-a", "projected_model_latency_us", 80, "model", {
+        suite: "timm",
+        source_mode: "infer",
+      }),
+      row(10, "timm/infer/model-a", "model_coverage_ratio", 1, "model"),
+      row(10, "hf/train/model-b", "model_coverage_ratio", 0.5, "model"),
+    ];
+
+    const summary = buildBetterBenchmarkSummary(data, [10, 20]);
+
+    expect(summary.kernel).toEqual({
+      geomean: 100,
+      median: 50,
+      mean: 50,
+      n: 1,
+    });
+    expect(summary.model).toEqual({
+      geomean: 25,
+      median: 20,
+      mean: 20,
+      n: 1,
+    });
+    expect(summary.models[0]).toEqual(
+      expect.objectContaining({ baseUs: 100, headUs: 80, deltaUs: 20 })
+    );
+    expect(summary.kernels[0]).toEqual(
+      expect.objectContaining({
+        baseUs: 10,
+        headUs: 5,
+        deltaUs: 5,
+        baseGapVsSol: 4,
+        headGapVsSol: 2,
+      })
+    );
+    expect(summary.suites).toEqual([
+      expect.objectContaining({
+        suiteMode: "timm/infer",
+        stats: expect.objectContaining({ geomean: 25, n: 1 }),
+      }),
+      expect.objectContaining({
+        suiteMode: "hf/train",
+        stats: null,
+        excluded: 1,
+      }),
+    ]);
+    expect(summary.coverage).toEqual({
+      matchedKernelPoints: 1,
+      leftOnlyKernelPoints: 1,
+      rightOnlyKernelPoints: 0,
+      invalidBaselineKernelPoints: 0,
+      invalidCandidateKernelPoints: 0,
+      incompatibleModels: 0,
+      includedModels: 1,
+      totalModels: 2,
+      baselineModels: {
+        total: 2,
+        included: 0,
+        excluded: 2,
+        meanCoverage: 0.75,
+        exclusionReasons: {},
+      },
+      candidateModels: {
+        total: 0,
+        included: 0,
+        excluded: 0,
+        meanCoverage: 0,
+        exclusionReasons: {},
+      },
+      baselineRun: {
+        totalRepros: null,
+        failedRepros: null,
+        invalidMeasurements: null,
+        missingShapeFiles: null,
+        unresolvedShapeMetadata: null,
+        available: false,
+      },
+      candidateRun: {
+        totalRepros: null,
+        failedRepros: null,
+        invalidMeasurements: null,
+        missingShapeFiles: null,
+        unresolvedShapeMetadata: null,
+        available: false,
+      },
+    });
+  });
+
+  test("compares a workflow with itself", () => {
+    const data = [row(10, "kernel-a", "latency_us", 10, "kernel")];
+
+    const summary = buildBetterBenchmarkSummary(data, [10, 10]);
+
+    expect(summary.kernel).toEqual({
+      geomean: 0,
+      median: 0,
+      mean: 0,
+      n: 1,
+    });
+  });
+
+  test("normalizes legacy and new kernel identities", () => {
+    const data = [
+      {
+        workflow_id: 10,
+        model: "pointwise_abcdef123456[resnet18_1234abcd]",
+        metric: "latency_us",
+        value: 10,
+        extra_key: {
+          timing_policy: "compiled_us",
+        } as Record<string, string>,
+      },
+      {
+        workflow_id: 20,
+        model: "pointwise_abcdef123456[1234abcd]",
+        metric: "latency_us",
+        value: 8,
+        extra_key: {
+          record_type: "kernel",
+          pattern_hash: "abcdef123456",
+          shape_hash: "1234abcd",
+          timing_policy: "compiled_us",
+        } as Record<string, string>,
+      },
+    ];
+
+    const summary = buildBetterBenchmarkSummary(data, [10, 20]);
+
+    expect(summary.kernel?.median).toBe(20);
+    expect(summary.kernels).toHaveLength(1);
+  });
+
+  test("rejects legacy compiled timing against new auto timing", () => {
+    const data = [
+      {
+        workflow_id: 10,
+        model: "pointwise_abcdef123456[resnet18_1234abcd]",
+        metric: "latency_us",
+        value: 10,
+        extra_key: {},
+      },
+      row(20, "pointwise_abcdef123456[1234abcd]", "latency_us", 8, "kernel", {
+        pattern_hash: "abcdef123456",
+        shape_hash: "1234abcd",
+        timing_policy: "auto",
+      }),
+    ];
+
+    const summary = buildBetterBenchmarkSummary(data, [10, 20]);
+    expect(summary.kernel).toBeNull();
+    expect(summary.comparisonUnavailableReason).toContain(
+      "different timing policy"
+    );
+  });
+
+  test("excludes genai microbenchmarks only from the headline", () => {
+    const data = [
+      row(10, "timm/infer/model-a", "projected_model_latency_us", 100, "model"),
+      row(20, "timm/infer/model-a", "projected_model_latency_us", 80, "model"),
+      row(
+        10,
+        "genai/static/SoftmaxForward",
+        "projected_model_latency_us",
+        100,
+        "model"
+      ),
+      row(
+        20,
+        "genai/static/SoftmaxForward",
+        "projected_model_latency_us",
+        50,
+        "model"
+      ),
+    ];
+
+    const summary = buildBetterBenchmarkSummary(data, [10, 20]);
+
+    expect(summary.model?.n).toBe(1);
+    expect(summary.model?.median).toBe(20);
+    expect(summary.models).toHaveLength(1);
+    expect(summary.suites.map((suite) => suite.suiteMode)).not.toContain(
+      "genai/static"
+    );
+  });
+
+  test("rejects an implicit workflow comparison", () => {
+    const data = [row(10, "kernel-a", "latency_us", 10, "kernel")];
+
+    expect(() => buildBetterBenchmarkSummary(data, [])).toThrow(
+      "requires explicit left/right workflows"
+    );
+  });
+
+  test("retains every shard job in a workflow", () => {
+    const data = [
+      {
+        ...row(10, "kernel-a", "latency_us", 10, "kernel"),
+        job_id: "base-shard-1",
+      },
+      {
+        ...row(10, "kernel-b", "latency_us", 20, "kernel"),
+        job_id: "base-shard-2",
+      },
+      {
+        ...row(20, "kernel-a", "latency_us", 5, "kernel"),
+        job_id: "head-shard-1",
+      },
+      {
+        ...row(20, "kernel-b", "latency_us", 10, "kernel"),
+        job_id: "head-shard-2",
+      },
+    ];
+
+    const summary = buildBetterBenchmarkSummary(data, [10, 20]);
+
+    expect(summary.kernel?.n).toBe(2);
+    expect(summary.kernel?.median).toBe(50);
+  });
+
+  test("uses only the latest run attempt for each workflow", () => {
+    const data = [
+      { ...row(10, "kernel-a", "latency_us", 10, "kernel"), run_attempt: 1 },
+      { ...row(10, "kernel-a", "latency_us", 8, "kernel"), run_attempt: 2 },
+      { ...row(20, "kernel-a", "latency_us", 4, "kernel"), run_attempt: 1 },
+    ];
+
+    const summary = buildBetterBenchmarkSummary(data, [10, 20]);
+
+    expect(summary.kernel?.median).toBe(50);
+  });
+
+  test("rejects incompatible accounting artifacts", () => {
+    const data = [
+      row(10, "timm/infer/model-a", "projected_model_latency_us", 10, "model", {
+        accounting_digest: "left",
+      }),
+      row(20, "timm/infer/model-a", "projected_model_latency_us", 5, "model", {
+        accounting_digest: "right",
+      }),
+      row(10, "kernel-a", "latency_us", 10, "kernel"),
+      row(20, "kernel-a", "latency_us", 5, "kernel"),
+    ];
+
+    const summary = buildBetterBenchmarkSummary(data, [10, 20]);
+    expect(summary.model).toBeNull();
+    expect(summary.kernel?.n).toBe(1);
+    expect(summary.modelUnavailableReason).toBe("");
+    expect(summary.coverage.incompatibleModels).toBe(1);
+  });
+
+  test("allows exact duplicates but rejects conflicting values", () => {
+    const exact = [
+      row(10, "kernel-a", "latency_us", 10, "kernel"),
+      row(10, "kernel-a", "latency_us", 10, "kernel"),
+      row(20, "kernel-a", "latency_us", 5, "kernel"),
+    ];
+    expect(buildBetterBenchmarkSummary(exact, [10, 20]).kernel?.n).toBe(1);
+
+    const conflicting = [
+      ...exact,
+      row(10, "kernel-a", "latency_us", 11, "kernel"),
+    ];
+    expect(() => buildBetterBenchmarkSummary(conflicting, [10, 20])).toThrow(
+      "Conflicting kernel values"
+    );
+  });
+
+  test("returns null aggregates when no exact matches exist", () => {
+    const data = [
+      row(10, "kernel-a", "latency_us", 10, "kernel"),
+      row(20, "kernel-b", "latency_us", 10, "kernel"),
+    ];
+
+    const summary = buildBetterBenchmarkSummary(data, [10, 20]);
+
+    expect(summary.kernel).toBeNull();
+    expect(summary.model).toBeNull();
+    expect(summary.kernels).toEqual([]);
+  });
+
+  test("returns an empty summary when selected workflows have no rows", () => {
+    const summary = buildBetterBenchmarkSummary([], [10, 20]);
+
+    expect(summary.kernel).toBeNull();
+    expect(summary.model).toBeNull();
+    expect(summary.coverage).toEqual({
+      matchedKernelPoints: 0,
+      leftOnlyKernelPoints: 0,
+      rightOnlyKernelPoints: 0,
+      invalidBaselineKernelPoints: 0,
+      invalidCandidateKernelPoints: 0,
+      incompatibleModels: 0,
+      includedModels: 0,
+      totalModels: 0,
+      baselineModels: {
+        total: 0,
+        included: 0,
+        excluded: 0,
+        meanCoverage: 0,
+        exclusionReasons: {},
+      },
+      candidateModels: {
+        total: 0,
+        included: 0,
+        excluded: 0,
+        meanCoverage: 0,
+        exclusionReasons: {},
+      },
+      baselineRun: {
+        totalRepros: null,
+        failedRepros: null,
+        invalidMeasurements: null,
+        missingShapeFiles: null,
+        unresolvedShapeMetadata: null,
+        available: false,
+      },
+      candidateRun: {
+        totalRepros: null,
+        failedRepros: null,
+        invalidMeasurements: null,
+        missingShapeFiles: null,
+        unresolvedShapeMetadata: null,
+        available: false,
+      },
+    });
+  });
+
+  test("surfaces invalid kernels and model exclusion details", () => {
+    const data = [
+      row(10, "kernel-invalid", "latency_us", 0, "kernel"),
+      row(20, "kernel-invalid", "latency_us", Number.NaN, "kernel"),
+      row(10, "timm/infer/good", "model_coverage_ratio", 1, "model", {
+        included: "true",
+      }),
+      row(10, "timm/infer/bad", "model_coverage_ratio", 0.5, "model", {
+        included: "false",
+        exclusion_reasons: "unmatched_kernel,trace_errors",
+      }),
+    ];
+
+    const summary = buildBetterBenchmarkSummary(data, [10, 20]);
+
+    expect(summary.coverage.invalidBaselineKernelPoints).toBe(1);
+    expect(summary.coverage.invalidCandidateKernelPoints).toBe(1);
+    expect(summary.coverage.baselineModels).toEqual({
+      total: 2,
+      included: 1,
+      excluded: 1,
+      meanCoverage: 0.75,
+      exclusionReasons: { unmatched_kernel: 1, trace_errors: 1 },
+    });
+  });
+});
+
+describe("BetterBenchmarkDataFetcher", () => {
+  test("preserves full timing precision in ClickHouse", () => {
+    const fetcher = getBenchmarkDataFetcher("better_benchmark_summary") as any;
+
+    expect(fetcher.build()).toContain(
+      "toFloat64(arrayAvg(o.metric.'benchmark_values')) AS value"
+    );
+    expect(fetcher.build()).not.toContain(
+      "floor(arrayAvg(o.metric.'benchmark_values'), 2)"
+    );
+  });
+
+  test("returns the standard response envelope", () => {
+    const fetcher = getBenchmarkDataFetcher("better_benchmark_summary") as any;
+    fetcher.toQueryParams({
+      repo: "pytorch/pytorch",
+      benchmarkName: "inductor-kernel-benchmark",
+      workflows: [10, 20],
+    });
+    const data = [
+      row(10, "kernel-a", "latency_us", 10, "kernel"),
+      row(20, "kernel-a", "latency_us", 5, "kernel"),
+    ];
+
+    const response = fetcher.applyFormat(data, ["better_summary"]);
+
+    expect(response.total_raw_rows).toBe(2);
+    expect(response.time_range.start).toBeNull();
+    expect(response.data.better_summary.kernel.n).toBe(1);
+  });
+});
+
+describe("BetterBenchmarkDashboardConfig", () => {
+  test("uses type-aware summary tables instead of the mixed generic table", () => {
+    const renderTypes =
+      BetterBenchmarkDashboardConfig.dataRender.renders?.map(
+        (render) => render.type
+      ) ?? [];
+
+    expect(renderTypes).toEqual([
+      "AutoBetterBenchmarkSummary",
+      "AutoBenchmarkComparisonGithubExternalLink",
+    ]);
+    expect(BetterBenchmarkDashboardConfig.dataRender.subSectionRenders).toEqual(
+      {
+        main: {
+          filterConstraint: {
+            mode: { disableOptions: ["inference"] },
+            dtype: { disableOptions: ["unknown"] },
+          },
+          renders: [],
+        },
+      }
+    );
+  });
+});

--- a/torchci/lib/benchmark/api_helper/backend/dataFetchers/queryBuilderUtils/betterBenchmarkSummary.ts
+++ b/torchci/lib/benchmark/api_helper/backend/dataFetchers/queryBuilderUtils/betterBenchmarkSummary.ts
@@ -1,0 +1,511 @@
+export type RawBenchmarkRow = {
+  workflow_id: string | number;
+  run_attempt?: string | number;
+  job_id?: string | number;
+  model: string;
+  metric: string;
+  value: number;
+  device?: string;
+  arch?: string;
+  extra_key?: Record<string, string>;
+  metadata_info?: Record<string, string>;
+};
+
+type Pair = {
+  id: string;
+  name: string;
+  baseUs: number;
+  headUs: number;
+  reductionPct: number;
+  speedup: number;
+  suite: string;
+  mode: string;
+  extra: Record<string, string>;
+};
+
+export type RollupStats = {
+  geomean: number;
+  median: number;
+  mean: number;
+  n: number;
+};
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2
+    ? sorted[middle]
+    : (sorted[middle - 1] + sorted[middle]) / 2;
+}
+
+function round(value: number): number {
+  return Math.round(value * 10000) / 10000;
+}
+
+function summarize(pairs: Pair[]): RollupStats | null {
+  if (pairs.length === 0) {
+    return null;
+  }
+  const reductions = pairs.map((pair) => pair.reductionPct);
+  const logSpeedups = pairs.map((pair) => Math.log(pair.speedup));
+  return {
+    geomean: round(
+      (Math.exp(
+        logSpeedups.reduce((sum, value) => sum + value, 0) / pairs.length
+      ) -
+        1) *
+        100
+    ),
+    median: round(median(reductions)),
+    mean: round(
+      reductions.reduce((sum, value) => sum + value, 0) / reductions.length
+    ),
+    n: pairs.length,
+  };
+}
+
+function isGenai(name: string): boolean {
+  return name.split("/", 1)[0].toLowerCase() === "genai";
+}
+
+function kernelIdentity(row: RawBenchmarkRow): string {
+  const patternHash = row.extra_key?.pattern_hash;
+  const shapeHash = row.extra_key?.shape_hash;
+  if (patternHash && shapeHash) {
+    return `${patternHash}/${shapeHash}`;
+  }
+
+  // Legacy records used repro_dir[model_shapehash], whereas new records use
+  // repro_dir[shapehash]. Normalize both to repro_dir[shapehash].
+  const match = row.model.match(/^(.*)\[([^\]]+)\]$/);
+  if (!match) {
+    return row.model;
+  }
+  const shape = match[2].split("_").at(-1) ?? match[2];
+  const pattern = match[1].split("_").at(-1) ?? "";
+  if (/^[0-9a-f]{12}$/i.test(pattern)) {
+    return `${pattern}/${shape}`;
+  }
+  return `${match[1]}[${shape}]`;
+}
+
+function selectWorkflowRows(
+  rows: RawBenchmarkRow[],
+  workflows: string[]
+): RawBenchmarkRow[] {
+  const selected = new Set(workflows);
+  const latestAttempts = new Map<string, number>();
+  for (const row of rows) {
+    const workflow = String(row.workflow_id);
+    if (!selected.has(workflow)) {
+      continue;
+    }
+    const attempt = Number(row.run_attempt ?? 1);
+    latestAttempts.set(
+      workflow,
+      Math.max(latestAttempts.get(workflow) ?? 1, attempt)
+    );
+  }
+  return rows.filter(
+    (row) =>
+      selected.has(String(row.workflow_id)) &&
+      Number(row.run_attempt ?? 1) ===
+        latestAttempts.get(String(row.workflow_id))
+  );
+}
+
+function singleMetadata(
+  rows: RawBenchmarkRow[],
+  workflow: string,
+  read: (_row: RawBenchmarkRow) => string | undefined,
+  label: string
+): string {
+  const values = new Set(
+    rows
+      .filter((row) => String(row.workflow_id) === workflow)
+      .map(read)
+      .filter((value): value is string => Boolean(value))
+  );
+  if (values.size > 1) {
+    throw new Error(
+      `Workflow ${workflow} has conflicting ${label}: ${[...values].join(", ")}`
+    );
+  }
+  return [...values][0] ?? "";
+}
+
+function validateCompatibility(
+  rows: RawBenchmarkRow[],
+  leftWorkflow: string,
+  rightWorkflow: string
+): string {
+  for (const [read, label, strict] of [
+    [(row: RawBenchmarkRow) => row.device, "device", false],
+    [(row: RawBenchmarkRow) => row.arch, "architecture", false],
+    [
+      (row: RawBenchmarkRow) => row.extra_key?.timing_policy,
+      "timing policy",
+      true,
+    ],
+  ] as const) {
+    const left = singleMetadata(rows, leftWorkflow, read, label);
+    const right = singleMetadata(rows, rightWorkflow, read, label);
+    if (
+      (strict && left !== right) ||
+      (!strict && left && right && left !== right)
+    ) {
+      return `Cannot compare workflows with different ${label}: ${left} vs ${right}`;
+    }
+  }
+  return "";
+}
+
+function indexedRows(
+  rows: RawBenchmarkRow[],
+  workflow: string,
+  recordType: "kernel" | "model",
+  metric: string
+): Map<string, RawBenchmarkRow> {
+  const points = new Map<string, RawBenchmarkRow>();
+  for (const row of rows) {
+    const rowRecordType = row.extra_key?.record_type || "kernel";
+    if (
+      String(row.workflow_id) !== workflow ||
+      row.metric !== metric ||
+      rowRecordType !== recordType ||
+      !Number.isFinite(Number(row.value)) ||
+      Number(row.value) <= 0
+    ) {
+      continue;
+    }
+    const id = recordType === "kernel" ? kernelIdentity(row) : row.model;
+    const previous = points.get(id);
+    if (previous && Number(previous.value) !== Number(row.value)) {
+      throw new Error(
+        `Conflicting ${recordType} values for workflow ${workflow}: ${id}`
+      );
+    }
+    points.set(id, row);
+  }
+  return points;
+}
+
+function invalidRowCount(
+  rows: RawBenchmarkRow[],
+  workflow: string,
+  recordType: "kernel" | "model",
+  metric: string
+): number {
+  return rows.filter((row) => {
+    const rowRecordType = row.extra_key?.record_type || "kernel";
+    return (
+      String(row.workflow_id) === workflow &&
+      row.metric === metric &&
+      rowRecordType === recordType &&
+      (!Number.isFinite(Number(row.value)) || Number(row.value) <= 0)
+    );
+  }).length;
+}
+
+function pairedRows(
+  rows: RawBenchmarkRow[],
+  leftWorkflow: string,
+  rightWorkflow: string,
+  recordType: "kernel" | "model",
+  metric: string
+): {
+  pairs: Pair[];
+  leftOnly: number;
+  rightOnly: number;
+  leftInvalid: number;
+  rightInvalid: number;
+  incompatible: number;
+} {
+  const base = indexedRows(rows, leftWorkflow, recordType, metric);
+  const head = indexedRows(rows, rightWorkflow, recordType, metric);
+  const pairs: Pair[] = [];
+  let incompatible = 0;
+  for (const [id, baseRow] of base.entries()) {
+    const headRow = head.get(id);
+    if (!headRow) {
+      continue;
+    }
+    if (recordType === "model") {
+      const baseAccounting =
+        baseRow.extra_key?.model_accounting_digest ||
+        baseRow.extra_key?.accounting_digest ||
+        "";
+      const headAccounting =
+        headRow.extra_key?.model_accounting_digest ||
+        headRow.extra_key?.accounting_digest ||
+        "";
+      if (
+        baseAccounting &&
+        headAccounting &&
+        baseAccounting !== headAccounting
+      ) {
+        incompatible += 1;
+        continue;
+      }
+    }
+    const baseUs = Number(baseRow.value);
+    const headUs = Number(headRow.value);
+    const reductionPct = (1 - headUs / baseUs) * 100;
+    const nameParts = baseRow.model.split("/", 3);
+    const suite =
+      recordType === "model"
+        ? nameParts[0] || "unknown"
+        : baseRow.extra_key?.suite || "unknown";
+    const mode =
+      recordType === "model"
+        ? nameParts[1] || "unknown"
+        : baseRow.extra_key?.source_mode || "unknown";
+    pairs.push({
+      id,
+      name: baseRow.model,
+      baseUs,
+      headUs,
+      reductionPct,
+      speedup: baseUs / headUs,
+      suite,
+      mode,
+      extra: baseRow.extra_key ?? {},
+    });
+  }
+  return {
+    pairs,
+    leftOnly: [...base.keys()].filter((id) => !head.has(id)).length,
+    rightOnly: [...head.keys()].filter((id) => !base.has(id)).length,
+    leftInvalid: invalidRowCount(rows, leftWorkflow, recordType, metric),
+    rightInvalid: invalidRowCount(rows, rightWorkflow, recordType, metric),
+    incompatible,
+  };
+}
+
+function modelCoverageSummary(rows: RawBenchmarkRow[], workflow: string) {
+  const coverageRows = rows.filter(
+    (row) =>
+      row.metric === "model_coverage_ratio" &&
+      row.extra_key?.record_type === "model" &&
+      String(row.workflow_id) === workflow &&
+      !isGenai(row.model)
+  );
+  const reasons: Record<string, number> = {};
+  let included = 0;
+  let coverageTotal = 0;
+  for (const row of coverageRows) {
+    const value = Number(row.value);
+    if (Number.isFinite(value)) {
+      coverageTotal += value;
+    }
+    if (row.extra_key?.included === "true") {
+      included += 1;
+    }
+    for (const reason of (row.extra_key?.exclusion_reasons ?? "")
+      .split(",")
+      .filter(Boolean)) {
+      reasons[reason] = (reasons[reason] ?? 0) + 1;
+    }
+  }
+  return {
+    total: coverageRows.length,
+    included,
+    excluded: coverageRows.length - included,
+    meanCoverage:
+      coverageRows.length > 0 ? round(coverageTotal / coverageRows.length) : 0,
+    exclusionReasons: reasons,
+  };
+}
+
+function runQualitySummary(rows: RawBenchmarkRow[], workflow: string) {
+  const readNumber = (key: string) => {
+    const raw = singleMetadata(
+      rows,
+      workflow,
+      (row) => row.extra_key?.[key],
+      key
+    );
+    if (!raw) {
+      return null;
+    }
+    const value = Number(raw);
+    return Number.isFinite(value) && value >= 0 ? value : null;
+  };
+  const summary = {
+    totalRepros: readNumber("sweep_total_repros"),
+    failedRepros: readNumber("sweep_failed_repros"),
+    invalidMeasurements: readNumber("sweep_invalid_measurements"),
+    missingShapeFiles: readNumber("sweep_missing_shape_files"),
+    unresolvedShapeMetadata: readNumber("sweep_unresolved_shape_metadata"),
+  };
+  return {
+    ...summary,
+    available: Object.values(summary).some((value) => value !== null),
+  };
+}
+
+export function buildBetterBenchmarkSummary(
+  rawRows: RawBenchmarkRow[],
+  workflowIds: Array<string | number>
+) {
+  if (workflowIds.length !== 2) {
+    throw new Error(
+      "Better Benchmark summary requires explicit left/right workflows"
+    );
+  }
+  const [leftWorkflow, rightWorkflow] = workflowIds.map(String);
+  for (const workflow of [leftWorkflow, rightWorkflow]) {
+    if (!/^\d+$/.test(workflow) || Number(workflow) <= 0) {
+      throw new Error(`Invalid workflow id: ${workflow}`);
+    }
+  }
+
+  const rows = selectWorkflowRows(rawRows, [leftWorkflow, rightWorkflow]);
+  const comparisonUnavailableReason = validateCompatibility(
+    rows,
+    leftWorkflow,
+    rightWorkflow
+  );
+  const emptyResult = {
+    pairs: [],
+    leftOnly: 0,
+    rightOnly: 0,
+    leftInvalid: 0,
+    rightInvalid: 0,
+    incompatible: 0,
+  };
+  const modelUnavailableReason = comparisonUnavailableReason;
+
+  const modelResult = modelUnavailableReason
+    ? emptyResult
+    : pairedRows(
+        rows,
+        leftWorkflow,
+        rightWorkflow,
+        "model",
+        "projected_model_latency_us"
+      );
+  const kernelResult = comparisonUnavailableReason
+    ? emptyResult
+    : pairedRows(rows, leftWorkflow, rightWorkflow, "kernel", "latency_us");
+  const models = modelResult.pairs;
+  const realModels = models.filter((model) => !isGenai(model.name));
+  const kernels = kernelResult.pairs;
+  const baselineKernelGaps = indexedRows(
+    rows,
+    leftWorkflow,
+    "kernel",
+    "gap_vs_sol"
+  );
+  const candidateKernelGaps = indexedRows(
+    rows,
+    rightWorkflow,
+    "kernel",
+    "gap_vs_sol"
+  );
+
+  const suiteGroups = new Map<string, Pair[]>();
+  for (const model of realModels) {
+    const key = `${model.suite}/${model.mode}`;
+    const group = suiteGroups.get(key) ?? [];
+    group.push(model);
+    suiteGroups.set(key, group);
+  }
+
+  const coverageRows = rows.filter(
+    (row) =>
+      row.metric === "model_coverage_ratio" &&
+      row.extra_key?.record_type === "model"
+  );
+  const realCoverageRows = coverageRows.filter((row) => !isGenai(row.model));
+  const coverageModels = new Set(realCoverageRows.map((row) => row.model));
+  const coverageBySuite = new Map<string, Set<string>>();
+  for (const row of realCoverageRows) {
+    const nameParts = row.model.split("/", 3);
+    const suite = row.extra_key?.suite || nameParts[0] || "unknown";
+    const mode = row.extra_key?.source_mode || nameParts[1] || "unknown";
+    const key = `${suite}/${mode}`;
+    const group = coverageBySuite.get(key) ?? new Set<string>();
+    group.add(row.model);
+    coverageBySuite.set(key, group);
+  }
+
+  const toMover = (
+    pair: Pair,
+    gaps: { baseline: number | null; candidate: number | null } = {
+      baseline: null,
+      candidate: null,
+    }
+  ) => ({
+    id: pair.id,
+    name: pair.name,
+    suite: pair.suite,
+    mode: pair.mode,
+    baseUs: round(pair.baseUs),
+    headUs: round(pair.headUs),
+    deltaUs: round(pair.baseUs - pair.headUs),
+    reductionPct: round(pair.reductionPct),
+    speedup: round(pair.speedup),
+    patternHash: pair.extra.pattern_hash ?? "",
+    shapeHash: pair.extra.shape_hash ?? "",
+    exampleModel: pair.extra.example_model ?? "",
+    baseGapVsSol: gaps.baseline == null ? null : round(gaps.baseline),
+    headGapVsSol: gaps.candidate == null ? null : round(gaps.candidate),
+  });
+
+  return {
+    comparison: {
+      leftWorkflow,
+      rightWorkflow,
+    },
+    comparisonUnavailableReason,
+    modelUnavailableReason,
+    model: summarize(realModels),
+    kernel: summarize(kernels),
+    suites: [...new Set([...suiteGroups.keys(), ...coverageBySuite.keys()])]
+      .map((suiteMode) => {
+        const pairs = suiteGroups.get(suiteMode) ?? [];
+        const total = coverageBySuite.get(suiteMode)?.size ?? pairs.length;
+        return {
+          id: suiteMode,
+          suiteMode,
+          stats: summarize(pairs),
+          total,
+          excluded: Math.max(0, total - pairs.length),
+        };
+      })
+      .sort(
+        (a, b) =>
+          (b.stats?.geomean ?? -Infinity) - (a.stats?.geomean ?? -Infinity)
+      ),
+    models: realModels.map((pair) => toMover(pair)),
+    kernels: kernels.map((pair) =>
+      toMover(pair, {
+        baseline: baselineKernelGaps.has(pair.id)
+          ? Number(baselineKernelGaps.get(pair.id)?.value)
+          : null,
+        candidate: candidateKernelGaps.has(pair.id)
+          ? Number(candidateKernelGaps.get(pair.id)?.value)
+          : null,
+      })
+    ),
+    coverage: {
+      matchedKernelPoints: kernels.length,
+      leftOnlyKernelPoints: kernelResult.leftOnly,
+      rightOnlyKernelPoints: kernelResult.rightOnly,
+      invalidBaselineKernelPoints: kernelResult.leftInvalid,
+      invalidCandidateKernelPoints: kernelResult.rightInvalid,
+      incompatibleModels: modelResult.incompatible,
+      includedModels: realModels.length,
+      totalModels: coverageModels.size || realModels.length,
+      baselineModels: modelCoverageSummary(rows, leftWorkflow),
+      candidateModels: modelCoverageSummary(rows, rightWorkflow),
+      baselineRun: runQualitySummary(rows, leftWorkflow),
+      candidateRun: runQualitySummary(rows, rightWorkflow),
+    },
+  };
+}
+
+export type BetterBenchmarkSummaryData = ReturnType<
+  typeof buildBetterBenchmarkSummary
+>;


### PR DESCRIPTION
## Summary

Adds a summary view for Better Benchmark results in PyTorch HUD.

- Shows overall model and kernel performance using geomean, median, mean, and comparable-record counts.
- Breaks results down by suite and mode.
- Shows the largest model and kernel gains/regressions, ranked by absolute latency impact.
- Displays comparison coverage and exclusion reasons.
- Links workflow IDs to their GitHub Actions runs.
- Uses lower-is-better green/red semantics with a neutral threshold for small changes.
- Adds a dedicated backend query path for Better Benchmark summary data.

The benchmark records are produced by https://github.com/pytorch/pytorch/pull/193991

## Test plan

- [x] `yarn tsc --noEmit`
- [x] Prettier check for changed files
- [x] ESLint for changed files
- [x] Better Benchmark summary Jest tests
- [x] Validate parsing of kernel, projected-model, coverage, and exclusion records
- [x] Validate suite/mode aggregation and mover ranking
- [x] Validate against uploaded B200 benchmark output