### PR TITLE
Add the @greenlight recheck handler

### DIFF
--- a/greenlight/tests/test_render_sync.py
+++ b/greenlight/tests/test_render_sync.py
@@ -1,9 +1,9 @@
-"""Pins the values Dr. CI's TypeScript renderer re-declares from greenlight's Python source.
+"""Pins the values torchci's TypeScript re-declares from greenlight's Python source.
 
-``torchci/lib/greenlight/greenlightRender.ts`` renders the same greenlight state the Python
-comment writer does, but re-declares the shared vocabulary as its own constants and nothing at
-build time links the two. Python is the source of truth: these tests fail when the TypeScript
-stops matching it, in either direction.
+Dr. CI's renderer and the ``@greenlight`` bot both re-state greenlight's shared vocabulary --
+statuses, headlines, the repo allowlist, the trusted-author list, the stale label -- as their
+own constants, and nothing at build time links the two sides. Python is the source of truth:
+these tests fail when the TypeScript stops matching it, in either direction.
 """
 
 import re
@@ -12,21 +12,29 @@ from urllib.parse import urlparse
 
 import pytest
 
-from greenlight import comment_format, constants
+from greenlight import comment_format, constants, review
 
 ROOT = Path(__file__).resolve().parents[2]
 
 _TS_RENDER = "torchci/lib/greenlight/greenlightRender.ts"
 _TS_CONFIG = "torchci/lib/greenlight/greenlightConfig.ts"
+_TS_TRUSTED = "torchci/lib/bot/greenlightTrustedAuthors.ts"
+_TS_BOT_HANDLER = "torchci/lib/bot/greenlightBotHandler.ts"
 _PY_RENDER = "greenlight/src/greenlight/comment_format.py"
 _PY_CONSTANTS = "greenlight/src/greenlight/constants.py"
+_PY_REVIEW = "greenlight/src/greenlight/review.py"
 
 assert (ROOT / _TS_RENDER).is_file()
 assert (ROOT / _TS_CONFIG).is_file()
+assert (ROOT / _TS_TRUSTED).is_file()
+assert (ROOT / _TS_BOT_HANDLER).is_file()
 
 _TS_UNICODE_ESCAPE_RE = re.compile(r"\\u([0-9a-fA-F]{4})")
 _TS_STATUS_RE = re.compile(r'^export const GREENLIGHT_STATUS_(\w+) =\s*"([^"]*)";$', re.MULTILINE)
 _TS_REPOS_RE = re.compile(r"^export const GREENLIGHT_REPOS: string\[\] =\s*\[([^\]]*)\]", re.MULTILINE)
+_TS_TRUSTED_AUTHORS_RE = re.compile(
+    r"^export const GREENLIGHT_TRUSTED_AUTHORS: string\[\] =\s*\[([^\]]*)\]", re.MULTILINE
+)
 _TS_QUOTED_RE = re.compile(r'"([^"]*)"')
 _TS_JOB_LINK_RE = re.compile(r"\[([^\]]+)\]\(\$\{\w+\}\)")
 _TS_REASON_PREFIX_RE = re.compile(r"`([^`$]*)\$\{inlineCode\(")
@@ -90,6 +98,14 @@ def _ts_repos() -> frozenset[str]:
     repos = frozenset(constants.normalize_repo(repo) for repo in _TS_QUOTED_RE.findall(m.group(1)))
     assert repos, f"`GREENLIGHT_REPOS` in {_TS_CONFIG} holds no entries: {_RESTRUCTURED}"
     return repos
+
+
+def _ts_trusted_authors() -> frozenset[str]:
+    m = _TS_TRUSTED_AUTHORS_RE.search(_read(_TS_TRUSTED))
+    assert m is not None, f"no `GREENLIGHT_TRUSTED_AUTHORS: string[] = [...]` in {_TS_TRUSTED}: {_RESTRUCTURED}"
+    authors = frozenset(_TS_QUOTED_RE.findall(m.group(1)))
+    assert authors, f"`GREENLIGHT_TRUSTED_AUTHORS` in {_TS_TRUSTED} holds no entries: {_RESTRUCTURED}"
+    return authors
 
 
 def _ts_job_link_labels() -> set[str]:
@@ -188,6 +204,27 @@ def test_repo_allowlist_matches_python() -> None:
         _TS_CONFIG,
         _PY_CONSTANTS,
         f"symmetric difference: {sorted(extracted ^ constants.DRCI_STATUS_COMMENT_REPOS)}",
+    )
+
+
+def test_trusted_authors_match_python() -> None:
+    extracted = _ts_trusted_authors()
+    # Exact-case on purpose: both sides lowercase only inside their own membership test, so the
+    # literal lists still have to agree. A login on one side alone is a live authz gap -- the bot
+    # and the backend would disagree about who may request a review.
+    assert extracted == review.TRUSTED_AUTHORS, _drift(
+        _TS_TRUSTED,
+        _PY_REVIEW,
+        f"symmetric difference: {sorted(extracted ^ review.TRUSTED_AUTHORS)}",
+    )
+
+
+def test_stale_label_matches_python() -> None:
+    extracted = _ts_string(_TS_BOT_HANDLER, "STALE_LABEL")
+    assert extracted == constants.STALE_LABEL, _drift(
+        _TS_BOT_HANDLER,
+        _PY_CONSTANTS,
+        f"STALE_LABEL is {extracted!r}, Python has {constants.STALE_LABEL!r}",
     )
 
 

--- a/torchci/lib/bot/greenlightBotHandler.ts
+++ b/torchci/lib/bot/greenlightBotHandler.ts
@@ -1,0 +1,205 @@
+import {
+  getHelp,
+  GreenlightCommandName,
+  isGreenlightCommand,
+  parseCommandName,
+} from "./greenlightCliParser";
+import { isTrustedAuthor } from "./greenlightTrustedAuthors";
+import {
+  GreenlightContext,
+  reviewDispatcher,
+  SourceRepoWriter,
+  sourceRepoWriter,
+} from "./greenlightWriter";
+import { hasWritePermissions, isPyTorchPyTorch } from "./utils";
+
+// GitHub label names are case-sensitive and the greenlight scanner compares the
+// raw string, so this has to stay exactly as the pytorch stale bot writes it.
+const STALE_LABEL = "Stale";
+
+export const RECHECK_DEDUPE_TTL_MS = 60 * 1000;
+
+const recentRechecks = new Map<string, number>();
+
+function isRecheckInFlight(key: string): boolean {
+  const expiresAt = recentRechecks.get(key);
+  return expiresAt !== undefined && expiresAt > Date.now();
+}
+
+function markRecheckInFlight(key: string): void {
+  const now = Date.now();
+  for (const [k, expiresAt] of recentRechecks) {
+    if (expiresAt <= now) {
+      recentRechecks.delete(k);
+    }
+  }
+  recentRechecks.set(key, now + RECHECK_DEDUPE_TTL_MS);
+}
+
+function forgetRecheckInFlight(key: string): void {
+  recentRechecks.delete(key);
+}
+
+/** Clear the in-memory recheck dedupe window (useful for testing). */
+export function clearRecheckDedupe(): void {
+  recentRechecks.clear();
+}
+
+function ackMessage(hadStaleLabel: boolean): string {
+  const removed = hadStaleLabel
+    ? `Removed the \`${STALE_LABEL}\` label and asked`
+    : "Asked";
+  return (
+    `${removed} Green Light to take another look.\n\n` +
+    `Green Light will re-review this pull request if it has changed since its ` +
+    `last verdict.`
+  );
+}
+
+function untrustedRequesterMessage(requester: string): string {
+  return (
+    `Green Light only acts on rechecks from its trusted-requester list, and ` +
+    `\`${requester}\` is not on it.\n\n` +
+    `The list is \`TRUSTED_AUTHORS\` in ` +
+    `\`greenlight/src/greenlight/review.py\` in pytorch/test-infra.`
+  );
+}
+
+async function handleRecheck(
+  ctx: GreenlightContext,
+  writer: SourceRepoWriter
+): Promise<void> {
+  const issue = ctx.payload.issue;
+  const owner = ctx.payload.repository.owner.login;
+  const repo = ctx.payload.repository.name;
+  const prNumber = issue.number;
+  const requester = ctx.payload.comment.user.login;
+
+  // Write permission is a far wider set than the list the backend will act on,
+  // and a refused recheck there ends in a clean green workflow run with no
+  // comment and no recorded state. Refusing here is the only place the
+  // requester can be told, so it has to happen before the bot reports success.
+  if (!isTrustedAuthor(requester)) {
+    await writer.comment(untrustedRequesterMessage(requester));
+    return;
+  }
+
+  if (issue.pull_request?.merged_at) {
+    await writer.comment(
+      "This pull request is already merged, so there is nothing for Green Light to review."
+    );
+    return;
+  }
+  if (issue.state !== "open") {
+    await writer.comment(
+      "This pull request is closed, so there is nothing for Green Light to review."
+    );
+    return;
+  }
+  if (issue.draft) {
+    await writer.comment(
+      "This pull request is a draft. Mark it ready for review and ask again."
+    );
+    return;
+  }
+  // The reviewer workflow this ultimately reaches, greenlight-pr-review.yml,
+  // takes no repo input: it hard-codes pytorch/pytorch for both the checkout
+  // and the verdict write, so a recheck dispatched from anywhere else would
+  // review an unrelated pull request of the same number.
+  if (!isPyTorchPyTorch(owner, repo)) {
+    await writer.comment(
+      "Green Light only reviews pytorch/pytorch pull requests today."
+    );
+    return;
+  }
+
+  const dedupeKey = `${owner}/${repo}/${prNumber}`;
+  if (isRecheckInFlight(dedupeKey)) {
+    ctx.log(`Skipping a repeated recheck of ${dedupeKey}`);
+    return;
+  }
+  // No await between the test above and this mark, so two deliveries the same
+  // warm instance is handling at once cannot both get past it and start
+  // reviewer runs that cancel each other mid-review.
+  markRecheckInFlight(dedupeKey);
+
+  const hadStaleLabel = issue.labels.some(
+    (label) => label.name === STALE_LABEL
+  );
+  const dispatcher = reviewDispatcher(ctx);
+
+  try {
+    // Both tokens are wanted on this path and neither depends on the other, so
+    // the two mints overlap instead of adding their round trips together.
+    await Promise.all([writer.ready(), dispatcher.ready()]);
+
+    // Removing the label is what keeps the pull request under automatic review
+    // afterwards: the dispatched recheck ignores the label entirely, but the
+    // periodic listing scan skips a Stale-labelled pull request once its
+    // recorded verdict is terminal, which is the state this recheck is about
+    // to reach.
+    if (hadStaleLabel) {
+      try {
+        await writer.removeLabel(STALE_LABEL);
+      } catch (error: any) {
+        // The label is only removed when the payload says it is there, so a 404
+        // means someone else got to it first -- which is the state we wanted.
+        if (error?.status !== 404) {
+          throw error;
+        }
+        ctx.log(`The ${STALE_LABEL} label was already gone from ${dedupeKey}`);
+      }
+    }
+
+    await dispatcher.dispatch(prNumber, requester);
+  } catch (error) {
+    // No run exists to deduplicate against, so holding the window shut would
+    // drop the requester's retry for a minute with nothing posted to say why.
+    forgetRecheckInFlight(dedupeKey);
+    throw error;
+  }
+
+  // Acknowledge last. Probot answers 202 and abandons the invocation nine
+  // seconds into a delivery, and GitHub never redelivers a webhook it failed to
+  // process, so any step here can be the last one that runs. Commenting only
+  // after the work means a truncated delivery leaves no comment claiming
+  // something that never happened.
+  await writer.comment(ackMessage(hadStaleLabel));
+  await writer.react("+1");
+}
+
+type CommandHandler = (
+  _ctx: GreenlightContext,
+  _writer: SourceRepoWriter
+) => Promise<void>;
+
+// Keyed by the command union, so adding a command to GREENLIGHT_COMMANDS
+// without giving it behaviour here does not compile.
+const COMMAND_HANDLERS: Record<GreenlightCommandName, CommandHandler> = {
+  async help(_ctx, writer) {
+    await writer.comment(getHelp());
+  },
+  recheck: handleRecheck,
+};
+
+export async function handleGreenlightCommand(
+  ctx: GreenlightContext,
+  inputArgs: string
+): Promise<void> {
+  const writer = sourceRepoWriter(ctx);
+  const name = parseCommandName(inputArgs);
+
+  // A comment notifies everyone subscribed to the pull request, so nothing the
+  // bot posts may be reachable by an arbitrary GitHub user: an unrecognized
+  // command and an unauthorized commenter both get a reaction and nothing else.
+  if (!isGreenlightCommand(name)) {
+    await writer.react("confused");
+    return;
+  }
+  if (!(await hasWritePermissions(ctx, ctx.payload.comment.user.login))) {
+    await writer.react("confused");
+    return;
+  }
+
+  await COMMAND_HANDLERS[name](ctx, writer);
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #8656
* #8655
* __->__ #8654
* #8653
* #8652
* #8651
* #8650
* #8649
* #8648
* #8647
* #8646

**Impact:** torchci deploy
**Risk:** medium

## What
Adds `lib/bot/greenlightBotHandler.ts`, which implements `recheck` and `help`, and extends
greenlight's Python drift test to pin the trusted-author list and the `Stale` label against
their Python definitions.

## Why
`recheck` is the point of the bot: it removes the `Stale` label, dispatches
`greenlight-review.yml` on pytorch/test-infra, then acknowledges - in that order, so the
acknowledgment describes work already done and a delivery cut short leaves no comment
claiming otherwise. Removing the label is what keeps the PR under automatic review: the
periodic listing scan skips a `Stale`-labelled PR once its recorded verdict is terminal.

Every command is gated on repo write permission; `recheck` additionally requires the
requester to be on greenlight's trusted-author list, checked before anything is touched,
because the backend's own refusal is a clean green no-op the requester would never see.
A comment notifies every PR subscriber, so an unrecognized command and an unauthorized
commenter get a reaction and nothing else. The scan stays the sole authorizer of the
review itself.

# Notes
The drift test fails in both directions, so a login or label changed on one side only reds
greenlight's suite instead of opening an authz gap between the bot and the backend.