### PR TITLE
[CRCR] Fix nightly health card to equal width with sibling cards

### DIFF
--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -250,6 +250,7 @@ function NightlyHealthCard({ repoFullName }: { repoFullName: string }) {
         borderTop: `3px solid ${borderColor}`,
         textAlign: "center",
         minWidth: 200,
+        flex: 1,
       }}
     >
       <Typography variant="caption" color="text.secondary">
@@ -259,7 +260,8 @@ function NightlyHealthCard({ repoFullName }: { repoFullName: string }) {
         {label}
       </Typography>
       <Typography variant="caption" color="text.secondary">
-        {passedCount}/{shasByTime.length} recent nightlies passed
+        {passedCount}/{shasByTime.length} of last {NIGHTLY_HEALTH_COUNT}{" "}
+        nightlies passed
       </Typography>
     </Paper>
   );


### PR DESCRIPTION
## Summary

On the per-repo nightly results page (e.g. `hud.pytorch.org/crcr/pytorch/crcr-test?event=nightly`), the CRCR Relay Health card was missing `flex: 1`, making it visually narrower than the "Nightly Runs" and "Failures" cards in the same row.

This PR adds `flex: 1` to `NightlyHealthCard` so all three cards in the row have equal width, matching the standard `StatCard` sizing.

Also updates sub-text to "of last N nightlies passed" for consistency with the PR-level health card phrasing.

## Test plan

- Verify the nightly health card has equal width to "Nightly Runs" and "Failures" cards
- Verify the card still renders correctly with its green/orange border and Healthy/Degraded label