### PR TITLE
Add /api/greenlight/pr_state route for the trymerge greenlight guard

### DIFF
--- a/torchci/pages/api/greenlight/pr_state.ts
+++ b/torchci/pages/api/greenlight/pr_state.ts
@@ -1,0 +1,131 @@
+import { checkAuthWithApiToken } from "lib/auth/auth";
+import { queryClickhouse } from "lib/clickhouse";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const MAX_PR_NUMBERS = 50;
+
+const REPO_RE = /^[A-Za-z0-9._-]{1,100}\/[A-Za-z0-9._-]{1,100}$/;
+
+// Row selection must stay identical to greenlight's own reader
+// (greenlight/src/greenlight/state.py): writer and reader have to agree on which row
+// is authoritative. There is deliberately no head_sha filter — it would collapse "no
+// verdict for this commit" and "verdict for an older commit" into the same empty
+// result, and could resurrect a verdict that a later review superseded.
+const QUERY = `
+SELECT pr_number, status, head_sha, run_id, version
+FROM misc.greenlight_pr_state
+WHERE repo = {repo: String}
+  AND pr_number IN {pr_numbers: Array(Int64)}
+ORDER BY pr_number, run_id DESC, version DESC
+LIMIT 1 BY pr_number
+`;
+
+interface GreenlightPRState {
+  pr_number: number;
+  status: string;
+  head_sha: string;
+  run_id: number;
+  version: string;
+}
+
+function firstParam(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function parsePrNumbers(raw: string): number[] | null {
+  const prNumbers: number[] = [];
+  for (const token of raw.split(",")) {
+    const trimmed = token.trim();
+    if (!/^\d+$/.test(trimmed)) {
+      return null;
+    }
+    const prNumber = Number(trimmed);
+    if (!Number.isSafeInteger(prNumber) || prNumber <= 0) {
+      return null;
+    }
+    prNumbers.push(prNumber);
+  }
+  return prNumbers;
+}
+
+function toIsoUtc(value: unknown): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  const raw = String(value).trim();
+  // ClickHouse only appends a zone suffix under date_time_output_format "iso", and
+  // Date() reads a zone-less string as machine-local time. The column is UTC, so pin
+  // the zone before parsing rather than inheriting whatever the runtime is set to.
+  const zoned = /(Z|[+-]\d{2}:?\d{2})$/.test(raw)
+    ? raw
+    : `${raw.replace(" ", "T")}Z`;
+  const parsed = new Date(zoned);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Unparsable greenlight_pr_state version: ${raw}`);
+  }
+  return parsed.toISOString();
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const auth = await checkAuthWithApiToken(req, res);
+  if (!auth.ok) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const repo = firstParam(req.query.repo);
+  const rawPrNumbers = firstParam(req.query.prNumbers);
+  if (!repo || !rawPrNumbers) {
+    return res
+      .status(400)
+      .json({ error: "Missing required params: repo, prNumbers" });
+  }
+
+  if (!REPO_RE.test(repo)) {
+    return res.status(400).json({ error: "repo must be owner/name" });
+  }
+
+  const prNumbers = parsePrNumbers(rawPrNumbers);
+  if (prNumbers === null) {
+    return res.status(400).json({
+      error: "prNumbers must be a comma-separated list of positive integers",
+    });
+  }
+  if (prNumbers.length > MAX_PR_NUMBERS) {
+    return res
+      .status(400)
+      .json({ error: `prNumbers accepts at most ${MAX_PR_NUMBERS} entries` });
+  }
+
+  try {
+    // useQueryCache is deliberately left off: this gates merges, and ClickHouse's
+    // 1-minute result cache would let a superseded verdict authorize a land.
+    const rows = await queryClickhouse(
+      QUERY,
+      { repo, pr_numbers: Array.from(new Set(prNumbers)) },
+      "greenlight_pr_state"
+    );
+    const states: GreenlightPRState[] = rows.map((row: any) => ({
+      pr_number: Number(row.pr_number),
+      status: row.status,
+      head_sha: row.head_sha,
+      run_id: Number(row.run_id),
+      version: toIsoUtc(row.version),
+    }));
+    return res
+      .setHeader("Cache-Control", "no-store")
+      .status(200)
+      .json({ states });
+  } catch (error) {
+    console.error("greenlight pr_state handler error:", error);
+    return res
+      .status(500)
+      .json({ error: "Failed to read greenlight PR state" });
+  }
+}

--- a/torchci/test/crcrResults.test.ts
+++ b/torchci/test/crcrResults.test.ts
@@ -1,7 +1,8 @@
-import { NextApiRequest, NextApiResponse } from "next";
+import { NextApiRequest } from "next";
 import * as authModule from "../lib/auth/auth";
 import * as crcrUtils from "../lib/crcr/crcrUtils";
 import handler from "../pages/api/crcr/results";
+import { mockRes } from "./nextApiMocks";
 
 jest.mock("../lib/crcr/crcrUtils", () => {
   const actual = jest.requireActual("../lib/crcr/crcrUtils");
@@ -50,22 +51,6 @@ function mockReq(overrides: Partial<NextApiRequest> = {}): NextApiRequest {
     },
     ...overrides,
   } as unknown as NextApiRequest;
-}
-
-function mockRes(): NextApiResponse & { _status: number; _json: any } {
-  const res: any = {
-    _status: 0,
-    _json: null,
-    status(code: number) {
-      res._status = code;
-      return res;
-    },
-    json(data: any) {
-      res._json = data;
-      return res;
-    },
-  };
-  return res;
 }
 
 describe("POST /api/crcr/results", () => {

--- a/torchci/test/greenlightPrState.test.ts
+++ b/torchci/test/greenlightPrState.test.ts
@@ -1,0 +1,305 @@
+import * as authModule from "lib/auth/auth";
+import * as clickhouse from "lib/clickhouse";
+import { NextApiRequest } from "next";
+import handler from "pages/api/greenlight/pr_state";
+import { mockRes } from "./nextApiMocks";
+
+jest.mock("lib/auth/auth", () => ({
+  checkAuthWithApiToken: jest.fn(),
+}));
+
+const mockCheckAuth = authModule.checkAuthWithApiToken as jest.Mock;
+
+function mockReq(
+  query: Record<string, any> = {},
+  method = "GET"
+): NextApiRequest {
+  return {
+    method,
+    headers: { "x-hud-internal-bot": "valid-token" },
+    query: { repo: "pytorch/pytorch", prNumbers: "123", ...query },
+  } as unknown as NextApiRequest;
+}
+
+function chRow(overrides: Record<string, any> = {}) {
+  return {
+    pr_number: 123,
+    status: "LAND",
+    head_sha: "a".repeat(40),
+    run_id: 32747018107,
+    version: "2026-08-25T12:34:56.000Z",
+    ...overrides,
+  };
+}
+
+describe("GET /api/greenlight/pr_state", () => {
+  let queryClickhouse: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCheckAuth.mockResolvedValue({ ok: true, type: "header" });
+    queryClickhouse = jest.spyOn(clickhouse, "queryClickhouse");
+    queryClickhouse.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("rejects non-GET methods with 405", async () => {
+    const res = mockRes();
+    await handler(mockReq({}, "POST"), res);
+    expect(res._status).toBe(405);
+    expect(res._json.error).toBe("Method not allowed");
+    expect(queryClickhouse).not.toHaveBeenCalled();
+  });
+
+  test("returns 401 when auth fails and does not query ClickHouse", async () => {
+    mockCheckAuth.mockResolvedValue({ ok: false });
+    const res = mockRes();
+    await handler(mockReq(), res);
+    expect(res._status).toBe(401);
+    expect(res._json.error).toBe("Unauthorized");
+    expect(queryClickhouse).not.toHaveBeenCalled();
+  });
+
+  test("returns one state per PR for a multi-PR request", async () => {
+    queryClickhouse.mockResolvedValue([
+      chRow({ pr_number: 1, status: "LAND", run_id: 10 }),
+      chRow({ pr_number: 2, status: "NO_LAND", run_id: 20 }),
+      chRow({ pr_number: 3, status: "AI_REVIEW_STARTED", run_id: 30 }),
+    ]);
+    const res = mockRes();
+    await handler(mockReq({ prNumbers: "1,2,3" }), res);
+
+    expect(res._status).toBe(200);
+    expect(res._json.states).toHaveLength(3);
+    expect(res._json.states[0]).toEqual({
+      pr_number: 1,
+      status: "LAND",
+      head_sha: "a".repeat(40),
+      run_id: 10,
+      version: "2026-08-25T12:34:56.000Z",
+    });
+    expect(queryClickhouse.mock.calls[0][1]).toEqual({
+      repo: "pytorch/pytorch",
+      pr_numbers: [1, 2, 3],
+    });
+  });
+
+  test("omits PRs with no ledger row rather than returning a placeholder", async () => {
+    queryClickhouse.mockResolvedValue([chRow({ pr_number: 2 })]);
+    const res = mockRes();
+    await handler(mockReq({ prNumbers: "1,2,3" }), res);
+
+    expect(res._status).toBe(200);
+    expect(res._json.states.map((s: any) => s.pr_number)).toEqual([2]);
+  });
+
+  test("returns an empty states array when no PR has a row", async () => {
+    const res = mockRes();
+    await handler(mockReq({ prNumbers: "1,2" }), res);
+
+    expect(res._status).toBe(200);
+    expect(res._json).toEqual({ states: [] });
+  });
+
+  test("selects the authoritative row server-side and never filters by head_sha", async () => {
+    const res = mockRes();
+    await handler(mockReq(), res);
+
+    const [query, , queryId, useQueryCache] = queryClickhouse.mock.calls[0];
+    expect(query).toContain("FROM misc.greenlight_pr_state");
+    expect(query).toContain("ORDER BY pr_number, run_id DESC, version DESC");
+    expect(query).toContain("LIMIT 1 BY pr_number");
+    expect(query).not.toContain("head_sha =");
+    expect(queryId).toBe("greenlight_pr_state");
+    expect(useQueryCache).toBeUndefined();
+  });
+
+  test("never selects or returns eval_hash", async () => {
+    queryClickhouse.mockResolvedValue([chRow({ eval_hash: "b".repeat(64) })]);
+    const res = mockRes();
+    await handler(mockReq(), res);
+
+    expect(queryClickhouse.mock.calls[0][0]).not.toContain("eval_hash");
+    expect(res._status).toBe(200);
+    expect(res._json.states[0]).not.toHaveProperty("eval_hash");
+  });
+
+  test("deduplicates repeated PR numbers before querying", async () => {
+    const res = mockRes();
+    await handler(mockReq({ prNumbers: "7,7,8" }), res);
+
+    expect(res._status).toBe(200);
+    expect(queryClickhouse.mock.calls[0][1].pr_numbers).toEqual([7, 8]);
+  });
+
+  test("tolerates whitespace around PR numbers", async () => {
+    const res = mockRes();
+    await handler(mockReq({ prNumbers: " 7 , 8 " }), res);
+
+    expect(res._status).toBe(200);
+    expect(queryClickhouse.mock.calls[0][1].pr_numbers).toEqual([7, 8]);
+  });
+
+  test("uses the first value when a param is repeated in the query string", async () => {
+    const res = mockRes();
+    await handler(
+      mockReq({ repo: ["pytorch/pytorch", "other/repo"], prNumbers: ["9"] }),
+      res
+    );
+
+    expect(res._status).toBe(200);
+    expect(queryClickhouse.mock.calls[0][1]).toEqual({
+      repo: "pytorch/pytorch",
+      pr_numbers: [9],
+    });
+  });
+
+  test("sets Cache-Control no-store", async () => {
+    const res = mockRes();
+    await handler(mockReq(), res);
+    expect(res._headers["Cache-Control"]).toBe("no-store");
+  });
+
+  describe("version normalization", () => {
+    async function versionOf(version: any): Promise<string> {
+      queryClickhouse.mockResolvedValue([chRow({ version })]);
+      const res = mockRes();
+      await handler(mockReq(), res);
+      expect(res._status).toBe(200);
+      return res._json.states[0].version;
+    }
+
+    test("passes through a Z-suffixed ClickHouse iso value", async () => {
+      expect(await versionOf("2026-08-25T18:06:28.881Z")).toBe(
+        "2026-08-25T18:06:28.881Z"
+      );
+    });
+
+    test("reads a zone-less value as UTC, not machine-local time", async () => {
+      // Pinned to a non-UTC zone so the assertion still fails if the route ever
+      // hands a zone-less ClickHouse timestamp straight to Date().
+      const tz = process.env.TZ;
+      process.env.TZ = "America/Los_Angeles";
+      try {
+        expect(await versionOf("2026-08-25 18:06:28.881")).toBe(
+          "2026-08-25T18:06:28.881Z"
+        );
+      } finally {
+        process.env.TZ = tz;
+      }
+    });
+
+    test("converts an offset-suffixed value to UTC", async () => {
+      expect(await versionOf("2026-08-25T20:06:28.881+02:00")).toBe(
+        "2026-08-25T18:06:28.881Z"
+      );
+    });
+
+    test("serializes a Date instance as ISO-8601 UTC", async () => {
+      const version = new Date(Date.UTC(2026, 7, 25, 18, 6, 28, 881));
+      expect(await versionOf(version)).toBe("2026-08-25T18:06:28.881Z");
+    });
+
+    test("fails closed with 500 on an unparsable version", async () => {
+      queryClickhouse.mockResolvedValue([chRow({ version: "not-a-date" })]);
+      const res = mockRes();
+      await handler(mockReq(), res);
+      expect(res._status).toBe(500);
+    });
+  });
+
+  describe("input validation", () => {
+    test.each<[string, Record<string, any>]>([
+      ["missing repo", { repo: undefined }],
+      ["empty repo", { repo: "" }],
+      ["missing prNumbers", { prNumbers: undefined }],
+      ["empty prNumbers", { prNumbers: "" }],
+    ])("returns 400 for %s", async (_name, query) => {
+      const res = mockRes();
+      await handler(mockReq(query), res);
+      expect(res._status).toBe(400);
+      expect(res._json.error).toBe("Missing required params: repo, prNumbers");
+      expect(queryClickhouse).not.toHaveBeenCalled();
+    });
+
+    test.each<[string, string]>([
+      ["no slash", "pytorch"],
+      ["a trailing slash", "pytorch/"],
+      ["a leading slash", "/pytorch"],
+      ["more than two segments", "pytorch/pytorch/extra"],
+      ["whitespace", "pytorch / pytorch"],
+      ["an owner longer than 100 chars", `${"a".repeat(101)}/pytorch`],
+      ["a name longer than 100 chars", `pytorch/${"a".repeat(101)}`],
+      ["a quote", `pytorch/pytorch" OR "1`],
+      ["a trailing space", "pytorch/pytorch "],
+      ["a null byte", "pytorch/pytorch\0"],
+      ["a newline", "pytorch/pytorch\n"],
+    ])("returns 400 for a repo with %s", async (_name, repo) => {
+      const res = mockRes();
+      await handler(mockReq({ repo }), res);
+      expect(res._status).toBe(400);
+      expect(res._json.error).toBe("repo must be owner/name");
+      expect(queryClickhouse).not.toHaveBeenCalled();
+    });
+
+    test.each<[string]>([
+      ["pytorch/pytorch"],
+      ["pytorch/test-infra"],
+      ["pytorch_labs/some.repo"],
+      [`${"a".repeat(100)}/${"b".repeat(100)}`],
+    ])("accepts the well-formed repo %s", async (repo) => {
+      const res = mockRes();
+      await handler(mockReq({ repo }), res);
+      expect(res._status).toBe(200);
+      expect(queryClickhouse.mock.calls[0][1].repo).toBe(repo);
+    });
+
+    test.each<[string, string]>([
+      ["non-numeric", "abc"],
+      ["negative", "-5"],
+      ["zero", "0"],
+      ["decimal", "1.5"],
+      ["exponent notation", "1e3"],
+      ["explicitly signed", "+5"],
+      ["one bad entry among good ones", "1,abc,3"],
+      ["a trailing separator", "1,2,"],
+      ["beyond the safe integer range", "9007199254740993"],
+    ])("returns 400 for %s prNumbers", async (_name, prNumbers) => {
+      const res = mockRes();
+      await handler(mockReq({ prNumbers }), res);
+      expect(res._status).toBe(400);
+      expect(res._json.error).toBe(
+        "prNumbers must be a comma-separated list of positive integers"
+      );
+      expect(queryClickhouse).not.toHaveBeenCalled();
+    });
+
+    test("returns 400 when more than 50 PR numbers are requested", async () => {
+      const prNumbers = Array.from({ length: 51 }, (_, i) => i + 1).join(",");
+      const res = mockRes();
+      await handler(mockReq({ prNumbers }), res);
+      expect(res._status).toBe(400);
+      expect(res._json.error).toBe("prNumbers accepts at most 50 entries");
+      expect(queryClickhouse).not.toHaveBeenCalled();
+    });
+
+    test("accepts exactly 50 PR numbers", async () => {
+      const prNumbers = Array.from({ length: 50 }, (_, i) => i + 1).join(",");
+      const res = mockRes();
+      await handler(mockReq({ prNumbers }), res);
+      expect(res._status).toBe(200);
+      expect(queryClickhouse.mock.calls[0][1].pr_numbers).toHaveLength(50);
+    });
+  });
+
+  test("returns 500 when the ClickHouse read fails", async () => {
+    queryClickhouse.mockRejectedValue(new Error("clickhouse unavailable"));
+    const res = mockRes();
+    await handler(mockReq(), res);
+    expect(res._status).toBe(500);
+    expect(res._json.error).toBe("Failed to read greenlight PR state");
+  });
+});

--- a/torchci/test/nextApiMocks.ts
+++ b/torchci/test/nextApiMocks.ts
@@ -1,0 +1,28 @@
+import type { NextApiResponse } from "next";
+
+export type MockApiResponse = NextApiResponse & {
+  _status: number;
+  _json: any;
+  _headers: Record<string, any>;
+};
+
+export function mockRes(): MockApiResponse {
+  const res: any = {
+    _status: 0,
+    _json: null,
+    _headers: {},
+    setHeader(name: string, value: any) {
+      res._headers[name] = value;
+      return res;
+    },
+    status(code: number) {
+      res._status = code;
+      return res;
+    },
+    json(data: any) {
+      res._json = data;
+      return res;
+    },
+  };
+  return res;
+}


### PR DESCRIPTION
**Impact:** new authenticated HUD API endpoint; consumed by pytorch/pytorch trymerge 
**Risk:** low

## What
Adds a read-only `GET /api/greenlight/pr_state` route that returns the authoritative greenlight verdict row per PR from `misc.greenlight_pr_state`, batched over up to 50 PR numbers. Also extracts the `mockRes` test helper into `test/nextApiMocks.ts` so the new tests and the existing crcr tests share one mock.

## Why
trymerge needs to verify at land time that greenlight actually approved the exact commit being merged — the `merge_rules.yaml` "Greenlight Review Bot" rule otherwise lets a single bot approval authorize any head. trymerge runs outside the ClickHouse network boundary, so it needs an HTTP front for the ledger; this is that front. The client side lives in `.github/scripts/greenlight_ledger.py` on pytorch/pytorch.

## Notes
Things worth a reviewer's attention, since they're load-bearing for merge correctness:

- Row selection (`ORDER BY pr_number, run_id DESC, version DESC LIMIT 1 BY pr_number`) is a deliberate copy of greenlight's own reader in `greenlight/src/greenlight/state.py`. If one side changes, both must.
- No `head_sha` filter, on purpose — the caller compares SHAs itself so it can distinguish "no verdict yet" from "verdict for an older commit".
- Query cache is off and `Cache-Control: no-store` is set: a stale minute here is enough to land on a superseded verdict.
- `eval_hash` is in the table but deliberately not selected or returned.
- `version` is normalized to ISO-8601 UTC because ClickHouse's zone suffix depends on output format, and an unparsable value 500s rather than silently passing through.

Auth uses the existing `x-hud-internal-bot` / session path; trymerge passes `HUD_API_TOKEN`. The 50-PR cap is mirrored as a constant on the client, which batches to stay under it.