### PR TITLE
Add Jane Xu to greenlight trusted authors

### DIFF
--- a/greenlight/src/greenlight/review.py
+++ b/greenlight/src/greenlight/review.py
@@ -63,6 +63,7 @@ TRUSTED_AUTHORS: set[str] = {
     "jeanschmidt",  # Jean Schmidt
     "ezyang",  # Edward Yang
     "drisspg",  # Driss Guessous
+    "janeyx99",  # Jane Xu
 }
 
 # Case-insensitive membership for the two authz gates (target-PR author and recheck requester);


### PR DESCRIPTION
**Impact:** greenlight PR review scan POC user list
**Risk:** low

## What
Adds `janeyx99` (Jane Xu) to the `TRUSTED_AUTHORS` set in greenlight's review scan.

## Why
The greenlight scan only fingerprints and dispatches the reviewer workflow for PRs opened by trusted authors. Adding Jane Xu opts her pytorch/pytorch PRs into the auto-review gate.