### PR TITLE
Drop the numpy cp315 preview-wheel injection

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -200,19 +200,7 @@ run_smoke_tests() {
 
     # For pip install also test with latest numpy
     if [[ ${MATRIX_PACKAGE_TYPE} == 'wheel' ]]; then
-        # PyPI publishes no cp315/cp315t numpy wheels, so a plain
-        # `pip install numpy` falls back to building from source: slow on Linux
-        # and macOS, and a hard failure on Windows, where MSVC cannot find
-        # stdalign.h ("fatal error C1083") while compiling numpy's SIMD headers.
-        # Preview wheels for every platform, Windows included, are on the
-        # nightly index -- take those instead, and never a source build.
-        if [[ ${MATRIX_PYTHON_VERSION} == "3.15" || ${MATRIX_PYTHON_VERSION} == "3.15t" ]]; then
-            pip3 install --pre numpy --upgrade --force-reinstall \
-                --only-binary=:all: \
-                --index-url https://download.pytorch.org/whl/nightly
-        else
-            pip3 install numpy --upgrade --force-reinstall
-        fi
+        pip3 install numpy --upgrade --force-reinstall
         ${PYTHON_RUN} ./smoke_test/smoke_test.py ${test_suffix} ${compile_check}
     fi
 

--- a/s3_management/update_dependencies.py
+++ b/s3_management/update_dependencies.py
@@ -885,28 +885,6 @@ PACKAGES_PER_PROJECT: Dict[str, List[Dict[str, str]]] = {
     "pycparser": [{"project": "vllm"}],
 }
 
-# Preview CPython ABI tags whose wheels are not yet published on PyPI. e.g.
-# numpy has no cp315 wheel on PyPI, so pip on Python 3.15 would fall back to a
-# source build and fail. The scientific-python nightly wheelhouse does publish
-# them, so we merge those links into our (otherwise PyPI-mirrored) numpy index.
-PREVIEW_PYTHON_TAGS = ("cp315",)
-
-# Restrict the preview-wheel injection to numpy on the nightly and test channels
-# only. Nothing else is touched.
-PREVIEW_WHEEL_INJECT_PACKAGES = {"numpy"}
-PREVIEW_WHEEL_INJECT_PREFIXES = {"whl/nightly", "whl/test"}
-
-# Upstream source of preview numpy wheels (scientific-python nightly wheelhouse).
-PREVIEW_NUMPY_INDEX_URL = (
-    "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/numpy/"
-)
-# Host used to absolutize the relative hrefs served by that index.
-PREVIEW_NUMPY_INDEX_BASE = "https://pypi.anaconda.org"
-# Only merge wheels from this numpy release line. Matches the final release and
-# its pre-releases (e.g. 2.6.0, 2.6.0.dev0, 2.6.0rc1) but not other lines such
-# as 2.7.0.dev0.
-PREVIEW_NUMPY_VERSION = "2.6.0"
-
 
 # NVIDIA packages that are published to PyPI rather than pypi.nvidia.com. The
 # nvidia-/cuda- prefix heuristic would send these to a 404 and silently freeze
@@ -1101,79 +1079,6 @@ def normalize_pkg_name(name: str) -> str:
     return re.sub(r"[-_.]+", "_", name).lower()
 
 
-def fetch_preview_numpy_anchors() -> List[tuple[str, str]]:
-    """Fetch preview-CPython numpy wheel links from the upstream nightly index.
-
-    PyPI does not publish cp315 numpy wheels, but the scientific-python nightly
-    wheelhouse does. Returns ``(filename, anchor_html)`` pairs for each wheel
-    whose ABI tag is in :data:`PREVIEW_PYTHON_TAGS`, with the href absolutized
-    so it stays valid when the index is copied into subdirectories. Returns an
-    empty list if the index cannot be fetched or has no preview wheels.
-    """
-    try:
-        html = download(PREVIEW_NUMPY_INDEX_URL).decode("utf-8", errors="ignore")
-    except Exception as e:
-        print(f"WARNING: could not fetch {PREVIEW_NUMPY_INDEX_URL}: {e}")
-        return []
-
-    # numpy-<version>-<pytag>-<abitag>-<plat>.whl -> version is the 2nd field.
-    version_re = re.compile(rf"^{re.escape(PREVIEW_NUMPY_VERSION)}(\D|$)")
-
-    anchors: List[tuple[str, str]] = []
-    for href, name in re.findall(r'<a href="([^"]+)"[^>]*>([^<]+)</a>', html):
-        filename = name.strip()
-        if not filename.endswith(".whl"):
-            continue
-        if not any(f"-{tag}-" in filename for tag in PREVIEW_PYTHON_TAGS):
-            continue
-        parts = filename.split("-")
-        if len(parts) < 2 or not version_re.match(parts[1]):
-            continue
-        # Absolutize the href against the upstream host.
-        if href.startswith("//"):
-            url = f"https:{href}"
-        elif href.startswith(("http://", "https://")):
-            url = href
-        else:
-            url = f"{PREVIEW_NUMPY_INDEX_BASE}/{href.lstrip('/')}"
-        anchors.append((filename, f'    <a href="{url}">{filename}</a><br/>'))
-    return anchors
-
-
-def append_preview_numpy_wheels(html: str, pkg_name: str, prefix: str) -> str:
-    """Merge upstream preview-CPython numpy wheel links into *html*.
-
-    The PyPI simple index does not list preview-CPython (e.g. cp315) wheels, so
-    we merge the links published on the scientific-python nightly wheelhouse for
-    any that are not already present.
-
-    Limited to numpy on the nightly and test channels; a no-op otherwise.
-    """
-    if (
-        normalize_pkg_name(pkg_name) not in PREVIEW_WHEEL_INJECT_PACKAGES
-        or prefix not in PREVIEW_WHEEL_INJECT_PREFIXES
-    ):
-        return html
-
-    additions = [
-        anchor
-        for filename, anchor in fetch_preview_numpy_anchors()
-        if filename not in html
-    ]
-
-    if not additions:
-        return html
-
-    print(
-        f"INFO: Merging {len(additions)} preview numpy wheel link(s) "
-        f"for {pkg_name} under {prefix}"
-    )
-    block = "\n".join(additions)
-    if "</body>" in html:
-        return html.replace("</body>", f"{block}\n  </body>", 1)
-    return f"{html}\n{block}\n"
-
-
 def append_retained_wheels(html: str, pkg_name: str, prefix: str) -> str:
     """Merge :data:`RETAINED_WHEELS` links for *pkg_name* into *html*.
 
@@ -1244,10 +1149,6 @@ def upload_package_using_simple_index(
     except Exception as e:
         print(f"Error fetching package {pkg_name}: {e}")
         return
-
-    # PyPI does not host preview-CPython (e.g. cp315) wheels; merge in the links
-    # published on the scientific-python nightly wheelhouse so pip can resolve them.
-    raw_html = append_preview_numpy_wheels(raw_html, pkg_name, prefix)
 
     # Upload modified index.html with absolute links
     upload_index_html(pkg_name, prefix, raw_html, source_url, dry_run=dry_run)


### PR DESCRIPTION
numpy **2.5.2** publishes cp315 and cp315t wheels on PyPI, so the workarounds built for their absence are no longer needed. Removes both halves.

## Why it is safe now

2.5.1 shipped **zero** cp315 wheels; 2.5.2 ships 22, covering every platform we validate:

| platform | cp315 | cp315t |
|---|---|---|
| `manylinux_2_28_x86_64` / `_aarch64` | yes | yes |
| macOS (x86_64 + arm64) | yes | yes |
| `win_amd64` / `win_arm64` | yes | yes |
| musllinux | yes | yes |

Windows was the case that motivated the special-casing (MSVC failing on `stdalign.h` during a source build), and it now has both wheels.

Paired with pytorch/pytorch#194741, which moves the 3.15 build pin from 2.5.1 to 2.5.2.

## 1. `s3_management/update_dependencies.py`

Removes the preview-wheel merge: `PREVIEW_PYTHON_TAGS`, `PREVIEW_WHEEL_INJECT_PACKAGES`, `PREVIEW_WHEEL_INJECT_PREFIXES`, `PREVIEW_NUMPY_INDEX_URL`, `PREVIEW_NUMPY_INDEX_BASE`, `PREVIEW_NUMPY_VERSION`, the two functions `fetch_preview_numpy_anchors()` / `append_preview_numpy_wheels()`, and the call site in the index-processing path.

The nightly and test numpy indexes now serve exactly what PyPI publishes, with no links merged in from the scientific-python nightly wheelhouse.

`normalize_pkg_name()` is **kept** — it is also used by `append_retained_wheels()` for `RETAINED_WHEELS`.

## 2. `.github/scripts/validate_binaries.sh`

```diff
-        if [[ ${MATRIX_PYTHON_VERSION} == "3.15" || ${MATRIX_PYTHON_VERSION} == "3.15t" ]]; then
-            pip3 install --pre numpy --upgrade --force-reinstall \
-                --only-binary=:all: \
-                --index-url https://download.pytorch.org/whl/nightly
-        else
-            pip3 install numpy --upgrade --force-reinstall
-        fi
+        pip3 install numpy --upgrade --force-reinstall
```

This is the more valuable half: 3.15 validation was resolving numpy from download.pytorch.org, so it was not exercising what a user gets from PyPI. Now every Python version takes the same path.

## Verification

- No dangling `PREVIEW_*` references (AST check: no such names remain).
- `normalize_pkg_name` and `append_retained_wheels` still defined; both preview functions gone.
- `py_compile` clean; `pyfmt_linter.py` clean under the repo-pinned toolchain (usort 1.0.8.post1 / isort 6.0.1 / ruff 0.14.4).
- `bash -n` clean on the validation script.

## Note on ordering

The injection targeted the **2.6.0** line (`PREVIEW_NUMPY_VERSION = "2.6.0"`), i.e. pre-release wheels ahead of PyPI. Nothing pins numpy 2.6.0.dev*, so dropping it should not change any resolution; 3.15 builds and validation will land on 2.5.2 from PyPI. If a future CPython again lands before numpy ships wheels, this mechanism is worth restoring — it was generic apart from the hard-coded version.