### PR TITLE
Add the @greenlight comment command parser

### DIFF
--- a/torchci/lib/bot/greenlightCliParser.ts
+++ b/torchci/lib/bot/greenlightCliParser.ts
@@ -1,0 +1,71 @@
+export const GREENLIGHT_MENTION = "@greenlight";
+
+// The mention has to open the line so that quoting an earlier comment does not
+// re-run the command it contained. Four or more leading spaces is an indented
+// markdown code block, which renders the line as sample text rather than as a
+// command addressed to the bot. Matched case-insensitively because GitHub
+// resolves mentions that way and greenlight's own is_bot_command
+// (greenlight/src/greenlight/pr_hash.py) lowercases the body before looking for
+// the trigger: a differently-cased mention the bot ignored would still be
+// dropped from the fingerprint, so the comment would count for nothing at all.
+const botCommandPattern = new RegExp(
+  `^ {0,3}${GREENLIGHT_MENTION} (.+)$`,
+  "im"
+);
+
+// A fence, an HTML comment and a <pre> block all render their contents as
+// sample text rather than as a live mention, so a trigger inside one is never
+// a command addressed to the bot. Each closing delimiter is optional because
+// CommonMark does not require one: an unclosed opener runs to the end of the
+// comment, and an unterminated HTML comment renders nothing visible at all.
+const quotedRegionPatterns = [
+  /```[\s\S]*?(?:```|$)/g,
+  /~~~[\s\S]*?(?:~~~|$)/g,
+  /<!--[\s\S]*?(?:-->|$)/g,
+  /<pre[\s>][\s\S]*?(?:<\/pre>|$)/gi,
+];
+
+// The command vocabulary. It generates the help text and decides which names
+// are valid; the handler keys its dispatch table off this type, so a command
+// added here has to be given behaviour there before the bot compiles.
+export const GREENLIGHT_COMMANDS = {
+  recheck: "Ask Green Light to look at this pull request again.",
+  help: "Show this message.",
+} as const;
+
+export type GreenlightCommandName = keyof typeof GREENLIGHT_COMMANDS;
+
+export function getInputArgs(commentBody: string): string {
+  const addressed = quotedRegionPatterns.reduce(
+    (body, pattern) => body.replace(pattern, ""),
+    commentBody
+  );
+  return addressed.match(botCommandPattern)?.[1].trim() ?? "";
+}
+
+export function parseCommandName(inputArgs: string): string {
+  // GitHub comments are prose, so the command is matched the way a reader would
+  // read it rather than the way a shell would.
+  return (inputArgs.split(/\s+/)[0] ?? "").toLowerCase();
+}
+
+export function isGreenlightCommand(
+  name: string
+): name is GreenlightCommandName {
+  return Object.prototype.hasOwnProperty.call(GREENLIGHT_COMMANDS, name);
+}
+
+export function getHelp(): string {
+  const rows = Object.entries(GREENLIGHT_COMMANDS).map(
+    ([name, description]) => `| \`${name}\` | ${description} |`
+  );
+  return [
+    "# Green Light Bot",
+    "",
+    `Comment a line that starts with \`${GREENLIGHT_MENTION} <command>\` on a pull request.`,
+    "",
+    "| command | description |",
+    "| --- | --- |",
+    ...rows,
+  ].join("\n");
+}

--- a/torchci/test/greenlightCliParser.test.ts
+++ b/torchci/test/greenlightCliParser.test.ts
@@ -1,0 +1,132 @@
+import {
+  getHelp,
+  getInputArgs,
+  GREENLIGHT_COMMANDS,
+  GREENLIGHT_MENTION,
+  isGreenlightCommand,
+  parseCommandName,
+} from "lib/bot/greenlightCliParser";
+
+describe("getInputArgs", () => {
+  test("takes the command off a line that opens with the mention", () => {
+    expect(getInputArgs("@greenlight recheck")).toBe("recheck");
+    expect(getInputArgs("please have a look\n@greenlight recheck")).toBe(
+      "recheck"
+    );
+    expect(getInputArgs("  @greenlight recheck  ")).toBe("recheck");
+  });
+
+  test("keeps the rest of the line", () => {
+    expect(getInputArgs("@greenlight recheck now please")).toBe(
+      "recheck now please"
+    );
+  });
+
+  test("ignores a mention that does not open its line", () => {
+    expect(getInputArgs("cc @greenlight recheck")).toBe("");
+    expect(getInputArgs("> @greenlight recheck")).toBe("");
+    expect(getInputArgs("`@greenlight recheck`")).toBe("");
+  });
+
+  test("ignores a mention with nothing after it", () => {
+    expect(getInputArgs("@greenlight")).toBe("");
+    expect(getInputArgs("@greenlight ")).toBe("");
+  });
+
+  test("reads a mention whatever case it was typed in", () => {
+    expect(getInputArgs("@GreenLight recheck")).toBe("recheck");
+    expect(getInputArgs("@GREENLIGHT Recheck")).toBe("Recheck");
+  });
+
+  test("ignores a mention inside a fenced code block", () => {
+    expect(getInputArgs("```\n@greenlight recheck\n```")).toBe("");
+    expect(getInputArgs("~~~\n@greenlight recheck\n~~~")).toBe("");
+    expect(getInputArgs("```suggestion\n@greenlight recheck\n```")).toBe("");
+  });
+
+  test("ignores a mention inside an HTML comment", () => {
+    expect(getInputArgs("<!-- @greenlight recheck -->")).toBe("");
+    expect(getInputArgs("<!--\n@greenlight recheck\n-->")).toBe("");
+  });
+
+  test("ignores a mention inside a pre block", () => {
+    expect(getInputArgs("<pre>\n@greenlight recheck\n</pre>")).toBe("");
+    expect(getInputArgs('<pre class="x">\n@greenlight recheck\n</pre>')).toBe(
+      ""
+    );
+  });
+
+  test("ignores a mention inside a region nobody closed", () => {
+    expect(getInputArgs("```\n@greenlight recheck")).toBe("");
+    expect(getInputArgs("~~~\n@greenlight recheck")).toBe("");
+    expect(getInputArgs("```python\n@greenlight recheck")).toBe("");
+    expect(getInputArgs("<!--\n@greenlight recheck")).toBe("");
+    expect(getInputArgs("<pre>\n@greenlight recheck")).toBe("");
+  });
+
+  test("keeps reading a mention after a tag that only looks like pre", () => {
+    expect(getInputArgs("<pretend>\n@greenlight recheck")).toBe("recheck");
+  });
+
+  test("ignores a mention indented into a code block", () => {
+    expect(getInputArgs("    @greenlight recheck")).toBe("");
+    expect(getInputArgs("   @greenlight recheck")).toBe("recheck");
+  });
+
+  test("still finds a command outside the block it skipped", () => {
+    expect(
+      getInputArgs("```\n@greenlight help\n```\n@greenlight recheck")
+    ).toBe("recheck");
+  });
+
+  test("ignores a comment with no mention at all", () => {
+    expect(getInputArgs("")).toBe("");
+    expect(getInputArgs("looks good to me")).toBe("");
+    expect(getInputArgs("@greenlighter recheck")).toBe("");
+  });
+});
+
+describe("parseCommandName", () => {
+  test("takes the first word", () => {
+    expect(parseCommandName("recheck now")).toBe("recheck");
+    expect(parseCommandName("recheck")).toBe("recheck");
+  });
+
+  test("folds case, because a comment is prose", () => {
+    expect(parseCommandName("RECHECK")).toBe("recheck");
+    expect(parseCommandName("Recheck please")).toBe("recheck");
+  });
+
+  test("gives an empty name for an empty argument string", () => {
+    expect(parseCommandName("")).toBe("");
+  });
+});
+
+describe("isGreenlightCommand", () => {
+  test("accepts every command the vocabulary declares", () => {
+    for (const name of Object.keys(GREENLIGHT_COMMANDS)) {
+      expect(isGreenlightCommand(name)).toBe(true);
+    }
+  });
+
+  test("rejects anything else, including inherited properties", () => {
+    expect(isGreenlightCommand("relabel")).toBe(false);
+    expect(isGreenlightCommand("")).toBe(false);
+    expect(isGreenlightCommand("toString")).toBe(false);
+    expect(isGreenlightCommand("constructor")).toBe(false);
+  });
+});
+
+describe("getHelp", () => {
+  test("lists every command in the vocabulary", () => {
+    const help = getHelp();
+    for (const [name, description] of Object.entries(GREENLIGHT_COMMANDS)) {
+      expect(help).toContain(`| \`${name}\` | ${description} |`);
+    }
+  });
+
+  test("shows the trigger the parser actually matches", () => {
+    expect(getHelp()).toContain(`\`${GREENLIGHT_MENTION} <command>\``);
+    expect(getInputArgs(`${GREENLIGHT_MENTION} help`)).toBe("help");
+  });
+});


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #8656
* #8655
* #8654
* #8653
* #8652
* #8651
* #8650
* __->__ #8649
* #8648
* #8647
* #8646

**Impact:** none at runtime; nothing calls it yet
**Risk:** low

## What
Adds `lib/bot/greenlightCliParser.ts`: pulls an `@greenlight <command>` instruction out of
a comment body, resolves the command name against a declared vocabulary, and generates the
help table from that same vocabulary.

## Why
Deciding whether a line in a GitHub comment is addressed to a bot is the part of this
easiest to get subtly wrong, so it lands on its own with its tests. The mention has to
open its line, so quoting an earlier comment does not re-run the command it contained, and
a mention GitHub renders as sample text - inside a fence, an HTML comment, a `<pre>` block,
or indented four spaces - is not an instruction. Matching is case-insensitive to stay in
step with greenlight's `is_bot_command`, which lowercases the body before looking for the
trigger: a differently-cased mention drops out of the PR fingerprint whether or not
anything acts on it.