### PR TITLE
Render artifact_url in per-repo CRCR dashboard tooltip

### DIFF
--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -419,6 +419,18 @@ function JobCellTooltipContent({ job }: { job: CrcrJobRow }) {
           </a>
         </div>
       )}
+      {job.artifact_url && (
+        <div style={{ marginTop: 2 }}>
+          <a
+            href={job.artifact_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: "var(--link-color, #58a6ff)" }}
+          >
+            View artifacts ›
+          </a>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Renders a "View artifacts" link in the `JobCellTooltipContent` on the per-repo dashboard (`/crcr/[org]/[repo]`) when `artifact_url` is non-empty
- The field was already queried from ClickHouse and present on `CrcrJobRow` but never displayed — this closes the gap
- Consistent with the existing "Artifacts" button on the HUD homepage PR view (`CrcrPrSection.tsx`)

## Mockup

https://subinz1.github.io/CRCR/mockups/artifact-url-tooltip-mockup.html

## Test plan

- [ ] Verify tooltip shows "View artifacts ›" link only when `artifact_url` is populated
- [ ] Verify link opens the correct artifact URL in a new tab
- [ ] Verify no visual regression when `artifact_url` is empty (most jobs)

Fixes https://github.com/pytorch/test-infra/issues/8546