### PR TITLE
Add Green Light App authentication

### DIFF
--- a/torchci/lib/bot/greenlightAppAuth.ts
+++ b/torchci/lib/bot/greenlightAppAuth.ts
@@ -1,0 +1,138 @@
+import { createAppAuth } from "@octokit/auth-app";
+import { Octokit } from "octokit";
+
+const PKCS1_HEADER = "-----BEGIN RSA PRIVATE KEY-----";
+const PKCS1_FOOTER = "-----END RSA PRIVATE KEY-----";
+
+export function greenlightPrivateKey(): string {
+  const raw = process.env.GREENLIGHT_APP_PRIVATE_KEY ?? "";
+  const key = raw.includes(PKCS1_HEADER)
+    ? raw
+    : Buffer.from(raw, "base64").toString();
+
+  if (
+    !key.includes(PKCS1_HEADER) ||
+    !key.includes(PKCS1_FOOTER) ||
+    !key.includes("\n")
+  ) {
+    throw new Error(
+      `GREENLIGHT_APP_PRIVATE_KEY must be a PKCS#1 PEM starting with ` +
+        `"${PKCS1_HEADER}", or the base64 encoding of one, with real ` +
+        `newlines. actions/create-github-app-token also accepts PKCS#8 ` +
+        `("-----BEGIN PRIVATE KEY-----"), which probot rejects, so a key ` +
+        `copied from the Actions secret may need converting first: ` +
+        `openssl rsa -traditional -in key.pem -out key.pkcs1.pem ` +
+        `(drop -traditional on LibreSSL, which rejects the flag and already ` +
+        `emits PKCS#1; OpenSSL 3.x needs it and silently re-emits PKCS#8 ` +
+        `without it)`
+    );
+  }
+  return key;
+}
+
+/**
+ * Probot answers 202 and abandons the invocation nine seconds into a delivery,
+ * without throwing, so anything the handler had left to write is dropped
+ * silently. Octokit's throttle plugin spaces mutating requests a second apart
+ * and its retry plugin backs off quadratically (1s, 4s, 9s) across three
+ * attempts, so a single transient 5xx spends the whole budget on its own.
+ * Retrying is wrong here regardless: the workflow dispatch is not idempotent --
+ * it can create the run and still answer 5xx -- and a duplicate reviewer run
+ * cancels the first one mid-review.
+ */
+const OCTOKIT_OPTIONS = {
+  throttle: { enabled: false },
+  retry: { enabled: false },
+};
+
+// A minted token's permissions must be a subset of what the App declares, or
+// the mint fails with a 422 instead of degrading to a narrower token.
+export const SOURCE_REPO_PERMISSIONS = { issues: "write" } as const;
+export const DISPATCH_PERMISSIONS = { actions: "write" } as const;
+
+export type ScopedPermissions =
+  | typeof SOURCE_REPO_PERMISSIONS
+  | typeof DISPATCH_PERMISSIONS;
+
+function appOctokit(): Octokit {
+  return new Octokit({
+    authStrategy: createAppAuth,
+    auth: {
+      appId: process.env.GREENLIGHT_APP_ID,
+      privateKey: greenlightPrivateKey(),
+    },
+    ...OCTOKIT_OPTIONS,
+  });
+}
+
+const installationIds = new Map<string, Promise<number>>();
+
+/** Forget a memoized installation id, so the next mint looks it up again. */
+export function clearInstallationIdCache(): void {
+  installationIds.clear();
+}
+
+function installationIdFor(
+  app: Octokit,
+  owner: string,
+  repo: string,
+  key: string
+): Promise<number> {
+  const memoized = installationIds.get(key);
+  if (memoized !== undefined) {
+    return memoized;
+  }
+
+  const pending = app
+    .request("GET /repos/{owner}/{repo}/installation", { owner, repo })
+    .then((response) => response.data.id)
+    .catch((error) => {
+      installationIds.delete(key);
+      throw new Error(
+        `Failed to look up the Green Light App installation on ${owner}/${repo}. ` +
+          `Is the App installed there? ${error}`
+      );
+    });
+  installationIds.set(key, pending);
+  return pending;
+}
+
+/**
+ * An installation token handed to a Probot handler carries the App's whole
+ * declared permission set on every repo of the installation, which for this App
+ * includes dispatching workflows in pytorch/test-infra. Every write the bot
+ * makes goes through a token minted here instead, narrowed to one repo and one
+ * permission, so a handler bug cannot reach past what that write needs.
+ *
+ * `knownInstallationId` skips the lookup round trip; webhook deliveries carry
+ * the installation the event came from.
+ */
+export async function mintScopedOctokit(
+  owner: string,
+  repo: string,
+  permissions: ScopedPermissions,
+  knownInstallationId?: number
+): Promise<Octokit> {
+  const app = appOctokit();
+  const key = `${owner}/${repo}`.toLowerCase();
+  const id =
+    knownInstallationId ?? (await installationIdFor(app, owner, repo, key));
+
+  let token;
+  try {
+    token = await app.request(
+      "POST /app/installations/{installation_id}/access_tokens",
+      { installation_id: id, repositories: [repo], permissions }
+    );
+  } catch (error) {
+    // Reinstalling the App gives it a new installation id, which would make
+    // every later mint fail against the memoized one until the module recycles.
+    installationIds.delete(key);
+    throw new Error(
+      `Failed to mint a Green Light token for ${owner}/${repo} on installation ` +
+        `${id}: ${error}`
+    );
+  }
+
+  return new Octokit({ auth: token.data.token, ...OCTOKIT_OPTIONS });
+}

--- a/torchci/package.json
+++ b/torchci/package.json
@@ -32,6 +32,7 @@
     "@mui/x-charts": "^8.10.2",
     "@mui/x-data-grid": "^8.10.2",
     "@mui/x-date-pickers": "^8.10.2",
+    "@octokit/auth-app": "^3.3.0",
     "@octokit/webhooks": "^13.3.0",
     "@octokit/webhooks-types": "^7.6.1",
     "@opensearch-project/opensearch": "^2.3.1",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #8656
* #8655
* #8654
* #8653
* #8652
* __->__ #8651
* #8650
* #8649
* #8648
* #8647
* #8646

**Impact:** torchci deploy
**Risk:** low

## What
Adds `lib/bot/greenlightAppAuth.ts`: normalises `GREENLIGHT_APP_PRIVATE_KEY` into a PKCS#1
PEM, and mints installation tokens narrowed to a single repo and a single permission,
memoizing the installation lookup. Adds the `@octokit/auth-app` dependency it imports.

## Why
An installation token handed to a Probot handler carries the App's whole declared
permission set on every repo of the installation, which for this App includes dispatching
workflows in pytorch/test-infra. Minting per write instead keeps a handler bug from
reaching past what that write needs. Retry and throttling are off deliberately: Probot
answers 202 and abandons the invocation nine seconds into a delivery, so a backing-off
retry can spend the whole budget on its own, and the workflow dispatch is not idempotent -
it can create the run and still answer 5xx, and a duplicate reviewer run cancels the first
one mid-review.

# Notes
`@octokit/auth-app` is pinned to `^3.3.0` on purpose: it matches the key already in
yarn.lock, so `yarn install --frozen-lockfile` still passes with no lockfile churn, and v3
is the generation built for `@octokit/core@3`, which `octokit@1.8.1` uses.