### PR TITLE
Create a materialized view for tests.all_test_runs

### DIFF
--- a/aws/lambda/clickhouse-replicator-s3/Makefile
+++ b/aws/lambda/clickhouse-replicator-s3/Makefile
@@ -5,7 +5,21 @@ prepare: clean
 	zip -g clickhouse-replicator-s3-deployment.zip lambda_function.py
 
 deploy: prepare
-	aws lambda update-function-code --function-name clickhouse-replicator-s3 --zip-file fileb://clickhouse-replicator-s3-deployment.zip
+	@set -eu; \
+	expected_code_sha="$$(aws lambda update-function-code \
+		--function-name clickhouse-replicator-s3 \
+		--zip-file fileb://clickhouse-replicator-s3-deployment.zip \
+		--query CodeSha256 --output text --no-cli-pager)"; \
+	aws lambda wait function-updated-v2 \
+		--function-name clickhouse-replicator-s3; \
+	deployed_code_sha="$$(aws lambda get-function-configuration \
+		--function-name clickhouse-replicator-s3 \
+		--query CodeSha256 --output text --no-cli-pager)"; \
+	if [ "$$expected_code_sha" != "$$deployed_code_sha" ]; then \
+		echo "deployed Lambda code hash does not match the requested update" >&2; \
+		exit 1; \
+	fi; \
+	echo "Lambda update completed: $$deployed_code_sha"
 
 clean:
 	rm -rf clickhouse-replicator-s3-deployment.zip packages

--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -103,8 +103,10 @@ def handle_test_run_s3_small(table, bucket, key) -> List[Dict[str, Any]]:
 
     # Cannot use general_adapter due to custom field for now()::DateTime64(9)
     # time_inserted
+    # This feed has a best-effort materialized view. A failure while writing to
+    # that view must not fail the primary all_test_runs insert.
     query = f"""
-    insert into {table}
+    insert into {table} settings materialized_views_ignore_errors=1
     select
         classname,
         duration,

--- a/clickhouse_db_schema/tests.all_test_runs_by_name/README.md
+++ b/clickhouse_db_schema/tests.all_test_runs_by_name/README.md
@@ -1,0 +1,62 @@
+# `tests.all_test_runs_by_name`
+
+A compact, test-identity-sorted copy of `tests.all_test_runs`, maintained by
+an incremental materialized view (`schema.sql` has the why and the intended
+queries). The table starts empty: parent history is intentionally not
+backfilled, gaps are not monitored, and the first few minutes after creation
+may be incomplete while ClickHouse Cloud propagates the view. The source
+ingester uses `materialized_views_ignore_errors=1`, so failures in this
+best-effort mirror do not reject inserts into `tests.all_test_runs`; those
+failures instead leave gaps in this table.
+
+## Deploy
+
+Requires `clickhouse-client` and admin credentials:
+
+1. Before merging, run as the Lambda's ClickHouse user (not an admin — the
+   constraint being tested is per-user):
+
+   ```sql
+   SELECT 1 SETTINGS materialized_views_ignore_errors=1
+   ```
+
+   The merged Lambda attaches this setting to every `tests.all_test_runs`
+   insert immediately — before the view exists — so a settings-profile
+   constraint that rejects it would break all test ingest at Lambda deploy
+   time, not at MV creation time. If the query is rejected, lift the
+   constraint before merging.
+2. Merge the change and wait for the
+   [`clickhouse-replicator-s3` deployment workflow](../../.github/workflows/clickhouse-replicator-s3-lambda.yml)
+   to finish successfully. The workflow waits for AWS to finish the update and
+   verifies the deployed code hash. The deployed Lambda must include
+   `materialized_views_ignore_errors=1` on the `tests.all_test_runs` insert.
+3. Wait at least 15 minutes after the workflow succeeds. This is Lambda's
+   maximum execution duration and ensures invocations that started with the
+   previous code have drained before the materialized view is created. Use
+   the wait to confirm ingest survived the setting change:
+   `tests.all_test_runs` still receives rows and `errors.gen_errors` gets no
+   new `tests.all_test_runs` entries.
+4. Deploy the ClickHouse objects, explicitly confirming both prerequisites:
+
+```sh
+export CLICKHOUSE_ENDPOINT=<ClickHouse Cloud host>
+export CLICKHOUSE_USERNAME=<admin user>
+export CLICKHOUSE_PASSWORD=<password> # optional when client config supplies it
+
+CONFIRM_INGESTER_DEPLOYED_AND_DRAINED=1 ./deploy.sh
+```
+
+The script is non-destructive: it never drops, replaces, truncates, or
+backfills anything. Re-running with both objects present validates them; on a
+partial installation it stops for manual inspection.
+
+## Removal (and partial-install cleanup)
+
+Once no consumer needs the table, drop the MV first so parent inserts stop
+targeting it, then the table. The Lambda safeguard may be reverted only after
+the `DROP VIEW` succeeds:
+
+```sql
+DROP VIEW tests.all_test_runs_by_name_mv;
+DROP TABLE tests.all_test_runs_by_name;
+```

--- a/clickhouse_db_schema/tests.all_test_runs_by_name/deploy.sh
+++ b/clickhouse_db_schema/tests.all_test_runs_by_name/deploy.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Create the future-only tests.all_test_runs_by_name pipeline.
+# This script never drops, replaces, truncates, or backfills either table.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+: "${CLICKHOUSE_ENDPOINT:?set CLICKHOUSE_ENDPOINT}"
+: "${CLICKHOUSE_USERNAME:?set CLICKHOUSE_USERNAME}"
+
+if [[ "${CONFIRM_INGESTER_DEPLOYED_AND_DRAINED:-}" != "1" ]]; then
+  cat >&2 <<'EOF'
+Refusing to create or validate the materialized view until the protected
+clickhouse-replicator-s3 Lambda is deployed and old invocations have drained.
+Follow the rollout procedure in README.md, then set:
+  CONFIRM_INGESTER_DEPLOYED_AND_DRAINED=1
+EOF
+  exit 1
+fi
+
+ch() {
+  local sql="$1"
+  local -a args=(
+    --host "$CLICKHOUSE_ENDPOINT"
+    --port "${CLICKHOUSE_PORT:-9440}"
+    --secure
+    --user "$CLICKHOUSE_USERNAME"
+  )
+  if [[ -n "${CLICKHOUSE_PASSWORD:-}" ]]; then
+    args+=(--password "$CLICKHOUSE_PASSWORD")
+  fi
+  clickhouse-client "${args[@]}" --query "$sql"
+}
+
+render_schema_part() {
+  local part="$1" sql
+  case "$part" in
+    table)
+      sql=$(awk '/^CREATE MATERIALIZED VIEW/{exit} {print}' schema.sql)
+      ;;
+    mv)
+      sql=$(awk '/^CREATE MATERIALIZED VIEW/{found=1} found {print}' schema.sql)
+      ;;
+    *)
+      echo "unknown schema part: $part" >&2
+      return 1
+      ;;
+  esac
+  printf '%s\n' "$sql"
+}
+
+validate_existing_mv() {
+  local target source
+  IFS=$'\t' read -r target source < <(
+    ch "SELECT
+          extract(replaceAll(create_table_query, '\`', ''),
+                  'TO[[:space:]]+([^[:space:]]+)'),
+          extract(replaceAll(as_select, '\`', ''),
+                  'FROM[[:space:]]+([^[:space:];]+)')
+        FROM system.tables
+        WHERE database = 'tests'
+          AND name = 'all_test_runs_by_name_mv'
+        FORMAT TSV"
+  ) || true
+
+  if [[ "$target" != "tests.all_test_runs_by_name" ||
+        "$source" != "tests.all_test_runs" ]]; then
+    echo "existing tests.all_test_runs_by_name_mv has an unexpected target or source" >&2
+    exit 1
+  fi
+}
+
+IFS=$'\t' read -r table_exists mv_exists < <(
+  ch "SELECT
+        countIf(name = 'all_test_runs_by_name'),
+        countIf(name = 'all_test_runs_by_name_mv')
+      FROM system.tables
+      WHERE database = 'tests'
+        AND name IN ('all_test_runs_by_name', 'all_test_runs_by_name_mv')
+      FORMAT TSV"
+)
+
+case "${table_exists}:${mv_exists}" in
+  0:0)
+    echo "== creating tests.all_test_runs_by_name"
+    ch "$(render_schema_part table)"
+    echo "== creating tests.all_test_runs_by_name_mv"
+    ch "$(render_schema_part mv)"
+    echo "Installed. Existing parent rows were not copied."
+    ;;
+  1:1)
+    echo "== table and MV already exist; leaving both unchanged"
+    validate_existing_mv
+    echo "Already installed."
+    ;;
+  *)
+    cat >&2 <<EOF
+Refusing to continue from a partial installation:
+  tests.all_test_runs_by_name exists:    ${table_exists}
+  tests.all_test_runs_by_name_mv exists: ${mv_exists}
+
+Inspect the existing object before either completing it manually or removing
+the partial installation in the order documented in README.md. This script
+never drops or replaces ClickHouse objects.
+EOF
+    exit 1
+    ;;
+esac

--- a/clickhouse_db_schema/tests.all_test_runs_by_name/schema.sql
+++ b/clickhouse_db_schema/tests.all_test_runs_by_name/schema.sql
@@ -1,0 +1,85 @@
+-- tests.all_test_runs_by_name: a lean, re-sorted copy of tests.all_test_runs
+-- keyed by test identity, so "history of one test" queries are fast.
+--
+-- The parent is ORDER BY (job_id, ...), which suits per-job queries but
+-- scatters one test's timeline, so a lookup like this takes minutes there
+-- and milliseconds here:
+--
+--   SELECT * FROM tests.all_test_runs_by_name
+--   WHERE file = '...' AND classname = '...' AND name = '...'
+--     AND time_inserted > now() - INTERVAL 30 DAY
+--
+-- The two heavy columns are excluded: skipped message bodies and meta. To get
+-- them, join back to the parent on job_id (its leading sort key), file,
+-- classname, name, invoking_file, and time_inserted. This key isn't strictly
+-- unique (the parent has rare duplicate rows), so use ANY LEFT JOIN or
+-- LIMIT 1 BY to avoid fan-out. failure/error/rerun bodies are rare, hence
+-- cheap, and are kept.
+--
+-- Incremental MV: fires on every insert into the append-only parent; existing
+-- parent history is intentionally not copied. To retire the pipeline, DROP
+-- the _mv FIRST, then the table.
+
+CREATE TABLE tests.all_test_runs_by_name
+(
+    `file` LowCardinality(String),
+    `classname` LowCardinality(String),
+    `name` String,
+    `invoking_file` LowCardinality(String),
+    `time_inserted` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    `job_id` Int64 CODEC(Delta(8), ZSTD(1)),
+    `workflow_id` Int64 CODEC(Delta(8), ZSTD(1)),
+    `workflow_run_attempt` Int32,
+    `status` LowCardinality(String),
+    `result` String,
+    `time` Float32,
+    `duration` Float32,
+    `line` Int64 CODEC(T64, ZSTD(1)),
+    `failure_count` UInt32 CODEC(T64, ZSTD(1)),
+    `error_count` UInt32 CODEC(T64, ZSTD(1)),
+    `rerun_count` UInt32 CODEC(T64, ZSTD(1)),
+    `skipped_count` UInt32 CODEC(T64, ZSTD(1)),
+    -- body types must match the parent exactly; the *_count columns above
+    -- stay so aggregations read 4 bytes/row instead of decompressing arrays
+    `failure` Array(Tuple(message String, text String, type String)),
+    `error` Array(Tuple(message String, text String, type String)),
+    `rerun` Array(Tuple(message String, text String)),
+    -- refines time windows inside the month-granular partitions
+    INDEX by_time_inserted time_inserted TYPE minmax GRANULARITY 1,
+    -- serves name-only lookups; name is 3rd in the sort key, off the prefix
+    INDEX by_name name TYPE set(0) GRANULARITY 4
+)
+-- No TTL: this is the compact long-retention history (~0.5-0.8 TiB/year vs
+-- ~3.2 for the parent, estimated 2026-08), and the parent can be TTL'd
+-- independently. Add retention later with MODIFY TTL + ttl_only_drop_parts=1.
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(time_inserted)
+ORDER BY (file, classname, name, time_inserted);
+
+CREATE MATERIALIZED VIEW tests.all_test_runs_by_name_mv
+TO tests.all_test_runs_by_name
+AS
+SELECT
+    file,
+    classname,
+    name,
+    invoking_file,
+    time_inserted,
+    job_id,
+    workflow_id,
+    workflow_run_attempt,
+    status,
+    result,
+    time,
+    duration,
+    line,
+    -- recomputed: the parent's MATERIALIZED *_count columns aren't reliably
+    -- present in the inserted block an MV sees; the arrays are
+    toUInt32(length(failure)) AS failure_count,
+    toUInt32(length(error)) AS error_count,
+    toUInt32(length(rerun)) AS rerun_count,
+    toUInt32(length(skipped)) AS skipped_count,
+    failure,
+    error,
+    rerun
+FROM tests.all_test_runs;


### PR DESCRIPTION
`tests.all_test_runs` stores test results, but its primary sort key begins with `job_id`, making history queries by test identity (file, classname, and name) slow. This PR adds a compact table sorted by test identity and an incremental materialized view that populates it for new inserts. This enables faster analysis of individual tests’ runtime and health.

I am intentionally NOT backfilling the table. The existing table is absolutely massive, so backfilling this will take a long time. Also, we write billions of rows a week, so we can easily get enough data within a day.

To make the deployment easier, I vibe-coded a deploy script.


_Authored with Codex & Claude_