### PR TITLE
Strip approvals when an untrusted contributor pushes to a PR

### DIFF
--- a/torchci/lib/bot/README.md
+++ b/torchci/lib/bot/README.md
@@ -219,18 +219,19 @@ ciflow_push_tags:
 
 ### stripApprovalBot.ts
 
-**Primary Purpose:** Removes PR approvals when PRs are reopened to ensure fresh review.
+**Primary Purpose:** Removes PR approvals when a PR is reopened, or when new commits are pushed to it, to ensure fresh review.
 
 **Key Features:**
 
-- **Approval dismissal**: Automatically dismisses all existing approvals on PR reopening
-- **Permission-based**: Only acts on PRs from users without write permissions
+- **Approval dismissal**: Automatically dismisses all existing approvals
+- **Permission-based**: On reopen, acts only on PRs authored by users without write permissions; on push, acts only when the pusher lacks write permissions, so a mergebot rebase or a maintainer pushing to a fork branch does not dismiss anything
 - **Notification messages**: Provides clear explanation for why approvals were removed
-- **Security-focused**: Ensures that reopened PRs (potentially after reverts) get fresh review
+- **Security-focused**: Stands in for GitHub's `dismiss_stale_reviews`, which `pytorch/pytorch` cannot enable because it requires `required_pull_request_reviews`, which in turn blocks the direct push to `main` that `pytorchmergebot` performs. Without it, an author without write permissions can get an approval on a benign commit, push anything on top, and `@pytorchbot merge` (which checks only that the PR is approved, not who is asking) lands it.
 
 **GitHub Webhooks:**
 
 - `pull_request.reopened`
+- `pull_request.synchronize`
 
 **Special Logic:** Maintains code review integrity by requiring fresh approvals after PR reopening
 

--- a/torchci/lib/bot/stripApprovalBot.ts
+++ b/torchci/lib/bot/stripApprovalBot.ts
@@ -1,5 +1,60 @@
-import { Context, Probot } from "probot";
+import { Context, Probot, ProbotOctokit } from "probot";
 import { hasWritePermissions, isPyTorchbotSupportedOrg } from "./utils";
+
+const REOPENED_MESSAGE =
+  "This PR was reopened (likely due to being reverted), so your approval was removed. Please request another review.";
+
+const SYNCHRONIZE_MESSAGE =
+  "New commits were pushed to this PR after it was approved, so your approval was removed. Please review the new commits and approve again.";
+
+interface PullRequestRef {
+  owner: string;
+  repo: string;
+  pull_number: number;
+}
+
+// Takes the octokit and the PR coordinates rather than the Context, because the union
+// of the two event contexts is too large for tsc to represent.
+async function dismissApprovals(
+  octokit: InstanceType<typeof ProbotOctokit>,
+  { owner, repo, pull_number }: PullRequestRef,
+  message: string
+): Promise<void> {
+  // Paginated because GitHub returns reviews oldest first: on a PR with more than
+  // one page of reviews, the unpaginated call returns the oldest page and leaves
+  // the recent approvals -- the ones that authorize a merge -- in place.
+  const reviews = await octokit.paginate(octokit.pulls.listReviews, {
+    owner,
+    repo,
+    pull_number,
+    per_page: 100,
+  });
+
+  for (const review of reviews.filter(
+    (review) => review.state === "APPROVED"
+  )) {
+    await octokit.pulls
+      .dismissReview({
+        owner,
+        repo,
+        pull_number,
+        review_id: review.id,
+        message,
+      })
+      .catch((error) => console.error(error));
+  }
+}
+
+function pullRequestRef(payload: {
+  repository: { owner: { login: string }; name: string };
+  pull_request: { number: number };
+}): PullRequestRef {
+  return {
+    owner: payload.repository.owner.login,
+    repo: payload.repository.name,
+    pull_number: payload.pull_request.number,
+  };
+}
 
 export default function stripApprovalBot(app: Probot): void {
   app.on(
@@ -11,40 +66,42 @@ export default function stripApprovalBot(app: Probot): void {
         return;
       }
 
-      const pr_author = ctx.payload.pull_request.user.login;
-      console.log("pr_author: ", pr_author);
-      // cause error
-      if (await hasWritePermissions(ctx, pr_author)) {
-        // if the user has write permissions, we don't need to strip approvals
+      // Keyed on the author: reopening is how a reverted PR gets its old approval
+      // back, and the author is who benefits from that.
+      if (await hasWritePermissions(ctx, ctx.payload.pull_request.user.login)) {
         return;
       }
 
-      const repo = ctx.payload.repository.name;
-      const issue_number = ctx.payload.pull_request.number;
+      await dismissApprovals(
+        ctx.octokit,
+        pullRequestRef(ctx.payload),
+        REOPENED_MESSAGE
+      );
+    }
+  );
 
-      const reviews = await ctx.octokit.pulls.listReviews({
-        owner,
-        repo,
-        pull_number: issue_number,
-      });
-
-      const approved_reviews = reviews.data.filter((review) => {
-        return review.state === "APPROVED";
-      });
-
-      for (const review of approved_reviews) {
-        await ctx.octokit.pulls
-          .dismissReview({
-            owner,
-            repo,
-            pull_number: issue_number,
-            review_id: review.id,
-            message:
-              "This PR was reopened (likely due to being reverted), so your approval was removed. Please request another review.",
-          })
-          .catch((error) => console.error(error));
+  app.on(
+    ["pull_request.synchronize"],
+    async (ctx: Context<"pull_request.synchronize">) => {
+      const owner = ctx.payload.repository.owner.login;
+      if (!isPyTorchbotSupportedOrg(owner)) {
+        ctx.log(`${__filename} isn't enabled on ${owner}'s repos`);
+        return;
       }
-      return;
+
+      // Keyed on the pusher rather than the PR author, for two reasons: `@pytorchbot
+      // merge -r` rebases as pytorchmergebot and must not strip the approval it is
+      // about to act on, and a maintainer pushing a fix to a fork branch has not
+      // invalidated their own review.
+      if (await hasWritePermissions(ctx, ctx.payload.sender.login)) {
+        return;
+      }
+
+      await dismissApprovals(
+        ctx.octokit,
+        pullRequestRef(ctx.payload),
+        SYNCHRONIZE_MESSAGE
+      );
     }
   );
 }

--- a/torchci/test/stripApprovals.test.ts
+++ b/torchci/test/stripApprovals.test.ts
@@ -5,6 +5,14 @@ import { handleScope, requireDeepCopy } from "./common";
 import * as utils from "./utils";
 nock.disableNetConnect();
 
+// The synchronize fixture is recorded on a personal repo, which the bot skips.
+function synchronizeEvent() {
+  const event = requireDeepCopy("./fixtures/pull_request.synchronize.json");
+  event.payload.repository.owner.login = "pytorch";
+  event.payload.repository.name = "pytorch";
+  return event;
+}
+
 describe("strip approvals bot", () => {
   let probot: Probot;
 
@@ -42,11 +50,110 @@ describe("strip approvals bot", () => {
       .get(`/repos/${owner}/${repo}/collaborators/${login}/permission`)
       .reply(200, { permission: "read" })
       .get(`/repos/${owner}/${repo}/pulls/${pr_number}/reviews`)
+      .query({ per_page: 100 })
       .reply(200, review_copy)
       .put(
         `/repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_first_id}/dismissals`
       )
       .reply(200, { state: "DISMISSED" });
+    await probot.receive(event);
+    handleScope(scope);
+  });
+
+  test("Strip reviews when a user without write permissions pushes", async () => {
+    const event = synchronizeEvent();
+    const review_copy = requireDeepCopy(
+      "./fixtures/pull_request_review_approved.json"
+    );
+    const owner = event.payload.repository.owner.login;
+    const repo = event.payload.repository.name;
+    const pr_number = event.payload.pull_request.number;
+    const login = "octocat";
+    event.payload.pull_request.user.login = login;
+    event.payload.sender.login = login;
+    const scope = nock("https://api.github.com")
+      .get(`/repos/${owner}/${repo}/collaborators/${login}/permission`)
+      .reply(200, { permission: "read" })
+      .get(`/repos/${owner}/${repo}/pulls/${pr_number}/reviews`)
+      .query({ per_page: 100 })
+      .reply(200, review_copy)
+      .put(
+        `/repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_copy[0].id}/dismissals`
+      )
+      .reply(200, { state: "DISMISSED" });
+    await probot.receive(event);
+    handleScope(scope);
+  });
+
+  test("Do nothing when a user with write permissions pushes", async () => {
+    const event = synchronizeEvent();
+    const owner = event.payload.repository.owner.login;
+    const repo = event.payload.repository.name;
+    const login = "maintainer";
+    event.payload.pull_request.user.login = "octocat";
+    event.payload.sender.login = login;
+    const scope = nock("https://api.github.com")
+      .get(`/repos/${owner}/${repo}/collaborators/${login}/permission`)
+      .reply(200, { permission: "write" });
+    await probot.receive(event);
+    handleScope(scope);
+  });
+
+  // `@pytorchbot merge -r` rebases as pytorchmergebot and then merges: stripping the
+  // approval here would make the merge it is running fail its own approval check.
+  test("Do nothing when mergebot rebases a PR from a user without write permissions", async () => {
+    const event = synchronizeEvent();
+    const owner = event.payload.repository.owner.login;
+    const repo = event.payload.repository.name;
+    event.payload.pull_request.user.login = "octocat";
+    event.payload.sender.login = "pytorchmergebot";
+    const scope = nock("https://api.github.com")
+      .get(`/repos/${owner}/${repo}/collaborators/pytorchmergebot/permission`)
+      .reply(200, { permission: "write" });
+    await probot.receive(event);
+    handleScope(scope);
+  });
+
+  test("Strip approvals that fall on a later page of reviews", async () => {
+    const event = synchronizeEvent();
+    const review_copy = requireDeepCopy(
+      "./fixtures/pull_request_review_approved.json"
+    );
+    const owner = event.payload.repository.owner.login;
+    const repo = event.payload.repository.name;
+    const pr_number = event.payload.pull_request.number;
+    const login = "octocat";
+    event.payload.sender.login = login;
+    const reviews_url = `https://api.github.com/repos/${owner}/${repo}/pulls/${pr_number}/reviews`;
+    // GitHub returns reviews oldest first, so the approval that authorizes the merge
+    // is the one most likely to be pushed off the first page.
+    const first_page = Array.from({ length: 100 }, (_, i) => ({
+      ...review_copy[0],
+      id: 1000 + i,
+      state: "COMMENTED",
+    }));
+    const scope = nock("https://api.github.com")
+      .get(`/repos/${owner}/${repo}/collaborators/${login}/permission`)
+      .reply(200, { permission: "read" })
+      .get(`/repos/${owner}/${repo}/pulls/${pr_number}/reviews`)
+      .query({ per_page: 100 })
+      .reply(200, first_page, {
+        link: `<${reviews_url}?per_page=100&page=2>; rel="next"`,
+      })
+      .get(`/repos/${owner}/${repo}/pulls/${pr_number}/reviews`)
+      .query({ per_page: 100, page: 2 })
+      .reply(200, review_copy)
+      .put(
+        `/repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_copy[0].id}/dismissals`
+      )
+      .reply(200, { state: "DISMISSED" });
+    await probot.receive(event);
+    handleScope(scope);
+  });
+
+  test("Do nothing on a repo outside the supported orgs", async () => {
+    const event = requireDeepCopy("./fixtures/pull_request.synchronize.json");
+    const scope = nock("https://api.github.com");
     await probot.receive(event);
     handleScope(scope);
   });


### PR DESCRIPTION
`stripApprovalBot` only dismisses approvals on `pull_request.reopened`. This adds
`pull_request.synchronize`, so an approval no longer survives new commits pushed by
someone without write access.

Without this, an author without write access can get an approval on a benign commit,
push anything on top, and `@pytorchbot merge` lands it — the merge command checks that
the PR is approved, not who is asking. GitHub's `dismiss_stale_reviews` would cover
this natively, but it requires `required_pull_request_reviews`, which would block
pytorchmergebot's direct push to `main`.

Keyed on the pusher rather than the PR author, so a `@pytorchbot merge -r` rebase
(pushed as pytorchmergebot) doesn't strip the approval the in-flight merge is about to
check.

Also switches `pulls.listReviews` to paginate: it defaulted to 30 per page and GitHub
returns reviews oldest first, so approvals past the first page were never dismissed.

## Test plan

```
cd torchci && npx jest test/stripApprovals.test.ts
```

7 passed. New cases: push without write access strips; push with write access doesn't;
mergebot rebase doesn't; approval on page 2 still dismissed; unsupported org untouched.

> Authored with the assistance of Claude Code, reviewed by me before submission.
