### PR TITLE
Introduce new keys for greenlight review PR

### DIFF
--- a/.github/workflows/greenlight-review.yml
+++ b/.github/workflows/greenlight-review.yml
@@ -128,6 +128,8 @@ jobs:
           CLICKHOUSE_ENDPOINT: ${{ secrets.CLICKHOUSE_HUD_USER_URL }}
           CLICKHOUSE_USERNAME: ${{ secrets.CLICKHOUSE_HUD_USER_USERNAME }}
           CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_HUD_USER_PASSWORD }}
+          PYTORCH_GREENLIGHT_DRCI_TOKEN: ${{ secrets.DRCI_BOT_KEY }}
+          PYTORCH_GREENLIGHT_DRCI_INTERNAL_TOKEN: ${{ secrets.HUD_API_TOKEN }}
           IN_PR: ${{ inputs.pr }}
           IN_REQUESTER: ${{ inputs.requester }}
           IN_MAX: ${{ inputs.max }}

--- a/greenlight/README.md
+++ b/greenlight/README.md
@@ -157,7 +157,7 @@ PYTORCH_GREENLIGHT_DRCI_TOKEN="$DRCI_BOT_KEY" just run drci-poke --pr 123
 
 It waits `PYTORCH_GREENLIGHT_DRCI_POKE_DELAY_SECONDS` (default 10) first, because Dr. CI reads
 the state from ClickHouse and the row has only just been handed to the S3 -> replicator path.
-It never raises: by the time it runs the merge gate has already fired and the row is uploaded,
+It swallows every failure: by the time it runs the merge gate has already fired and the row is uploaded,
 so failing would only turn the job that gates auto-landing red over a cosmetic refresh — and
 the sweep still backstops a lost poke. The reviewer workflow runs it from both the
 `announce_start` and `record` jobs, right after each uploads its row, with
@@ -198,8 +198,9 @@ variables (`CLICKHOUSE_HOST` or its `CLICKHOUSE_ENDPOINT` alias, `CLICKHOUSE_USE
 `CLICKHOUSE_PASSWORD`, and `CLICKHOUSE_PORT`, default `8443`).
 
 `PYTORCH_GREENLIGHT_MAX_RUNTIME_SECONDS` (default `600`, `0` = disabled) bounds every
-iteration in both one-shot and `--loop` mode. In `--loop` mode, SIGTERM/SIGINT are
-observed only between iterations, so the per-iteration timeout is what interrupts a
+iteration in both one-shot and `--loop` mode, the scan's in-process Dr. CI pokes included —
+those swallow their own failures but let the timeout through. In `--loop` mode, SIGTERM/SIGINT
+are observed only between iterations, so the per-iteration timeout is what interrupts a
 hung run.
 
 ## Deployment
@@ -217,9 +218,12 @@ under the Lambda runtime); single-instance and hang-bounding come from
 `reserved_concurrent_executions = 1` and the Lambda function timeout instead.
 
 The scan's Dr. CI poke needs `PYTORCH_GREENLIGHT_DRCI_TOKEN` (and optionally
-`PYTORCH_GREENLIGHT_DRCI_INTERNAL_TOKEN`) in the function environment. Without it every poke
-logs a warning and no-ops, leaving the `AI_REVIEW_DISPATCHED` state to surface on Dr. CI's
-15-minute sweep — the scan itself still succeeds.
+`PYTORCH_GREENLIGHT_DRCI_INTERNAL_TOKEN`) wherever the scan runs: the Lambda reads both from its
+function environment, provisioned by the gha-infra terraform, and the manual /
+`@greenlight recheck` entry point (`greenlight-review.yml`) passes them from the `DRCI_BOT_KEY`
+and `HUD_API_TOKEN` secrets. Without the token every poke logs a warning and no-ops, leaving the
+`AI_REVIEW_DISPATCHED` state to surface on Dr. CI's 15-minute sweep — the scan itself still
+succeeds.
 
 The zip ships in test-infra's shared lambda release alongside every other lambda:
 
@@ -380,7 +384,7 @@ src/greenlight/
   decision.py      # decide which scanned PRs need a (re-)dispatch (new/changed vs. in-flight AI_REVIEW_STARTED)
   dispatch.py      # trigger the reviewer workflow on pytorch/test-infra via workflow_dispatch
   verdict.py       # one-shot: emit a verdict row for S3->replicator, then approve/dismiss and (unless Dr. CI renders it) comment
-  drci_poke.py     # ask Dr. CI to rebuild one PR's comment (drci-poke subcommand and the scan's dispatch poke); never raises
+  drci_poke.py     # ask Dr. CI to rebuild one PR's comment (drci-poke subcommand and the scan's dispatch poke); swallows its own failures
   github_client.py # GitHub PR access: read PR list/fingerprint + post verdict actions
   clickhouse_client.py # ClickHouse connection helper for the service's read (SELECT) queries
   pr_hash.py       # eval_hash land-guard: deterministic PR fingerprint hash

--- a/greenlight/src/greenlight/drci_poke.py
+++ b/greenlight/src/greenlight/drci_poke.py
@@ -11,9 +11,11 @@ Dr. CI reads the state from ClickHouse, which is fed by the S3 -> replicator pat
 only just written to, hence the configurable pre-POST delay: poking before the row is ingested
 re-renders the comment from the state the poke was meant to replace.
 
-The poke never raises. By the time it runs the merge gate has already fired and the state row is
-uploaded, so a failure has nothing left to protect: raising would only turn the job that gates
-auto-landing red over a cosmetic refresh, and the scheduled sweep still backstops a lost poke.
+The poke swallows every failure. By the time it runs the merge gate has already fired and the state
+row is uploaded, so a failure has nothing left to protect: raising would only turn the job that
+gates auto-landing red over a cosmetic refresh, and the scheduled sweep still backstops a lost poke.
+``IterationTimeout`` is the one exception: it is the caller's per-iteration watchdog signal, not a
+poke failure, and swallowing it would strand the scan past its deadline because SIGALRM is one-shot.
 """
 
 from __future__ import annotations
@@ -24,6 +26,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlencode
 
 from greenlight.constants import DRCI_ENDPOINT
+from greenlight.guards import IterationTimeout
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -69,7 +72,8 @@ def poke(
 ) -> None:
     """Wait out the ingestion delay, then POST one refresh request for ``repo``#``pr_number``.
 
-    Logs and swallows every failure, including a non-2xx response.
+    Logs and swallows every failure, including a non-2xx response. ``IterationTimeout`` still
+    propagates so the caller's per-iteration watchdog can abort.
     """
     org, _, name = repo.partition("/")
     if not org or not name:
@@ -93,6 +97,8 @@ def poke(
             logger.info("waiting %ss for state ingestion before poking Dr. CI for %s#%d", delay, repo, pr_number)
             sleep(delay)
         status = post(url, body, headers)
+    except IterationTimeout:
+        raise
     except Exception as exc:
         logger.error("Dr. CI poke for %s#%d failed: %s", repo, pr_number, exc, exc_info=True)
         return

--- a/greenlight/tests/test_drci_poke.py
+++ b/greenlight/tests/test_drci_poke.py
@@ -8,6 +8,7 @@ import pytest
 
 from greenlight import drci_poke
 from greenlight.constants import DRCI_ENDPOINT
+from greenlight.guards import IterationTimeout
 
 
 class _Recorder:
@@ -199,6 +200,32 @@ def test_poke_swallows_sleep_failure_without_posting(poke_config, caplog):
 
     assert post.calls == []
     assert any("Dr. CI poke for pytorch/pytorch#9 failed" in record.getMessage() for record in caplog.records)
+
+
+def test_poke_propagates_iteration_timeout_from_the_post(poke_config):
+    def timing_out_post(url: str, body: bytes, headers: dict[str, str]) -> NoReturn:
+        raise IterationTimeout("iteration exceeded")
+
+    # IterationTimeout is the caller's per-iteration watchdog signal, not a poke failure: SIGALRM is
+    # one-shot, so swallowing it would strand the scan past its deadline with the poke unretried.
+    with pytest.raises(IterationTimeout):
+        drci_poke.poke("pytorch/pytorch", 9, poke_config(), sleep=_boom_sleep, post=timing_out_post)
+
+
+def test_poke_propagates_iteration_timeout_from_the_sleep(poke_config):
+    rec = _Recorder()
+    post = _FakePost(rec)
+
+    def timing_out_sleep(seconds: float) -> NoReturn:
+        raise IterationTimeout("iteration exceeded")
+
+    # The delay is the longest stretch of the poke, so the alarm most often lands here.
+    with pytest.raises(IterationTimeout):
+        drci_poke.poke(
+            "pytorch/pytorch", 9, poke_config(drci_poke_delay_seconds=1.0), sleep=timing_out_sleep, post=post
+        )
+
+    assert post.calls == []
 
 
 class _FakeResponse:

--- a/greenlight/tests/test_drci_poke.py
+++ b/greenlight/tests/test_drci_poke.py
@@ -219,7 +219,6 @@ def test_poke_propagates_iteration_timeout_from_the_sleep(poke_config):
     def timing_out_sleep(seconds: float) -> NoReturn:
         raise IterationTimeout("iteration exceeded")
 
-    # The delay is the longest stretch of the poke, so the alarm most often lands here.
     with pytest.raises(IterationTimeout):
         drci_poke.poke(
             "pytorch/pytorch", 9, poke_config(drci_poke_delay_seconds=1.0), sleep=timing_out_sleep, post=post


### PR DESCRIPTION
**Impact:** greenlight only
**Risk:** low

## What

Two small fixes to the scan's in-process Dr. CI poke:

- `greenlight-review.yml` now exports `PYTORCH_GREENLIGHT_DRCI_TOKEN` / `PYTORCH_GREENLIGHT_DRCI_INTERNAL_TOKEN` (from `DRCI_BOT_KEY` / `HUD_API_TOKEN`) to the scan step.
- `drci_poke.poke` re-raises `IterationTimeout` instead of swallowing it, matching what `scan_runner._dispatch_one` already does around `emit_dispatched`.

## Why

When the dispatch poke was added, only the Lambda got the tokens (via the gha-infra terraform). The workflow entry point never got them, so every manual scan or `@greenlight recheck` logged "no Dr. CI token configured" and no-op'd — the state only showed up on Dr. CI's 15-minute sweep.

The `IterationTimeout` bit is the same class of bug as the one already fixed in `scan_runner`: `poke`'s blanket `except Exception` also caught the per-iteration watchdog signal. SIGALRM is one-shot, so swallowing it means the alarm is spent and the scan runs past its deadline with nothing left to interrupt it. The poke still swallows everything else — a lost poke is cosmetic and the sweep backstops it.