### PR TITLE
[CRCR] Move relay health card to first position in PR summary row

### DIFF
--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -21,6 +21,7 @@ import NextLink from "next/link";
 import { useRouter } from "next/router";
 import {
   createContext,
+  ReactNode,
   useCallback,
   useContext,
   useEffect,
@@ -121,7 +122,13 @@ function StatCard({
   );
 }
 
-function SummaryCards({ stats }: { stats: SummaryStats }) {
+function SummaryCards({
+  stats,
+  healthCard,
+}: {
+  stats: SummaryStats;
+  healthCard?: ReactNode;
+}) {
   const passColor =
     stats.pass_rate >= 1.0
       ? "#2e7d32"
@@ -132,12 +139,15 @@ function SummaryCards({ stats }: { stats: SummaryStats }) {
   return (
     <Stack spacing={2}>
       <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
-        <StatCard
-          label="Pass Rate"
-          value={`${(stats.pass_rate * 100).toFixed(1)}%`}
-          sub={`${stats.successes}/${stats.total_jobs} jobs`}
-          color={passColor}
-        />
+        {healthCard}
+        {!healthCard && (
+          <StatCard
+            label="Pass Rate"
+            value={`${(stats.pass_rate * 100).toFixed(1)}%`}
+            sub={`${stats.successes}/${stats.total_jobs} jobs`}
+            color={passColor}
+          />
+        )}
         <StatCard
           label="Total PRs"
           value={stats.total_prs}
@@ -361,7 +371,7 @@ function RelayHealthCard({
         {label}
       </Typography>
       <Typography variant="caption" color="text.secondary">
-        {passedCount}/{healthPrs.length} recent PRs passed
+        {passedCount}/{healthPrs.length} of last {HEALTH_COUNT} PRs passed
       </Typography>
     </Paper>
   );
@@ -1426,13 +1436,15 @@ export default function CrcrBackendPage() {
 
             {!isNightly && (
               <>
-                {isCrcrTest && (
-                  <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
-                    <RelayHealthCard healthPrs={healthPrs} />
-                  </Box>
-                )}
                 {stats ? (
-                  <SummaryCards stats={stats} />
+                  <SummaryCards
+                    stats={stats}
+                    healthCard={
+                      isCrcrTest ? (
+                        <RelayHealthCard healthPrs={healthPrs} />
+                      ) : undefined
+                    }
+                  />
                 ) : (
                   <Skeleton variant="rectangular" height={140} />
                 )}

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -371,7 +371,7 @@ function RelayHealthCard({
         {label}
       </Typography>
       <Typography variant="caption" color="text.secondary">
-        {passedCount}/{healthPrs.length} of last {HEALTH_COUNT} PRs passed
+        {passedCount}/{healthPrs.length} of last {healthPrs.length} PRs passed
       </Typography>
     </Paper>
   );
@@ -1440,7 +1440,7 @@ export default function CrcrBackendPage() {
                   <SummaryCards
                     stats={stats}
                     healthCard={
-                      isCrcrTest ? (
+                      isCrcrTest && healthPrs?.length ? (
                         <RelayHealthCard healthPrs={healthPrs} />
                       ) : undefined
                     }


### PR DESCRIPTION
## Summary

On the per-repo PR results page (e.g. `hud.pytorch.org/crcr/pytorch/crcr-test`), the CRCR Relay Health card was rendered as a standalone element above the summary stat cards. This made it visually disconnected and used different sizing.

This PR moves the health card to be the **first card** in the summary row, **replacing Pass Rate** for crcr-test. The row becomes: CRCR Relay Health, Total PRs, Failures (3 cards). For non-crcr-test repos, Pass Rate remains as before.

Pass Rate (job-level, successes/total_jobs over the time window) and Relay Health (PR-level, last N PRs) are different metrics. The health card is more actionable for the crcr-test dashboard since it directly surfaces whether recent PRs passed end-to-end. Job-level pass rate is still visible in the second row's Timeout Rate card context.

Changes:

- `SummaryCards` accepts an optional `healthCard` prop rendered as the first item in the top row
- When `healthCard` is present, Pass Rate is replaced (not shown alongside)
- `healthCard` is gated on `healthPrs?.length` so Pass Rate shows during SWR first paint
- Sub-text uses actual `healthPrs.length` instead of `HEALTH_COUNT` to avoid "3/3 of last 5"
- Remove the standalone `<Box>` wrapper that previously rendered the health card separately

## Test plan

- Verify the health card appears as the first card in the summary row on `pytorch/crcr-test`
- Verify it has equal width to the other cards (Total PRs, Failures)
- Verify non-crcr-test repos still render Pass Rate + Total PRs + Failures
- Verify during SWR loading, Pass Rate shows until health data arrives