### PR TITLE
Allow *-preview targets in create-target mode

### DIFF
--- a/.github/workflows/update-s3-dependencies.yml
+++ b/.github/workflows/update-s3-dependencies.yml
@@ -71,11 +71,12 @@ jobs:
             exit 1
           fi
           # Validate target matches expected patterns
-          if [[ ! "${TARGET}" =~ ^(cu[0-9]+|rocm[0-9]+\.[0-9]+)$ ]]; then
+          if [[ ! "${TARGET}" =~ ^(cu[0-9]+|rocm[0-9]+\.[0-9]+|[a-z0-9.]+-preview)$ ]]; then
             echo "ERROR: Invalid target format '${TARGET}'"
             echo "Valid formats:"
             echo "  - CUDA: cu118, cu121, cu126, cu128, cu129, cu130, etc."
             echo "  - ROCm: rocm5.7, rocm6.0, rocm6.4, rocm7.1, rocm7.2, etc."
+            echo "  - Preview: rocm-preview, etc."
             exit 1
           fi
           echo "Target '${TARGET}' is valid"

--- a/s3_management/update_dependencies.py
+++ b/s3_management/update_dependencies.py
@@ -16,6 +16,7 @@ VALID_TARGET_PATTERNS = [
     r"^cu[0-9]+$",  # CUDA: cu118, cu121, cu126, cu128, cu129, cu130, cuXYZ
     r"^rocm[0-9]+\.[0-9]+$",  # ROCm: rocm5.7, rocm6.0, rocm6.4, rocm7.1, rocm7.2
     r"^xpu$",  # Intel XPU
+    r"^[a-z0-9.]+-preview$",  # Preview: rocm-preview
 ]
 
 # Cloudflare R2 configuration for writing indexes


### PR DESCRIPTION
Required for: https://github.com/pytorch/pytorch/issues/189756

Fixes the `create-target` run that failed on `target: rocm-preview`:

https://github.com/pytorch/test-infra/actions/runs/30951059775/job/92132946339

```
ERROR: Invalid target format 'rocm-preview'
```

The target regex only allowed `cu<N>` and `rocm<X>.<Y>`. Adds `*-preview` to both the workflow guard and `VALID_TARGET_PATTERNS` in `update_dependencies.py`.

Verified both regexes accept `rocm-preview`, `rocm7.2`, `cu130`, `cu130-preview` and still reject `rocm-prev`, `rocm`, `preview`, `-preview`, `nonsense`, empty. `get_packages_for_target` already classifies `rocm-preview` as ROCm (`startswith("rocm")`), so no other change is needed.