### PR TITLE
Mirror greenlight's trusted-author list in TypeScript

### DIFF
--- a/torchci/lib/bot/greenlightTrustedAuthors.ts
+++ b/torchci/lib/bot/greenlightTrustedAuthors.ts
@@ -1,0 +1,32 @@
+// The logins Green Light's backend will act on. Mirrors TRUSTED_AUTHORS in
+// greenlight/src/greenlight/review.py, which is the source of truth: the
+// backend refuses a recheck from anyone else and returns cleanly, with no
+// comment, no state row and a green workflow run, so a requester off this list
+// gets no feedback from anywhere unless the bot itself refuses first.
+//
+// Kept as a plain array literal because greenlight/tests/test_render_sync.py
+// pins it against the Python set by regex-parsing this source, the same way it
+// pins GREENLIGHT_REPOS in torchci/lib/greenlight/greenlightConfig.ts.
+export const GREENLIGHT_TRUSTED_AUTHORS: string[] = [
+  "albanD",
+  "jathu",
+  "atalman",
+  "huydhn",
+  "izaitsevfb",
+  "georgehong",
+  "jeanschmidt",
+  "ezyang",
+  "drisspg",
+  "janeyx99",
+];
+
+// GitHub logins are case-insensitive, and review.py folds the same way before
+// comparing, so a differently-cased login must not fall out of the gate here
+// and then be accepted there.
+const trustedLower = new Set(
+  GREENLIGHT_TRUSTED_AUTHORS.map((login) => login.toLowerCase())
+);
+
+export function isTrustedAuthor(login: string): boolean {
+  return trustedLower.has(login.toLowerCase());
+}

--- a/torchci/test/greenlightTrustedAuthors.test.ts
+++ b/torchci/test/greenlightTrustedAuthors.test.ts
@@ -1,0 +1,33 @@
+import {
+  GREENLIGHT_TRUSTED_AUTHORS,
+  isTrustedAuthor,
+} from "lib/bot/greenlightTrustedAuthors";
+
+describe("isTrustedAuthor", () => {
+  test("accepts every login on the list", () => {
+    for (const login of GREENLIGHT_TRUSTED_AUTHORS) {
+      expect(isTrustedAuthor(login)).toBe(true);
+    }
+  });
+
+  test("accepts a login whatever case GitHub delivers it in", () => {
+    for (const login of GREENLIGHT_TRUSTED_AUTHORS) {
+      expect(isTrustedAuthor(login.toUpperCase())).toBe(true);
+      expect(isTrustedAuthor(login.toLowerCase())).toBe(true);
+    }
+  });
+
+  test("rejects anyone else", () => {
+    expect(isTrustedAuthor("ghuser")).toBe(false);
+    expect(isTrustedAuthor("")).toBe(false);
+    expect(isTrustedAuthor("pytorch-bot[bot]")).toBe(false);
+  });
+
+  test("holds no blank or duplicated entries", () => {
+    const folded = GREENLIGHT_TRUSTED_AUTHORS.map((login) =>
+      login.toLowerCase()
+    );
+    expect(folded.filter((login) => login.trim().length === 0)).toEqual([]);
+    expect(new Set(folded).size).toBe(GREENLIGHT_TRUSTED_AUTHORS.length);
+  });
+});


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #8656
* #8655
* #8654
* #8653
* #8652
* #8651
* __->__ #8650
* #8649
* #8648
* #8647
* #8646

**Impact:** none at runtime; nothing calls it yet
**Risk:** low

## What
Adds `lib/bot/greenlightTrustedAuthors.ts`, a copy of `TRUSTED_AUTHORS` from
`greenlight/src/greenlight/review.py` plus a case-insensitive membership test.

## Why
Green Light's backend acts only for the logins on that Python list, and refuses everyone
else by exiting cleanly - no comment, no state row, a green workflow run. Someone off the
list hears nothing from anywhere unless something refuses earlier, and refusing earlier
needs the list on the TypeScript side. It stays a plain array literal so it can be
regex-parsed and pinned against Python, the way `GREENLIGHT_REPOS` already is.

# Notes
The drift test pinning this against Python lands with the recheck handler, not here: it
asserts both files exist and would error at collection time until they do.