### PR TITLE
Give the Green Light scan workflow a per-PR concurrency group

### DIFF
--- a/.github/workflows/greenlight-review.yml
+++ b/.github/workflows/greenlight-review.yml
@@ -46,10 +46,12 @@ on:
           - WARNING
           - ERROR
 
-# Singleton: only one scan runs at a time, and a new dispatch waits rather than
-# cancelling an in-flight scan (which could leave dispatch bookkeeping half-done).
+# One run at a time per target: each recheck gets its own group keyed on the PR number, and the
+# listing scan (empty `pr`) gets the `scan` group, so rechecks never contend with each other or
+# with the scan. Within a group a new dispatch waits rather than cancelling an in-flight run
+# (which could leave dispatch bookkeeping half-done).
 concurrency:
-  group: ${{ github.workflow }}-singleton
+  group: ${{ github.workflow }}-${{ inputs.pr || 'scan' }}
   cancel-in-progress: false
 
 permissions:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #8656
* #8655
* #8654
* #8653
* #8652
* #8651
* #8650
* #8649
* __->__ #8648
* #8647
* #8646

**Impact:** CI only (pytorch/test-infra Actions)
**Risk:** low

## What
Keys `greenlight-review.yml`'s concurrency group on the `pr` input instead of a single
global group, with the listing scan (no `pr`) falling into a `scan` group of its own.

## Why
Fixes silently dropped runs. GitHub keeps at most one pending run per concurrency group,
so with every dispatch sharing one group and `cancel-in-progress: false`, a third
concurrent dispatch evicts the queued second one: that review never happens and nothing
reports it. Per-target groups stop rechecks contending with each other or with the
periodic scan, while keeping the serialisation within a group that stops a cancelled run
leaving dispatch bookkeeping half-done.