### PR TITLE
[CRCR] Add metrics for max execution time and end-to-end time in summary stats

### DIFF
--- a/torchci/clickhouse_queries/crcr_backend_summary/query.sql
+++ b/torchci/clickhouse_queries/crcr_backend_summary/query.sql
@@ -5,6 +5,9 @@ WITH deduped AS (
         conclusion,
         queue_time,
         execution_time,
+        run_id,
+        started_at,
+        completed_at,
         ROW_NUMBER() OVER (
             PARTITION BY run_id, job_name
             ORDER BY run_attempt DESC
@@ -16,6 +19,24 @@ WITH deduped AS (
         AND started_at > now() - INTERVAL {days: UInt64} DAY
         AND status = 'completed'
         AND pr_number > 0
+),
+
+base AS (
+    SELECT
+        conclusion,
+        job_name,
+        pr_number,
+        queue_time,
+        execution_time,
+        max(queue_time) OVER (PARTITION BY run_id) AS run_queue_time_s,
+        dateDiff(
+            'second',
+            min(started_at) OVER (PARTITION BY run_id),
+            max(completed_at) OVER (PARTITION BY run_id)
+        ) AS run_span_s,
+        row_number() OVER (PARTITION BY run_id ORDER BY job_name) AS run_rn
+    FROM deduped
+    WHERE rn = 1
 )
 
 SELECT
@@ -53,20 +74,18 @@ SELECT
     avg(execution_time) AS avg_exec_time_s,
     max(execution_time) AS max_exec_time_s,
     quantile(0.95)(execution_time) AS p95_exec_time_s,
-    -- End-to-end = queue_time + execution_time. RFC-0050's L3 gate defines
-    -- this as the P50 (median) time-to-signal. queue_time is null
-    -- on retries (dispatch-relative queue time is meaningless once a re-run
-    -- reuses the original delivery_id), so it's coalesced to 0 -- a retried
-    -- job's execution_time still counts toward the aggregate instead of the
-    -- whole row dropping out.
-    median(coalesce(queue_time, 0) + execution_time) AS median_e2e_time_s,
-    quantile(0.95)(coalesce(queue_time, 0) + execution_time) AS p95_e2e_time_s,
+    -- E2E time is per-run (RFC-0050); run_rn = 1 keeps one sample per run.
+    medianIf(
+        run_queue_time_s + run_span_s,
+        run_rn = 1 AND run_queue_time_s IS NOT NULL
+    ) AS median_e2e_time_s,
+    quantileIf(0.95)(
+        run_queue_time_s + run_span_s,
+        run_rn = 1 AND run_queue_time_s IS NOT NULL
+    ) AS p95_e2e_time_s,
     if(
         total_jobs > 0,
         timed_out / total_jobs,
         0
     ) AS timeout_rate
-FROM
-    deduped
-WHERE
-    rn = 1
+FROM base

--- a/torchci/clickhouse_queries/crcr_backend_summary/query.sql
+++ b/torchci/clickhouse_queries/crcr_backend_summary/query.sql
@@ -73,13 +73,14 @@ SELECT
     avg(queue_time) AS avg_queue_time_s,
     avg(execution_time) AS avg_exec_time_s,
     max(execution_time) AS max_exec_time_s,
-    quantile(0.95)(execution_time) AS p95_exec_time_s,
+    quantileExact(0.95)(execution_time) AS p95_exec_time_s,
     -- E2E time is per-run (RFC-0050); run_rn = 1 keeps one sample per run.
-    medianIf(
+    -- Exact (not sampled) quantiles since this gates L3 promotion decisions.
+    quantileExactIf(0.5)(
         run_queue_time_s + run_span_s,
         run_rn = 1 AND run_queue_time_s IS NOT NULL
     ) AS median_e2e_time_s,
-    quantileIf(0.95)(
+    quantileExactIf(0.95)(
         run_queue_time_s + run_span_s,
         run_rn = 1 AND run_queue_time_s IS NOT NULL
     ) AS p95_e2e_time_s,

--- a/torchci/clickhouse_queries/crcr_backend_summary/query.sql
+++ b/torchci/clickhouse_queries/crcr_backend_summary/query.sql
@@ -51,6 +51,16 @@ SELECT
     uniqExact(pr_number) AS total_prs,
     avg(queue_time) AS avg_queue_time_s,
     avg(execution_time) AS avg_exec_time_s,
+    max(execution_time) AS max_exec_time_s,
+    quantile(0.95)(execution_time) AS p95_exec_time_s,
+    -- End-to-end = queue_time + execution_time. RFC-0050's L3 gate defines
+    -- this as the P50 (median) time-to-signal. queue_time is null
+    -- on retries (dispatch-relative queue time is meaningless once a re-run
+    -- reuses the original delivery_id), so it's coalesced to 0 -- a retried
+    -- job's execution_time still counts toward the aggregate instead of the
+    -- whole row dropping out.
+    median(coalesce(queue_time, 0) + execution_time) AS median_e2e_time_s,
+    quantile(0.95)(coalesce(queue_time, 0) + execution_time) AS p95_e2e_time_s,
     if(
         total_jobs > 0,
         timed_out / total_jobs,

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -9,6 +9,7 @@ import {
   SelectChangeEvent,
   Skeleton,
   Stack,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import { durationDisplay } from "components/common/TimeUtils";
@@ -99,11 +100,13 @@ function StatCard({
   value,
   sub,
   color,
+  tooltip,
 }: {
   label: string;
   value: string | number;
   sub?: string;
   color?: string;
+  tooltip?: string;
 }) {
   return (
     <Paper
@@ -118,6 +121,17 @@ function StatCard({
     >
       <Typography variant="caption" color="text.secondary">
         {label}
+        {tooltip && (
+          <Tooltip title={tooltip}>
+            <Box
+              component="span"
+              sx={{ cursor: "help", ml: 0.5 }}
+              aria-label={`About ${label}`}
+            >
+              ⓘ
+            </Box>
+          </Tooltip>
+        )}
       </Typography>
       <Typography variant="h5" sx={{ fontWeight: 600, color: color }}>
         {value}
@@ -203,6 +217,7 @@ function SummaryCards({ stats }: { stats: SummaryStats }) {
               ? "#d32f2f"
               : undefined
           }
+          tooltip="The single longest job run in this window. p95 = the run time 95% of jobs finish within — a steadier read than the max, which one outlier job can skew."
         />
         <StatCard
           label="End-to-End Time (P50)"
@@ -222,6 +237,7 @@ function SummaryCards({ stats }: { stats: SummaryStats }) {
               ? "#d32f2f"
               : undefined
           }
+          tooltip="P50 (median) time from dispatch to CI status: half of jobs are faster than this, half slower. p95 = the time 95% of jobs finish within."
         />
         <StatCard
           label="Timeout Rate"

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -125,6 +125,7 @@ function StatCard({
           <Tooltip title={tooltip}>
             <Box
               component="span"
+              tabIndex={0}
               sx={{ cursor: "help", ml: 0.5 }}
               aria-label={`About ${label}`}
             >

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -243,7 +243,13 @@ function SummaryCards({ stats }: { stats: SummaryStats }) {
           label="Timeout Rate"
           value={`${(stats.timeout_rate * 100).toFixed(1)}%`}
           sub={`${stats.timed_out} timed out / ${stats.total_jobs} jobs`}
-          color={stats.timeout_rate >= L3_TIMEOUT_RATE ? "#d32f2f" : undefined}
+          color={
+            stats.timeout_rate >= L3_TIMEOUT_RATE
+              ? "#d32f2f"
+              : stats.timeout_rate > 0
+              ? "#ed6c02"
+              : undefined
+          }
         />
       </Box>
     </Stack>

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -79,10 +79,20 @@ interface SummaryStats {
   total_prs: number;
   avg_queue_time_s: number | null;
   avg_exec_time_s: number | null;
+  max_exec_time_s: number | null;
+  median_e2e_time_s: number | null;
+  p95_exec_time_s: number | null;
+  p95_e2e_time_s: number | null;
   timeout_rate: number;
 }
 
 // ---- Summary Stat Cards ----
+
+// RFC-0050 L3 promotion/demotion infrastructure gates (rfcs#102, ratified).
+const L3_AVG_QUEUE_TIME_S = 30 * 60; // < 30 min
+const L3_MAX_EXEC_TIME_S = 3 * 3600; // < 3 h
+const L3_E2E_TIME_S = 3 * 3600; // < 3 h (P50 time-to-signal)
+const L3_TIMEOUT_RATE = 0.01; // < 1%
 
 function StatCard({
   label,
@@ -159,6 +169,12 @@ function SummaryCards({ stats }: { stats: SummaryStats }) {
               : "–"
           }
           sub="dispatch to start"
+          color={
+            stats.avg_queue_time_s != null &&
+            stats.avg_queue_time_s > L3_AVG_QUEUE_TIME_S
+              ? "#d32f2f"
+              : undefined
+          }
         />
         <StatCard
           label="Avg Execution Time"
@@ -170,16 +186,48 @@ function SummaryCards({ stats }: { stats: SummaryStats }) {
           sub="start to completion"
         />
         <StatCard
+          label="Max Execution Time"
+          value={
+            stats.max_exec_time_s != null
+              ? durationDisplay(Math.round(stats.max_exec_time_s))
+              : "–"
+          }
+          sub={
+            stats.p95_exec_time_s != null
+              ? `p95: ${durationDisplay(Math.round(stats.p95_exec_time_s))}`
+              : "start to completion"
+          }
+          color={
+            stats.max_exec_time_s != null &&
+            stats.max_exec_time_s > L3_MAX_EXEC_TIME_S
+              ? "#d32f2f"
+              : undefined
+          }
+        />
+        <StatCard
+          label="End-to-End Time (P50)"
+          value={
+            stats.median_e2e_time_s != null
+              ? durationDisplay(Math.round(stats.median_e2e_time_s))
+              : "–"
+          }
+          sub={
+            stats.p95_e2e_time_s != null
+              ? `p95: ${durationDisplay(Math.round(stats.p95_e2e_time_s))}`
+              : "dispatch to CI status"
+          }
+          color={
+            stats.median_e2e_time_s != null &&
+            stats.median_e2e_time_s > L3_E2E_TIME_S
+              ? "#d32f2f"
+              : undefined
+          }
+        />
+        <StatCard
           label="Timeout Rate"
           value={`${(stats.timeout_rate * 100).toFixed(1)}%`}
           sub={`${stats.timed_out} timed out / ${stats.total_jobs} jobs`}
-          color={
-            stats.timeout_rate >= 0.1
-              ? "#d32f2f"
-              : stats.timeout_rate > 0
-              ? "#ed6c02"
-              : undefined
-          }
+          color={stats.timeout_rate >= L3_TIMEOUT_RATE ? "#d32f2f" : undefined}
         />
       </Box>
     </Stack>


### PR DESCRIPTION
Adds the L3 promotion/demotion infrastructure metrics from RFC-0050 ([pytorch/rfcs#102](https://github.com/pytorch/rfcs/pull/102), now merged) to the CRCR backend summary.

## Changes

- `crcr_backend_summary/query.sql`: adds `max_exec_time_s`, `median_e2e_time_s` (end-to-end = queue wait + execution, as **P50**, matching the ratified RFC), and `p95_exec_time_s` / `p95_e2e_time_s` as additional diagnostic percentiles. Uses `quantileExact`/`quantileExactIf` rather than the sampled `quantile`/`median`, since these numbers can gate L3 promotion decisions.
- `/crcr/[org]/[repo]`: adds "Max Execution Time" and "End-to-End Time (P50)" stat cards (p95 shown as the sub-label), and wires up the ratified RFC-0050 thresholds (avg queue < 30m, max execution < 3h, end-to-end P50 < 3h, timeout rate < 1%) so a card turns red when a repo breaches its gate.
- Adds an ⓘ info icon next to the two new labels; hovering it explains what P50/P95 mean for anyone unfamiliar with the terms. Keyboard-reachable (`tabIndex={0}`), not just mouse-hover.

## Heads up: timeout-rate threshold change

The timeout-rate gate tightens 10x (`>= 0.1` → `>= 0.01`), correct per the ratified RFC. This will likely flip a number of cards red on merge — that's expected, not a regression.

## End-to-end time is computed per run, not per job

RFC-0050 defines end-to-end time as "the P50 time-to-signal, from webhook delivery to CI status report" — a property of one workflow run, not of an individual job. #8557 also made `queue_time` workflow-level: only the first job in a run to report `in_progress` gets a `queue_time` sample; every other job in that run reports `NULL`.

Aggregating `queue_time + execution_time` per job row (as an earlier version of this PR did, via `coalesce(queue_time, 0)`) would treat every one of those `NULL`s as "didn't queue" once #8557 lands, collapsing the E2E median toward plain execution time and silently hiding real queue wait.

Instead, the query now:
- partitions job rows by `(run_id, run_attempt)` using window functions,
- takes the one non-null `queue_time` per run (`max(queue_time) OVER (...)` — NULL if the run never got a sample, e.g. a retry, which is excluded from the E2E calc rather than coalesced to 0),
- adds the run's wall-clock span from its first job's `started_at` to its last job's `completed_at` (this also captures the idle gap between dependent jobs — e.g. a test job waiting on a build job to finish — which isn't recorded in either `queue_time` or any single job's `execution_time`),
- and takes the median/P95 across runs (one sample per run), not across job rows.

Thanks @atalman for catching this in review.

Fixes #8551

