### PR TITLE
[CRCR] Add SQL query and update RepoTenure interface for tenure tracking

### DIFF
--- a/torchci/clickhouse_queries/crcr_repo_tenure/params.json
+++ b/torchci/clickhouse_queries/crcr_repo_tenure/params.json
@@ -1,0 +1,10 @@
+{
+  "params": {
+    "repo": "String"
+  },
+  "tests": [
+    {
+      "repo": "<company>/<repo>"
+    }
+  ]
+}

--- a/torchci/clickhouse_queries/crcr_repo_tenure/query.sql
+++ b/torchci/clickhouse_queries/crcr_repo_tenure/query.sql
@@ -1,12 +1,16 @@
 -- level_since = earliest started_at at the repo's current level; floors at ~100 days due to crcr_workflow_job's TTL.
+-- current_level uses argMax to deterministically pick the level as of the most recent started_at.
+-- first_seen/last_seen span all levels, for the "2 weeks of recent data" L3 promotion prerequisite.
 WITH (
-    SELECT anyLast(downstream_repo_level)
+    SELECT argMax(downstream_repo_level, started_at)
     FROM default.crcr_workflow_job FINAL
     WHERE downstream_repo = {repo: String}
 ) AS current_level
 SELECT
     current_level,
-    minIf(started_at, downstream_repo_level = current_level) AS level_since
+    minIf(started_at, downstream_repo_level = current_level) AS level_since,
+    min(started_at) AS first_seen,
+    max(started_at) AS last_seen
 FROM
     default.crcr_workflow_job FINAL
 WHERE

--- a/torchci/clickhouse_queries/crcr_repo_tenure/query.sql
+++ b/torchci/clickhouse_queries/crcr_repo_tenure/query.sql
@@ -1,10 +1,11 @@
 -- level_since = earliest started_at at the repo's current level; floors at ~100 days due to crcr_workflow_job's TTL.
 -- current_level uses argMax to deterministically pick the level as of the most recent started_at.
 -- first_seen/last_seen span all levels, for the "2 weeks of recent data" L3 promotion prerequisite.
+-- started_at > 0 excludes rows with an epoch (1970-01-01) timestamp.
 WITH (
     SELECT argMax(downstream_repo_level, started_at)
     FROM default.crcr_workflow_job FINAL
-    WHERE downstream_repo = {repo: String}
+    WHERE downstream_repo = {repo: String} AND started_at > 0
 ) AS current_level
 SELECT
     current_level,
@@ -15,3 +16,4 @@ FROM
     default.crcr_workflow_job FINAL
 WHERE
     downstream_repo = {repo: String}
+    AND started_at > 0

--- a/torchci/clickhouse_queries/crcr_repo_tenure/query.sql
+++ b/torchci/clickhouse_queries/crcr_repo_tenure/query.sql
@@ -1,0 +1,13 @@
+-- level_since = earliest started_at at the repo's current level; floors at ~100 days due to crcr_workflow_job's TTL.
+WITH (
+    SELECT anyLast(downstream_repo_level)
+    FROM default.crcr_workflow_job FINAL
+    WHERE downstream_repo = {repo: String}
+) AS current_level
+SELECT
+    current_level,
+    minIf(started_at, downstream_repo_level = current_level) AS level_since
+FROM
+    default.crcr_workflow_job FINAL
+WHERE
+    downstream_repo = {repo: String}

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -85,6 +85,8 @@ interface SummaryStats {
 interface RepoTenure {
   current_level: string;
   level_since: string;
+  first_seen: string;
+  last_seen: string;
 }
 
 // "2 months ago" / "5 days ago"; caps at "100+ days ago" since level_since
@@ -97,6 +99,20 @@ function tenureDisplay(sinceIso: string): string {
   if (days < 60) return `${days} day${days === 1 ? "" : "s"} ago`;
   const months = Math.floor(days / 30);
   return `${months} month${months === 1 ? "" : "s"} ago`;
+}
+
+// "47 days of data" — spans first_seen -> last_seen across all levels, not
+// just the current one. Covers the L3 promotion prerequisite's second half
+// ("the HUD must have at least 2 weeks of recent data").
+function dataCoverageDisplay(
+  firstSeenIso: string,
+  lastSeenIso: string
+): string {
+  const days = Math.floor(
+    (new Date(lastSeenIso).getTime() - new Date(firstSeenIso).getTime()) /
+      (1000 * 60 * 60 * 24)
+  );
+  return `${days} day${days === 1 ? "" : "s"} of data`;
 }
 
 // ---- Summary Stat Cards ----
@@ -1439,7 +1455,8 @@ export default function CrcrBackendPage() {
                   {!isNightly && tenure && tenure.current_level && (
                     <Typography variant="body2" color="text.secondary">
                       {tenure.current_level} since{" "}
-                      {tenureDisplay(tenure.level_since)}
+                      {tenureDisplay(tenure.level_since)} ·{" "}
+                      {dataCoverageDisplay(tenure.first_seen, tenure.last_seen)}
                     </Typography>
                   )}
                 </Stack>

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -82,6 +82,23 @@ interface SummaryStats {
   timeout_rate: number;
 }
 
+interface RepoTenure {
+  current_level: string;
+  level_since: string;
+}
+
+// "2 months ago" / "5 days ago"; caps at "100+ days ago" since level_since
+// itself floors there (see query.sql).
+function tenureDisplay(sinceIso: string): string {
+  const days = Math.floor(
+    (Date.now() - new Date(sinceIso).getTime()) / (1000 * 60 * 60 * 24)
+  );
+  if (days >= 100) return "100+ days ago";
+  if (days < 60) return `${days} day${days === 1 ? "" : "s"} ago`;
+  const months = Math.floor(days / 30);
+  return `${months} month${months === 1 ? "" : "s"} ago`;
+}
+
 // ---- Summary Stat Cards ----
 
 function StatCard({
@@ -1309,6 +1326,21 @@ export default function CrcrBackendPage() {
   );
   const stats = summaryData?.[0] ?? null;
 
+  // Not scoped by the days selector -- tenure at the current level is a
+  // full-history question (RFC-0050: "operating at L2 for at least 1 month").
+  const tenureUrl =
+    repoFullName && !isNightly
+      ? `/api/clickhouse/crcr_repo_tenure?parameters=${encodeURIComponent(
+          JSON.stringify({ repo: repoFullName })
+        )}`
+      : null;
+  const { data: tenureData } = useSWR<RepoTenure[]>(
+    tenureUrl,
+    fetcherHandleError,
+    { refreshInterval: 60_000 }
+  );
+  const tenure = tenureData?.[0] ?? null;
+
   const isCrcrTest = repoFullName === "pytorch/crcr-test";
   const healthUrl =
     isCrcrTest && !isNightly
@@ -1404,6 +1436,12 @@ export default function CrcrBackendPage() {
                   >
                     GitHub ↗
                   </Link>
+                  {!isNightly && tenure && tenure.current_level && (
+                    <Typography variant="body2" color="text.secondary">
+                      {tenure.current_level} since{" "}
+                      {tenureDisplay(tenure.level_since)}
+                    </Typography>
+                  )}
                 </Stack>
               </Stack>
               <Stack direction="row" spacing={2} alignItems="center">
@@ -1418,6 +1456,7 @@ export default function CrcrBackendPage() {
                   >
                     <MenuItem value={1}>Last 24h</MenuItem>
                     <MenuItem value={7}>Last 7 days</MenuItem>
+                    <MenuItem value={14}>Last 14 days</MenuItem>
                     <MenuItem value={30}>Last 30 days</MenuItem>
                   </Select>
                 </FormControl>


### PR DESCRIPTION
Adds the two RFC-0050 L3 promotion prerequisites ([pytorch/rfcs#102](https://github.com/pytorch/rfcs/pull/102), now merged) to `/crcr/[org]/[repo]`.

## Changes

- New `crcr_repo_tenure` query: returns the repo's current relay level and how long it's been there (`level_since`), for the "operating at L2 for at least 1 month" prerequisite. Displayed as "L2 since 2 months ago" next to the repo title.
  - Known limitation (noted in the query): `crcr_workflow_job` has a 100-day TTL, so tenure floors at "100+ days ago" for long-tenured repos instead of the true start date. A durable fix needs a TTL-free rollup table, tracked as a follow-up rather than done here.
- Adds "Last 14 days" to the Time Range selector, matching the RFC's other prerequisite ("all metrics must be met throughout the most recent 2-week window") — the existing per-metric stat cards (from #8551 / #8635) can now be viewed over that exact window.

Fixes #8553
