### PR TITLE
Add the Green Light bot's scoped GitHub write surface

### DIFF
--- a/torchci/lib/bot/greenlightWriter.ts
+++ b/torchci/lib/bot/greenlightWriter.ts
@@ -1,0 +1,137 @@
+import { Context } from "probot";
+import {
+  DISPATCH_PERMISSIONS,
+  mintScopedOctokit,
+  SOURCE_REPO_PERMISSIONS,
+} from "./greenlightAppAuth";
+
+export type GreenlightContext = Context<"issue_comment.created">;
+
+export type Reaction = "+1" | "confused";
+
+const DISPATCH_OWNER = "pytorch";
+const DISPATCH_REPO = "test-infra";
+const DISPATCH_WORKFLOW = "greenlight-review.yml";
+const DISPATCH_REF = "main";
+
+function memoize<T>(build: () => Promise<T>): () => Promise<T> {
+  let pending: Promise<T> | undefined;
+  return () => {
+    if (pending === undefined) {
+      pending = build();
+    }
+    return pending;
+  };
+}
+
+export interface SourceRepoWriter {
+  /** Mint the token now, so an unrelated mint can be in flight at the same time. */
+  ready: () => Promise<void>;
+  comment: (_body: string) => Promise<void>;
+  react: (_content: Reaction) => Promise<void>;
+  removeLabel: (_name: string) => Promise<void>;
+}
+
+/**
+ * The bot's write surface on the repo the comment came from. The scoped token is
+ * minted at most once per delivery, and only if something is actually written.
+ */
+export function sourceRepoWriter(ctx: GreenlightContext): SourceRepoWriter {
+  const owner = ctx.payload.repository.owner.login;
+  const repo = ctx.payload.repository.name;
+  const octokit = memoize(() =>
+    mintScopedOctokit(
+      owner,
+      repo,
+      SOURCE_REPO_PERMISSIONS,
+      ctx.payload.installation?.id
+    )
+  );
+
+  return {
+    async ready() {
+      await octokit();
+    },
+
+    async comment(body: string) {
+      ctx.log(`Commenting on ${ctx.payload.issue.html_url}`);
+      await (
+        await octokit()
+      ).rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: ctx.payload.issue.number,
+        body,
+      });
+    },
+
+    async react(content: Reaction) {
+      ctx.log(
+        `Reacting with "${content}" to comment ${ctx.payload.comment.html_url}`
+      );
+      await (
+        await octokit()
+      ).rest.reactions.createForIssueComment({
+        owner,
+        repo,
+        comment_id: ctx.payload.comment.id,
+        content,
+      });
+    },
+
+    async removeLabel(name: string) {
+      ctx.log(`Removing the ${name} label from ${ctx.payload.issue.html_url}`);
+      await (
+        await octokit()
+      ).rest.issues.removeLabel({
+        owner,
+        repo,
+        issue_number: ctx.payload.issue.number,
+        name,
+      });
+    },
+  };
+}
+
+export interface ReviewDispatcher {
+  /** Mint the token now, so an unrelated mint can be in flight at the same time. */
+  ready: () => Promise<void>;
+  dispatch: (_prNumber: number, _requester: string) => Promise<void>;
+}
+
+/** Starts the Green Light reviewer workflow that lives in pytorch/test-infra. */
+export function reviewDispatcher(ctx: GreenlightContext): ReviewDispatcher {
+  const octokit = memoize(() =>
+    mintScopedOctokit(DISPATCH_OWNER, DISPATCH_REPO, DISPATCH_PERMISSIONS)
+  );
+
+  return {
+    async ready() {
+      await octokit();
+    },
+
+    async dispatch(prNumber: number, requester: string) {
+      ctx.log(
+        `Dispatching ${DISPATCH_WORKFLOW} for pull request ${prNumber} on ` +
+          `behalf of ${requester}`
+      );
+      await (
+        await octokit()
+      ).rest.actions.createWorkflowDispatch({
+        owner: DISPATCH_OWNER,
+        repo: DISPATCH_REPO,
+        workflow_id: DISPATCH_WORKFLOW,
+        ref: DISPATCH_REF,
+        // The workflow appends --timeout-minutes to the CLI whatever its input
+        // holds, and argparse parses that one as an int, so sending it as an
+        // empty string exits 2 and reds the run. Only --max and the two sent
+        // here are guarded by a non-empty test. Leaving it out makes
+        // workflow_dispatch substitute the default the workflow declares.
+        inputs: {
+          pr: String(prNumber),
+          requester,
+        },
+      });
+    },
+  };
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #8656
* #8655
* #8654
* __->__ #8653
* #8652
* #8651
* #8650
* #8649
* #8648
* #8647
* #8646

**Impact:** torchci deploy
**Risk:** low

## What
Adds `lib/bot/greenlightWriter.ts`: comment, react and remove-label on the repo a comment
came from, plus a dispatcher for `greenlight-review.yml` in pytorch/test-infra. Each
surface mints its scoped token at most once per delivery, and only if something is written.

## Why
Collecting the writes behind two small interfaces keeps token scoping in one place and
keeps the command handler free of octokit calls, which is what makes the handler testable.
The source-repo token needs `issues: write` on one repo; the dispatch token needs
`actions: write` on pytorch/test-infra. `ready()` is exposed separately so a caller that
wants both can start the two mints together rather than paying their round trips in
sequence.