### PR TITLE
[CRCR] Refactor PR context extraction to improve clarity and reuse across handlers

### DIFF
--- a/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
@@ -407,7 +407,7 @@ def handle(config: RelayConfig, body: dict, verified_repo: str) -> dict:
     # the PR check. Both the cache entry and the check run always belong to a
     # specific PR -- get_dispatch_jobs is only ever looked up by a PR's head
     # SHA (see event_handler._handle_pr_labeled) -- so without a pr_number,
-    #  there is nothing to cache and no check run to create.
+    # there is nothing to cache and no check run to create.
     if repo_level.value >= AllowlistLevel.L3.value:
         pr_number, head_sha = extract_pr_context(body)
         if head_sha and pr_number:

--- a/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
@@ -404,11 +404,13 @@ def handle(config: RelayConfig, body: dict, verified_repo: str) -> dict:
 
     # L3+: cache the job and create its upstream check run. Runs after state
     # validation (above) but before HUD forwarding, so a HUD error cannot block
-    # the PR check. Without a head_sha there is neither a check run to create nor
-    # a cache entry the label handler could ever look up.
+    # the PR check. Both the cache entry and the check run always belong to a
+    # specific PR -- get_dispatch_jobs is only ever looked up by a PR's head
+    # SHA (see event_handler._handle_pr_labeled) -- so without a pr_number,
+    #  there is nothing to cache and no check run to create.
     if repo_level.value >= AllowlistLevel.L3.value:
         pr_number, head_sha = extract_pr_context(body)
-        if head_sha:
+        if head_sha and pr_number:
             conclusion = (body.get("workflow") or {}).get("conclusion")
             details_url = f"https://github.com/{verified_repo}/actions/runs/{run_id}"
 
@@ -426,15 +428,8 @@ def handle(config: RelayConfig, body: dict, verified_repo: str) -> dict:
                 job_name=job_name,
             )
 
-            # A check run always mirrors a specific PR's status, so without a
-            # pr_number (e.g. a push straight to main -- the merge landing
-            # itself, not a ciflow/trunk/<pr> tag) there is no PR to attach
-            # one to, regardless of what needs_check_run/is_check_run_wanted
-            # would otherwise say.
-            needs_cr = bool(pr_number) and allowlist.needs_check_run(
-                verified_repo, extract_pr_labels(body)
-            )
-            if not needs_cr and pr_number and repo_level == AllowlistLevel.L3:
+            needs_cr = allowlist.needs_check_run(verified_repo, extract_pr_labels(body))
+            if not needs_cr and repo_level == AllowlistLevel.L3:
                 # The downstream's echoed payload labels may not reflect the PR's
                 # current state (e.g. on reopen). Fall back to the per-commit flag
                 # recorded at dispatch / label time for this (head_sha, repo).

--- a/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
@@ -14,6 +14,7 @@ from utils.misc import (
     CallbackStateRecord,
     DISPATCH_RUN_ATTEMPT,
     DISPATCH_RUN_ID,
+    extract_pr_context,
     extract_pr_labels,
     HTTPException,
 )
@@ -406,9 +407,7 @@ def handle(config: RelayConfig, body: dict, verified_repo: str) -> dict:
     # the PR check. Without a head_sha there is neither a check run to create nor
     # a cache entry the label handler could ever look up.
     if repo_level.value >= AllowlistLevel.L3.value:
-        pr_field = (body.get("payload") or {}).get("pull_request") or {}
-        head_sha = (pr_field.get("head") or {}).get("sha", "")
-        pr_number = str(pr_field.get("number") or "")
+        pr_number, head_sha = extract_pr_context(body)
         if head_sha:
             conclusion = (body.get("workflow") or {}).get("conclusion")
             details_url = f"https://github.com/{verified_repo}/actions/runs/{run_id}"
@@ -427,8 +426,15 @@ def handle(config: RelayConfig, body: dict, verified_repo: str) -> dict:
                 job_name=job_name,
             )
 
-            needs_cr = allowlist.needs_check_run(verified_repo, extract_pr_labels(body))
-            if not needs_cr and repo_level == AllowlistLevel.L3:
+            # A check run always mirrors a specific PR's status, so without a
+            # pr_number (e.g. a push straight to main -- the merge landing
+            # itself, not a ciflow/trunk/<pr> tag) there is no PR to attach
+            # one to, regardless of what needs_check_run/is_check_run_wanted
+            # would otherwise say.
+            needs_cr = bool(pr_number) and allowlist.needs_check_run(
+                verified_repo, extract_pr_labels(body)
+            )
+            if not needs_cr and pr_number and repo_level == AllowlistLevel.L3:
                 # The downstream's echoed payload labels may not reflect the PR's
                 # current state (e.g. on reopen). Fall back to the per-commit flag
                 # recorded at dispatch / label time for this (head_sha, repo).

--- a/aws/lambda/cross_repo_ci_relay/callback/cleanup_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/cleanup_handler.py
@@ -17,7 +17,7 @@ from utils import gh_helper
 from utils.allowlist import AllowlistLevel, AllowlistMap, load_allowlist
 from utils.config import RelayConfig
 from utils.hud import forward_to_hud
-from utils.misc import CallbackState, extract_pr_labels
+from utils.misc import CallbackState, extract_pr_context, extract_pr_labels
 
 
 logger = logging.getLogger(__name__)
@@ -81,10 +81,11 @@ def _finalize_timed_out_check_run(
     if level is None or level.value < AllowlistLevel.L3.value:
         return
 
-    pr_field = (body.get("payload") or {}).get("pull_request") or {}
-    head_sha = (pr_field.get("head") or {}).get("sha", "")
-    pr_number = str(pr_field.get("number") or "")
-    if not head_sha:
+    # A check run always mirrors a specific PR, so a zombie with no
+    # resolvable pr_number (e.g. it was dispatched by a plain push to main,
+    # not a ciflow/trunk/<pr> tag) has no check run to finalize.
+    pr_number, head_sha = extract_pr_context(body)
+    if not head_sha or not pr_number:
         return
 
     # Only finalize repos that actually had a check run at in_progress time —

--- a/aws/lambda/cross_repo_ci_relay/tests/test_callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_callback_handler.py
@@ -55,6 +55,27 @@ def _body(
     }
 
 
+def _push_body(status="in_progress", ref="refs/tags/ciflow/trunk/42", after="abc123"):
+    return {
+        "event_type": "push",
+        "delivery_id": "del-123",
+        "payload": {
+            "ref": ref,
+            "after": after,
+            "repository": {"full_name": "pytorch/pytorch"},
+        },
+        "workflow": {
+            "status": status,
+            "conclusion": "success" if status == "completed" else None,
+            "name": "CI",
+            "url": "http://ci.example.com/run/1",
+            "workflow_name": "default",
+            "run_id": 99999,
+            "run_attempt": 1,
+        },
+    }
+
+
 class TestCallbackHandler(unittest.TestCase):
     def setUp(self):
         self.patcher_allowlist = patch("callback.callback_handler.load_allowlist")
@@ -461,6 +482,30 @@ class TestCallbackCheckRunUpdate(unittest.TestCase):
         kw = self.mock_gh.create_check_run.call_args[1]
         self.assertEqual(kw["head_sha"], "abc123")
         self.assertEqual(kw["status"], "in_progress")
+
+    def test_push_ciflow_trunk_l4_creates_check_run(self):
+        """The headline bug: a push-triggered L4 run must still get an
+        upstream check run, resolving head_sha/pr_number from the ref."""
+        self.mock_gh.create_check_run.return_value = 999
+
+        handle(_cfg(), _push_body(), verified_repo="org/repo")
+
+        self.mock_gh.create_check_run.assert_called_once()
+        kw = self.mock_gh.create_check_run.call_args[1]
+        self.assertEqual(kw["head_sha"], "abc123")
+        self.assertEqual(kw["external_id"], "99999:42")  # run_id:pr_number
+
+    def test_push_to_main_skips_check_run_and_cache(self):
+        """A plain push to main (the merge landing itself) has no PR to
+        attach a check run to, and nothing will ever look up a cache entry
+        keyed by a merge commit's SHA, so neither happens."""
+        result = handle(
+            _cfg(), _push_body(ref="refs/heads/main"), verified_repo="org/repo"
+        )
+
+        self.assertEqual(result, {"ok": True, "status": "in_progress"})
+        self.mock_gh.create_check_run.assert_not_called()
+        self.mock_redis.set_dispatch_job.assert_not_called()
 
     def test_reopen_in_progress_creates_new_check_run(self):
         """Reopen scenario: prior completed CR exists; in_progress always creates a new one."""

--- a/aws/lambda/cross_repo_ci_relay/tests/test_cleanup_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_cleanup_handler.py
@@ -309,6 +309,42 @@ class TestCleanupCheckRunFinalize(unittest.TestCase):
         self.assertEqual(kw["conclusion"], "timed_out")
         self.assertEqual(kw["head_sha"], "abc123")
 
+    def test_push_ciflow_trunk_l4_zombie_finalizes_check_run(self):
+        """A push-triggered (ciflow/trunk/<pr> tag) zombie resolves head_sha
+        from the ref instead of the pull_request shape."""
+        zombie = self._level_zombie("L4")
+        body = zombie["state_record"].payload["untrusted"]["callback_payload"]
+        body["event_type"] = "push"
+        body["payload"] = {
+            "ref": "refs/tags/ciflow/trunk/42",
+            "after": "def456",
+            "repository": {"full_name": "pytorch/pytorch"},
+        }
+        self.mock_redis.scan_expired_in_progress.return_value = [zombie]
+
+        handle(_cfg())
+
+        self.mock_gh.create_check_run.assert_called_once()
+        kw = self.mock_gh.create_check_run.call_args[1]
+        self.assertEqual(kw["head_sha"], "def456")
+
+    def test_push_to_main_zombie_does_not_finalize_check_run(self):
+        """A zombie from a plain push to main has no PR to attach a check
+        run to, so none is finalized."""
+        zombie = self._level_zombie("L4")
+        body = zombie["state_record"].payload["untrusted"]["callback_payload"]
+        body["event_type"] = "push"
+        body["payload"] = {
+            "ref": "refs/heads/main",
+            "after": "def456",
+            "repository": {"full_name": "pytorch/pytorch"},
+        }
+        self.mock_redis.scan_expired_in_progress.return_value = [zombie]
+
+        handle(_cfg())
+
+        self.mock_gh.create_check_run.assert_not_called()
+
     def test_l2_zombie_does_not_finalize_check_run(self):
         # Default zombie is L2 → the stored-level pre-check short-circuits, no
         # upstream check run and no per-repo allowlist lookup.

--- a/aws/lambda/cross_repo_ci_relay/tests/test_event_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_event_handler.py
@@ -37,6 +37,15 @@ def _payload_with_labels(action="synchronize", labels=None):
     return payload
 
 
+def _push_payload(ref="refs/tags/ciflow/trunk/42", after="def456"):
+    return {
+        "ref": ref,
+        "after": after,
+        "repository": {"full_name": "pytorch/pytorch"},
+        "installation": {"id": 99},
+    }
+
+
 class TestEventHandler(unittest.TestCase):
     def test_ignored_action(self):
         self.assertEqual(
@@ -128,6 +137,26 @@ class TestDispatchCheckRunCreation(unittest.TestCase):
         handle(_cfg(), _payload(), "pull_request", "del-2")
 
         mock_create_cr.assert_not_called()
+
+    @patch("webhook.event_handler.redis_helper.mark_check_run_wanted")
+    @patch("webhook.event_handler.redis_helper.set_callback_state")
+    @patch("webhook.event_handler.gh_helper.create_repository_dispatch")
+    @patch("webhook.event_handler.gh_helper.get_repo_access_token", return_value="tok")
+    @patch("webhook.event_handler.load_allowlist")
+    def test_push_ciflow_trunk_marks_check_run_wanted(
+        self, mock_load, _tok, _dispatch, _state, mock_mark_wanted
+    ):
+        """A ciflow/trunk/<pr> push resolves head_sha from payload.after via
+        extract_pr_context, so the check-run-wanted marker still gets set."""
+        mock_map = MagicMock()
+        mock_map.get_repos_at_or_above_level.return_value = (["org/repo"], [])
+        mock_load.return_value = mock_map
+
+        handle(_cfg(), _push_payload(), "push", "del-3")
+
+        mock_mark_wanted.assert_called_once_with(
+            unittest.mock.ANY, "def456", "org/repo"
+        )
 
 
 class TestPrLabeledHandler(unittest.TestCase):

--- a/aws/lambda/cross_repo_ci_relay/tests/test_misc.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_misc.py
@@ -1,0 +1,21 @@
+import unittest
+
+from utils.misc import extract_pr_context
+
+
+class TestExtractPrContext(unittest.TestCase):
+    def test_pull_request_event(self):
+        envelope = {
+            "payload": {"pull_request": {"number": 42, "head": {"sha": "abc123"}}}
+        }
+        self.assertEqual(extract_pr_context(envelope), ("42", "abc123"))
+
+    def test_push_ciflow_trunk_ref(self):
+        envelope = {
+            "payload": {"ref": "refs/tags/ciflow/trunk/12345", "after": "def456"}
+        }
+        self.assertEqual(extract_pr_context(envelope), ("12345", "def456"))
+
+    def test_push_non_ciflow_ref(self):
+        envelope = {"payload": {"ref": "refs/heads/main", "after": "def456"}}
+        self.assertEqual(extract_pr_context(envelope), ("", "def456"))

--- a/aws/lambda/cross_repo_ci_relay/tests/test_misc.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_misc.py
@@ -19,3 +19,16 @@ class TestExtractPrContext(unittest.TestCase):
     def test_push_non_ciflow_ref(self):
         envelope = {"payload": {"ref": "refs/heads/main", "after": "def456"}}
         self.assertEqual(extract_pr_context(envelope), ("", "def456"))
+
+    def test_push_deleted_ciflow_trunk_ref_ignored(self):
+        """Deleting the ciflow/trunk/<pr> tag (e.g. label removed, PR closed)
+        reports the null SHA with the ref unchanged -- must not be treated
+        as a real (pr_number, head_sha), or GitHub 422s on the fake SHA."""
+        envelope = {
+            "payload": {
+                "ref": "refs/tags/ciflow/trunk/42",
+                "after": "0" * 40,
+                "deleted": True,
+            }
+        }
+        self.assertEqual(extract_pr_context(envelope), ("", ""))

--- a/aws/lambda/cross_repo_ci_relay/utils/misc.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/misc.py
@@ -64,12 +64,15 @@ def extract_pr_labels(envelope: dict) -> set[str]:
     Both the webhook dispatch ``client_payload`` and the downstream callback
     ``body`` carry the original webhook under ``payload.pull_request``, so the
     labels live at ``payload.pull_request.labels`` in either case.
+
+    Always empty for a ``push`` event (no ``pull_request`` key).
     """
     pull_request = (envelope.get("payload") or {}).get("pull_request") or {}
     return {lbl.get("name", "") for lbl in (pull_request.get("labels") or [])}
 
 
 _CIFLOW_TRUNK_REF_RE = re.compile(r"/ciflow/trunk/(\d+)$")
+_NULL_SHA = "0" * 40
 
 
 def extract_pr_context(envelope: dict) -> tuple[str, str]:
@@ -78,10 +81,17 @@ def extract_pr_context(envelope: dict) -> tuple[str, str]:
     Prefers the ``pull_request`` event shape. Falls back to a ``push`` event:
     PR number is recovered only from a ``ciflow/trunk/<pr_number>`` ref (the
     tag ``@pytorchbot merge`` pushes to trigger trunk validation before
-    landing), head_sha from ``payload.after``. Any other push ref (e.g. a
-    landed merge on main, or a different ciflow/<label> tag) has no PR to
-    attach to, so this returns ``("", head_sha)`` for it, which callers
-    already treat as "no upstream check run" correctly.
+    landing) -- other ``ciflow/<label>`` tags are equally PR-scoped but are
+    deliberately left unhandled here since trunk validation is the only one
+    this relay currently needs to recognize. head_sha comes from
+    ``payload.after``. Any other push ref (e.g. a landed merge on main) has
+    no PR to attach to, so this returns ``("", head_sha)`` for it, which
+    callers already treat as "no upstream check run" correctly.
+
+    A ref *deletion* push (``deleted: true``) reports ``after`` as the null
+    SHA with the ref left pointing at whatever was just deleted, so it's special-
+    cased to ("", "") rather than returning a pr_number paired with a SHA
+    that doesn't exist (GitHub's create-check-run API 422s on it).
     """
     payload = envelope.get("payload") or {}
     pull_request = payload.get("pull_request") or {}
@@ -91,6 +101,8 @@ def extract_pr_context(envelope: dict) -> tuple[str, str]:
         return pr_number, head_sha
 
     head_sha = payload.get("after", "")
+    if payload.get("deleted") or head_sha == _NULL_SHA:
+        return "", ""
     match = _CIFLOW_TRUNK_REF_RE.search(payload.get("ref", ""))
     pr_number = match.group(1) if match else ""
     return pr_number, head_sha

--- a/aws/lambda/cross_repo_ci_relay/utils/misc.py
+++ b/aws/lambda/cross_repo_ci_relay/utils/misc.py
@@ -7,6 +7,7 @@ and there's no shared abstraction to organise them under.
 from __future__ import annotations
 
 import base64
+import re
 from dataclasses import dataclass
 from enum import Enum
 from typing import TypedDict
@@ -66,6 +67,33 @@ def extract_pr_labels(envelope: dict) -> set[str]:
     """
     pull_request = (envelope.get("payload") or {}).get("pull_request") or {}
     return {lbl.get("name", "") for lbl in (pull_request.get("labels") or [])}
+
+
+_CIFLOW_TRUNK_REF_RE = re.compile(r"/ciflow/trunk/(\d+)$")
+
+
+def extract_pr_context(envelope: dict) -> tuple[str, str]:
+    """Return (pr_number, head_sha) from a dispatch/callback envelope.
+
+    Prefers the ``pull_request`` event shape. Falls back to a ``push`` event:
+    PR number is recovered only from a ``ciflow/trunk/<pr_number>`` ref (the
+    tag ``@pytorchbot merge`` pushes to trigger trunk validation before
+    landing), head_sha from ``payload.after``. Any other push ref (e.g. a
+    landed merge on main, or a different ciflow/<label> tag) has no PR to
+    attach to, so this returns ``("", head_sha)`` for it, which callers
+    already treat as "no upstream check run" correctly.
+    """
+    payload = envelope.get("payload") or {}
+    pull_request = payload.get("pull_request") or {}
+    pr_number = str(pull_request.get("number") or "")
+    head_sha = (pull_request.get("head") or {}).get("sha", "")
+    if pr_number and head_sha:
+        return pr_number, head_sha
+
+    head_sha = payload.get("after", "")
+    match = _CIFLOW_TRUNK_REF_RE.search(payload.get("ref", ""))
+    pr_number = match.group(1) if match else ""
+    return pr_number, head_sha
 
 
 def parse_lambda_event(event: dict) -> tuple[str, str, bytes, dict]:

--- a/aws/lambda/cross_repo_ci_relay/webhook/event_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/webhook/event_handler.py
@@ -13,6 +13,7 @@ from utils.misc import (
     DISPATCH_RUN_ATTEMPT,
     DISPATCH_RUN_ID,
     EventDispatchPayload,
+    extract_pr_context,
     extract_pr_labels,
     HTTPException,
 )
@@ -63,12 +64,8 @@ def _dispatch_one(
         # flag so the callback creates it even when the downstream echoes back a
         # dispatch payload whose labels don't reflect the PR's current state
         # (e.g. on reopen, where no new `labeled` event fires to set this flag).
-        head_sha = (
-            ((client_payload.get("payload") or {}).get("pull_request") or {})
-            .get("head", {})
-            .get("sha", "")
-        )
-        if head_sha:
+        pr_number, head_sha = extract_pr_context(client_payload)
+        if head_sha and pr_number:
             redis_helper.mark_check_run_wanted(config, head_sha, downstream_repo)
 
 


### PR DESCRIPTION
Fixes the headline bug in #8619: push-triggered **L4** runs (unconditional check-run demand) get no upstream check run. `extract_pr_context()` resolves `pr_number`/`head_sha` from a `ciflow/trunk/<pr>` push ref, and `cleanup_handler.py`'s zombie-timeout finalizer gets the same fix.

Partially addresses the L3 case: `extract_pr_labels` is still always empty for push (no `pull_request` payload to read labels from), so L3's label-gated check-run demand still relies on a prior `pull_request.labeled` event having set the per-commit `is_check_run_wanted` Redis flag for that head_sha — a push report alone can't satisfy it. Tracked as a follow-up rather than solved here.

Also guards against ref-deletion pushes (`deleted: true`, null SHA) being misread as a valid `(pr_number, head_sha)` pair.
