### PR TITLE
Document the Green Light comment bot

### DIFF
--- a/.github/workflows/greenlight-review.yml
+++ b/.github/workflows/greenlight-review.yml
@@ -1,11 +1,11 @@
 name: Green Light Scan
 
 # The periodic pytorch/pytorch PR scan runs as the `greenlight-scan` AWS Lambda
-# (pytorch-gha-infra-2, us-east-1, EventBridge rate(5 minutes)). This workflow is now the manual /
-# `@greenlight recheck` entry point: dispatched by filename from a pytorch/pytorch trigger (or run
-# by hand), it runs the same greenlight scanner (`greenlight review`) — lists open pytorch/pytorch
-# PRs from trusted authors and dispatches greenlight-pr-review.yml for each new or changed PR.
-# Read-only on ClickHouse; dispatches the reviewer workflow via the App token.
+# (pytorch-gha-infra-2, us-east-1, EventBridge rate(5 minutes)). This workflow is the
+# `@greenlight recheck` / manual entry point: dispatched by filename by the greenlight Probot bot
+# in torchci (or run by hand), it runs the same greenlight scanner (`greenlight review`) — lists
+# open pytorch/pytorch PRs from trusted authors and dispatches greenlight-pr-review.yml for each
+# new or changed PR. Read-only on ClickHouse; dispatches the reviewer workflow via the App token.
 
 on:
   workflow_dispatch:

--- a/greenlight/CHEATSHEET.md
+++ b/greenlight/CHEATSHEET.md
@@ -13,8 +13,9 @@ one-shot `verdict` and `drci-poke` subcommands:
   for each, compute its fingerprint (`eval_hash`), read its latest state from
   `misc.greenlight_pr_state`, and dispatch the reviewer workflow
   (`greenlight-pr-review.yml` on `pytorch/test-infra`) for new or changed PRs. Draft PRs are
-  dropped from the listing scan entirely — never fingerprinted or dispatched — though an explicit
-  `@greenlight recheck` (the `--pr` path) still reviews a draft. A PR whose
+  dropped from the listing scan entirely — never fingerprinted or dispatched. The drop is in the
+  listing fetch alone, so `--pr N` reviews a draft; the bot turns a draft down rather than
+  dispatching one, so a draft never reaches that path via `@greenlight recheck`. A PR whose
   `updated_at` is older than `PYTORCH_GREENLIGHT_REVIEW_WINDOW_HOURS` (default 24), or that carries
   the `Stale` label, is skipped without fingerprinting unless a review is in-flight or retry-eligible
   (cancelled/failed); an explicit `@greenlight recheck` (the `--pr` path) reviews it regardless. A PR a
@@ -64,6 +65,7 @@ just review --pr 123 --requester alice  # recheck PR #123 for alice (author and 
 just review --max 5                  # cap this iteration at 5 dispatches
 just review --ref my-branch          # dispatch the reviewer workflow at this test-infra ref (default main)
 just review --timeout-minutes 60     # re-dispatch an in-flight review after 60 min (default 45)
+just review --pr 123 --force         # re-dispatch PR #123 even if already decided (needs --pr, not --loop)
 just review --pr 123 --allow-untrusted-author  # LOCAL ONLY: skip the --pr author check
 ```
 
@@ -78,24 +80,61 @@ holds the lock (`2` is an argparse usage error).
 
 The scan flags combine: `--pr N` restricts the scan to one PR, `--max N` caps how many
 dispatches a single iteration issues, `--ref` sets the `pytorch/test-infra` ref the
-reviewer workflow is dispatched at (default `main`), and `--timeout-minutes` (default 45)
-is how long an `AI_REVIEW_STARTED` review counts as in-flight before it is re-dispatched.
+reviewer workflow is dispatched at (default `main`), `--timeout-minutes` (default 45)
+is how long an `AI_REVIEW_STARTED` review counts as in-flight before it is re-dispatched,
+and `--force` skips the dispatch decision altogether (it needs `--pr` and rejects `--loop`).
 That 45 is above the reviewer workflow's own ~37-40 min budget, so with the default the
 scanner lets a running review finish (or time out and record a verdict) before it
 re-dispatches, rather than cancelling and restarting one that is still running; lower
 `--timeout-minutes` in the deployment if you need a stuck review reclaimed sooner.
 
-`@greenlight recheck` on a `pytorch/pytorch` PR (via the separately deployed trigger) dispatches
-`greenlight-review.yml` with the PR number and commenter as `--pr N --requester <login>`. The scan
-is the sole authorizer: `--pr` refuses unless PR N's author is trusted, and `--requester` refuses
-unless the commenter is trusted too (case-insensitive; a refusal is a clean exit 0). The local-only
+The greenlight Probot bot in torchci understands two commands. `@greenlight help` replies with the
+list of available commands and has no other effect — no label change, no dispatch.
+
+`@greenlight recheck` on a `pytorch/pytorch` PR makes the bot remove the `Stale` label if present,
+dispatch `greenlight-review.yml` with the PR number and commenter as `--pr N --requester <login>`,
+and only then acknowledge, with a comment plus a reaction on the triggering comment. The
+acknowledgment comes last so it describes work already done — a delivery cut short partway leaves
+no comment claiming otherwise — and it states only what the bot did, never that a review has
+started. The mention must open its line, mention and command name are both case-insensitive
+(matching `pr_hash.is_bot_command`, which lowercases the body), and a mention inside a fence, an
+HTML comment, a `<pre>` block or an indented code block is ignored — closed or not.
+
+The bot declines on the PR when the PR is merged, closed, a draft, or not in `pytorch/pytorch`,
+and when the requester is not a greenlight trusted author — it checks that last one itself, before
+touching the PR, because the scan's own refusal is a silent green no-op that would leave the
+requester with no feedback at all. A comment notifies every PR subscriber, so comments are
+reserved for commenters who already hold write access on the repo; anyone else, and any
+unrecognized command, gets a reaction instead. Write access is the coarse gate and covers every
+command, `help` included; the trusted-author list is the narrow one that decides whether a recheck
+runs. Two gates sit above those: the bot serves only a fixed set of orgs — a comment anywhere else
+is ignored outright — and, within those, only the repos its allowlist enables. Separately, a
+repeated recheck of the same PR inside a short in-memory window is silently dropped rather than
+dispatched twice.
+
+`--force` exists as a CLI flag but is not a `greenlight-review.yml` input, so a recheck cannot
+reach it and goes through `decide` like any other scan. `decide` dispatches on more than a changed
+fingerprint — never reviewed, changed `eval_hash`, an in-flight marker past `--timeout-minutes`,
+or a `CANCELLED`/`FAILED` row past the same window — so a recheck after a cancelled or failed
+review dispatches even if nothing changed. Only a terminal verdict with an unchanged `eval_hash`
+is skipped.
+
+Removing the `Stale` label is what keeps the PR in the periodic scan, which skips a
+`Stale`-labeled PR once its recorded verdict is terminal; `pytorch/pytorch`'s stale bot also
+closes a `Stale` PR outright after 30 further days without an update. The unlabel delivers
+`pull_request.unlabeled` to the pytorch-bot App, so `checkLabelsBot` frequently adds its own
+"needs a `release notes:` label" comment to the same PR — expected, not a greenlight bug.
+
+The scan authorizes independently of the bot: `--pr` refuses unless PR N's author is trusted, and
+`--requester` refuses unless the commenter is trusted too (case-insensitive; a refusal is a clean
+exit 0). The local-only
 `--allow-untrusted-author` skips the target-author check for iteration and is never a workflow
 input. Unlike the listing scan, `--pr` ignores an existing approval and reviews anyway; if the PR
 has a changes-requested review it does not review but posts a single comment that it will not
 re-review while a reviewer's requested changes stand, reconsidering once the reviewer dismisses or
 resolves that review. That refusal comment carries its own marker and is posted by greenlight on
 every repo, `pytorch/pytorch` included — only the status comment is delegated to Dr. CI. The
-command is not yet advertised in the status surface.
+status surface carries no `@greenlight recheck` hint.
 
 Daemon mode loops the phase on an interval:
 
@@ -148,7 +187,8 @@ the other lambda zips -> pin that tag in the `pytorch-gha-infra-2` `runners/comm
 The end-to-end flow, per trusted-author PR:
 
 1. `review` scans the open PRs, dropping any draft PR from the listing outright — never
-   fingerprinted or dispatched, though `@greenlight recheck` via `--pr` still reviews a draft. For
+   fingerprinted or dispatched. The drop is in the listing fetch alone, so `--pr N` reviews a
+   draft, but the bot turns a draft down rather than dispatching one. For
    each remaining PR it computes its fingerprint (`eval_hash`) — unless
    the PR's `updated_at` is older than `PYTORCH_GREENLIGHT_REVIEW_WINDOW_HOURS` (default 24) or it
    carries the `Stale` label, and it has no in-flight or retry-eligible (cancelled/failed) review,

--- a/greenlight/README.md
+++ b/greenlight/README.md
@@ -28,13 +28,14 @@ trusted authors in `pytorch/pytorch` and, for each one, computes its fingerprint
 `misc.greenlight_pr_state`, and dispatches the reviewer workflow
 (`greenlight-pr-review.yml` on `pytorch/test-infra`) for PRs that are new or changed since
 their last review. Draft PRs are dropped from the listing scan entirely — never fingerprinted or
-dispatched — though an explicit `@greenlight recheck` (the `--pr` path) still reviews a draft.
-A PR whose `updated_at` is older than
-`PYTORCH_GREENLIGHT_REVIEW_WINDOW_HOURS` (default 24), or that carries the `Stale` label, is
-skipped without fingerprinting unless it has an in-flight or retry-eligible (cancelled/failed)
-review to re-check; an explicit `@greenlight recheck` (the `--pr` path) reviews it regardless. An
-in-flight review — one marked `AI_REVIEW_STARTED` — is left alone until the `--timeout-minutes`
-re-dispatch window elapses.
+dispatched. That drop lives in the listing fetch alone, so `greenlight review --pr N` reviews a
+draft like any other PR; a draft never reaches that path through `@greenlight recheck`, because
+the bot turns a draft down before it dispatches (see "Rechecking a PR"). A PR whose `updated_at`
+is older than `PYTORCH_GREENLIGHT_REVIEW_WINDOW_HOURS` (default 24), or that carries the `Stale`
+label, is skipped without fingerprinting unless it has an in-flight or retry-eligible
+(cancelled/failed) review to re-check; an explicit `@greenlight recheck` (the `--pr` path) reviews
+it regardless. An in-flight review — one marked `AI_REVIEW_STARTED` — is left alone until the
+`--timeout-minutes` re-dispatch window elapses.
 The listing scan also skips a PR a human has already decided — approved by a merge-authorized
 login (any `approved_by` in `pytorch/pytorch`'s `merge_rules.yaml`, taken across all rules
 regardless of the PR's changed paths, bots excluded) or with changes requested by any non-bot
@@ -54,6 +55,7 @@ just run review --pr 123 --requester alice  # recheck PR #123 for alice (author 
 just run review --max 5              # cap this iteration at 5 dispatches
 just run review --ref my-branch      # dispatch the reviewer workflow at this test-infra ref (default main)
 just run review --timeout-minutes 60 # re-dispatch an in-flight review after 60 min (default 45)
+just run review --pr 123 --force     # re-dispatch PR #123 even if already decided (needs --pr, not --loop)
 just run review --pr 123 --allow-untrusted-author  # LOCAL ONLY: skip the --pr author check
 ```
 
@@ -70,12 +72,78 @@ reclaimed sooner.
 ### Rechecking a PR (`@greenlight recheck`)
 
 A trusted author can re-trigger a review by commenting `@greenlight recheck` on a
-`pytorch/pytorch` PR. A thin `pytorch/pytorch` workflow (deployed separately) dispatches
-`greenlight-review.yml` with the PR number and the commenter's login, and the scan re-checks
-that one PR through the `--pr` path.
+`pytorch/pytorch` PR. The greenlight Probot bot in torchci
+(`torchci/pages/api/greenlight/webhooks.ts`) understands two commands, `recheck` and `help`;
+`@greenlight help` replies with the list of available commands and has no other effect — no
+comment beyond that reply, no label change, no dispatch.
 
-The scan is the single source of authorization and enforces two gates against the trusted-author
-set (`review.TRUSTED_AUTHORS`), matched case-insensitively:
+The command is read the way a human reads it, not the way a shell would: mention and command name
+are both matched case-insensitively, the mention must open its line, and a mention that renders as
+sample text rather than as an instruction — inside a fence, an HTML comment or a `<pre>` block, or
+indented far enough to be a markdown code block — is ignored. Those regions need no closing
+delimiter to count, so an unterminated `<!--` swallows the rest of the comment, exactly as GitHub
+does when it renders nothing there. Matching the mention case-insensitively is what keeps the bot
+in step with `pr_hash.is_bot_command`, which lowercases the body before looking for the trigger: a
+differently-cased mention is dropped from the PR's fingerprint whether or not the bot acts on it.
+
+An accepted `recheck` does its work in this order: it removes the `Stale` label if the PR carries
+it, dispatches `greenlight-review.yml` with the PR number and the commenter's login as
+`--pr N --requester <login>` — which puts the PR through the scan's `--pr` path — and only then
+acknowledges, with a comment plus a reaction on the triggering comment. The acknowledgment comes
+last so it describes work already done rather than work merely intended; a delivery cut short
+partway therefore leaves no comment claiming something that never happened. It states only what
+the bot did, and never that a review has started, because every gate below it — an untrusted
+target author, a PR the scan decides needs no re-review, an in-flight review — ends the run
+cleanly and green.
+
+When the bot declines a `recheck` it says so on the PR, so a requester can always tell the
+command was read. It declines when the PR is merged, when it is closed, when it is a draft, when
+the repo is not `pytorch/pytorch` — `greenlight-pr-review.yml` hard-codes that repo for both the
+checkout and the verdict write, so a recheck dispatched from anywhere else would review an
+unrelated PR of the same number — and when the requester is not a greenlight trusted author. The
+bot enforces that last one itself, before it changes anything on the PR, because the scan's own
+refusal is a clean green no-op that leaves no trace anywhere (see the authorization gates below);
+without an up-front check in the bot, an untrusted requester would get no feedback at all.
+
+Which form that answer takes depends on who is asking. Anything the bot posts as a comment
+notifies every subscriber on the PR, so comments are reserved for commenters who already hold
+write access on the repo; anyone else — and any unrecognized command — gets a reaction and nothing
+more. Write access is the coarse gate and applies to every command, `help` included; the
+trusted-author list is the narrow one, and only the narrow one decides whether a recheck runs.
+
+Two filters run above all of that. The bot serves only a fixed set of orgs — an `@greenlight`
+command anywhere else is ignored outright, with no answer of any kind — and within those, only the
+repos its allowlist enables. Separately, a repeated `recheck` on the same PR inside a short
+in-memory window is silently dropped rather than dispatched again, so a double-posted comment
+cannot start two reviewer runs.
+
+`--force` does exist, but only as a CLI flag (`greenlight review --pr N --force`, which
+short-circuits `decision.decide` outright). It is deliberately not a `greenlight-review.yml`
+input, so the recheck path cannot reach it — the same posture as `--allow-untrusted-author`. A
+recheck is therefore decided by `decide` like any other scan, and `decide` dispatches on more than
+a changed fingerprint: a PR never reviewed, a changed `eval_hash`, an in-flight marker older than
+`--timeout-minutes`, or a `CANCELLED`/`FAILED` row past that same window. Only a PR whose recorded
+verdict is terminal and whose `eval_hash` is unchanged is skipped — so rechecking a PR whose last
+review was cancelled or failed does dispatch, unchanged or not.
+
+Removing the `Stale` label is what keeps the PR under review afterwards, and it outlasts the
+recheck. The `--pr` path already ignores the label — `_candidate_numbers` reports no labels for a
+single-PR target — but the listing scan skips a `Stale`-labeled PR whose recorded state is
+terminal, so leaving the label on would drop the PR back out of the periodic scan the moment the
+recheck's verdict lands. `pytorch/pytorch`'s stale bot (`.github/workflows/stale.yml`) runs hourly
+off the same `updated_at` greenlight reads and never removes the label itself; it closes a
+`Stale` PR outright after 30 further days without an update, and re-adds the label plus re-posts
+its message on any unlabelled PR whose `updated_at` is older than 60 days.
+
+The unlabel also reaches a bot greenlight does not control. `pull_request.unlabeled` is delivered
+to the pytorch-bot App, where `torchci/lib/bot/checkLabelsBot.ts` posts "This PR needs a `release
+notes:` label" on any `pytorch/pytorch` PR carrying neither a `release notes:` label nor
+`topic: not user facing`. A PR untouched long enough to be labeled `Stale` is disproportionately
+likely to be missing both, so a recheck often produces that second, unrelated comment. That is
+`checkLabelsBot` behaving as designed, not a greenlight fault.
+
+The scan enforces authorization independently of the bot, with two gates against the
+trusted-author set (`review.TRUSTED_AUTHORS`), matched case-insensitively:
 
 - **Target-author gate** — `--pr N` looks up PR `N`'s author and refuses (no fingerprint, no
   dispatch, no review) unless that author is trusted. Unlike the listing scan, `--pr` names an
@@ -83,6 +151,10 @@ set (`review.TRUSTED_AUTHORS`), matched case-insensitively:
 - **Requester gate** — `--requester <login>`, when given, additionally requires `<login>` to be
   trusted; an untrusted requester is refused before any network work, and the requester is logged
   for audit.
+
+The bot's own trusted-author check duplicates the requester gate on purpose. The gate here stays
+the enforcing one, because a `greenlight-review.yml` dispatch can arrive without passing through
+the bot at all — run by hand, or from anything else holding the App's `actions: write`.
 
 A refusal is a clean no-op (exit 0), not a failure. `--allow-untrusted-author` is a **local-only**
 flag that skips the target-author gate for iteration; it is deliberately not exposed as a
@@ -96,9 +168,9 @@ changes-requested review, greenlight does not review; it posts a single comment 
 re-review while a reviewer's requested changes stand, and reconsiders once the reviewer dismisses
 or resolves that review (not merely on the next push).
 
-The user-facing `@greenlight recheck` hint is not yet advertised in the status surface — Dr. CI's
-Green Light section on `pytorch/pytorch`, greenlight's own comment elsewhere (see "Who posts the
-status comment"); that is added once the `pytorch/pytorch` trigger is deployed.
+The status surface — Dr. CI's Green Light section on `pytorch/pytorch`, greenlight's own comment
+elsewhere (see "Who posts the status comment") — carries no `@greenlight recheck` hint, so the
+command is not discoverable from the PR itself.
 
 ### Recording a verdict
 
@@ -219,11 +291,11 @@ under the Lambda runtime); single-instance and hang-bounding come from
 
 The scan's Dr. CI poke needs `PYTORCH_GREENLIGHT_DRCI_TOKEN` (and optionally
 `PYTORCH_GREENLIGHT_DRCI_INTERNAL_TOKEN`) wherever the scan runs: the Lambda reads both from its
-function environment, provisioned by the gha-infra terraform, and the manual /
-`@greenlight recheck` entry point (`greenlight-review.yml`) passes them from the `DRCI_BOT_KEY`
-and `HUD_API_TOKEN` secrets. Without the token every poke logs a warning and no-ops, leaving the
-`AI_REVIEW_DISPATCHED` state to surface on Dr. CI's 15-minute sweep — the scan itself still
-succeeds.
+function environment, provisioned by the gha-infra terraform, and the `@greenlight recheck` entry
+point (`greenlight-review.yml`, dispatched by the greenlight Probot bot or run by hand) passes
+them from the `DRCI_BOT_KEY` and `HUD_API_TOKEN` secrets. Without the token every poke logs a
+warning and no-ops, leaving the `AI_REVIEW_DISPATCHED` state to surface on Dr. CI's 15-minute
+sweep — the scan itself still succeeds.
 
 The zip ships in test-infra's shared lambda release alongside every other lambda:
 
@@ -304,8 +376,9 @@ from a fixed set of trusted authors in `pytorch/pytorch`, computes each PR's fin
 (`eval_hash`), reads the PR's latest recorded state from `misc.greenlight_pr_state`, and
 dispatches the reviewer workflow (`greenlight-pr-review.yml` on `pytorch/test-infra`) for
 PRs that are new or changed. Draft PRs are dropped from the listing scan entirely — never
-fingerprinted or dispatched — though an explicit `@greenlight recheck` (the `--pr` path) still
-reviews a draft. PRs whose `updated_at` is older than the review window
+fingerprinted or dispatched; the drop is in the listing fetch alone, so `--pr N` reviews a
+draft, but the bot turns a draft down rather than dispatching one. PRs whose `updated_at` is
+older than the review window
 (`PYTORCH_GREENLIGHT_REVIEW_WINDOW_HOURS`, default 24), or that carry the `Stale` label, are
 skipped without fingerprinting unless a review is in-flight or retry-eligible (cancelled/failed);
 an explicit `@greenlight recheck` (the `--pr` path) reviews such a PR regardless. PRs a human has already decided

--- a/torchci/docs/architecture.md
+++ b/torchci/docs/architecture.md
@@ -17,6 +17,11 @@ flowchart LR
    dynamodb --> replicatorlambda@{ shape: das, label: "AWS Lambda
    clickhouse-replicator-dynamo"}
    replicatorlambda --> ClickHouse
+   greenlightapp[Github App
+   Green Light] --> greenlightvercel@{ shape: das, label: "vercel
+   /api/greenlight/webhooks" }
+   greenlightvercel --> dispatch[Actions workflow_dispatch
+   greenlight-review.yml]
 ```
 
 Whenever something happens on GitHub, a [webhook event] is created and sent to
@@ -37,12 +42,20 @@ written to `torchci-workflow-job`.
 ClickHouse [ingests from DynamoDB using an AWS Lambda][ch_dynamo] to automatically pick up
 changes in the tables.
 
+`torchci` serves a second GitHub App, Green Light, on a second endpoint
+([`/api/greenlight/webhooks`]). It is a separate Probot instance with its own
+app id, private key and webhook secret, and it writes nothing to DynamoDB: it
+answers `@greenlight` comments on pull requests by dispatching the Green Light
+reviewer workflow in `pytorch/test-infra`. The two apps are installed
+independently of each other, so a repo can have either one without the other.
+
 [webhook event]: https://docs.github.com/en/developers/webhooks-and-events/webhooks/about-webhooks
 [webhook payload]: https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads
 [`issues`]: https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#issues
 [github apps]: https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps
 [pytorch bot]: https://github.com/apps/pytorch-bot
 [`/api/github/webhooks`]: https://github.com/pytorch/test-infra/blob/main/torchci/pages/api/github/webhooks.ts
+[`/api/greenlight/webhooks`]: https://github.com/pytorch/test-infra/blob/main/torchci/pages/api/greenlight/webhooks.ts
 [ch_dynamo]: https://github.com/pytorch/test-infra/tree/6abfc539d0ce7daf0fcd07533de37b8723e6454a/aws/lambda/clickhouse-replicator-dynamo
 
 ## Secondary write paths
@@ -109,5 +122,16 @@ To get the basic HUD working, you will need to:
 
 You won't get any of the other goodies listed in "Secondary write paths" above,
 but other than that, things should work!
+
+The Green Light app is installed separately, and step 1 does nothing for it. To
+get `@greenlight` commands working on a repo you also need to:
+
+1. Install the Green Light app on that repo, so the bot can comment, react and
+   remove labels there.
+2. Install the Green Light app on `pytorch/test-infra` as well. The bot mints a
+   token scoped to that repo to dispatch the reviewer workflow, so without this
+   install every `@greenlight recheck` fails at the dispatch.
+3. Add the repo to the bot's allowlist (`GREENLIGHT_BOT_REPOS` on the Vercel
+   project). A repo missing from it is refused even with both installs in place.
 
 [build/ci pocs]: https://pytorch.org/docs/master/community/persons_of_interest.html#build-ci

--- a/torchci/lib/bot/README.md
+++ b/torchci/lib/bot/README.md
@@ -15,6 +15,7 @@
     - [stripApprovalBot.ts](#stripapprovalbotts)
     - [codevNoWritePermBot.ts](#codevnowritepermbotts)
     - [drciBot.ts](#drcibotts)
+    - [greenlightBot.ts](#greenlightbotts)
   - [External Integrations](#external-integrations)
     - [Data Storage](#data-storage)
     - [CI Systems](#ci-systems)
@@ -32,7 +33,7 @@
 
 The PyTorch bot is a GitHub webhook automation system built with **Probot** that manages CI/CD workflows, code reviews, and development operations for the PyTorch ecosystem. It's deployed as a Next.js application on Vercel and integrates with multiple external services.
 
-- **Main Entry**: `lib/bot/index.ts:17` - Registers all bot modules with Probot
+- **Main Entry**: `lib/bot/index.ts:19` - Registers the PyTorch Bot app's modules with Probot, served at `/api/github/webhooks`. `greenlightBot.ts` is deliberately _not_ registered here: it runs as a second Probot instance under a second GitHub App on its own route (see [greenlightBot.ts](#greenlightbotts))
 
 ## Bot Modules
 
@@ -267,6 +268,43 @@ ciflow_push_tags:
 - `pull_request.opened`, `pull_request.synchronize`
 
 **Special Logic:** Serves as the interface between GitHub PRs and the comprehensive Dr. CI dashboard system
+
+### greenlightBot.ts
+
+**Primary Purpose:** Handles `@greenlight` commands on pull requests, so a trusted author can ask the Green Light AI reviewer to look at a PR again without leaving GitHub.
+
+**Separate Probot instance:** Unlike every other module on this page, this bot is not registered in `index.ts` and is not served by `/api/github/webhooks`. It runs as its own Probot instance under its own GitHub App (the Green Light App), mounted on its own route at `pages/api/greenlight/webhooks.ts`. The two apps have separate app IDs, private keys, webhook secrets and installations, so installing the PyTorch Bot app on a repo does nothing for this bot — the Green Light App has to be installed there separately.
+
+**Supported Commands (via `greenlightCliParser`):**
+
+- `recheck` — Ask Green Light to review the pull request again.
+- `help` — List the available commands. Has no other effect.
+
+**GitHub Webhooks:**
+
+- `issue_comment.created` — Pull requests only, and never on `edited`, so touching an old comment cannot re-run the command it holds. Comments authored by bots are ignored. Only a line that _starts_ with the mention is parsed, so quoting an earlier comment does not re-run its command. Both the mention and the command name are matched case-insensitively, which keeps the bot in step with greenlight's `is_bot_command` (`greenlight/src/greenlight/pr_hash.py`): that lowercases the body before looking for the trigger, so a differently-cased mention is dropped from the PR's fingerprint whether or not the bot acts on it. A mention that renders as sample text rather than as a live instruction is skipped — indented far enough to be a markdown code block, or inside a fence, an HTML comment or a `<pre>` block. Closing delimiters are optional, because CommonMark does not require them: an unclosed opener runs to the end of the comment, which matters most for an unterminated `<!--`, where nothing renders at all. A multiline `<code>` element is the one such region not skipped; inline `<code>` is already covered by the line-start anchor.
+
+**Key Features:**
+
+- **Least-privilege writes**: every write mints a fresh installation token scoped to a single repo and a single permission, instead of reusing the broad token Probot hands the handler.
+- **Two-layer authorization**: a coarse write-permission check gates every command, and a commenter without write access — or one using an unrecognized command — gets a reaction rather than a comment, since a comment notifies every subscriber on the PR. A `recheck` additionally requires the requester to be on Green Light's trusted-author list (`greenlightTrustedAuthors.ts`, mirroring `TRUSTED_AUTHORS` in `greenlight/src/greenlight/review.py`), checked before the bot changes anything.
+- **Org and repo gating**: only the orgs `isPyTorchbotSupportedOrg` allows, and within those only the repos named in the `GREENLIGHT_BOT_REPOS` allowlist. Enabling a repo is a configuration change rather than a code change, but Vercel applies environment variable changes only to new deployments, so it still takes a redeploy. An unset `GREENLIGHT_BOT_REPOS` enables the bot on nothing, and the route refuses to start without it.
+- **Duplicate suppression**: a repeated `recheck` of the same PR inside a short in-memory window is dropped rather than starting a second reviewer run.
+- **Workflow dispatch**: an accepted `recheck` removes the `Stale` label if present, dispatches `greenlight-review.yml` in `pytorch/test-infra` with the PR number and the commenter's login, then posts its acknowledgment comment and reacts to the triggering comment. The acknowledgment is written after the work it describes, so a delivery cut short partway leaves no comment claiming something that never happened.
+
+**Special Logic:** `greenlight-review.yml` dispatches a reviewer that hard-codes `pytorch/pytorch`, so a `recheck` anywhere else is declined rather than dispatched against an unrelated PR of the same number. Removing the `Stale` label emits `pull_request.unlabeled` to the PyTorch Bot app, where `checkLabelsBot.ts` posts its `release notes:` label reminder if the PR lacks one — a common, expected side effect of a recheck on a long-idle PR.
+
+**Related files:**
+
+- `greenlightBot.ts` — Probot registration; bot-author, org and repo filtering.
+- `greenlightBotHandler.ts` — Command handling, refusals, label removal, dispatch.
+- `greenlightCliParser.ts` — Command vocabulary and the help text generated from it.
+- `greenlightTrustedAuthors.ts` — The logins the bot and the Green Light backend will act for.
+- `greenlightBotConfig.ts` — Required environment variables and the repo allowlist accessor.
+- `greenlightAppAuth.ts` — Private-key handling and scoped installation-token minting.
+- `greenlightWriter.ts` — The comment/react/label write surface and the workflow dispatcher.
+- `repoAllowlist.ts` — `GREENLIGHT_BOT_REPOS` parsing and matching.
+- `pages/api/greenlight/webhooks.ts` — The route and the Probot instance for the Green Light App.
 
 ## External Integrations
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #8656
* #8655
* #8654
* #8653
* #8652
* #8651
* #8650
* #8649
* #8648
* #8647
* #8646

**Impact:** documentation only
**Risk:** low

## What
Describes the bot in `torchci/lib/bot/README.md` and `torchci/docs/architecture.md`, and
its commands, gates and side effects in `greenlight/README.md` and `greenlight/CHEATSHEET.md`.
Updates the `greenlight-review.yml` header to name the bot as what dispatches it.

## Why
This is the first module under `lib/bot/` that is not registered in `index.ts` and not
served by `/api/github/webhooks`, so the page listing the bot modules would otherwise be
wrong about how it is wired. The architecture doc's setup section covered only the PyTorch
Bot install, which grants this bot nothing: enabling `@greenlight` on a repo takes an
install there, an install on pytorch/test-infra, and an allowlist entry.