### PR TITLE
Leave abandoned-run jobs out of the queued-jobs numbers, behind a toggle

### DIFF
--- a/torchci/clickhouse_queries/queued_jobs/query.sql
+++ b/torchci/clickhouse_queries/queued_jobs/query.sql
@@ -4,6 +4,14 @@
 --- For ARC runners (labels containing l-): jobs in 'queued' status + jobs in 'in_progress'
 ---   still initializing containers (<=2 steps completed). Jobs with a recorded
 ---   conclusion are excluded to avoid counting stale entries.
+---
+--- Each row additionally carries is_stale, an ADVISORY flag marking a job whose
+--- parent workflow run looks abandoned by GitHub. The discriminator, and the
+--- reasons it cannot be treated as proof, are documented in
+--- clickhouse_queries/queued_jobs_by_label/query.sql; it must stay in sync with
+--- that query, since the metrics page uses one to summarise the other. This
+--- query neither filters nor reorders on it, and the metrics page does not
+--- either by default; it only annotates the row.
 WITH possible_queued_jobs AS (
     SELECT
         id,
@@ -21,6 +29,17 @@ WITH possible_queued_jobs AS (
              AND conclusion = ''
              AND arrayExists(x -> x LIKE '%l-%', labels))
         )
+),
+--- Runner pools demonstrably serving work — see queued_jobs_by_label/query.sql
+--- for why the abandoned label is withheld from a pool that is not, and why the
+--- key is the whole label array. Keep this CTE identical to the one there;
+--- test/queuedJobsStale.test.ts enforces that.
+live_runner_pools AS (
+    SELECT DISTINCT labels
+    FROM default.workflow_job
+    WHERE
+        created_at > (CURRENT_TIMESTAMP() - INTERVAL 1 HOUR)
+        AND runner_name != ''
 ),
 --- EC2/LF runners: existing logic, only jobs in queued status
 ec2_queued_jobs AS (
@@ -41,6 +60,15 @@ ec2_queued_jobs AS (
                 job.labels[1]
             )
         ) AS machine_type,
+        (
+            workflow.updated_at = workflow.created_at
+            AND workflow.created_at < (CURRENT_TIMESTAMP() - INTERVAL 6 HOUR)
+            AND job.status = 'queued'
+            AND job.runner_name = ''
+            AND LENGTH(job.steps) = 0
+            AND LENGTH(job.labels) > 0
+            AND job.labels IN (SELECT labels FROM live_runner_pools)
+        ) AS is_stale,
         workflow.head_sha AS head_sha,
         workflow.head_branch AS head_branch,
         workflow.event AS event,
@@ -90,6 +118,15 @@ arc_queued_jobs AS (
             job.labels[2],
             job.labels[1]
         ) AS machine_type,
+        (
+            workflow.updated_at = workflow.created_at
+            AND workflow.created_at < (CURRENT_TIMESTAMP() - INTERVAL 6 HOUR)
+            AND job.status = 'queued'
+            AND job.runner_name = ''
+            AND LENGTH(job.steps) = 0
+            AND LENGTH(job.labels) > 0
+            AND job.labels IN (SELECT labels FROM live_runner_pools)
+        ) AS is_stale,
         workflow.head_sha AS head_sha,
         workflow.head_branch AS head_branch,
         workflow.event AS event,

--- a/torchci/clickhouse_queries/queued_jobs_by_label/query.sql
+++ b/torchci/clickhouse_queries/queued_jobs_by_label/query.sql
@@ -5,6 +5,13 @@
 ---   initialization time (before actual work starts). Phase 2 captures jobs that
 ---   are in_progress but still initializing containers (<=2 steps completed).
 ---   Jobs with a recorded conclusion are excluded to avoid counting stale entries.
+---
+--- This query additionally reports how many of a machine type's queued jobs
+--- look like they belong to a workflow run GitHub abandoned (stale_count /
+--- oldest_stale_s). That is ADVISORY only: count and avg_queue_s still cover
+--- every queued job exactly as they always have, so no consumer and no reader
+--- loses an alarm because the heuristic guessed wrong. See the is_stale
+--- definition below for what it can and cannot establish.
 WITH possible_queued_jobs as (
     select id, run_id from default.workflow_job where
     created_at < (CURRENT_TIMESTAMP() - INTERVAL 5 MINUTE)
@@ -18,6 +25,38 @@ WITH possible_queued_jobs as (
          AND conclusion = ''
          AND arrayExists(x -> x LIKE '%l-%', labels))
     )
+),
+--- Runner pools that are demonstrably serving work: a job created in the last
+--- hour asking for this exact label set has since been picked up by a runner.
+--- runner_name is the reliable "did this actually start" test — status and
+--- started_at both lie on jobs whose webhooks went missing, which is the very
+--- population being classified below.
+---
+--- This is the guard that keeps a genuine outage visible. A pool with no
+--- eligible runners, no capacity, or a broken runner group ALSO leaves its jobs
+--- untouched and its parent runs frozen, and would otherwise be written off as
+--- abandoned exactly when someone needs to see it. Requiring the pool to be
+--- alive can only ever REMOVE the stale label, never add one.
+---
+--- Keyed on the whole `labels` array rather than on the displayed machine_type,
+--- because that array is what the job is actually scheduled against;
+--- machine_type is one element of it, so two different pools can share one.
+--- runner_group_name deliberately plays no part: it is empty while a job is
+--- queued and only filled in once a runner takes it, so including it would mean
+--- a queued job could never match anything (measured 2026-08-25 — every started
+--- ubuntu-24.04 job reads 'GitHub Actions', every queued one reads '').
+---
+--- Two consequences worth knowing. A job whose label set nothing else has run
+--- in the last hour is never called abandoned, so ghosts do linger on very
+--- low-volume pools; that is the safe direction. And classification is
+--- workload-dependent — an unchanged job can move between live and abandoned
+--- as unrelated work enters and leaves the window.
+live_runner_pools AS (
+    SELECT DISTINCT labels
+    FROM default.workflow_job
+    WHERE
+        created_at > (CURRENT_TIMESTAMP() - INTERVAL 1 HOUR)
+        AND runner_name != ''
 ),
 --- EC2/LF runners: existing logic, only jobs in queued status
 ec2_queued_jobs AS (
@@ -37,7 +76,65 @@ ec2_queued_jobs AS (
                 'N/A'
             ),
             IF(LENGTH(job.labels) > 1, job.labels [ 2 ], job.labels [ 1 ])
-        ) AS machine_type
+        ) AS machine_type,
+        --- Abandoned run: pytorch/pytorch creates each workflow twice per
+        --- ghstack push and the concurrency group cancels the loser seconds
+        --- later. When GitHub drops that cancellation the losing run is
+        --- orphaned — it stays 'queued' forever and its updated_at never moves
+        --- off created_at, because not one of its jobs ever transitioned. Its
+        --- jobs then sit here until the 1 WEEK window above ages them out,
+        --- which is days of a permanent 5d+ row on the metrics page.
+        ---
+        --- Three independent things all have to hold, because no one of them
+        --- is conclusive on its own:
+        ---   1. the run never made any progress at all, and is old enough that
+        ---      "not yet" is not an explanation. A run created minutes ago
+        ---      also has updated_at = created_at. Measured on the live
+        ---      population 2026-08-25, frozen runs are either younger than 6h
+        ---      (legitimately waiting; 164 jobs, none queued over 1h) or older
+        ---      than 24h (abandoned; 11 jobs, oldest queued 6.8 days) — the
+        ---      6h-to-24h band was empty.
+        ---   2. this job in particular never started. Without this an
+        ---      in_progress ARC job (which arc_queued_jobs deliberately admits
+        ---      while containers initialise) could inherit the label from its
+        ---      parent's timestamps alone.
+        ---   3. the job asks for a non-empty label set that something else has
+        ---      run recently — see live_runner_pools above. An empty label
+        ---      array carries no pool identity at all, so it is excluded
+        ---      rather than matched against whatever else happens to be empty.
+        ---
+        --- None of that is proof, and the gap is not closable from this data.
+        --- A run every one of whose jobs is starving looks identical, and
+        --- `labels` is the job's REQUEST, not the pool's identity — GitHub also
+        --- matches on runner group and repository access, and runner_group_name
+        --- is empty until a runner picks the job up, so it cannot be part of
+        --- the key. The one signal that would be conclusive is the completed
+        --- duplicate run, and joining workflow_run to itself by head_sha took
+        --- 18s against this table versus ~2s for the whole query, which is not
+        --- affordable on a panel that refreshes every 5 minutes.
+        ---
+        --- So this stays ADVISORY. It changes no default: count and avg_queue_s
+        --- still cover every queued job, the metrics page still shows them with
+        --- their usual red/yellow thresholds and still sorts on them by
+        --- default, and no row is hidden, greyed or demoted. A wrong guess
+        --- costs a wrong label and nothing else. A reader can sort or filter on
+        --- the new column like any other — that is their choice, made visibly
+        --- and undone by a click.
+        ---
+        --- What must not happen is this deciding anything on its own. Resist
+        --- wiring it into an automatic filter, a default sort, or an alert
+        --- threshold: the moment it picks what an oncaller sees first without
+        --- being asked, every limitation above turns into a way to bury a real
+        --- outage.
+        (
+            workflow.updated_at = workflow.created_at
+            AND workflow.created_at < (CURRENT_TIMESTAMP() - INTERVAL 6 HOUR)
+            AND job.status = 'queued'
+            AND job.runner_name = ''
+            AND LENGTH(job.steps) = 0
+            AND LENGTH(job.labels) > 0
+            AND job.labels IN (SELECT labels FROM live_runner_pools)
+        ) AS is_stale
     FROM
         default.workflow_job job final
         JOIN default.workflow_run workflow final ON workflow.id = job.run_id
@@ -58,7 +155,18 @@ arc_queued_jobs AS (
         DATE_DIFF('second', job.created_at, CURRENT_TIMESTAMP()) AS queue_s,
         CONCAT(workflow.name, ' / ', job.name) AS name,
         job.html_url,
-        IF(LENGTH(job.labels) > 1, job.labels [ 2 ], job.labels [ 1 ]) AS machine_type
+        IF(LENGTH(job.labels) > 1, job.labels [ 2 ], job.labels [ 1 ]) AS machine_type,
+        --- Same abandoned-run discriminator as ec2_queued_jobs above. Keep the
+        --- two textually identical; test/queuedJobsStale.test.ts enforces it.
+        (
+            workflow.updated_at = workflow.created_at
+            AND workflow.created_at < (CURRENT_TIMESTAMP() - INTERVAL 6 HOUR)
+            AND job.status = 'queued'
+            AND job.runner_name = ''
+            AND LENGTH(job.steps) = 0
+            AND LENGTH(job.labels) > 0
+            AND job.labels IN (SELECT labels FROM live_runner_pools)
+        ) AS is_stale
     FROM
         default.workflow_job job final
         JOIN default.workflow_run workflow final ON workflow.id = job.run_id
@@ -86,15 +194,28 @@ arc_queued_jobs AS (
              AND job.created_at > (CURRENT_TIMESTAMP() - INTERVAL 10 MINUTE))
         )
 )
+--- Classify per JOB and then aggregate. Judging a whole machine_type at once
+--- would let one suspect job speak for a healthy live queue sharing its name.
+---
+--- Everything here is additive. count, avg_queue_s, machine_type, time and the
+--- row ordering are byte-for-byte what they were, because this query is served
+--- unauthenticated at /api/clickhouse/queued_jobs_by_label and out-of-repo
+--- consumers cannot be enumerated. The two new columns are the whole change,
+--- and nothing acts on them automatically: not the ordering here, and not the
+--- metrics page, which sorts on avg_queue_s as it always did.
 SELECT
     COUNT(*) AS count,
+    --- Misnamed since it was introduced: a MAX, not an average. Left alone for
+    --- the same compatibility reason as count.
     MAX(queue_s) AS avg_queue_s,
+    COUNTIf(is_stale) AS stale_count,
+    MAXIf(queue_s, is_stale) AS oldest_stale_s,
     machine_type,
     CURRENT_TIMESTAMP() AS time
 FROM (
-    SELECT queue_s, machine_type FROM ec2_queued_jobs
+    SELECT queue_s, is_stale, machine_type FROM ec2_queued_jobs
     UNION ALL
-    SELECT queue_s, machine_type FROM arc_queued_jobs
+    SELECT queue_s, is_stale, machine_type FROM arc_queued_jobs
 )
 GROUP BY
     machine_type

--- a/torchci/clickhouse_queries/queued_jobs_by_label/query.sql
+++ b/torchci/clickhouse_queries/queued_jobs_by_label/query.sql
@@ -113,19 +113,18 @@ ec2_queued_jobs AS (
         --- 18s against this table versus ~2s for the whole query, which is not
         --- affordable on a panel that refreshes every 5 minutes.
         ---
-        --- So this stays ADVISORY. It changes no default: count and avg_queue_s
-        --- still cover every queued job, the metrics page still shows them with
-        --- their usual red/yellow thresholds and still sorts on them by
-        --- default, and no row is hidden, greyed or demoted. A wrong guess
-        --- costs a wrong label and nothing else. A reader can sort or filter on
-        --- the new column like any other — that is their choice, made visibly
-        --- and undone by a click.
+        --- Because it is a guess, the rule is that a reader is never left
+        --- unaware that it fired. count and avg_queue_s here always cover every
+        --- queued job, and the metrics page's toggle for leaving the suspected
+        --- ones out states their number and oldest age on screen whenever any
+        --- exist, keeps every machine type in the table either way, and is
+        --- undone by one click. So the worst a wrong guess does is understate a
+        --- row beside a line saying so.
         ---
-        --- What must not happen is this deciding anything on its own. Resist
-        --- wiring it into an automatic filter, a default sort, or an alert
-        --- threshold: the moment it picks what an oncaller sees first without
-        --- being asked, every limitation above turns into a way to bury a real
-        --- outage.
+        --- What must not happen is this hiding something silently. Resist
+        --- wiring it into a query-side filter, a default sort, or an alert
+        --- threshold — anywhere its effect is not announced next to its result,
+        --- every limitation above turns into a way to bury a real outage.
         (
             workflow.updated_at = workflow.created_at
             AND workflow.created_at < (CURRENT_TIMESTAMP() - INTERVAL 6 HOUR)
@@ -200,14 +199,20 @@ arc_queued_jobs AS (
 --- Everything here is additive. count, avg_queue_s, machine_type, time and the
 --- row ordering are byte-for-byte what they were, because this query is served
 --- unauthenticated at /api/clickhouse/queued_jobs_by_label and out-of-repo
---- consumers cannot be enumerated. The two new columns are the whole change,
---- and nothing acts on them automatically: not the ordering here, and not the
---- metrics page, which sorts on avg_queue_s as it always did.
+--- consumers cannot be enumerated. The four new columns are the whole change,
+--- and the row ordering here does not use them.
+---
+--- live_count / live_max_queue_s are the same two figures with the suspected
+--- jobs left out. The metrics page offers them behind a toggle that names how
+--- many jobs it is leaving out and lets the reader put them back; both sets are
+--- returned so that choice is the page's to make and not this query's.
 SELECT
     COUNT(*) AS count,
     --- Misnamed since it was introduced: a MAX, not an average. Left alone for
     --- the same compatibility reason as count.
     MAX(queue_s) AS avg_queue_s,
+    COUNTIf(NOT is_stale) AS live_count,
+    MAXIf(queue_s, NOT is_stale) AS live_max_queue_s,
     COUNTIf(is_stale) AS stale_count,
     MAXIf(queue_s, is_stale) AS oldest_stale_s,
     machine_type,

--- a/torchci/components/metrics/panels/QueuedJobsByMachineTypeTable.tsx
+++ b/torchci/components/metrics/panels/QueuedJobsByMachineTypeTable.tsx
@@ -1,0 +1,246 @@
+import { Link, Typography } from "@mui/material";
+import { GridColDef } from "@mui/x-data-grid";
+import { durationDisplay } from "components/common/TimeUtils";
+import { TablePanelWithData } from "components/metrics/panels/TablePanel";
+import { fetcher } from "lib/GeneralUtils";
+import { useMemo, useState } from "react";
+import useSWR from "swr";
+
+// "Queued Jobs by Machine Type", with the option to leave out jobs whose
+// workflow run looks abandoned by GitHub.
+//
+// Those jobs are real rows in ClickHouse that no runner will ever pick up, and
+// they can sit in this table for a week showing multi-day queue times for a
+// pool that is actually healthy. Leaving them out is the default, because the
+// number a reader wants is "how long is the wait right now".
+//
+// It is only a guess — see clickhouse_queries/queued_jobs_by_label/query.sql
+// for what the classifier can and cannot establish — so two rules constrain it.
+//
+// It never acts unannounced. While any job is being left out, the panel title
+// says how many and how old, one click puts them back, and every machine type
+// stays in the table either way.
+//
+// And it never decides the reading order. The DEFAULT sort is the hidden
+// sort_queue_s below, which is always the raw queue time, so while that sort is
+// active — which is every unattended view of this page — flipping the toggle
+// cannot move a machine type down the table or off the bottom of it. That is
+// how a mistaken guess would hide a real outage from someone scanning the top.
+// A reader who clicks a header is then sorting on what they can actually see,
+// and rows do move when they toggle after that: they changed the definition of
+// the figure they sorted by, and holding the old order would be the misleading
+// choice.
+export default function QueuedJobsByMachineTypeTable({
+  onMachineTypeClick,
+}: {
+  onMachineTypeClick: (_machineType: string) => void;
+}) {
+  const [countSuspectedStuck, setCountSuspectedStuck] = useState(false);
+
+  const url = `/api/clickhouse/queued_jobs_by_label?parameters=${encodeURIComponent(
+    JSON.stringify({})
+  )}`;
+
+  const { data } = useSWR(url, fetcher, {
+    refreshInterval: 5 * 60 * 1000, // refresh every 5 minutes
+  });
+
+  const rows: any[] = data ?? [];
+
+  // A payload without the classifier's columns — a mixed-version deploy, or a
+  // response cached from before they existed — must not be filtered against
+  // fields that are not there, which would put NaN in every cell. Note that
+  // Number(null), Number("") and Number(false) are all a finite 0, so a
+  // presence test has to reject those shapes rather than coerce them. On any
+  // doubt, fall back to the raw figures, which have always been present, and
+  // offer no toggle at all.
+  const isCount = (value: any) =>
+    (typeof value === "number" ||
+      (typeof value === "string" && value.trim() !== "")) &&
+    // Every field checked with this is a COUNTIf or a DATE_DIFF in seconds, so
+    // a negative or fractional one is not a number this panel can render —
+    // "-1 jobs look stuck" is worse than falling back to the raw figures.
+    Number.isSafeInteger(Number(value)) &&
+    Number(value) >= 0;
+  const canLeaveOutStuck =
+    rows.length > 0 &&
+    rows.every(
+      (row) =>
+        row != null &&
+        typeof row === "object" &&
+        ["count", "live_count", "live_max_queue_s", "stale_count"].every(
+          (field) => isCount(row[field])
+        ) &&
+        // Only required where it will actually be read, but required there:
+        // the promise this panel makes is to say how many jobs it left out AND
+        // how old, and a missing age would quietly render that as zero.
+        (Number(row.stale_count) === 0 || isCount(row.oldest_stale_s)) &&
+        // The query defines these as COUNT(*), COUNTIf(NOT is_stale) and
+        // COUNTIf(is_stale) over one population, so this always holds. If it
+        // does not, the payload is not the one this panel was written for.
+        Number(row.live_count) + Number(row.stale_count) === Number(row.count)
+    );
+  const leaveOutStuck = canLeaveOutStuck && !countSuspectedStuck;
+
+  const stuckJobs = canLeaveOutStuck
+    ? rows.reduce((n, row) => n + Number(row.stale_count), 0)
+    : 0;
+  // Only rows that actually contribute a suspected job. A row with none of them
+  // is the one whose oldest_stale_s the guard above does not require, so
+  // reading it here would let an unvalidated value set the age in the title.
+  const oldestStuckS = canLeaveOutStuck
+    ? rows.reduce(
+        (oldest, row) =>
+          Number(row.stale_count) > 0
+            ? Math.max(oldest, Number(row.oldest_stale_s))
+            : oldest,
+        0
+      )
+    : 0;
+
+  // What a row's two headline figures say — and, once a reader sorts or filters
+  // on them, what those act on too.
+  const shownCount = (row: any) =>
+    leaveOutStuck ? Number(row.live_count) : Number(row.count);
+  const shownQueueS = (row: any) =>
+    leaveOutStuck ? Number(row.live_max_queue_s) : Number(row.avg_queue_s);
+
+  const columns: GridColDef[] = useMemo(
+    () => [
+      {
+        field: "count",
+        headerName: "Count",
+        flex: 1,
+        type: "number",
+        valueGetter: (_value: any, row: any) => shownCount(row),
+      },
+      {
+        field: "avg_queue_s",
+        headerName: "Queue time",
+        flex: 1,
+        type: "number",
+        // A machine type with nothing left once the suspected jobs are removed
+        // has no queue time, which is not the same as a queue time of zero.
+        // null rather than 0 keeps that distinction in the value itself, so
+        // sorting, "is empty" and the absence of a colour all agree with the
+        // dash on screen.
+        valueGetter: (_value: any, row: any) =>
+          shownCount(row) === 0 ? null : shownQueueS(row),
+        valueFormatter: (params: number | null) =>
+          params == null ? "—" : durationDisplay(params),
+        cellClassName: (params) => {
+          if (params.value == null) return "";
+          const queueTimeHours = params.value / 3600;
+          if (queueTimeHours >= 4) return "queue-time-red";
+          if (queueTimeHours >= 1) return "queue-time-yellow";
+          return "";
+        },
+      },
+      {
+        field: "stale_count",
+        headerName: "Suspected stuck",
+        description:
+          "How many of this machine type's queued jobs match the " +
+          "abandoned-run heuristic: the workflow run is over 6h old and its " +
+          "recorded update time still equals its creation time, the job is " +
+          "still queued with no runner and no steps recorded, and some job " +
+          "created in the last hour with exactly the same labels did get a " +
+          "runner. Labels are not the whole of what a job is scheduled " +
+          "against, so this can be wrong in either direction. Use the link in " +
+          "the title to count these jobs again.",
+        flex: 1,
+        type: "number",
+        // COUNTIf is a UInt64 and should arrive as a JSON number, but that was
+        // not verifiable end-to-end; a string would sort "10" below "2".
+        valueGetter: (value: any) => Number(value),
+        // Descending first: an ascending click would push every affected row
+        // below the blanks, the one ordering a reader would not expect from a
+        // column about exceptions.
+        sortingOrder: ["desc", "asc", null],
+        // Blank rather than "0" so the column reads as an exception marker.
+        // NaN, from a payload without the column, is blank for the same reason.
+        valueFormatter: (params: number, row: any) =>
+          params > 0
+            ? `${params} · ${durationDisplay(Number(row.oldest_stale_s))}`
+            : "",
+      },
+      { field: "machine_type", headerName: "Machine Type", flex: 3 },
+      // Not displayed. Carries the raw queue time so the DEFAULT ordering is
+      // the same in both modes; see the note at the top of the file. Hiding a
+      // column does not by itself keep it out of the filter panel, the column
+      // chooser or an all-columns export, and a filter on a value nobody can
+      // see is worse than no filter — hence the opt-outs. `sortable: false`
+      // only disables sorting by header interaction; the initial sort model
+      // below still orders by this column.
+      {
+        field: "sort_queue_s",
+        sortable: false,
+        filterable: false,
+        hideable: false,
+        disableExport: true,
+        disableColumnMenu: true,
+        valueGetter: (_value: any, row: any) => Number(row.avg_queue_s),
+      },
+    ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [leaveOutStuck]
+  );
+
+  const title =
+    stuckJobs === 0 ? (
+      "Queued Jobs by Machine Type"
+    ) : (
+      <span>
+        Queued Jobs by Machine Type{" "}
+        <Typography component="span" fontSize="13px" fontWeight="400">
+          — {stuckJobs} job{stuckJobs === 1 ? "" : "s"} look stuck (oldest{" "}
+          {durationDisplay(oldestStuckS)}),{" "}
+          {leaveOutStuck ? "not counted below" : "counted below"}.{" "}
+          <Link
+            component="button"
+            underline="always"
+            fontSize="13px"
+            onClick={() => setCountSuspectedStuck(!countSuspectedStuck)}
+          >
+            {leaveOutStuck ? "Count them" : "Leave them out"}
+          </Link>
+        </Typography>
+      </span>
+    );
+
+  return (
+    <TablePanelWithData
+      title={title}
+      data={data}
+      columns={columns}
+      dataGridProps={{
+        getRowId: (el: any) => el.machine_type,
+        // Both under initialState. As a controlled `columnVisibilityModel` prop
+        // with no change handler, this would freeze visibility for EVERY column
+        // and leave the column chooser unable to hide anything.
+        initialState: {
+          columns: { columnVisibilityModel: { sort_queue_s: false } },
+          sorting: {
+            sortModel: [{ field: "sort_queue_s", sort: "desc" }],
+          },
+        },
+        onRowClick: (params: any) => {
+          onMachineTypeClick(params.row.machine_type);
+        },
+        sx: {
+          "& .queue-time-yellow": {
+            backgroundColor: "#B8860B", // Dark goldenrod
+            color: "white",
+          },
+          "& .queue-time-red": {
+            backgroundColor: "#B22222", // Fire brick red
+            color: "white",
+          },
+          "& .MuiDataGrid-row": {
+            cursor: "pointer",
+          },
+        },
+      }}
+    />
+  );
+}

--- a/torchci/components/metrics/panels/QueuedJobsByMachineTypeTable.tsx
+++ b/torchci/components/metrics/panels/QueuedJobsByMachineTypeTable.tsx
@@ -1,4 +1,4 @@
-import { Link, Typography } from "@mui/material";
+import { Link, Tooltip, Typography } from "@mui/material";
 import { GridColDef } from "@mui/x-data-grid";
 import { durationDisplay } from "components/common/TimeUtils";
 import { TablePanelWithData } from "components/metrics/panels/TablePanel";
@@ -6,30 +6,29 @@ import { fetcher } from "lib/GeneralUtils";
 import { useMemo, useState } from "react";
 import useSWR from "swr";
 
-// "Queued Jobs by Machine Type", with the option to leave out jobs whose
-// workflow run looks abandoned by GitHub.
+// "Queued Jobs by Machine Type", with jobs whose workflow run looks abandoned
+// by GitHub left out by default.
 //
-// Those jobs are real rows in ClickHouse that no runner will ever pick up, and
-// they can sit in this table for a week showing multi-day queue times for a
-// pool that is actually healthy. Leaving them out is the default, because the
-// number a reader wants is "how long is the wait right now".
+// Those jobs are real rows in ClickHouse that in all likelihood no runner will
+// pick up, and they can sit in this table for a week showing multi-day queue
+// times for a pool that is actually healthy. Leaving them out is the default,
+// because the number a reader wants is "how long is the wait right now". A
+// machine type with nothing left once they are gone has no queue to report, so
+// its row is dropped rather than shown as a zero.
 //
 // It is only a guess — see clickhouse_queries/queued_jobs_by_label/query.sql
-// for what the classifier can and cannot establish — so two rules constrain it.
+// for what the classifier can and cannot establish — so it never acts
+// unannounced. The panel title is the whole of that promise now that there is
+// no per-row marker: while anything is being left out it says how many jobs,
+// how old, and NAMES every machine type that left the table with them. One
+// click puts all of it back.
 //
-// It never acts unannounced. While any job is being left out, the panel title
-// says how many and how old, one click puts them back, and every machine type
-// stays in the table either way.
-//
-// And it never decides the reading order. The DEFAULT sort is the hidden
-// sort_queue_s below, which is always the raw queue time, so while that sort is
-// active — which is every unattended view of this page — flipping the toggle
-// cannot move a machine type down the table or off the bottom of it. That is
-// how a mistaken guess would hide a real outage from someone scanning the top.
-// A reader who clicks a header is then sorting on what they can actually see,
-// and rows do move when they toggle after that: they changed the definition of
-// the figure they sorted by, and holding the old order would be the misleading
-// choice.
+// The classifier's own liveness condition is what usually keeps a real outage
+// on screen: a job is only suspect when some other job asking for exactly its
+// labels reached a runner in the last hour, so a pool serving nothing keeps
+// every job counted. It is not a guarantee — labels are not the whole of what
+// a job is scheduled against, and a pool that fails outright can stay inside
+// that one-hour window — which is why the title names what it hid.
 export default function QueuedJobsByMachineTypeTable({
   onMachineTypeClick,
 }: {
@@ -105,6 +104,26 @@ export default function QueuedJobsByMachineTypeTable({
   const shownQueueS = (row: any) =>
     leaveOutStuck ? Number(row.live_max_queue_s) : Number(row.avg_queue_s);
 
+  // A machine type with no jobs left has no queue to report, so it leaves the
+  // table until the toggle brings it back. `data` rather than `rows` so
+  // `undefined` still reaches TablePanelWithData as the loading state.
+  const shownRows = leaveOutStuck
+    ? rows.filter((row) => shownCount(row) > 0)
+    : data;
+  // Named, not counted. A row is the only per-machine-type signal this panel
+  // has, so an oncall reading a title that says two pools vanished still has to
+  // guess which — and the one they are looking for is the one most likely to be
+  // missing.
+  const hiddenTypes: string[] = leaveOutStuck
+    ? rows.filter((row) => shownCount(row) === 0).map((row) => row.machine_type)
+    : [];
+  const hiddenList =
+    hiddenTypes.length <= 3
+      ? hiddenTypes.join(", ")
+      : `${hiddenTypes.slice(0, 3).join(", ")} and ${
+          hiddenTypes.length - 3
+        } more`;
+
   const columns: GridColDef[] = useMemo(
     () => [
       {
@@ -119,73 +138,24 @@ export default function QueuedJobsByMachineTypeTable({
         headerName: "Queue time",
         flex: 1,
         type: "number",
-        // A machine type with nothing left once the suspected jobs are removed
-        // has no queue time, which is not the same as a queue time of zero.
-        // null rather than 0 keeps that distinction in the value itself, so
-        // sorting, "is empty" and the absence of a colour all agree with the
-        // dash on screen.
-        valueGetter: (_value: any, row: any) =>
-          shownCount(row) === 0 ? null : shownQueueS(row),
-        valueFormatter: (params: number | null) =>
-          params == null ? "—" : durationDisplay(params),
+        valueGetter: (_value: any, row: any) => shownQueueS(row),
+        valueFormatter: (params: number) => durationDisplay(params),
         cellClassName: (params) => {
-          if (params.value == null) return "";
           const queueTimeHours = params.value / 3600;
           if (queueTimeHours >= 4) return "queue-time-red";
           if (queueTimeHours >= 1) return "queue-time-yellow";
           return "";
         },
       },
-      {
-        field: "stale_count",
-        headerName: "Suspected stuck",
-        description:
-          "How many of this machine type's queued jobs match the " +
-          "abandoned-run heuristic: the workflow run is over 6h old and its " +
-          "recorded update time still equals its creation time, the job is " +
-          "still queued with no runner and no steps recorded, and some job " +
-          "created in the last hour with exactly the same labels did get a " +
-          "runner. Labels are not the whole of what a job is scheduled " +
-          "against, so this can be wrong in either direction. Use the link in " +
-          "the title to count these jobs again.",
-        flex: 1,
-        type: "number",
-        // COUNTIf is a UInt64 and should arrive as a JSON number, but that was
-        // not verifiable end-to-end; a string would sort "10" below "2".
-        valueGetter: (value: any) => Number(value),
-        // Descending first: an ascending click would push every affected row
-        // below the blanks, the one ordering a reader would not expect from a
-        // column about exceptions.
-        sortingOrder: ["desc", "asc", null],
-        // Blank rather than "0" so the column reads as an exception marker.
-        // NaN, from a payload without the column, is blank for the same reason.
-        valueFormatter: (params: number, row: any) =>
-          params > 0
-            ? `${params} · ${durationDisplay(Number(row.oldest_stale_s))}`
-            : "",
-      },
-      { field: "machine_type", headerName: "Machine Type", flex: 3 },
-      // Not displayed. Carries the raw queue time so the DEFAULT ordering is
-      // the same in both modes; see the note at the top of the file. Hiding a
-      // column does not by itself keep it out of the filter panel, the column
-      // chooser or an all-columns export, and a filter on a value nobody can
-      // see is worse than no filter — hence the opt-outs. `sortable: false`
-      // only disables sorting by header interaction; the initial sort model
-      // below still orders by this column.
-      {
-        field: "sort_queue_s",
-        sortable: false,
-        filterable: false,
-        hideable: false,
-        disableExport: true,
-        disableColumnMenu: true,
-        valueGetter: (_value: any, row: any) => Number(row.avg_queue_s),
-      },
+      { field: "machine_type", headerName: "Machine Type", flex: 4 },
     ],
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [leaveOutStuck]
   );
 
+  // The whole of what tells a reader something is missing, so it names both
+  // things that can be: the jobs left out of every figure, and the machine
+  // types that lost their last job and left the table with it.
   const title =
     stuckJobs === 0 ? (
       "Queued Jobs by Machine Type"
@@ -195,15 +165,30 @@ export default function QueuedJobsByMachineTypeTable({
         <Typography component="span" fontSize="13px" fontWeight="400">
           — {stuckJobs} job{stuckJobs === 1 ? "" : "s"} look stuck (oldest{" "}
           {durationDisplay(oldestStuckS)}),{" "}
-          {leaveOutStuck ? "not counted below" : "counted below"}.{" "}
-          <Link
-            component="button"
-            underline="always"
-            fontSize="13px"
-            onClick={() => setCountSuspectedStuck(!countSuspectedStuck)}
+          {leaveOutStuck ? "left out" : "counted below"}
+          {leaveOutStuck && hiddenTypes.length > 0
+            ? `; ${hiddenList} hidden`
+            : ""}
+          .{" "}
+          <Tooltip
+            title={
+              "A queued job is called stuck when its workflow run is over 6h " +
+              "old and has never been updated, the job itself never reached a " +
+              "runner, and some other job asking for exactly the same labels " +
+              "did reach one in the last hour. Labels are not the whole of " +
+              "what a job is scheduled against, so this can be wrong in " +
+              "either direction."
+            }
           >
-            {leaveOutStuck ? "Count them" : "Leave them out"}
-          </Link>
+            <Link
+              component="button"
+              underline="always"
+              fontSize="13px"
+              onClick={() => setCountSuspectedStuck(!countSuspectedStuck)}
+            >
+              {leaveOutStuck ? "Show them" : "Leave them out"}
+            </Link>
+          </Tooltip>
         </Typography>
       </span>
     );
@@ -211,17 +196,13 @@ export default function QueuedJobsByMachineTypeTable({
   return (
     <TablePanelWithData
       title={title}
-      data={data}
+      data={shownRows}
       columns={columns}
       dataGridProps={{
         getRowId: (el: any) => el.machine_type,
-        // Both under initialState. As a controlled `columnVisibilityModel` prop
-        // with no change handler, this would freeze visibility for EVERY column
-        // and leave the column chooser unable to hide anything.
         initialState: {
-          columns: { columnVisibilityModel: { sort_queue_s: false } },
           sorting: {
-            sortModel: [{ field: "sort_queue_s", sort: "desc" }],
+            sortModel: [{ field: "avg_queue_s", sort: "desc" }],
           },
         },
         onRowClick: (params: any) => {

--- a/torchci/components/metrics/panels/QueuedJobsTable.tsx
+++ b/torchci/components/metrics/panels/QueuedJobsTable.tsx
@@ -54,7 +54,10 @@ export default function QueuedJobsTable({
           field: "queue_s",
           headerName: "Time in Queue",
           flex: 1,
-          valueFormatter: (params: number) => durationDisplay(params),
+          valueFormatter: (params: number, row: any) =>
+            row.is_stale
+              ? `${durationDisplay(params)} (suspected stuck)`
+              : durationDisplay(params),
         },
         { field: "machine_type", headerName: "Machine Type", flex: 1 },
         {
@@ -151,6 +154,7 @@ export default function QueuedJobsTable({
         { field: "event" },
         { field: "source_type" },
         { field: "ciflow_id" },
+        { field: "is_stale" },
       ]}
       dataGridProps={{
         columnVisibilityModel: {
@@ -160,6 +164,7 @@ export default function QueuedJobsTable({
           event: false,
           source_type: false,
           ciflow_id: false,
+          is_stale: false,
         },
         getRowId: (el: any) => el.html_url,
       }}

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -16,6 +16,7 @@ import { GridRenderCellParams } from "@mui/x-data-grid";
 import { DateTimePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { durationDisplay } from "components/common/TimeUtils";
+import QueuedJobsByMachineTypeTable from "components/metrics/panels/QueuedJobsByMachineTypeTable";
 import QueuedJobsTable from "components/metrics/panels/QueuedJobsTable";
 import ScalarPanel, {
   ScalarPanelWithValue,
@@ -857,87 +858,8 @@ export default function Page() {
         </Grid>
 
         <Grid size={{ xs: 6 }} height={ROW_HEIGHT}>
-          <TablePanel
-            title={"Queued Jobs by Machine Type"}
-            queryName={"queued_jobs_by_label"}
-            queryParams={{}}
-            columns={[
-              { field: "count", headerName: "Count", flex: 1 },
-              {
-                field: "avg_queue_s",
-                headerName: "Queue time",
-                flex: 1,
-                valueFormatter: (params: number) => durationDisplay(params),
-                cellClassName: (params) => {
-                  const queueTimeHours = params.value / 3600;
-                  if (queueTimeHours >= 4) return "queue-time-red";
-                  if (queueTimeHours >= 1) return "queue-time-yellow";
-                  return "";
-                },
-              },
-              {
-                field: "stale_count",
-                headerName: "Suspected stuck",
-                description:
-                  "A hint, not a verdict. Counts jobs where the workflow run " +
-                  "is over 6h old and its recorded update time still equals " +
-                  "its creation time; the job is still queued with no runner " +
-                  "and no steps recorded, and asks for a non-empty label set; " +
-                  "and some job created in the last hour with exactly those " +
-                  "labels did get a runner. Labels are not the whole of what a " +
-                  "job is scheduled against, so this can be wrong in either " +
-                  "direction. Count and Queue time still include these jobs, " +
-                  "and nothing is hidden or reordered by default. Sort by this " +
-                  "column to group them.",
-                flex: 1,
-                // COUNTIf is a UInt64. It should arrive as a JSON number, but
-                // that was not verifiable end-to-end, and a string here would
-                // sort "10" below "2" once someone sorts on the column. Coerce
-                // and declare the type rather than rely on it.
-                type: "number",
-                valueGetter: (value: any) => Number(value),
-                // Descending first: an ascending click would push every
-                // suspected row below the blanks, which is the one ordering a
-                // reader would not expect from a column about exceptions.
-                sortingOrder: ["desc", "asc", null],
-                // Blank rather than "0" so the column reads as an exception
-                // marker.
-                valueFormatter: (params: number, row: any) =>
-                  params > 0
-                    ? `${params} · ${durationDisplay(row.oldest_stale_s)}`
-                    : "",
-              },
-              { field: "machine_type", headerName: "Machine Type", flex: 3 },
-            ]}
-            dataGridProps={{
-              getRowId: (el: any) => el.machine_type,
-              // Deliberately still sorted on avg_queue_s. Demoting a row
-              // because it looks abandoned would put a heuristic in charge of
-              // what an oncaller reads first, and this one cannot tell an
-              // abandoned run from one whose every job is starving. The new
-              // column labels those rows; it does not move them.
-              initialState: {
-                sorting: {
-                  sortModel: [{ field: "avg_queue_s", sort: "desc" }],
-                },
-              },
-              onRowClick: (params: any) => {
-                setMachineTypeFilter(params.row.machine_type);
-              },
-              sx: {
-                "& .queue-time-yellow": {
-                  backgroundColor: "#B8860B", // Dark goldenrod
-                  color: "white",
-                },
-                "& .queue-time-red": {
-                  backgroundColor: "#B22222", // Fire brick red
-                  color: "white",
-                },
-                "& .MuiDataGrid-row": {
-                  cursor: "pointer",
-                },
-              },
-            }}
+          <QueuedJobsByMachineTypeTable
+            onMachineTypeClick={setMachineTypeFilter}
           />
         </Grid>
 

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -875,10 +875,47 @@ export default function Page() {
                   return "";
                 },
               },
-              { field: "machine_type", headerName: "Machine Type", flex: 4 },
+              {
+                field: "stale_count",
+                headerName: "Suspected stuck",
+                description:
+                  "A hint, not a verdict. Counts jobs where the workflow run " +
+                  "is over 6h old and its recorded update time still equals " +
+                  "its creation time; the job is still queued with no runner " +
+                  "and no steps recorded, and asks for a non-empty label set; " +
+                  "and some job created in the last hour with exactly those " +
+                  "labels did get a runner. Labels are not the whole of what a " +
+                  "job is scheduled against, so this can be wrong in either " +
+                  "direction. Count and Queue time still include these jobs, " +
+                  "and nothing is hidden or reordered by default. Sort by this " +
+                  "column to group them.",
+                flex: 1,
+                // COUNTIf is a UInt64. It should arrive as a JSON number, but
+                // that was not verifiable end-to-end, and a string here would
+                // sort "10" below "2" once someone sorts on the column. Coerce
+                // and declare the type rather than rely on it.
+                type: "number",
+                valueGetter: (value: any) => Number(value),
+                // Descending first: an ascending click would push every
+                // suspected row below the blanks, which is the one ordering a
+                // reader would not expect from a column about exceptions.
+                sortingOrder: ["desc", "asc", null],
+                // Blank rather than "0" so the column reads as an exception
+                // marker.
+                valueFormatter: (params: number, row: any) =>
+                  params > 0
+                    ? `${params} · ${durationDisplay(row.oldest_stale_s)}`
+                    : "",
+              },
+              { field: "machine_type", headerName: "Machine Type", flex: 3 },
             ]}
             dataGridProps={{
               getRowId: (el: any) => el.machine_type,
+              // Deliberately still sorted on avg_queue_s. Demoting a row
+              // because it looks abandoned would put a heuristic in charge of
+              // what an oncaller reads first, and this one cannot tell an
+              // abandoned run from one whose every job is starving. The new
+              // column labels those rows; it does not move them.
               initialState: {
                 sorting: {
                   sortModel: [{ field: "avg_queue_s", sort: "desc" }],

--- a/torchci/test/queuedJobsStale.test.ts
+++ b/torchci/test/queuedJobsStale.test.ts
@@ -1,0 +1,152 @@
+import { readFileSync } from "fs";
+import path from "path";
+
+// The "suspected stuck" classification lives in ClickHouse, duplicated across
+// two queries: queued_jobs_by_label (the "Queued Jobs by Machine Type" summary)
+// and queued_jobs (the job list it drills into). The metrics page presents one
+// as the summary of the other, so if the two drift the summary silently stops
+// describing the list. There is no TS function to import, so these tests pin
+// the SQL text itself.
+//
+// The predicate and the CTE it depends on are asserted as EXACT normalized
+// strings rather than by keyword. Keyword checks look reassuring and are not:
+// they survive an AND becoming an OR, or a `<` becoming a `>`, if both copies
+// are edited together. Exact equality means any semantic edit fails here and
+// has to be made deliberately, in both files and in this expectation.
+//
+// The other thing pinned here is that the SQL never acts on the classification
+// — it only reports it. It is a heuristic that cannot tell an abandoned run
+// from one whose every job is starving, so a query-side filter or ordering
+// built on it would be a way to bury a real outage, with nothing on screen to
+// say so. Every place is_stale is allowed to appear is enumerated below.
+// (A reader sorting or filtering the rendered table is a different thing: that
+// is visible and reversible, and these tests say nothing about it.)
+//
+// What these tests do NOT do is run the queries. Nothing here shows the SQL
+// returns correct rows.
+
+const queryPath = (name: string) =>
+  path.resolve(__dirname, "..", "clickhouse_queries", name, "query.sql");
+
+const BY_LABEL = readFileSync(queryPath("queued_jobs_by_label"), "utf-8");
+const JOB_LIST = readFileSync(queryPath("queued_jobs"), "utf-8");
+
+// The parenthesised `(...) AS is_stale` expression, wherever it appears.
+const IS_STALE_RE = /\(\s*workflow\.updated_at[\s\S]*?\)\s*AS is_stale/g;
+// The body of the live_runner_pools CTE the predicate depends on.
+const LIVE_POOLS_RE = /live_runner_pools AS \([\s\S]*?\n\)/g;
+
+const stripComments = (sql: string) => sql.replace(/---.*$/gm, "");
+
+const collapse = (sql: string) => sql.replace(/\s+/g, " ").trim();
+
+const normalize = (sql: string) => collapse(stripComments(sql));
+
+const matchAll = (sql: string, re: RegExp) =>
+  (stripComments(sql).match(re) ?? []).map(collapse);
+
+// Every remaining mention of is_stale once the predicate definitions are taken
+// out, one per line, trimmed. Comparing the whole list against an expected list
+// is deliberate: a regex looking for `WHERE ... is_stale` can be walked around
+// with a function call or a line break, whereas a new use of is_stale anywhere
+// shows up here as an unexpected entry.
+const isStaleUses = (sql: string) =>
+  stripComments(sql)
+    .replace(IS_STALE_RE, "IS_STALE_DEFINITION")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.includes("is_stale"));
+
+// Three independent things have to hold before a job is called suspect: the run
+// made no progress at all and is old enough that "not yet" is not the
+// explanation; this job never reached a runner; and it asks for a non-empty
+// label set something else has run recently, so a starved pool is not blamed on
+// GitHub. None of it is proof — see the query comments for what it cannot rule
+// out, and why the result is therefore never acted on.
+const EXPECTED_PREDICATE =
+  "( workflow.updated_at = workflow.created_at " +
+  "AND workflow.created_at < (CURRENT_TIMESTAMP() - INTERVAL 6 HOUR) " +
+  "AND job.status = 'queued' " +
+  "AND job.runner_name = '' " +
+  "AND LENGTH(job.steps) = 0 " +
+  "AND LENGTH(job.labels) > 0 " +
+  "AND job.labels IN (SELECT labels FROM live_runner_pools) " +
+  ") AS is_stale";
+
+const EXPECTED_LIVE_POOLS =
+  "live_runner_pools AS ( SELECT DISTINCT labels FROM default.workflow_job " +
+  "WHERE created_at > (CURRENT_TIMESTAMP() - INTERVAL 1 HOUR) " +
+  "AND runner_name != '' )";
+
+describe("the suspected-stuck classifier is identical in both queries", () => {
+  test("all four is_stale predicates match the expected expression exactly", () => {
+    const all = [
+      ...matchAll(BY_LABEL, IS_STALE_RE),
+      ...matchAll(JOB_LIST, IS_STALE_RE),
+    ];
+
+    // Two per file: one in the EC2/LF branch, one in the ARC branch.
+    expect(all).toHaveLength(4);
+    for (const predicate of all) {
+      expect(predicate).toBe(EXPECTED_PREDICATE);
+    }
+  });
+
+  test("both live_runner_pools definitions match exactly", () => {
+    // Widening this window, or changing its key, changes what the predicate
+    // above means without touching the predicate itself.
+    const all = [
+      ...matchAll(BY_LABEL, LIVE_POOLS_RE),
+      ...matchAll(JOB_LIST, LIVE_POOLS_RE),
+    ];
+
+    expect(all).toHaveLength(2);
+    for (const cte of all) {
+      expect(cte).toBe(EXPECTED_LIVE_POOLS);
+    }
+  });
+});
+
+describe("the summary query only adds columns", () => {
+  test("count, avg_queue_s and the row order are untouched", () => {
+    // Served unauthenticated at /api/clickhouse/queued_jobs_by_label, so these
+    // must keep covering every queued job, suspect ones included.
+    expect(BY_LABEL).toContain("COUNT(*) AS count");
+    expect(BY_LABEL).toContain("MAX(queue_s) AS avg_queue_s");
+    // Pinned through to the end of the statement. A prefix match would accept
+    // `ORDER BY count DESC, stale_count DESC`, which is exactly the tie-break
+    // that would quietly hand the ordering back to the heuristic.
+    expect(normalize(BY_LABEL)).toContain(
+      "GROUP BY machine_type ORDER BY count DESC " +
+        "SETTINGS allow_experimental_analyzer = 1;"
+    );
+  });
+
+  test("the two new columns are the whole change", () => {
+    expect(BY_LABEL).toContain("COUNTIf(is_stale) AS stale_count");
+    expect(BY_LABEL).toContain("MAXIf(queue_s, is_stale) AS oldest_stale_s");
+  });
+
+  test("is_stale is read only by those two aggregates", () => {
+    // Anything else — a HAVING, a WHERE, an ORDER BY term — would let the guess
+    // decide which machine types appear or in what order.
+    expect(isStaleUses(BY_LABEL)).toEqual([
+      "COUNTIf(is_stale) AS stale_count,",
+      "MAXIf(queue_s, is_stale) AS oldest_stale_s,",
+      "SELECT queue_s, is_stale, machine_type FROM ec2_queued_jobs",
+      "SELECT queue_s, is_stale, machine_type FROM arc_queued_jobs",
+    ]);
+  });
+});
+
+describe("the job list only adds a column", () => {
+  test("row order is untouched", () => {
+    expect(normalize(JOB_LIST)).toContain(
+      "ORDER BY queue_s DESC SETTINGS allow_experimental_analyzer = 1;"
+    );
+  });
+
+  test("is_stale is selected and nothing more", () => {
+    expect(isStaleUses(JOB_LIST)).toEqual([]);
+  });
+});

--- a/torchci/test/queuedJobsStale.test.ts
+++ b/torchci/test/queuedJobsStale.test.ts
@@ -122,15 +122,25 @@ describe("the summary query only adds columns", () => {
     );
   });
 
-  test("the two new columns are the whole change", () => {
+  test("the four new columns are the whole change", () => {
+    // live_* are the same two figures with the suspected jobs left out. The
+    // metrics page offers them behind a toggle; both sets are returned so that
+    // choice belongs to the page, where it can be announced and undone, rather
+    // than to this query, where it could not be.
+    expect(BY_LABEL).toContain("COUNTIf(NOT is_stale) AS live_count");
+    expect(BY_LABEL).toContain(
+      "MAXIf(queue_s, NOT is_stale) AS live_max_queue_s"
+    );
     expect(BY_LABEL).toContain("COUNTIf(is_stale) AS stale_count");
     expect(BY_LABEL).toContain("MAXIf(queue_s, is_stale) AS oldest_stale_s");
   });
 
-  test("is_stale is read only by those two aggregates", () => {
-    // Anything else — a HAVING, a WHERE, an ORDER BY term — would let the guess
-    // decide which machine types appear or in what order.
+  test("is_stale is read only by those four aggregates", () => {
+    // Anything else — a HAVING, a WHERE, an ORDER BY term — would drop or
+    // reorder rows where no toggle could show the reader it had happened.
     expect(isStaleUses(BY_LABEL)).toEqual([
+      "COUNTIf(NOT is_stale) AS live_count,",
+      "MAXIf(queue_s, NOT is_stale) AS live_max_queue_s,",
       "COUNTIf(is_stale) AS stale_count,",
       "MAXIf(queue_s, is_stale) AS oldest_stale_s,",
       "SELECT queue_s, is_stale, machine_type FROM ec2_queued_jobs",


### PR DESCRIPTION
✴️ iz2: opened on behalf of @izaitsevfb.

## Problem

On [hud.pytorch.org/metrics](https://hud.pytorch.org/metrics), "Queued Jobs by Machine Type" counts jobs that are not waiting for anything. pytorch/pytorch creates each workflow twice per ghstack push and the concurrency group cancels the loser; when GitHub never delivers that cancellation, the loser's jobs stay `queued` indefinitely — until the query's 1-week window ages them out and a fresh batch takes their place. GitHub's REST API agrees with ClickHouse here, so this is not a data artifact.

A recent sample: 17 jobs making `ubuntu-24.04` and `linux.24_04.4x` both read 1.3d — while `ubuntu-24.04` started 923 jobs in the last hour. Runs in this state appear on 27 of the last 30 days.

## Proposed solution

Leave those jobs out of Count and Queue time by default, behind a toggle, and say so in the panel title: *"17 jobs look stuck (oldest 1.3d), left out; ubuntu-24.04, linux.24_04.4x hidden. Show them"*. A machine type with nothing left once they are gone has no queue to report, so its row leaves the table rather than reading `0 / —`. The "Jobs in Queue" drill-down marks the same jobs `(suspected stuck)`.

A job is suspect only when all three hold:

1. its workflow run is over 6h old and `updated_at` still equals `created_at` — frozen candidates are bimodal by parent-run age, 164 jobs under 6h and none at all between 6h and 24h;
2. the job is still `queued`, with no runner and no steps, and requests a non-empty label set;
3. some job with exactly those labels did get a runner in the last hour.

(3) is the outage guard: a pool with no eligible runners freezes its runs in exactly the same way, so nothing is written off unless the pool is demonstrably serving work.

## What changes?

The heuristic cannot distinguish an abandoned run from one whose every job is starving. `labels` is the job's *request*, not the scheduler's pool identity — GitHub also matches on runner group and repository access, and the array comparison is order-sensitive — so (3) does not prove the suspect job could itself have run. Two cases survive the guard: a partially-starving pool, and a pool that has just failed outright, whose pre-failure successes keep satisfying (3) for up to an hour.

**So the panel title is load-bearing, and it names what it hid.** Whenever anything is left out it gives the job count, the oldest age, and every machine type that left the table, and one click restores all of it. That is the only per-pool signal left, which is why it lists names rather than a count. Everything else about the table is unchanged: the default sort is the visible Queue time, as it was before this PR.

The API change is additive: `queued_jobs_by_label` gains `live_count`, `live_max_queue_s`, `stale_count` and `oldest_stale_s`; `queued_jobs` gains `is_stale`. Existing columns and both `ORDER BY`s are byte-identical, because `/api/clickhouse/queued_jobs_by_label` is served unauthenticated and out-of-repo consumers can't be enumerated. A payload missing the new columns, or one failing `live_count + stale_count == count`, falls back to the raw figures and offers no toggle. The queries themselves never filter or order on the classification — that stays in the page, where it can be announced and undone.

Not touched: `queued_jobs_aggregate`, which feeds the AWS autoscalers. Same underlying exposure, but changing autoscaler input is its owners' call.

The conclusive signal would be the completed duplicate run — a dedup loser has a terminal-state twin with the same `head_sha`, a starving run does not. It works, but the self-join costs 18s against ~2s for the whole query, so it is not affordable on a panel that refreshes every 5 minutes.

## Test plan

- Live against pytorch/pytorch: 12 rows, 2.05s vs ~1.9s baseline, every healthy machine type at `stale_count = 0`. Mutation-tested the liveness guard — drop `ubuntu-24.04` from the live set and its 6 jobs stay fully counted and its row on screen.
- `test/queuedJobsStale.test.ts` pins the predicate and the `live_runner_pools` CTE as exact strings across both queries, and enumerates every place `is_stale` may appear so a query-side filter or ordering can't be added silently.
- prettier, `next lint` and jest (51 suites) pass. Two pre-existing jest failures and one `tsc` error remain: they come from a missing `@aws-sdk/client-lambda` in my checkout and reproduce identically on the base commit.
- **Not done — needs a reviewer with the page running.** I have no browser in this environment, and the row-hiding and title text have no component test (this repo has none). Worth checking: rows disappear and come back with the toggle, the title names the right machine types, the filter panel and column chooser, and CSV export.
