### PR TITLE
File vLLM torch-nightly triage issues by default

### DIFF
--- a/.github/workflows/vllm-torch-nightly-triage.yml
+++ b/.github/workflows/vllm-torch-nightly-triage.yml
@@ -6,8 +6,8 @@ name: vLLM torch-nightly triage
 # "Full CI run - nightly" from the same HEAD in the same cron slot, so the pair is a
 # controlled A/B. This job reports jobs that fail in the former and pass in the latter.
 #
-# Reports to the job log, the run summary, and an artifact. Issue filing is opt-in:
-# it runs only when the file_issues dispatch input is set, and files into
+# Reports to the job log, the run summary, and an artifact. Issues are filed by default
+# -- on the cron, and on a dispatch unless file_issues is unchecked -- into
 # pytorch/test-infra (not pytorch/pytorch).
 #
 # ClickHouse stores job metadata only (the tables carry log_url pointers, not log
@@ -18,9 +18,9 @@ on:
   workflow_dispatch:
     inputs:
       file_issues:
-        description: "File umbrella/child issues in test-infra (otherwise dry-run)"
+        description: "File umbrella/child issues in test-infra (uncheck for a dry-run)"
         type: boolean
-        default: false
+        default: true
       torch_version_override:
         description: "Torch minor version (e.g. 2.14) when detection fails"
         type: string
@@ -248,11 +248,15 @@ jobs:
   # be able to open issues. The agent emits data; this job files it with a script, so
   # what gets created is decided by code rather than by the model.
   #
-  # Opt-in: dry-runs unless the file_issues input says otherwise. A dry run prints the
-  # umbrella title and the child issues it would create, which is the cheap way to
-  # sanity-check agent output. Enabling this for the cron means flipping the input's
-  # default to true -- a repo variable would be nicer, but the `vars` context is not
-  # recognised by the actionlint pinned in this repo's lintrunner config.
+  # Files by default. Uncheck file_issues on a dispatch for a dry run, which prints the
+  # umbrella title and the child issues it would create -- the cheap way to sanity-check
+  # agent output before letting it write.
+  #
+  # The cron is handled by the explicit event_name check rather than by the input
+  # default: workflow_dispatch input defaults are not applied to schedule runs, so on a
+  # cron `inputs.file_issues` is empty and would dry-run forever. Same idiom as
+  # trigger_nightly.yml. (A repo variable would read better, but the `vars` context is
+  # not recognised by the actionlint pinned in this repo's lintrunner config.)
   file-issues:
     needs: [triage, root-cause]
     if: |
@@ -281,7 +285,7 @@ jobs:
         working-directory: tools
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EXECUTE: ${{ inputs.file_issues && '--execute' || '' }}
+          EXECUTE: ${{ (github.event_name == 'schedule' || inputs.file_issues) && '--execute' || '' }}
           OVERRIDE: ${{ inputs.torch_version_override }}
         run: |
           set -euo pipefail

--- a/.github/workflows/vllm-torch-nightly-triage.yml
+++ b/.github/workflows/vllm-torch-nightly-triage.yml
@@ -7,8 +7,7 @@ name: vLLM torch-nightly triage
 # controlled A/B. This job reports jobs that fail in the former and pass in the latter.
 #
 # Reports to the job log, the run summary, and an artifact. Issues are filed by default
-# -- on the cron, and on a dispatch unless file_issues is unchecked -- into
-# pytorch/test-infra (not pytorch/pytorch).
+# into pytorch/test-infra (not pytorch/pytorch).
 #
 # ClickHouse stores job metadata only (the tables carry log_url pointers, not log
 # bodies), so this answers *which* jobs regressed, not *why*. Root-causing means
@@ -248,15 +247,10 @@ jobs:
   # be able to open issues. The agent emits data; this job files it with a script, so
   # what gets created is decided by code rather than by the model.
   #
-  # Files by default. Uncheck file_issues on a dispatch for a dry run, which prints the
-  # umbrella title and the child issues it would create -- the cheap way to sanity-check
-  # agent output before letting it write.
+  # Files by default; uncheck file_issues on a dispatch for a dry run.
   #
-  # The cron is handled by the explicit event_name check rather than by the input
-  # default: workflow_dispatch input defaults are not applied to schedule runs, so on a
-  # cron `inputs.file_issues` is empty and would dry-run forever. Same idiom as
-  # trigger_nightly.yml. (A repo variable would read better, but the `vars` context is
-  # not recognised by the actionlint pinned in this repo's lintrunner config.)
+  # The schedule is checked explicitly because workflow_dispatch input defaults do not
+  # apply to cron runs -- `inputs.file_issues` is empty there and would dry-run forever.
   file-issues:
     needs: [triage, root-cause]
     if: |

--- a/tools/torchci/tests/test_vllm_triage_file_issues.py
+++ b/tools/torchci/tests/test_vllm_triage_file_issues.py
@@ -1,0 +1,112 @@
+"""Tests for the filing gate in the vLLM torch-nightly triage.
+
+The gate reads fields the analysis agent writes into findings.json. Those two
+sides live in different files (the agent's schema is prompted from
+.github/workflows/vllm-torch-nightly-triage.yml), so a rename on one side is
+invisible to the other -- exactly how ``confidence`` ->
+``classification_confidence`` silently disabled all filing. Each case below
+pins one field of that contract.
+"""
+
+import unittest
+
+from torchci.vllm_triage_file_issues import (
+    classification_confidence,
+    eligible,
+    new_failure_confidence,
+)
+
+
+def cause(**overrides):
+    """A cause that is eligible, so each test can break exactly one field."""
+    base = {
+        "title": "torch.compile miscompiles fused rmsnorm",
+        "signature": "AssertionError: Tensor-likes are not close",
+        "clusters": [":nvidia: (H100) Kernels"],
+        "routing": "pytorch/pytorch",
+        "classification_confidence": "high",
+        "new_failure_confidence": "high",
+        "determined": True,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestEligible(unittest.TestCase):
+    def test_high_confidence_torch_cause_is_filed(self):
+        self.assertTrue(eligible(cause()))
+
+    def test_undetermined_cause_is_skipped(self):
+        self.assertFalse(eligible(cause(determined=False)))
+
+    def test_non_torch_routing_is_skipped(self):
+        self.assertFalse(eligible(cause(routing="vllm-project/vllm")))
+        self.assertFalse(eligible(cause(routing="infra")))
+
+    def test_routing_is_matched_case_and_space_insensitively(self):
+        self.assertTrue(eligible(cause(routing=" PyTorch/PyTorch ")))
+
+    def test_low_classification_confidence_is_skipped(self):
+        self.assertFalse(eligible(cause(classification_confidence="medium")))
+        self.assertFalse(eligible(cause(classification_confidence="low")))
+
+    def test_known_variant_is_skipped_but_medium_is_filed(self):
+        # low == "likely a variant of an existing known issue", which would
+        # duplicate a child issue; medium is still worth a look.
+        self.assertFalse(eligible(cause(new_failure_confidence="low")))
+        self.assertTrue(eligible(cause(new_failure_confidence="medium")))
+
+    def test_med_and_medium_are_the_same_level(self):
+        # CONFIDENCE.md documents "med"; the workflow schema says "medium".
+        self.assertEqual(
+            new_failure_confidence({"new_failure_confidence": "med"}), "medium"
+        )
+        self.assertEqual(
+            classification_confidence({"classification_confidence": "MED"}), "medium"
+        )
+        # "med" classification is below the bar in either spelling.
+        self.assertFalse(eligible(cause(classification_confidence="med")))
+
+    def test_legacy_confidence_field_still_gates(self):
+        # Pre-rename findings.json: one `confidence`, no new_failure_confidence.
+        legacy = {
+            "routing": "pytorch/pytorch",
+            "confidence": "high",
+            "determined": True,
+        }
+        self.assertTrue(eligible(legacy))
+        self.assertFalse(eligible({**legacy, "confidence": "low"}))
+
+    def test_missing_confidence_is_not_eligible_and_is_reported_as_absent(self):
+        no_conf = {"routing": "pytorch/pytorch", "determined": True}
+        self.assertFalse(eligible(no_conf))
+        self.assertEqual(classification_confidence(no_conf), "")
+        self.assertEqual(new_failure_confidence(no_conf), "")
+
+    def test_current_agent_schema_is_understood(self):
+        # Shape emitted by run 33008738638, which filed nothing: the gate must
+        # skip these on routing alone, not because it cannot read the fields.
+        observed = [
+            {
+                "title": "torch-nightly cpu and arm64 CI images missing from ECR",
+                "routing": "infra",
+                "classification_confidence": "high",
+                "new_failure_confidence": "high",
+                "determined": True,
+            },
+            {
+                "title": "nixl_ep has no torch-2.15 ABI variant",
+                "routing": "vllm-project/vllm",
+                "classification_confidence": "medium",
+                "new_failure_confidence": "high",
+                "determined": True,
+            },
+        ]
+        self.assertEqual([eligible(c) for c in observed], [False, False])
+        self.assertEqual(
+            [classification_confidence(c) for c in observed], ["high", "medium"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/torchci/vllm_triage_file_issues.py
+++ b/tools/torchci/vllm_triage_file_issues.py
@@ -157,7 +157,9 @@ def child_body(cause: Dict[str, Any], report: Dict[str, Any], key: str) -> str:
         sections.append(f"## Representative jobs\n\n{jobs}")
     sections.append(
         f"## Suggested routing\n\n{cause.get('routing', 'undetermined')} "
-        f"(agent confidence: {cause.get('confidence', 'unknown')})"
+        f"(agent confidence: classification "
+        f"{classification_confidence(cause) or 'unknown'}, new-failure "
+        f"{new_failure_confidence(cause) or 'unknown'})"
     )
     sections.append(
         "---\n\n"
@@ -169,16 +171,45 @@ def child_body(cause: Dict[str, Any], report: Dict[str, Any], key: str) -> str:
     return "\n\n".join(sections) + "\n"
 
 
+def _level(value: Any) -> str:
+    """Normalise a confidence level. ``med`` and ``medium`` are both in use."""
+    level = str(value or "").strip().lower()
+    return "medium" if level == "med" else level
+
+
+def classification_confidence(cause: Dict[str, Any]) -> str:
+    """How sure the agent is that the routing is right.
+
+    The agent's schema renamed the original ``confidence`` to
+    ``classification_confidence`` and added ``new_failure_confidence``; the old
+    name is still read so archived findings.json artifacts keep gating correctly.
+    """
+    return _level(cause.get("classification_confidence") or cause.get("confidence"))
+
+
+def new_failure_confidence(cause: Dict[str, Any]) -> str:
+    """How sure the agent is that this is a new regression, not a known variant.
+
+    Absent in the pre-rename schema, where "" reads as "not stated" and does not
+    disqualify a cause.
+    """
+    return _level(cause.get("new_failure_confidence"))
+
+
 def eligible(cause: Dict[str, Any]) -> bool:
     """High-confidence torch/triton causes only.
 
     Infra-looking clusters and anything the agent could not root-cause stay out of
     the tracker: at three runs a week, filing uncertain causes would bury the real
     ones. They remain visible in the run summary and the umbrella's context section.
+
+    ``new_failure_confidence: low`` means "likely a variant of an existing known
+    issue", so filing it would duplicate a child issue that already exists.
     """
     return (
         bool(cause.get("determined"))
-        and str(cause.get("confidence", "")).lower() == "high"
+        and classification_confidence(cause) == "high"
+        and new_failure_confidence(cause) != "low"
         and str(cause.get("routing", "")).strip().lower() == "pytorch/pytorch"
     )
 
@@ -234,6 +265,17 @@ def main() -> int:
         )
         return 0
 
+    # A schema change on the agent side silently zeroes out the gate, which reads
+    # as a quiet "nothing to file" run. Say so instead.
+    unscored = [c for c in causes if not classification_confidence(c)]
+    if unscored:
+        print(
+            f"WARNING: {len(unscored)} of {len(causes)} cause(s) carry no "
+            "classification_confidence (nor legacy confidence) field. No cause can "
+            "be eligible without it -- the agent's findings schema may have changed.",
+            file=sys.stderr,
+        )
+
     selected = [c for c in causes if eligible(c)]
     skipped = [c for c in causes if not eligible(c)]
     print(f"{len(causes)} cause(s): {len(selected)} eligible, {len(skipped)} skipped")
@@ -241,7 +283,9 @@ def main() -> int:
         print(
             f"  skip: {c.get('title', '<untitled>')!r} "
             f"(determined={c.get('determined')}, "
-            f"confidence={c.get('confidence')}, routing={c.get('routing')})"
+            f"classification_confidence={classification_confidence(c) or None}, "
+            f"new_failure_confidence={new_failure_confidence(c) or None}, "
+            f"routing={c.get('routing')})"
         )
     if len(selected) > args.max_issues:
         print(


### PR DESCRIPTION
## Summary

The triage cron has been dry-running since it landed. `EXECUTE` was gated solely on `inputs.file_issues`, which defaulted to `false`, so no issues have ever been filed.

## Why flipping the default alone isn't enough

The existing comment said:

> Enabling this for the cron means flipping the input's default to true

That's not correct — **`workflow_dispatch` input defaults are not applied to `schedule` runs**. On a cron, `inputs.file_issues` evaluates to empty regardless of the declared default, so the job would have kept dry-running forever.

`trigger_nightly.yml` in this repo demonstrates the point: it declares `default: all` on its input and *still* carries an explicit `github.event_name == 'schedule' ||` clause on every job. That clause would be redundant if defaults applied to cron.

So this PR does both:

- `file_issues` defaults to `true` — a manual dispatch files unless you uncheck it.
- `EXECUTE` also fires on `github.event_name == 'schedule'`, matching the `trigger_nightly.yml` idiom.

```diff
-          EXECUTE: ${{ inputs.file_issues && '--execute' || '' }}
+          EXECUTE: ${{ (github.event_name == 'schedule' || inputs.file_issues) && '--execute' || '' }}
```

The stale comment is corrected in place so the next person doesn't repeat the mistake.

## Resulting behaviour

| event | files? |
| --- | --- |
| `schedule` (cron) | **yes** |
| `workflow_dispatch`, box checked | **yes** |
| `workflow_dispatch`, box unchecked | no — dry-run |
| `pull_request` | job does not run (`if:` already excludes it) |

Verified by evaluating the expression under GitHub's `a && b || c` semantics for all four cases.

The dry-run path is kept deliberately: unchecking the box is how you sanity-check agent output before letting it open issues.

## Unchanged

Filing still targets `pytorch/test-infra` (not `pytorch/pytorch`), still uses the default `GITHUB_TOKEN`, and remains in a job separate from the one that reads untrusted Buildkite logs — so a prompt injection in a CI log still cannot reach `issues: write`.

## Note

First real cron after this merges will file against whatever the agent finds, including any backlog of currently-unreported causes. If you'd rather see that set first, dispatch once with `file_issues` **unchecked** to get the dry-run listing before the next scheduled slot (Tue/Wed/Fri 17:00 UTC).

---

Filed with the help of Claude Code.

## Also in this PR: the filing gate could never pass

Flipping the default alone would still have filed nothing. `eligible()` in `tools/torchci/vllm_triage_file_issues.py` gates on `cause["confidence"] == "high"`, but #8539 split that field into `classification_confidence` and `new_failure_confidence`. The filer (last touched in #8488) was never updated, so the comparison has been `None == "high"` for every cause since 2026-08-17.

Visible in run [33008738638](https://github.com/pytorch/test-infra/actions/runs/33008738638), which ran with `--execute` and still filed nothing:

```
3 cause(s): 0 eligible, 3 skipped
  skip: '...' (determined=True, confidence=None, routing=infra)
```

That run had nothing to file on routing grounds anyway (1 `infra`, 2 `vllm-project/vllm`), which is what masked the bug.

Changes:

- read `classification_confidence`, falling back to the legacy `confidence` so archived findings still gate correctly
- skip `new_failure_confidence: low` -- per `CONFIDENCE.md` that means "likely a variant of an existing known issue", i.e. a duplicate child issue
- normalise `med`/`medium` (`CONFIDENCE.md` says `med`, the workflow schema says `medium`)
- warn when no confidence field is recognised, so the next schema drift shows up in the run summary instead of looking like a quiet "nothing to file"
- print both levels in the skip lines
- add `tools/torchci/tests/test_vllm_triage_file_issues.py`, which pins the agent-schema contract that broke here

### Test plan

`python3 -m unittest torchci.tests.test_vllm_triage_file_issues` -- 10 tests, all pass.

Replaying the real `findings.json` from run 33008738638 through the fixed filer still skips all three, now with readable reasons:

```
3 cause(s): 0 eligible, 3 skipped
  skip: '...ECR...' (determined=True, classification_confidence=high, new_failure_confidence=high, routing=infra)
  skip: '...nixl_ep...' (determined=True, classification_confidence=medium, new_failure_confidence=high, routing=vllm-project/vllm)
  skip: '...Rust frontend...' (determined=True, classification_confidence=high, new_failure_confidence=medium, routing=vllm-project/vllm)
```

and a synthetic `routing=pytorch/pytorch, high/high` cause now files, while its `new_failure_confidence: low` sibling is skipped:

```
2 cause(s): 1 eligible, 1 skipped
  child: Inductor miscompiles fused rmsnorm on H100  key=ad96f41f7789c6c2
```
