### PR TITLE
Extract the repo allowlist helper out of logUploader

### DIFF
--- a/torchci/lib/bot/logUploader.ts
+++ b/torchci/lib/bot/logUploader.ts
@@ -1,36 +1,7 @@
 import { invokeLogUploader } from "lib/lambda";
 import { Context, Probot } from "probot";
+import { isRepoEnabled, parseRepoAllowlist } from "./repoAllowlist";
 import { isPyTorchbotSupportedOrg, isVLLM } from "./utils";
-
-/**
- * Comma-separated list of repos whose logs this handler uploads. Entries are
- * either `owner/repo` or `owner/*`; an empty or unset value disables the
- * handler entirely.
- *
- * This exists so the cutover from the github-status-test webhook can be done a
- * repo at a time. While a repo still has that webhook, both paths write the same
- * S3 key -- harmless, but it doubles classifier calls, so the allowlist is what
- * bounds the overlap. Rolling back is editing this variable.
- */
-export function parseRepoAllowlist(raw: string | undefined): Set<string> {
-  return new Set(
-    (raw ?? "")
-      .split(",")
-      .map((entry) => entry.trim().toLowerCase())
-      .filter((entry) => entry.length > 0)
-  );
-}
-
-export function isRepoEnabled(
-  allowlist: Set<string>,
-  owner: string,
-  repo: string
-): boolean {
-  return (
-    allowlist.has(`${owner}/${repo}`.toLowerCase()) ||
-    allowlist.has(`${owner.toLowerCase()}/*`)
-  );
-}
 
 async function handleCompletedJob(event: Context<"workflow_job">) {
   if (event.payload.action !== "completed") {
@@ -44,6 +15,10 @@ async function handleCompletedJob(event: Context<"workflow_job">) {
     return;
   }
 
+  // The allowlist exists so the cutover from the github-status-test webhook can
+  // be done a repo at a time. While a repo still has that webhook, both paths
+  // write the same S3 key -- harmless, but it doubles classifier calls, so the
+  // allowlist is what bounds the overlap. Rolling back is editing this variable.
   const allowlist = parseRepoAllowlist(process.env.LOG_UPLOADER_REPOS);
   if (!isRepoEnabled(allowlist, owner, repo)) {
     return;

--- a/torchci/lib/bot/repoAllowlist.ts
+++ b/torchci/lib/bot/repoAllowlist.ts
@@ -1,0 +1,24 @@
+/**
+ * A repo allowlist is a comma-separated list of `owner/repo` or `owner/*`
+ * entries. Matching is case-insensitive, and an empty or unset value parses to
+ * an empty set, which enables nothing.
+ */
+export function parseRepoAllowlist(raw: string | undefined): Set<string> {
+  return new Set(
+    (raw ?? "")
+      .split(",")
+      .map((entry) => entry.trim().toLowerCase())
+      .filter((entry) => entry.length > 0)
+  );
+}
+
+export function isRepoEnabled(
+  allowlist: Set<string>,
+  owner: string,
+  repo: string
+): boolean {
+  return (
+    allowlist.has(`${owner}/${repo}`.toLowerCase()) ||
+    allowlist.has(`${owner.toLowerCase()}/*`)
+  );
+}

--- a/torchci/test/logUploader.test.ts
+++ b/torchci/test/logUploader.test.ts
@@ -1,7 +1,4 @@
-import logUploader, {
-  isRepoEnabled,
-  parseRepoAllowlist,
-} from "lib/bot/logUploader";
+import logUploader from "lib/bot/logUploader";
 import * as lambda from "lib/lambda";
 import nock from "nock";
 import { Probot } from "probot";
@@ -26,48 +23,6 @@ function workflowJobPayload({
     },
   };
 }
-
-describe("parseRepoAllowlist", () => {
-  test("an unset value disables the handler", () => {
-    expect(parseRepoAllowlist(undefined).size).toBe(0);
-    expect(parseRepoAllowlist("").size).toBe(0);
-  });
-
-  test("entries are trimmed and lowercased", () => {
-    expect(parseRepoAllowlist(" Pytorch/PyTorch , meta-pytorch/* ")).toEqual(
-      new Set(["pytorch/pytorch", "meta-pytorch/*"])
-    );
-  });
-
-  test("empty entries from a trailing comma are dropped", () => {
-    expect(parseRepoAllowlist("pytorch/pytorch,,").size).toBe(1);
-  });
-});
-
-describe("isRepoEnabled", () => {
-  test("matches an exact repo", () => {
-    const allowlist = parseRepoAllowlist("pytorch/pytorch");
-    expect(isRepoEnabled(allowlist, "pytorch", "pytorch")).toBe(true);
-    expect(isRepoEnabled(allowlist, "pytorch", "executorch")).toBe(false);
-  });
-
-  test("matches a whole org via a wildcard", () => {
-    const allowlist = parseRepoAllowlist("meta-pytorch/*");
-    expect(isRepoEnabled(allowlist, "meta-pytorch", "torchcomms")).toBe(true);
-    expect(isRepoEnabled(allowlist, "meta-pytorch", "monarch")).toBe(true);
-    expect(isRepoEnabled(allowlist, "pytorch", "pytorch")).toBe(false);
-  });
-
-  test("an org wildcard does not leak into a similarly named org", () => {
-    const allowlist = parseRepoAllowlist("pytorch/*");
-    expect(isRepoEnabled(allowlist, "meta-pytorch", "torchcomms")).toBe(false);
-  });
-
-  test("comparison is case insensitive", () => {
-    const allowlist = parseRepoAllowlist("PyTorch/PyTorch");
-    expect(isRepoEnabled(allowlist, "pytorch", "pytorch")).toBe(true);
-  });
-});
 
 describe("logUploader", () => {
   let probot: Probot;

--- a/torchci/test/repoAllowlist.test.ts
+++ b/torchci/test/repoAllowlist.test.ts
@@ -1,0 +1,43 @@
+import { isRepoEnabled, parseRepoAllowlist } from "lib/bot/repoAllowlist";
+
+describe("parseRepoAllowlist", () => {
+  test("an unset value disables the handler", () => {
+    expect(parseRepoAllowlist(undefined).size).toBe(0);
+    expect(parseRepoAllowlist("").size).toBe(0);
+  });
+
+  test("entries are trimmed and lowercased", () => {
+    expect(parseRepoAllowlist(" Pytorch/PyTorch , meta-pytorch/* ")).toEqual(
+      new Set(["pytorch/pytorch", "meta-pytorch/*"])
+    );
+  });
+
+  test("empty entries from a trailing comma are dropped", () => {
+    expect(parseRepoAllowlist("pytorch/pytorch,,").size).toBe(1);
+  });
+});
+
+describe("isRepoEnabled", () => {
+  test("matches an exact repo", () => {
+    const allowlist = parseRepoAllowlist("pytorch/pytorch");
+    expect(isRepoEnabled(allowlist, "pytorch", "pytorch")).toBe(true);
+    expect(isRepoEnabled(allowlist, "pytorch", "executorch")).toBe(false);
+  });
+
+  test("matches a whole org via a wildcard", () => {
+    const allowlist = parseRepoAllowlist("meta-pytorch/*");
+    expect(isRepoEnabled(allowlist, "meta-pytorch", "torchcomms")).toBe(true);
+    expect(isRepoEnabled(allowlist, "meta-pytorch", "monarch")).toBe(true);
+    expect(isRepoEnabled(allowlist, "pytorch", "pytorch")).toBe(false);
+  });
+
+  test("an org wildcard does not leak into a similarly named org", () => {
+    const allowlist = parseRepoAllowlist("pytorch/*");
+    expect(isRepoEnabled(allowlist, "meta-pytorch", "torchcomms")).toBe(false);
+  });
+
+  test("comparison is case insensitive", () => {
+    const allowlist = parseRepoAllowlist("PyTorch/PyTorch");
+    expect(isRepoEnabled(allowlist, "pytorch", "pytorch")).toBe(true);
+  });
+});


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #8656
* #8655
* #8654
* #8653
* #8652
* #8651
* #8650
* #8649
* #8648
* #8647
* __->__ #8646

**Impact:** torchci deploy
**Risk:** low

## What
Moves `parseRepoAllowlist` and `isRepoEnabled` out of `lib/bot/logUploader.ts` into
`lib/bot/repoAllowlist.ts`, along with their tests. logUploader imports them and keeps the
comment explaining why its own allowlist exists. No behaviour change.

## Why
Both functions parse a generic comma-separated `owner/repo` / `owner/*` list and have
nothing to do with uploading logs. Another webhook handler needs the same on/off switch,
and importing it from logUploader would couple an unrelated handler to it.