### PR TITLE
[HUD] Add repository picker to live queue

### DIFF
--- a/torchci/clickhouse_queries/queued_jobs/params.json
+++ b/torchci/clickhouse_queries/queued_jobs/params.json
@@ -1,4 +1,16 @@
 {
-  "params": {},
-  "tests": []
+  "params": {
+    "repo": "String"
+  },
+  "defaults": {
+    "repo": "pytorch/pytorch"
+  },
+  "tests": [
+    {
+      "repo": "pytorch/pytorch"
+    },
+    {
+      "repo": "pytorch/executorch"
+    }
+  ]
 }

--- a/torchci/clickhouse_queries/queued_jobs/query.sql
+++ b/torchci/clickhouse_queries/queued_jobs/query.sql
@@ -44,6 +44,7 @@ ec2_queued_jobs AS (
         workflow.head_sha AS head_sha,
         workflow.head_branch AS head_branch,
         workflow.event AS event,
+        workflow.repository.'full_name' AS repository,
         CASE
             WHEN
                 workflow.head_branch LIKE 'trunk/%'
@@ -68,7 +69,7 @@ ec2_queued_jobs AS (
     WHERE
         job.id IN (SELECT id FROM possible_queued_jobs)
         AND workflow.id IN (SELECT run_id FROM possible_queued_jobs)
-        AND workflow.repository.'full_name' = 'pytorch/pytorch'
+        AND workflow.repository.'full_name' = {repo: String}
         AND job.status = 'queued'
         AND LENGTH(job.steps) = 0
         AND workflow.status != 'completed'
@@ -93,6 +94,7 @@ arc_queued_jobs AS (
         workflow.head_sha AS head_sha,
         workflow.head_branch AS head_branch,
         workflow.event AS event,
+        workflow.repository.'full_name' AS repository,
         CASE
             WHEN
                 workflow.head_branch LIKE 'trunk/%'
@@ -117,7 +119,7 @@ arc_queued_jobs AS (
     WHERE
         job.id in (select id from possible_queued_jobs)
         and workflow.id in (select run_id from possible_queued_jobs)
-        and workflow.repository. 'full_name' = 'pytorch/pytorch'
+        and workflow.repository. 'full_name' = {repo: String}
         --- ARC runner detection: labels contain l- pattern
         AND arrayExists(x -> x LIKE '%l-%', job.labels)
         AND workflow.status != 'completed'

--- a/torchci/clickhouse_queries/queued_jobs_by_label/params.json
+++ b/torchci/clickhouse_queries/queued_jobs_by_label/params.json
@@ -1,4 +1,16 @@
 {
-  "params": {},
-  "tests": []
+  "params": {
+    "repo": "String"
+  },
+  "defaults": {
+    "repo": "pytorch/pytorch"
+  },
+  "tests": [
+    {
+      "repo": "pytorch/pytorch"
+    },
+    {
+      "repo": "pytorch/executorch"
+    }
+  ]
 }

--- a/torchci/clickhouse_queries/queued_jobs_by_label/query.sql
+++ b/torchci/clickhouse_queries/queued_jobs_by_label/query.sql
@@ -44,7 +44,7 @@ ec2_queued_jobs AS (
     WHERE
         job.id in (select id from possible_queued_jobs)
         and workflow.id in (select run_id from possible_queued_jobs)
-        and workflow.repository. 'full_name' = 'pytorch/pytorch'
+        and workflow.repository. 'full_name' = {repo: String}
         AND job.status = 'queued'
         AND job.created_at < (CURRENT_TIMESTAMP() - INTERVAL 5 MINUTE)
         AND LENGTH(job.steps) = 0
@@ -65,7 +65,7 @@ arc_queued_jobs AS (
     WHERE
         job.id in (select id from possible_queued_jobs)
         and workflow.id in (select run_id from possible_queued_jobs)
-        and workflow.repository. 'full_name' = 'pytorch/pytorch'
+        and workflow.repository. 'full_name' = {repo: String}
         --- ARC runner detection: labels contain l- pattern
         AND arrayExists(x -> x LIKE '%l-%', job.labels)
         AND workflow.status != 'completed'

--- a/torchci/components/metrics/panels/QueuedJobsTable.tsx
+++ b/torchci/components/metrics/panels/QueuedJobsTable.tsx
@@ -7,14 +7,16 @@ import { fetcher } from "lib/GeneralUtils";
 import useSWR from "swr";
 
 export default function QueuedJobsTable({
+  repository,
   machineTypeFilter,
   onClearFilter,
 }: {
+  repository: string;
   machineTypeFilter: string | null;
   onClearFilter: () => void;
 }) {
   const url = `/api/clickhouse/queued_jobs?parameters=${encodeURIComponent(
-    JSON.stringify({})
+    JSON.stringify({ repo: repository })
   )}`;
 
   const { data } = useSWR(url, fetcher, {
@@ -82,7 +84,7 @@ export default function QueuedJobsTable({
             const fullSha = row.head_sha || "";
             const sourceType = row.source_type;
             const ciflowId = row.ciflow_id;
-            const hudCommitUrl = `https://hud.pytorch.org/pytorch/pytorch/commit/${fullSha}`;
+            const hudCommitUrl = `https://hud.pytorch.org/${row.repository}/commit/${fullSha}`;
 
             if (sourceType === "autorevert") {
               return (
@@ -103,7 +105,7 @@ export default function QueuedJobsTable({
                 <span>
                   ciflow{" "}
                   <a
-                    href={`https://github.com/pytorch/pytorch/pull/${ciflowId}`}
+                    href={`https://github.com/${row.repository}/pull/${ciflowId}`}
                     target="_blank"
                     rel="noopener noreferrer"
                   >

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -35,6 +35,8 @@ import { default as useSWR, default as useSWRImmutable } from "swr";
 const DISABLED_TESTS_CONDENSED_URL =
   "https://raw.githubusercontent.com/pytorch/test-infra/refs/heads/generated-stats/stats/disabled-tests-condensed.json";
 
+const QUEUE_REPOSITORIES = ["pytorch/pytorch", "pytorch/executorch"];
+
 function getGranularityForDays(days: number): Granularity {
   if (days >= 90) return "week";
   if (days >= 14) return "day";
@@ -484,6 +486,8 @@ export default function Page() {
   const [machineTypeFilter, setMachineTypeFilter] = useState<string | null>(
     null
   );
+  const [queueRepository, setQueueRepository] =
+    useState<string>("pytorch/pytorch");
   const [usePercentage, setUsePercentage] = useState<boolean>(false);
 
   // For custom time range, calculate actual days; otherwise use the preset timeRange
@@ -856,11 +860,39 @@ export default function Page() {
           </Stack>
         </Grid>
 
+        <Grid size={{ xs: 12 }}>
+          <Stack direction="row" spacing={2} alignItems="center">
+            <Typography variant="h6" sx={{ fontWeight: "bold" }}>
+              Live job queue
+            </Typography>
+            <FormControl size="small" sx={{ minWidth: 220 }}>
+              <InputLabel id="queue-repository-select-label">
+                Repository
+              </InputLabel>
+              <Select
+                labelId="queue-repository-select-label"
+                value={queueRepository}
+                label="Repository"
+                onChange={(event: SelectChangeEvent<string>) => {
+                  setQueueRepository(event.target.value);
+                  setMachineTypeFilter(null);
+                }}
+              >
+                {QUEUE_REPOSITORIES.map((repository) => (
+                  <MenuItem key={repository} value={repository}>
+                    {repository}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Stack>
+        </Grid>
+
         <Grid size={{ xs: 6 }} height={ROW_HEIGHT}>
           <TablePanel
             title={"Queued Jobs by Machine Type"}
             queryName={"queued_jobs_by_label"}
-            queryParams={{}}
+            queryParams={{ repo: queueRepository }}
             columns={[
               { field: "count", headerName: "Count", flex: 1 },
               {
@@ -906,6 +938,7 @@ export default function Page() {
 
         <Grid size={{ xs: 6 }} height={ROW_HEIGHT}>
           <QueuedJobsTable
+            repository={queueRepository}
             machineTypeFilter={machineTypeFilter}
             onClearFilter={() => setMachineTypeFilter(null)}
           />
@@ -913,7 +946,7 @@ export default function Page() {
 
         <Grid size={{ xs: 6 }} height={ROW_HEIGHT}>
           <TimeSeriesPanel
-            title={"Queue times historical"}
+            title={"PyTorch queue times historical"}
             queryName={"queue_times_historical"}
             queryParams={{
               ...timeParams,


### PR DESCRIPTION
Parameterize the live queued-job queries and let the metrics page switch between PyTorch and ExecuTorch. Keep historical queue metrics labeled as PyTorch-only and make detail links repository-aware. This PR keeps the queue scoped to the picker, but long term, we might want to update the entire page to have the same distinction.