### PR TITLE
Update wincanarylf scale-config for testing Windows 2019 GHA CI - 20260826001402

### DIFF
--- a/.github/canary-scale-config.yml
+++ b/.github/canary-scale-config.yml
@@ -276,7 +276,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   c.windows.g4dn.xlarge.nonephemeral:
     disk_size: 256
     instance_type: g4dn.xlarge
@@ -286,7 +286,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   c.windows.4xlarge:
     disk_size: 256
     instance_type: c5d.4xlarge
@@ -296,7 +296,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   c.windows.4xlarge.nonephemeral:
     disk_size: 256
     instance_type: c5d.4xlarge
@@ -306,7 +306,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   c.windows.12xlarge:
     disk_size: 256
     instance_type: c5d.12xlarge
@@ -316,7 +316,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   c.windows.12xlarge.nonephemeral:
     disk_size: 256
     instance_type: c5d.12xlarge
@@ -326,7 +326,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   c.windows.8xlarge.nvidia.gpu:
     disk_size: 256
     instance_type: p3.2xlarge
@@ -336,7 +336,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   c.windows.8xlarge.nvidia.gpu.nonephemeral:
     disk_size: 256
     instance_type: p3.2xlarge
@@ -346,7 +346,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   c.windows.g5.4xlarge.nvidia.gpu:
     disk_size: 256
     instance_type: g5.4xlarge
@@ -356,7 +356,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   c.linux.2xlarge.memory:
     disk_size: 200
     instance_type: r5.2xlarge

--- a/.github/lf-canary-scale-config.yml
+++ b/.github/lf-canary-scale-config.yml
@@ -291,7 +291,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   lf.c.windows.g4dn.xlarge.nonephemeral:
     disk_size: 256
     instance_type: g4dn.xlarge
@@ -301,7 +301,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   lf.c.windows.4xlarge:
     disk_size: 256
     instance_type: c5d.4xlarge
@@ -311,7 +311,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   lf.c.windows.4xlarge.nonephemeral:
     disk_size: 256
     instance_type: c5d.4xlarge
@@ -321,7 +321,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   lf.c.windows.12xlarge:
     disk_size: 256
     instance_type: c5d.12xlarge
@@ -331,7 +331,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   lf.c.windows.12xlarge.nonephemeral:
     disk_size: 256
     instance_type: c5d.12xlarge
@@ -341,7 +341,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   lf.c.windows.8xlarge.nvidia.gpu:
     disk_size: 256
     instance_type: p3.2xlarge
@@ -351,7 +351,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   lf.c.windows.8xlarge.nvidia.gpu.nonephemeral:
     disk_size: 256
     instance_type: p3.2xlarge
@@ -361,7 +361,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   lf.c.windows.g5.4xlarge.nvidia.gpu:
     disk_size: 256
     instance_type: g5.4xlarge
@@ -371,7 +371,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   lf.c.linux.2xlarge.memory:
     disk_size: 200
     instance_type: r5.2xlarge

--- a/.github/lf-scale-config.yml
+++ b/.github/lf-scale-config.yml
@@ -276,7 +276,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   lf.windows.g4dn.xlarge.nonephemeral:
     disk_size: 256
     instance_type: g4dn.xlarge
@@ -286,7 +286,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   lf.windows.4xlarge:
     disk_size: 256
     instance_type: c5d.4xlarge
@@ -296,7 +296,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   lf.windows.4xlarge.nonephemeral:
     disk_size: 256
     instance_type: c5d.4xlarge
@@ -306,7 +306,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   lf.windows.12xlarge:
     disk_size: 256
     instance_type: c5d.12xlarge
@@ -316,7 +316,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   lf.windows.12xlarge.nonephemeral:
     disk_size: 256
     instance_type: c5d.12xlarge
@@ -326,7 +326,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   lf.windows.8xlarge.nvidia.gpu:
     disk_size: 256
     instance_type: p3.2xlarge
@@ -336,7 +336,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   lf.windows.8xlarge.nvidia.gpu.nonephemeral:
     disk_size: 256
     instance_type: p3.2xlarge
@@ -346,7 +346,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   lf.windows.g5.4xlarge.nvidia.gpu:
     disk_size: 256
     instance_type: g5.4xlarge
@@ -356,7 +356,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   lf.linux.2xlarge.memory:
     disk_size: 200
     instance_type: r5.2xlarge

--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -272,7 +272,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   windows.g4dn.xlarge.nonephemeral:
     disk_size: 256
     instance_type: g4dn.xlarge
@@ -282,7 +282,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   windows.4xlarge:
     disk_size: 256
     instance_type: c5d.4xlarge
@@ -292,7 +292,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   windows.4xlarge.nonephemeral:
     disk_size: 256
     instance_type: c5d.4xlarge
@@ -302,7 +302,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   windows.12xlarge:
     disk_size: 256
     instance_type: c5d.12xlarge
@@ -312,7 +312,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   windows.12xlarge.nonephemeral:
     disk_size: 256
     instance_type: c5d.12xlarge
@@ -322,7 +322,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   windows.8xlarge.nvidia.gpu:
     disk_size: 256
     instance_type: p3.2xlarge
@@ -332,7 +332,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   windows.8xlarge.nvidia.gpu.nonephemeral:
     disk_size: 256
     instance_type: p3.2xlarge
@@ -342,7 +342,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   windows.g5.4xlarge.nvidia.gpu:
     disk_size: 256
     instance_type: g5.4xlarge
@@ -352,7 +352,7 @@ runner_types:
       wincanary:
         ami: Windows 2019 GHA CI - 20250812161628|308535385114
       wincanarylf:
-        ami: Windows 2019 GHA CI - 20260501125018|391835788720
+        ami: Windows 2019 GHA CI - 20260826001402|391835788720
   linux.2xlarge.memory:
     disk_size: 200
     instance_type: r5.2xlarge


### PR DESCRIPTION
Testing Windows AMI with CUDA 13.4 support:
* https://github.com/pytorch/test-infra/pull/8465

Update wincanary for testing new AMI : `Windows 2019 GHA CI - 20260826001402`

Bumps the `wincanarylf` AMI from `20260501125018` to `20260826001402` (account `391835788720`) across all four scale-config files, 9 runner types each:

- `.github/scale-config.yml`
- `.github/lf-scale-config.yml`
- `.github/canary-scale-config.yml`
- `.github/lf-canary-scale-config.yml`

`wincanary` (account `308535385114`) is unchanged.

Same shape as #7893.

## Test plan

`python3 .github/scripts/validate_scale_config.py` passes locally:

```
scaled-config.yml is valid
scale-config.yml is consistent with .github/canary-scale-config.yml
scale-config.yml is consistent with .github/lf-scale-config.yml
scale-config.yml is consistent with .github/lf-canary-scale-config.yml
All validations successful
```
