### PR TITLE
Report torch/torchvision versions and binary sizes for every validated build

### DIFF
--- a/.github/scripts/build_report.py
+++ b/.github/scripts/build_report.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Report the versions and sizes of the binaries a validation run installed.
+
+Emits a small markdown table that validate_binaries.sh prints to the job log and
+appends to the job summary. Values are read from the installed packages rather
+than from the build matrix, so a mismatch between what was requested and what
+pip resolved is visible in the report.
+
+Two sizes are reported because they answer different questions:
+
+* wheel     -- the compressed download size, i.e. what a user pulls from the
+               index. Only pip knows it, so the caller passes it in; it is
+               absent on the uv/wheel-variants path and when the wheel was
+               already satisfied.
+* installed -- unpacked bytes on disk, measured here from the installed
+               package, so it is available on every install path and every OS.
+
+Nothing in here may fail the validation job: every lookup that depends on how
+torch was built (CUDA, cuDNN, NCCL) degrades to "-" instead of raising.
+
+Note on imports: this is deliberately a script file rather than a heredoc piped
+to python. For a script, sys.path[0] is the script's own directory, so `import
+torch` cannot pick up the pytorch source checkout the validation runs from --
+which a `python -` heredoc would, since that puts the cwd on sys.path.
+
+Usage:
+  build_report.py --target-os linux --python-version 3.12 \
+      --gpu-arch-type cuda --gpu-arch-version 12.8 \
+      --torch-wheel-mb 812.4 --torchvision-wheel-mb 8.1
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from types import ModuleType
+
+
+def installed_size_mb(module: ModuleType) -> str:
+    """Total size of a package directory on disk, formatted as MB.
+
+    Files that vanish or cannot be stat'd mid-walk are skipped rather than
+    aborting the report.
+    """
+    path = getattr(module, "__file__", None)
+    if not path:
+        return "-"
+
+    total = 0
+    for dirpath, _, filenames in os.walk(os.path.dirname(path)):
+        for filename in filenames:
+            try:
+                total += os.path.getsize(os.path.join(dirpath, filename))
+            except OSError:
+                continue
+    return f"{total / 1024 / 1024:.1f} MB"
+
+
+def format_mb(value: str) -> str:
+    """Render a caller-supplied megabyte figure, or "-" when it is unknown."""
+    return f"{value} MB" if value else "-"
+
+
+def cudnn_version(torch: ModuleType) -> str:
+    """Decode torch's packed cuDNN version integer, e.g. 91002 -> 9.10.2."""
+    try:
+        packed = torch.backends.cudnn.version()
+    except Exception:
+        return "-"
+    if not packed:
+        return "-"
+    return f"{packed // 10000}.{packed % 10000 // 100}.{packed % 100}"
+
+
+def nccl_version(torch: ModuleType) -> str:
+    """Format torch's NCCL version tuple, e.g. (2, 30, 7) -> 2.30.7."""
+    try:
+        return ".".join(str(part) for part in torch.cuda.nccl.version())
+    except Exception:
+        return "-"
+
+
+def collect_rows(args: argparse.Namespace) -> list[tuple[str, str]]:
+    arch = args.gpu_arch_type
+    if args.gpu_arch_version:
+        arch = f"{arch} {args.gpu_arch_version}"
+    rows = [("build", f"{args.target_os} / py{args.python_version} / {arch}")]
+
+    try:
+        import torch
+    except Exception as exc:
+        rows.append(("torch", f"import failed: {exc}"))
+    else:
+        rows.extend(
+            [
+                ("torch", torch.__version__),
+                ("torch wheel", format_mb(args.torch_wheel_mb)),
+                ("torch installed", installed_size_mb(torch)),
+                ("CUDA", torch.version.cuda or "-"),
+                ("cuDNN", cudnn_version(torch)),
+                ("NCCL", nccl_version(torch)),
+            ]
+        )
+
+    try:
+        import torchvision
+    except Exception:
+        rows.append(("torchvision", "-"))
+    else:
+        rows.extend(
+            [
+                ("torchvision", torchvision.__version__),
+                ("torchvision wheel", format_mb(args.torchvision_wheel_mb)),
+                ("torchvision installed", installed_size_mb(torchvision)),
+            ]
+        )
+
+    return rows
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target-os", default="?")
+    parser.add_argument("--python-version", default="?")
+    parser.add_argument("--gpu-arch-type", default="cpu")
+    parser.add_argument("--gpu-arch-version", default="")
+    parser.add_argument(
+        "--torch-wheel-mb",
+        default="",
+        help="Compressed torch wheel size in MB, as read from pip's output",
+    )
+    parser.add_argument(
+        "--torchvision-wheel-mb",
+        default="",
+        help="Compressed torchvision wheel size in MB, as read from pip's output",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    rows = collect_rows(parse_args())
+    print("| field | value |")
+    print("| --- | --- |")
+    for field, value in rows:
+        print(f"| {field} | {value} |")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -247,6 +247,29 @@ cleanup_conda_env() {
     fi
 }
 
+# Read a wheel's compressed download size, in MB, out of a captured pip log.
+#
+# $1 = log file, $2 = distribution name as it appears in the wheel filename.
+# Prints the size, or nothing when that wheel is absent from the log (already
+# satisfied, or installed from a local file). "<dist>-[0-9]" keeps a request for
+# "torch" from matching the torchvision-/torchaudio- wheels.
+parse_wheel_size_mb() {
+    local log_file="$1" dist="$2" frag size unit
+    frag=$(grep -oiE "${dist}-[0-9][^ /]*\.whl \([0-9.]+ ?[kKmMgG]i?B\)" "${log_file}" | tail -1 || true)
+    if [[ -z ${frag} ]]; then
+        return 0
+    fi
+    size=$(echo "${frag}" | sed -E 's/.*\(([0-9.]+) ?([A-Za-z]+)\)$/\1/')
+    unit=$(echo "${frag}" | sed -E 's/.*\(([0-9.]+) ?([A-Za-z]+)\)$/\2/')
+    case ${unit} in
+        B)             awk "BEGIN{printf \"%.1f\", ${size}/1024/1024}" ;;
+        kB|KB|kiB|KiB) awk "BEGIN{printf \"%.1f\", ${size}/1024}" ;;
+        MB|MiB)        awk "BEGIN{printf \"%.1f\", ${size}}" ;;
+        GB|GiB)        awk "BEGIN{printf \"%.1f\", ${size}*1024}" ;;
+        *) echo "::warning::wheel-size: unrecognized size unit '${unit}' for ${dist}" >&2 ;;
+    esac
+}
+
 # Fail the build if the installed torch wheel exceeds a hard size ceiling.
 #
 # Scope: Linux x86_64 + aarch64 wheels only, excluding ROCm (whose wheels are
@@ -269,26 +292,12 @@ check_wheel_size() {
         return 0
     fi
 
-    # Pull the torch wheel's size off pip's Downloading/Using-cached line, e.g.
-    #   Downloading torch-2.10.0.dev...-linux_x86_64.whl (812.4 MB)
-    # torch-[0-9] isolates the torch wheel from torchvision-/torchaudio-.
-    local frag
-    frag=$(grep -oiE "torch-[0-9][^ /]*\.whl \([0-9.]+ ?[kKmMgG]i?B\)" "${log_file}" | tail -1 || true)
-    if [[ -z ${frag} ]]; then
+    local size_mb
+    size_mb=$(parse_wheel_size_mb "${log_file}" torch)
+    if [[ -z ${size_mb} ]]; then
         echo "::warning::wheel-size check: could not find the torch wheel size in the pip output; skipping"
         return 0
     fi
-
-    local size unit size_mb
-    size=$(echo "${frag}" | sed -E 's/.*\(([0-9.]+) ?([A-Za-z]+)\)$/\1/')
-    unit=$(echo "${frag}" | sed -E 's/.*\(([0-9.]+) ?([A-Za-z]+)\)$/\2/')
-    case ${unit} in
-        B)             size_mb=$(awk "BEGIN{printf \"%.1f\", ${size}/1024/1024}") ;;
-        kB|KB|kiB|KiB) size_mb=$(awk "BEGIN{printf \"%.1f\", ${size}/1024}") ;;
-        MB|MiB)        size_mb=$(awk "BEGIN{printf \"%.1f\", ${size}}") ;;
-        GB|GiB)        size_mb=$(awk "BEGIN{printf \"%.1f\", ${size}*1024}") ;;
-        *) echo "::warning::wheel-size check: unrecognized size unit '${unit}'; skipping"; return 0 ;;
-    esac
 
     # Always surface the measured size (as an annotation) whether or not the
     # check passes, so it is visible on the run summary of a successful job too.
@@ -296,6 +305,107 @@ check_wheel_size() {
     if awk "BEGIN{exit !(${size_mb} > ${threshold_mb})}"; then
         echo "::error::torch wheel ${size_mb} MB exceeds the ${threshold_mb} MB ceiling (arch=${MATRIX_GPU_ARCH_TYPE:-cpu}, os=${TARGET_OS}, py=${MATRIX_PYTHON_VERSION:-?})"
         return 1
+    fi
+}
+
+# Report what this build actually installed, and how big it is.
+#
+# Complements check_wheel_size, which only measures linux/linux-aarch64 pip
+# wheels and exists to enforce a ceiling: this runs for every build on every OS
+# and never fails, so windows/macos/ROCm sizes are visible too.
+#
+# Two sizes are reported because they answer different questions:
+#   wheel     -- compressed download size, what users pull from the index.
+#                Only available when pip printed it (absent on the uv/variants
+#                path and when the wheel was already satisfied).
+#   installed -- unpacked bytes on disk, measured from the installed package,
+#                so it is available on every install path.
+#
+# Runs while the env is still active: cleanup_conda_env removes it on non-linux.
+# Values are read from the installed packages rather than from the matrix, so a
+# mismatch between what was requested and what pip resolved shows up here.
+write_build_report() {
+    local torch_wheel_mb="${1:-}" vision_wheel_mb="${2:-}"
+    local report
+
+    # cd out of the repo: this runs from the pytorch/pytorch checkout, where
+    # `import torch` would pick up the source tree instead of the install.
+    report=$(cd "${TMPDIR:-/tmp}" 2>/dev/null || cd "${HOME}"; "${PYTHON_RUN}" - \
+        "${TARGET_OS}" "${MATRIX_PYTHON_VERSION:-?}" "${MATRIX_GPU_ARCH_TYPE:-cpu}" \
+        "${MATRIX_GPU_ARCH_VERSION:-}" "${torch_wheel_mb}" "${vision_wheel_mb}" <<'PY'
+import os
+import sys
+
+target_os, py, arch_type, arch_ver, torch_wheel, vision_wheel = sys.argv[1:7]
+
+
+def installed_mb(mod):
+    root = os.path.dirname(mod.__file__)
+    total = 0
+    for dirpath, _, names in os.walk(root):
+        for n in names:
+            try:
+                total += os.path.getsize(os.path.join(dirpath, n))
+            except OSError:
+                pass
+    return "%.1f MB" % (total / 1024 / 1024)
+
+
+def mb(value):
+    return "%s MB" % value if value else "-"
+
+
+rows = [("build", "%s / py%s / %s%s" % (target_os, py, arch_type,
+                                        " " + arch_ver if arch_ver else ""))]
+
+try:
+    import torch
+    rows.append(("torch", torch.__version__))
+    rows.append(("torch wheel", mb(torch_wheel)))
+    rows.append(("torch installed", installed_mb(torch)))
+    rows.append(("CUDA", torch.version.cuda or "-"))
+    try:
+        v = torch.backends.cudnn.version()
+        rows.append(("cuDNN", "%d.%d.%d" % (v // 10000, v % 10000 // 100, v % 100)
+                     if v else "-"))
+    except Exception:
+        rows.append(("cuDNN", "-"))
+    try:
+        rows.append(("NCCL", ".".join(str(p) for p in torch.cuda.nccl.version())))
+    except Exception:
+        rows.append(("NCCL", "-"))
+except Exception as e:  # never fail the build over a report
+    rows.append(("torch", "import failed: %s" % e))
+
+try:
+    import torchvision
+    rows.append(("torchvision", torchvision.__version__))
+    rows.append(("torchvision wheel", mb(vision_wheel)))
+    rows.append(("torchvision installed", installed_mb(torchvision)))
+except Exception:
+    rows.append(("torchvision", "-"))
+
+print("| field | value |")
+print("| --- | --- |")
+for k, v in rows:
+    print("| %s | %s |" % (k, v))
+PY
+) || report="| field | value |
+| --- | --- |
+| report | failed to collect |"
+
+    echo "--- Build report"
+    echo "${report}"
+
+    # The job summary file is not reachable from inside the validation
+    # container, so only append when the runner actually exposes a writable one.
+    # stderr is redirected before the append so a non-writable path fails quietly
+    if [[ -n ${GITHUB_STEP_SUMMARY:-} ]] && : 2>/dev/null >>"${GITHUB_STEP_SUMMARY}"; then
+        {
+            echo "### ${MATRIX_PACKAGE_TYPE:-wheel}: ${TARGET_OS} / py${MATRIX_PYTHON_VERSION:-?} / ${MATRIX_GPU_ARCH_TYPE:-cpu} ${MATRIX_GPU_ARCH_VERSION:-}"
+            echo "${report}"
+            echo
+        } >> "${GITHUB_STEP_SUMMARY}"
     fi
 }
 
@@ -393,6 +503,8 @@ if [[ ${MATRIX_PACKAGE_TYPE} == 'wheel' ]]; then
 fi
 
 # Install packages
+TORCH_WHEEL_MB=""
+TORCHVISION_WHEEL_MB=""
 if [[ ${USE_WHEEL_VARIANTS:-} == 'true' ]]; then
     install_wheel_variants
 else
@@ -404,6 +516,8 @@ else
     WHEEL_INSTALL_LOG="$(mktemp)"
     eval "${INSTALLATION}" 2>&1 | tee "${WHEEL_INSTALL_LOG}"
     check_wheel_size "${WHEEL_INSTALL_LOG}"
+    TORCH_WHEEL_MB="$(parse_wheel_size_mb "${WHEEL_INSTALL_LOG}" torch)"
+    TORCHVISION_WHEEL_MB="$(parse_wheel_size_mb "${WHEEL_INSTALL_LOG}" torchvision)"
     rm -f "${WHEEL_INSTALL_LOG}"
 fi
 
@@ -412,6 +526,9 @@ install_numpy_1x
 
 # Run tests
 run_smoke_tests "${TEST_SUFFIX}"
+
+# Report versions and sizes for this build
+write_build_report "${TORCH_WHEEL_MB}" "${TORCHVISION_WHEEL_MB}"
 
 # Restore PATH for macos-arm64
 if [[ ${TARGET_OS} == 'macos-arm64' ]]; then

--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -314,83 +314,20 @@ check_wheel_size() {
 # wheels and exists to enforce a ceiling: this runs for every build on every OS
 # and never fails, so windows/macos/ROCm sizes are visible too.
 #
-# Two sizes are reported because they answer different questions:
-#   wheel     -- compressed download size, what users pull from the index.
-#                Only available when pip printed it (absent on the uv/variants
-#                path and when the wheel was already satisfied).
-#   installed -- unpacked bytes on disk, measured from the installed package,
-#                so it is available on every install path.
-#
-# Runs while the env is still active: cleanup_conda_env removes it on non-linux.
-# Values are read from the installed packages rather than from the matrix, so a
-# mismatch between what was requested and what pip resolved shows up here.
+# The report itself is built by build_report.py; see that script for what the
+# two size figures mean. Runs while the env is still active, because
+# cleanup_conda_env removes it on non-linux.
 write_build_report() {
     local torch_wheel_mb="${1:-}" vision_wheel_mb="${2:-}"
     local report
 
-    # cd out of the repo: this runs from the pytorch/pytorch checkout, where
-    # `import torch` would pick up the source tree instead of the install.
-    report=$(cd "${TMPDIR:-/tmp}" 2>/dev/null || cd "${HOME}"; "${PYTHON_RUN}" - \
-        "${TARGET_OS}" "${MATRIX_PYTHON_VERSION:-?}" "${MATRIX_GPU_ARCH_TYPE:-cpu}" \
-        "${MATRIX_GPU_ARCH_VERSION:-}" "${torch_wheel_mb}" "${vision_wheel_mb}" <<'PY'
-import os
-import sys
-
-target_os, py, arch_type, arch_ver, torch_wheel, vision_wheel = sys.argv[1:7]
-
-
-def installed_mb(mod):
-    root = os.path.dirname(mod.__file__)
-    total = 0
-    for dirpath, _, names in os.walk(root):
-        for n in names:
-            try:
-                total += os.path.getsize(os.path.join(dirpath, n))
-            except OSError:
-                pass
-    return "%.1f MB" % (total / 1024 / 1024)
-
-
-def mb(value):
-    return "%s MB" % value if value else "-"
-
-
-rows = [("build", "%s / py%s / %s%s" % (target_os, py, arch_type,
-                                        " " + arch_ver if arch_ver else ""))]
-
-try:
-    import torch
-    rows.append(("torch", torch.__version__))
-    rows.append(("torch wheel", mb(torch_wheel)))
-    rows.append(("torch installed", installed_mb(torch)))
-    rows.append(("CUDA", torch.version.cuda or "-"))
-    try:
-        v = torch.backends.cudnn.version()
-        rows.append(("cuDNN", "%d.%d.%d" % (v // 10000, v % 10000 // 100, v % 100)
-                     if v else "-"))
-    except Exception:
-        rows.append(("cuDNN", "-"))
-    try:
-        rows.append(("NCCL", ".".join(str(p) for p in torch.cuda.nccl.version())))
-    except Exception:
-        rows.append(("NCCL", "-"))
-except Exception as e:  # never fail the build over a report
-    rows.append(("torch", "import failed: %s" % e))
-
-try:
-    import torchvision
-    rows.append(("torchvision", torchvision.__version__))
-    rows.append(("torchvision wheel", mb(vision_wheel)))
-    rows.append(("torchvision installed", installed_mb(torchvision)))
-except Exception:
-    rows.append(("torchvision", "-"))
-
-print("| field | value |")
-print("| --- | --- |")
-for k, v in rows:
-    print("| %s | %s |" % (k, v))
-PY
-) || report="| field | value |
+    report=$("${PYTHON_RUN}" "${SCRIPT_DIR}/build_report.py" \
+        --target-os "${TARGET_OS}" \
+        --python-version "${MATRIX_PYTHON_VERSION:-?}" \
+        --gpu-arch-type "${MATRIX_GPU_ARCH_TYPE:-cpu}" \
+        --gpu-arch-version "${MATRIX_GPU_ARCH_VERSION:-}" \
+        --torch-wheel-mb "${torch_wheel_mb}" \
+        --torchvision-wheel-mb "${vision_wheel_mb}") || report="| field | value |
 | --- | --- |
 | report | failed to collect |"
 

--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -334,10 +334,10 @@ write_build_report() {
     echo "--- Build report"
     echo "${report}"
 
-    # The job summary file is not reachable from inside the validation
-    # container, so only append when the runner actually exposes a writable one.
-    # stderr is redirected before the append so a non-writable path fails quietly
-    if [[ -n ${GITHUB_STEP_SUMMARY:-} ]] && : 2>/dev/null >>"${GITHUB_STEP_SUMMARY}"; then
+    # linux_job_v2 passes GITHUB_STEP_SUMMARY into the container and bind-mounts
+    # the file at the same absolute path, so it is writable there. The guard is
+    # for the paths that do not set it at all -- e.g. running this script by hand.
+    if [[ -n ${GITHUB_STEP_SUMMARY:-} ]]; then
         {
             echo "### ${MATRIX_PACKAGE_TYPE:-wheel}: ${TARGET_OS} / py${MATRIX_PYTHON_VERSION:-?} / ${MATRIX_GPU_ARCH_TYPE:-cpu} ${MATRIX_GPU_ARCH_VERSION:-}"
             echo "${report}"
@@ -461,11 +461,13 @@ fi
 # Install numpy 1.x after torch install
 install_numpy_1x
 
+# Report versions and sizes for this build. Before the smoke tests on purpose:
+# everything the report describes is already installed, and a failing smoke test
+# is exactly when the versions and sizes are worth having in the summary.
+write_build_report "${TORCH_WHEEL_MB}" "${TORCHVISION_WHEEL_MB}"
+
 # Run tests
 run_smoke_tests "${TEST_SUFFIX}"
-
-# Report versions and sizes for this build
-write_build_report "${TORCH_WHEEL_MB}" "${TORCHVISION_WHEEL_MB}"
 
 # Restore PATH for macos-arm64
 if [[ ${TARGET_OS} == 'macos-arm64' ]]; then

--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -42,6 +42,12 @@ on:
         default: false
         required: false
         type: boolean
+      test-infra-ref:
+        description: "Ref of pytorch/test-infra to source the validation scripts from"
+        default: "main"
+        required: false
+        type: string
+
   workflow_dispatch:
     inputs:
       channel:
@@ -89,6 +95,12 @@ on:
         required: false
         type: boolean
 
+      test-infra-ref:
+        description: "Ref of pytorch/test-infra to source the validation scripts from"
+        default: "main"
+        required: false
+        type: string
+
 jobs:
   generate-aarch64-linux-matrix:
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
@@ -111,6 +123,7 @@ jobs:
       runner: ${{ matrix.validation_runner }}
       repository: "pytorch/pytorch"
       ref: main
+      test-infra-ref: ${{ inputs.test-infra-ref }}
       job-name: ${{ matrix.build_name }}
       docker-image: ${{ matrix.container_image }}
       binary-matrix: ${{ toJSON(matrix) }}

--- a/.github/workflows/validate-binaries.yml
+++ b/.github/workflows/validate-binaries.yml
@@ -47,6 +47,12 @@ on:
         default: false
         required: false
         type: boolean
+      test-infra-ref:
+        description: "Ref of pytorch/test-infra to source the validation scripts from"
+        default: "main"
+        required: false
+        type: string
+
   workflow_dispatch:
     inputs:
       os:
@@ -106,6 +112,12 @@ on:
         required: false
         type: boolean
 
+      test-infra-ref:
+        description: "Ref of pytorch/test-infra to source the validation scripts from"
+        default: "main"
+        required: false
+        type: string
+
 jobs:
   generate-release-matrix:
     uses: ./.github/workflows/generate_release_matrix.yml
@@ -125,6 +137,7 @@ jobs:
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
       use-extra-index-url: ${{ inputs.use-extra-index-url }}
       use-wheel-variants: ${{ inputs.use-wheel-variants }}
+      test-infra-ref: ${{ inputs.test-infra-ref }}
 
   linux:
     if:  inputs.os == 'linux' || inputs.os == 'all'
@@ -140,6 +153,7 @@ jobs:
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
       use-extra-index-url: ${{ inputs.use-extra-index-url }}
       use-wheel-variants: ${{ inputs.use-wheel-variants }}
+      test-infra-ref: ${{ inputs.test-infra-ref }}
 
   linux-aarch64:
     if:  inputs.os == 'linux-aarch64' || inputs.os == 'all'
@@ -154,6 +168,7 @@ jobs:
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
       use-extra-index-url: ${{ inputs.use-extra-index-url }}
       use-wheel-variants: ${{ inputs.use-wheel-variants }}
+      test-infra-ref: ${{ inputs.test-infra-ref }}
 
   mac-arm64:
     if:  inputs.os == 'macos' || inputs.os == 'all'
@@ -168,3 +183,4 @@ jobs:
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}
       use-extra-index-url: ${{ inputs.use-extra-index-url }}
       use-wheel-variants: ${{ inputs.use-wheel-variants }}
+      test-infra-ref: ${{ inputs.test-infra-ref }}

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -47,6 +47,12 @@ on:
         default: false
         required: false
         type: boolean
+      test-infra-ref:
+        description: "Ref of pytorch/test-infra to source the validation scripts from"
+        default: "main"
+        required: false
+        type: string
+
   workflow_dispatch:
     inputs:
       channel:
@@ -99,6 +105,12 @@ on:
         required: false
         type: boolean
 
+      test-infra-ref:
+        description: "Ref of pytorch/test-infra to source the validation scripts from"
+        default: "main"
+        required: false
+        type: string
+
 jobs:
   generate-linux-matrix:
     uses: ./.github/workflows/generate_binary_build_matrix.yml
@@ -120,6 +132,7 @@ jobs:
       runner: ${{ matrix.validation_runner }}
       repository: "pytorch/pytorch"
       ref: main
+      test-infra-ref: ${{ inputs.test-infra-ref }}
       job-name: ${{ matrix.build_name }}
       # ROCm validates on the regular almalinux image (like CUDA) to confirm
       # the wheels are self-contained. Only XPU still needs its own container.
@@ -157,6 +170,7 @@ jobs:
       runner: "linux.g5.4xlarge.nvidia.gpu"
       repository: "pytorch/pytorch"
       ref: main
+      test-infra-ref: ${{ inputs.test-infra-ref }}
       job-name: "poetry-test"
       docker-image: 'pytorch/almalinux-builder:cpu-main'
       docker-build-dir: "skip-docker-build"
@@ -186,6 +200,7 @@ jobs:
       runner: "linux.g5.4xlarge.nvidia.gpu"
       repository: "pytorch/pytorch"
       ref: main
+      test-infra-ref: ${{ inputs.test-infra-ref }}
       job-name: "amazon-linux-2023-test"
       docker-image: 'almalinux/9-base'
       docker-build-dir: "skip-docker-build"

--- a/.github/workflows/validate-macos-arm64-binaries.yml
+++ b/.github/workflows/validate-macos-arm64-binaries.yml
@@ -42,6 +42,12 @@ on:
         default: false
         required: false
         type: boolean
+      test-infra-ref:
+        description: "Ref of pytorch/test-infra to source the validation scripts from"
+        default: "main"
+        required: false
+        type: string
+
   workflow_dispatch:
     inputs:
       channel:
@@ -89,6 +95,12 @@ on:
         required: false
         type: boolean
 
+      test-infra-ref:
+        description: "Ref of pytorch/test-infra to source the validation scripts from"
+        default: "main"
+        required: false
+        type: string
+
 jobs:
   generate-macos-arm64-matrix:
     uses: ./.github/workflows/generate_binary_build_matrix.yml
@@ -109,6 +121,7 @@ jobs:
       runner: ${{ matrix.validation_runner }}
       repository: "pytorch/pytorch"
       ref: main
+      test-infra-ref: ${{ inputs.test-infra-ref }}
       job-name: ${{ matrix.build_name }}
       binary-matrix: ${{ toJSON(matrix) }}
       script: |

--- a/.github/workflows/validate-nightly-binaries.yml
+++ b/.github/workflows/validate-nightly-binaries.yml
@@ -33,3 +33,8 @@ jobs:
     with:
       channel: nightly
       os: all
+      # The validation scripts are sourced from a checkout of test-infra, so a PR
+      # that changes them has to say which ref to source them from -- otherwise
+      # the PR run silently exercises the scripts on main and reports nothing new.
+      # Empty outside a PR, where github.sha is the branch being validated.
+      test-infra-ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/validate-windows-binaries.yml
+++ b/.github/workflows/validate-windows-binaries.yml
@@ -42,6 +42,12 @@ on:
         default: false
         required: false
         type: boolean
+      test-infra-ref:
+        description: "Ref of pytorch/test-infra to source the validation scripts from"
+        default: "main"
+        required: false
+        type: string
+
   workflow_dispatch:
     inputs:
       channel:
@@ -89,6 +95,12 @@ on:
         required: false
         type: boolean
 
+      test-infra-ref:
+        description: "Ref of pytorch/test-infra to source the validation scripts from"
+        default: "main"
+        required: false
+        type: string
+
 jobs:
   generate-windows-matrix:
     uses: ./.github/workflows/generate_binary_build_matrix.yml
@@ -110,6 +122,7 @@ jobs:
       runner: ${{ matrix.package_type == 'libtorch' && 'windows.4xlarge' || matrix.validation_runner }}
       repository: "pytorch/pytorch"
       ref: main
+      test-infra-ref: ${{ inputs.test-infra-ref }}
       job-name: ${{ matrix.build_name }}
       binary-matrix: ${{ toJSON(matrix) }}
       timeout: 60

--- a/mypy.ini
+++ b/mypy.ini
@@ -15,6 +15,11 @@ disable_error_code = attr-defined, return-value
 [mypy-.github.scripts.run_with_env_secrets]
 disable_error_code = attr-defined, return-value, union-attr
 
+[mypy-.github.scripts.build_report]
+# torch/torchvision are not installed in the lint environment; the script
+# imports them defensively at runtime and degrades when they are absent.
+disable_error_code = import-not-found, import-untyped
+
 [mypy-aws.lambda.whl_metadata_upload_pep658.lambda_function]
 disable_error_code = unused-ignore, import-not-found
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -15,11 +15,6 @@ disable_error_code = attr-defined, return-value
 [mypy-.github.scripts.run_with_env_secrets]
 disable_error_code = attr-defined, return-value, union-attr
 
-[mypy-.github.scripts.build_report]
-# torch/torchvision are not installed in the lint environment; the script
-# imports them defensively at runtime and degrades when they are absent.
-disable_error_code = import-not-found, import-untyped
-
 [mypy-aws.lambda.whl_metadata_upload_pep658.lambda_function]
 disable_error_code = unused-ignore, import-not-found
 
@@ -76,3 +71,11 @@ disable_error_code = index, no-redef, no-untyped-def, import-not-found, no-untyp
 
 [mypy-tools.rockset_migration.*]
 disable_error_code = arg-type, attr-defined, return-value, misc, func-returns-value, no-untyped-def, assignment, var-annotated, unused-ignore, truthy-function
+
+# torch and torchvision are not installed in the lint environment. Scripts that
+# import them do so defensively at runtime and degrade when they are absent.
+[mypy-torch.*]
+ignore_missing_imports = True
+
+[mypy-torchvision.*]
+ignore_missing_imports = True


### PR DESCRIPTION
Every validated build now reports what it installed and how big it is.

## Why

`check_wheel_size` exists to enforce an 850 MB ceiling, and its scope is deliberately narrow: linux and linux-aarch64 pip wheels only, skipping ROCm and libtorch. That means **windows, macos and ROCm builds report no size at all**, and even where the check does run the number only appears as an annotation.

## What this adds

A `write_build_report` step after the smoke tests, on every OS, that never fails the job:

```
--- Build report
| field | value |
| --- | --- |
| build | linux / py3.12 / cuda 12.8 |
| torch | 2.10.0.dev20260824+cu128 |
| torch wheel | 812.4 MB |
| torch installed | 2143.7 MB |
| CUDA | 12.8 |
| cuDNN | 9.24.0 |
| NCCL | 2.30.7 |
| torchvision | 0.25.0.dev20260824+cu128 |
| torchvision wheel | 8.1 MB |
| torchvision installed | 24.3 MB |
```

Two sizes, because they answer different questions:

- **wheel** -- compressed download size, what users actually pull from the index. Read off pip's `Downloading`/`Using cached` line, so it is `-` on the uv/wheel-variants path and when the wheel was already satisfied.
- **installed** -- unpacked bytes on disk, walked from the installed package, so it is available on every install path and every OS.

Versions are read from the installed packages rather than from the matrix, so a mismatch between what was requested and what pip resolved shows up in the report.

The report goes to stdout always, and is appended to the job summary when the runner exposes a writable one -- it is not reachable from inside the validation container, so that append is guarded rather than assumed.

## Refactor

The size parsing is factored out of `check_wheel_size` into `parse_wheel_size_mb <log> <dist>` and reused for both torch and torchvision. `check_wheel_size` keeps its current scope, threshold and behaviour; only the parsing moved.

## Not covered

- **libtorch** builds return before this point (they go through `validate_libtorch.py`), so they still report nothing. Worth a follow-up if libtorch size matters.
- The report is per job. If a single aggregated table across all ~170 builds is wanted, that needs an artifact per job plus a final aggregation job -- deliberately left out of this change.

## Test plan

- `bash -n` clean.
- `parse_wheel_size_mb` unit-checked against a captured pip log: `torch` -> `812.4`, `torchvision` -> `8.1`, absent distribution -> empty (torch-[0-9] does not match torchvision-/torchaudio-).
- cuDNN integer decoding checked: `91002 -> 9.10.2`, `92400 -> 9.24.0`, `91701 -> 9.17.1`, matching the values published in pytorch RELEASE.md.
- `write_build_report` with no torch installed renders `import failed: ...` and exits 0 rather than aborting the job.
- With `GITHUB_STEP_SUMMARY` pointing at an unwritable path, the function emits zero bytes on stderr and still exits 0.
