### PR TITLE
Correct the webhook-redelivery comment in logUploader

### DIFF
--- a/torchci/lib/bot/logUploader.ts
+++ b/torchci/lib/bot/logUploader.ts
@@ -31,9 +31,10 @@ async function handleCompletedJob(event: Context<"workflow_job">) {
       conclusion: event.payload.workflow_job.conclusion,
     });
   } catch (error) {
-    // Never fail the webhook over a log. GitHub would redeliver the whole event,
-    // re-running every other handler, to retry something Dr.CI already repairs
-    // on its own via backfillMissingLog.
+    // Never fail the webhook over a log. Rejecting marks the whole delivery
+    // failed -- one delivery shared with every other workflow_job handler -- and
+    // GitHub does not redeliver automatically, so throwing buys no retry either.
+    // Dr.CI re-requests a missing log through backfillMissingLog on its next run.
     event.log.error(
       `Failed to queue a log upload for ${event.payload.repository.full_name} ` +
         `job ${event.payload.workflow_job.id}: ${error}`

--- a/torchci/test/logUploader.test.ts
+++ b/torchci/test/logUploader.test.ts
@@ -99,8 +99,9 @@ describe("logUploader", () => {
     ["the Lambda API is unreachable", "TimeoutError"],
     ["Lambda throttles us", "TooManyRequestsException"],
   ])("a failed invoke does not fail the webhook when %s", async (_l, name) => {
-    // Throwing here would make GitHub redeliver the event and re-run every other
-    // handler, to retry something Dr.CI repairs on its own.
+    // Throwing here buys nothing: GitHub does not redeliver a webhook it failed
+    // to process, so the only effect is a delivery marked failed for something
+    // Dr.CI repairs on its own.
     const error = new Error(name);
     error.name = name;
     invoke.mockRejectedValue(error);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #8656
* #8655
* #8654
* #8653
* #8652
* #8651
* #8650
* #8649
* #8648
* __->__ #8647
* #8646

**Impact:** none at runtime
**Risk:** low

## What
Rewrites the comment on the swallowed `invokeLogUploader` failure, in the handler and in
the test that covers it. Comment text only.

## Why
The old wording claimed that throwing would make GitHub redeliver the event and re-run
every other handler. Neither holds: GitHub does not redeliver a delivery it failed to
process, and octokit runs every registered handler regardless of what any one of them
does. The real cost of throwing is marking the whole shared delivery failed while buying
no retry, for a log Dr. CI re-requests through `backfillMissingLog` on its next run.