### PR TITLE
Add Green Light bot configuration

### DIFF
--- a/torchci/.env.example
+++ b/torchci/.env.example
@@ -6,6 +6,15 @@ PRIVATE_KEY=
 APP_ID=
 WEBHOOK_SECRET=
 
+# GitHub App credentials for the Green Light comment bot, which runs as its own
+# probot instance on /api/greenlight/webhooks. Only needed if testing it locally.
+GREENLIGHT_APP_ID=
+GREENLIGHT_APP_PRIVATE_KEY=
+GREENLIGHT_WEBHOOK_SECRET=
+# Comma-separated owner/repo or owner/* list the @greenlight bot answers on. It
+# is the bot's on/off switch and enables nothing when unset.
+GREENLIGHT_BOT_REPOS=pytorch/pytorch
+
 # AWS Access key for Dynamo/S3. Only needed if testing lambda stuff locally.
 OUR_AWS_ACCESS_KEY_ID=
 OUR_AWS_SECRET_ACCESS_KEY=

--- a/torchci/lib/bot/greenlightBotConfig.ts
+++ b/torchci/lib/bot/greenlightBotConfig.ts
@@ -1,0 +1,31 @@
+import { greenlightPrivateKey } from "./greenlightAppAuth";
+import { parseRepoAllowlist } from "./repoAllowlist";
+
+const REPOS_ENV_VAR = "GREENLIGHT_BOT_REPOS";
+
+const REQUIRED_ENV_VARS = [
+  "GREENLIGHT_APP_ID",
+  "GREENLIGHT_APP_PRIVATE_KEY",
+  "GREENLIGHT_WEBHOOK_SECRET",
+  REPOS_ENV_VAR,
+];
+
+/** The repos `@greenlight` answers on, as an `owner/repo` or `owner/*` list. */
+export function greenlightRepos(): Set<string> {
+  return parseRepoAllowlist(process.env[REPOS_ENV_VAR]);
+}
+
+export function assertGreenlightBotConfig(): void {
+  const missing = REQUIRED_ENV_VARS.filter((name) => !process.env[name]);
+  if (missing.length > 0) {
+    throw new Error(
+      `The greenlight bot cannot start without ${missing.join(", ")}. Probot ` +
+        `falls back to an appId of NaN and to the literal webhook secret ` +
+        `"development" when the App variables are unset, which rejects every ` +
+        `delivery without reporting anything at startup, and an unset ` +
+        `${REPOS_ENV_VAR} enables the bot on nothing at all. Set them on the ` +
+        `Vercel project; the values are in Keeper.`
+    );
+  }
+  greenlightPrivateKey();
+}

--- a/torchci/test/greenlightBotConfig.test.ts
+++ b/torchci/test/greenlightBotConfig.test.ts
@@ -1,0 +1,147 @@
+import { generateKeyPairSync } from "crypto";
+import { greenlightPrivateKey } from "lib/bot/greenlightAppAuth";
+import {
+  assertGreenlightBotConfig,
+  greenlightRepos,
+} from "lib/bot/greenlightBotConfig";
+
+const ENV_VARS = [
+  "GREENLIGHT_APP_ID",
+  "GREENLIGHT_APP_PRIVATE_KEY",
+  "GREENLIGHT_WEBHOOK_SECRET",
+  "GREENLIGHT_BOT_REPOS",
+];
+
+let pkcs1: string;
+let pkcs8: string;
+
+function setEnv(values: Record<string, string | undefined>) {
+  for (const name of ENV_VARS) {
+    const value = values[name];
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  }
+}
+
+function completeEnv(
+  overrides: Record<string, string | undefined> = {}
+): Record<string, string | undefined> {
+  return {
+    GREENLIGHT_APP_ID: "4441283",
+    GREENLIGHT_APP_PRIVATE_KEY: pkcs1,
+    GREENLIGHT_WEBHOOK_SECRET: "s3cret",
+    GREENLIGHT_BOT_REPOS: "pytorch/pytorch",
+    ...overrides,
+  };
+}
+
+describe("greenlight bot configuration", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeAll(() => {
+    const pair = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    pkcs1 = pair.privateKey.export({ type: "pkcs1", format: "pem" }).toString();
+    pkcs8 = pair.privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+    for (const name of ENV_VARS) {
+      saved[name] = process.env[name];
+    }
+  });
+
+  afterAll(() => {
+    setEnv(saved);
+  });
+
+  describe("greenlightRepos", () => {
+    test("parses the allowlist out of the environment", () => {
+      setEnv(
+        completeEnv({ GREENLIGHT_BOT_REPOS: "pytorch/pytorch, PyTorch/*" })
+      );
+      expect(greenlightRepos()).toEqual(
+        new Set(["pytorch/pytorch", "pytorch/*"])
+      );
+    });
+
+    test("enables nothing when it is unset", () => {
+      setEnv(completeEnv({ GREENLIGHT_BOT_REPOS: undefined }));
+      expect(greenlightRepos()).toEqual(new Set());
+    });
+
+    test("picks up a change without a restart", () => {
+      setEnv(completeEnv({ GREENLIGHT_BOT_REPOS: "pytorch/pytorch" }));
+      expect(greenlightRepos()).toEqual(new Set(["pytorch/pytorch"]));
+      setEnv(completeEnv({ GREENLIGHT_BOT_REPOS: "pytorch/executorch" }));
+      expect(greenlightRepos()).toEqual(new Set(["pytorch/executorch"]));
+    });
+  });
+
+  describe("assertGreenlightBotConfig", () => {
+    test("passes on a complete environment", () => {
+      setEnv(completeEnv());
+      expect(() => assertGreenlightBotConfig()).not.toThrow();
+    });
+
+    test.each(ENV_VARS)("names %s when it is missing", (name) => {
+      setEnv(completeEnv({ [name]: undefined }));
+      expect(() => assertGreenlightBotConfig()).toThrow(name);
+    });
+
+    test("names every missing variable at once", () => {
+      setEnv({});
+      expect(() => assertGreenlightBotConfig()).toThrow(ENV_VARS.join(", "));
+    });
+
+    test("rejects a key probot cannot read", () => {
+      setEnv(completeEnv({ GREENLIGHT_APP_PRIVATE_KEY: pkcs8 }));
+      expect(() => assertGreenlightBotConfig()).toThrow("PKCS#1");
+    });
+  });
+
+  describe("greenlightPrivateKey", () => {
+    test("takes a PKCS#1 PEM as it is", () => {
+      setEnv(completeEnv({ GREENLIGHT_APP_PRIVATE_KEY: pkcs1 }));
+      expect(greenlightPrivateKey()).toBe(pkcs1);
+    });
+
+    test("decodes a base64-encoded PKCS#1 PEM", () => {
+      setEnv(
+        completeEnv({
+          GREENLIGHT_APP_PRIVATE_KEY: Buffer.from(pkcs1).toString("base64"),
+        })
+      );
+      expect(greenlightPrivateKey()).toBe(pkcs1);
+    });
+
+    test("rejects a PKCS#8 PEM, which the Actions secret may hold", () => {
+      setEnv(completeEnv({ GREENLIGHT_APP_PRIVATE_KEY: pkcs8 }));
+      expect(() => greenlightPrivateKey()).toThrow("openssl rsa");
+    });
+
+    test("rejects a base64-encoded PKCS#8 PEM", () => {
+      setEnv(
+        completeEnv({
+          GREENLIGHT_APP_PRIVATE_KEY: Buffer.from(pkcs8).toString("base64"),
+        })
+      );
+      expect(() => greenlightPrivateKey()).toThrow("PKCS#1");
+    });
+
+    test("rejects a PEM whose newlines were lost in transit", () => {
+      setEnv(
+        completeEnv({
+          GREENLIGHT_APP_PRIVATE_KEY: pkcs1.replace(/\n/g, ""),
+        })
+      );
+      expect(() => greenlightPrivateKey()).toThrow("real newlines");
+    });
+
+    test("rejects an unset key", () => {
+      setEnv(completeEnv({ GREENLIGHT_APP_PRIVATE_KEY: undefined }));
+      expect(() => greenlightPrivateKey()).toThrow(
+        "GREENLIGHT_APP_PRIVATE_KEY"
+      );
+    });
+  });
+});


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #8656
* #8655
* #8654
* #8653
* __->__ #8652
* #8651
* #8650
* #8649
* #8648
* #8647
* #8646

**Impact:** torchci deploy
**Risk:** low

## What
Adds `lib/bot/greenlightBotConfig.ts`: the `GREENLIGHT_BOT_REPOS` allowlist accessor and a
startup assertion over the four environment variables the bot needs. Documents all four in
`.env.example`.

## Why
Probot falls back to an appId of `NaN` and to the literal webhook secret `"development"`
when its App variables are unset, which rejects every delivery while reporting nothing at
startup. Asserting instead turns a misconfigured deploy into one actionable error naming
what is missing. `GREENLIGHT_BOT_REPOS` fails closed: unset, it enables the bot on nothing.