### PR TITLE
Fail fast when --apply has no admin:org token for runner groups

### DIFF
--- a/tools/scripts/release_manage_runner_groups.py
+++ b/tools/scripts/release_manage_runner_groups.py
@@ -535,12 +535,22 @@ def reconcile_repo_access(
     return True
 
 
+def resolve_token(explicit: Optional[str]) -> Tuple[str, str]:
+    """Return (token, where it came from) so errors can name the missing input."""
+    if explicit:
+        return explicit, "--token"
+    token = os.getenv("RUNNER_GROUP_TOKEN")
+    if token:
+        return token, "RUNNER_GROUP_TOKEN"
+    return os.getenv("GITHUB_TOKEN", ""), "GITHUB_TOKEN"
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--token",
         type=str,
-        default=os.getenv("RUNNER_GROUP_TOKEN") or os.getenv("GITHUB_TOKEN", ""),
+        default=None,
         help="GitHub token for managing runner groups (or RUNNER_GROUP_TOKEN/GITHUB_TOKEN)",
     )
     parser.add_argument(
@@ -553,11 +563,24 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-    if not args.token:
+    token, token_source = resolve_token(args.token)
+    if not token:
         raise SystemExit(
             "A GitHub token is required (--token, RUNNER_GROUP_TOKEN or GITHUB_TOKEN)"
         )
-    client = GitHubClient(args.token)
+    # Managing runner groups hits /orgs/{org}/actions/runner-groups, which needs
+    # admin:org. The Actions-provided GITHUB_TOKEN is repo-scoped and can never
+    # have it, so --apply with that token always 403s. Fail here rather than
+    # after the discovery pass, and before any mutation has been attempted.
+    if args.apply and token_source == "GITHUB_TOKEN":
+        raise SystemExit(
+            "--apply needs a token with admin:org, but RUNNER_GROUP_TOKEN is "
+            "unset so the repo-scoped GITHUB_TOKEN was used, which cannot "
+            f"manage /orgs/{ORG}/actions/runner-groups. Check that the "
+            "RUNNER_GROUP_TOKEN secret exists in the 'runner-group' environment "
+            "and has not expired."
+        )
+    client = GitHubClient(token)
 
     refs = get_target_refs(client)
     log(f"Target refs: {refs}")
@@ -574,6 +597,13 @@ def main() -> None:
         if status == 403 and not args.apply:
             log("No access to runner groups; discovery-only run")
             return
+        if status == 403:
+            raise SystemExit(
+                f"403 reading /orgs/{ORG}/actions/runner-groups with the token "
+                f"from {token_source}. That token lacks admin:org -- if it is "
+                "RUNNER_GROUP_TOKEN, the secret is likely expired or was "
+                "re-issued without the scope."
+            ) from error
         raise
 
     repo_id = get_repo_id(client)


### PR DESCRIPTION
## Problem

[`Refresh release runner groups`](https://github.com/pytorch/pytorch/actions/runs/33005392673/job/98297702271) failed with a bare traceback:

```
requests.exceptions.HTTPError: 403 Client Error: Forbidden for url:
  https://api.github.com/orgs/pytorch/actions/runner-groups?per_page=100
  - body: {"message":"Resource not accessible by integration ..."}
```

The job env shows why:

```
env:
  RUNNER_GROUP_TOKEN:          <-- empty
  GITHUB_TOKEN: ***
  SHOULD_APPLY: true
```

`RUNNER_GROUP_TOKEN` was empty, so this line silently fell back to `GITHUB_TOKEN`:

```python
default=os.getenv("RUNNER_GROUP_TOKEN") or os.getenv("GITHUB_TOKEN", ""),
```

`GITHUB_TOKEN` is repo-scoped and can never hold `admin:org`, so `/orgs/{org}/actions/runner-groups` is *guaranteed* to 403. But the script only discovered that after running the whole discovery pass and printing all 41 desired references — and it was in `--apply` mode, i.e. the path that mutates runner groups.

## Change

Track where the token came from, and reject `--apply` up front when it fell back to `GITHUB_TOKEN`:

```
--apply needs a token with admin:org, but RUNNER_GROUP_TOKEN is unset so the
repo-scoped GITHUB_TOKEN was used, which cannot manage
/orgs/pytorch/actions/runner-groups. Check that the RUNNER_GROUP_TOKEN secret
exists in the 'runner-group' environment and has not expired.
```

Also convert a 403 in apply mode into a targeted message rather than re-raising the raw `HTTPError`, covering the case where `RUNNER_GROUP_TOKEN` *is* set but has expired or was re-issued without the scope.

**Dry-run behaviour is unchanged** — it still tolerates a 403 and reports a discovery-only run, so PRs without access keep working.

## Verification

Exercised every token/mode combination against the real module:

| case | result |
| --- | --- |
| dry-run, `GITHUB_TOKEN` only | proceeds |
| apply, `RUNNER_GROUP_TOKEN` set | proceeds |
| apply, explicit `--token` | proceeds |
| **apply, `GITHUB_TOKEN` only** | **blocked, before any network call** |
| no token at all | blocked (existing behaviour) |

The explicit-`--token` case matters: a naive `if args.apply and not os.getenv("RUNNER_GROUP_TOKEN")` check would have wrongly rejected a valid `--token <pat>` invocation, which is why the token source is tracked rather than just probing the env.

## Scope

This does **not** fix the underlying outage. `RUNNER_GROUP_TOKEN` still has to be present and valid in the `runner-group` environment — most likely an expired PAT, since the workflow previously worked. This change only makes the failure say so instead of surfacing as an opaque 403 after a full discovery pass.

---

Filed with the help of Claude Code.
