### PR TITLE
[CRCR] Add failed-test drill-down UI to per-backend dashboard

### DIFF
--- a/torchci/clickhouse_queries/crcr_backend_dashboard/query.sql
+++ b/torchci/clickhouse_queries/crcr_backend_dashboard/query.sql
@@ -19,7 +19,8 @@ SELECT
     workflow_run_url,
     artifact_url,
     queue_time,
-    execution_time
+    execution_time,
+    failed_tests_json
 FROM
     default.crcr_workflow_job FINAL
 WHERE

--- a/torchci/clickhouse_queries/crcr_nightly_dashboard/query.sql
+++ b/torchci/clickhouse_queries/crcr_nightly_dashboard/query.sql
@@ -18,7 +18,8 @@ SELECT
     workflow_run_url,
     artifact_url,
     queue_time,
-    execution_time
+    execution_time,
+    failed_tests_json
 FROM
     default.crcr_workflow_job FINAL
 WHERE

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -525,7 +525,10 @@ function JobCellTooltipContent({ job }: { job: CrcrJobRow }) {
               {t.stacktrace && (
                 <details style={{ marginLeft: 12, fontSize: "0.65rem" }}>
                   <summary
-                    style={{ color: "rgba(255,255,255,0.5)", cursor: "pointer" }}
+                    style={{
+                      color: "rgba(255,255,255,0.5)",
+                      cursor: "pointer",
+                    }}
                   >
                     stacktrace
                   </summary>

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -480,6 +480,7 @@ function JobCellTooltipContent({ job }: { job: CrcrJobRow }) {
     name: string;
     classname?: string;
     message?: string;
+    stacktrace?: string;
   }> = [];
   if (job.failed_tests_json) {
     try {
@@ -520,6 +521,26 @@ function JobCellTooltipContent({ job }: { job: CrcrJobRow }) {
                 >
                   {t.message}
                 </div>
+              )}
+              {t.stacktrace && (
+                <details style={{ marginLeft: 12, fontSize: "0.65rem" }}>
+                  <summary
+                    style={{ color: "rgba(255,255,255,0.5)", cursor: "pointer" }}
+                  >
+                    stacktrace
+                  </summary>
+                  <pre
+                    style={{
+                      whiteSpace: "pre-wrap",
+                      color: "rgba(255,255,255,0.5)",
+                      maxHeight: 120,
+                      overflow: "auto",
+                      margin: "2px 0",
+                    }}
+                  >
+                    {t.stacktrace}
+                  </pre>
+                </details>
               )}
             </div>
           ))}

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -69,6 +69,7 @@ interface CrcrJobRow {
   artifact_url: string;
   queue_time: number | null;
   execution_time: number | null;
+  failed_tests_json: string;
 }
 
 interface SummaryStats {
@@ -475,9 +476,60 @@ function JobCellTooltipContent({ job }: { job: CrcrJobRow }) {
     job.queue_time != null ? `Queue: ${job.queue_time.toFixed(1)}s` : null,
   ].filter(Boolean);
 
+  let failedTests: Array<{
+    name: string;
+    classname?: string;
+    message?: string;
+  }> = [];
+  if (job.failed_tests_json) {
+    try {
+      failedTests = JSON.parse(job.failed_tests_json);
+    } catch {
+      // ignore malformed JSON
+    }
+  }
+
   return (
     <div style={{ whiteSpace: "pre-line", fontSize: "0.8rem" }}>
       {lines.join("\n")}
+      {failedTests.length > 0 && (
+        <div
+          style={{
+            marginTop: 8,
+            borderTop: "1px solid rgba(255,255,255,0.2)",
+            paddingTop: 6,
+          }}
+        >
+          <div style={{ fontWeight: 600, marginBottom: 4 }}>
+            Failed tests ({failedTests.length}):
+          </div>
+          {failedTests.slice(0, 10).map((t, i) => (
+            <div key={i} style={{ marginBottom: 3 }}>
+              <span style={{ color: "#f85149" }}>✗</span>{" "}
+              {t.classname ? `${t.classname}::${t.name}` : t.name}
+              {t.message && (
+                <div
+                  style={{
+                    fontSize: "0.7rem",
+                    color: "rgba(255,255,255,0.6)",
+                    marginLeft: 12,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    maxWidth: 300,
+                  }}
+                >
+                  {t.message}
+                </div>
+              )}
+            </div>
+          ))}
+          {failedTests.length > 10 && (
+            <div style={{ color: "rgba(255,255,255,0.5)", fontSize: "0.7rem" }}>
+              … and {failedTests.length - 10} more
+            </div>
+          )}
+        </div>
+      )}
       {url && (
         <div style={{ marginTop: 4 }}>
           <a


### PR DESCRIPTION
## Summary

Adds the UI drill-down for failed tests in the CRCR per-backend dashboard tooltip, complementing the ingest path in #8607.

**Changes:**
1. **ClickHouse queries** — Add `failed_tests_json` to SELECT in `crcr_backend_dashboard` and `crcr_nightly_dashboard`
2. **`CrcrJobRow` type** — Add `failed_tests_json: string` field
3. **Tooltip UI** — Parse and render failed tests in `JobCellTooltipContent`:
   - Shows up to 10 failed tests with classname::name format
   - Displays truncated error message
   - Collapsible stacktrace via `<details>` element
   - Overflow indicator for > 10 tests

All changes are **optional** — cells without `failed_tests_json` render as before.

Depends on #8607
Addresses #8545, #8548

## Test plan

- Verify tooltip renders normally for jobs without failed_tests_json
- Verify failed tests appear in tooltip when present
- Verify stacktrace is collapsible
- Verify overflow indicator shows when > 10 tests