### PR TITLE
linux_job_v3: fix the workspace permissions instead of recreating it

### DIFF
--- a/.github/workflows/linux_job_v3.yml
+++ b/.github/workflows/linux_job_v3.yml
@@ -134,14 +134,23 @@ jobs:
       options: ${{ inputs.gpu-arch-type == 'cuda' && '--gpus all' || '' }}
     timeout-minutes: ${{ inputs.timeout }}
     steps:
-      - name: Clean workspace
+      - name: Fix workspace permissions
         shell: bash
         run: |
           set -euxo pipefail
-          echo "::group::Cleanup debug output"
-          rm -rfv "${GITHUB_WORKSPACE}"
-          mkdir -p "${GITHUB_WORKSPACE}"
-          echo "::endgroup::"
+          # An OSDC pod is ephemeral, so the workspace starts empty and there is
+          # nothing to clean. What a job does need is to be able to write into it:
+          # the GH hook creates it as uid 1001
+          # (https://github.com/actions/runner-images/issues/10936), which an
+          # image defaulting to a uid 1000 ec2-user mirror cannot do -- pytorch's
+          # `USER jenkins` and executorch's `USER ci-user` both are that shape.
+          # Same fix as pytorch/pytorch's setup-linux, and chmod rather than
+          # recreating the directory keeps the GH hook (uid 1001, gid 1001) able
+          # to clean up after the job.
+          #
+          # An image running as root can already write and often ships no sudo,
+          # so a failure here is not fatal.
+          sudo chmod -R 777 "${GITHUB_WORKSPACE}" 2>/dev/null || true
 
       - name: Checkout repository (${{ inputs.test-infra-repository }}@${{ inputs.test-infra-ref }})
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/test_linux_job_v3.yml
+++ b/.github/workflows/test_linux_job_v3.yml
@@ -97,6 +97,29 @@ jobs:
       script: |
         source /etc/os-release && [[ "${ID}" = "almalinux" ]] || exit 1
         git --version
+        # Root branch of "Clean workspace": it must not need sudo, which images
+        # like nvidia/cuda and bare distro images do not ship.
+        [[ "$(id -u)" -eq 0 ]] || { echo "expected to run as root"; exit 1; }
+  # Non-root branch of "Clean workspace". The GH hook creates the workspace as
+  # uid 1001, so an image defaulting to a uid 1000 user cannot unlink it and the
+  # job used to die on `rm: cannot remove ...: Permission denied` before any
+  # other step ran. pytorch's CI images are exactly this shape (USER jenkins).
+  test-non-root-docker-image:
+    uses: ./.github/workflows/linux_job_v3.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      runner: mt-l-x86iavx512-8-64
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      docker-image: ghcr.io/pytorch/ci-image:pytorch-linux-jammy-py3.10-clang21
+      script: |
+        [[ "$(id -u)" -ne 0 ]] || { echo "expected a non-root default user"; exit 1; }
+        # Reaching the script at all proves the cleanup and the checkout worked;
+        # confirm the workspace is usable rather than merely present.
+        touch "${GITHUB_WORKSPACE}/.writable_probe"
+        git -C "${GITHUB_WORKSPACE}/${GITHUB_REPOSITORY}" rev-parse HEAD
   test-upload-artifact:
     uses: ./.github/workflows/linux_job_v3.yml
     permissions:


### PR DESCRIPTION
`Clean workspace`, the first step of every v3 job, dies with a non-root image:

```
rm: cannot remove '/__w/executorch/executorch': Permission denied
```

and every later step skips. The GH hook creates `GITHUB_WORKSPACE` as uid 1001 ([runner-images#10936](https://github.com/actions/runner-images/issues/10936)), while CI images commonly default to a uid 1000 user mirroring `ec2-user` — pytorch's `USER jenkins` and executorch's `USER ci-user` both do. It only surfaces with a non-root image, which is why jobs on `pytorch/almalinux-builder` have never hit it. Reproducer: [pytorch/executorch#22245](https://github.com/pytorch/executorch/pull/22245), the first v3 caller to pass a repo CI image.

**An OSDC pod is ephemeral, so there is nothing to clean.** The workspace starts empty — the failing `rm -rfv` printed no `removed` lines before erroring — and the step is carried over from v2, where EC2 runners were reused between jobs. What a job actually needs is to be able to write into the directory the hook created, so this chmods it and drops the removal, which is what pytorch/pytorch does in [`.github/actions/setup-linux`](https://github.com/pytorch/pytorch/blob/d3b8bf0a11cba909aac9e8cdf8b81af8d59a251e/.github/actions/setup-linux/action.yml#L53-L63) for its ARC path ([pytorch/pytorch#178973](https://github.com/pytorch/pytorch/pull/178973)).

Worth recording: adding a chmod *before* the `rm` does not work, and the test below caught it. Unlinking the workspace needs write on its parent `/__w/<repo>`, which chmodding the workspace does not grant — the chmod succeeded and the `rm` failed anyway.

Root images can already write and often ship no `sudo` (`nvidia/cuda`, bare distro images), so the chmod tolerates failure rather than being gated on a user check.

## Tests

`test_linux_job_v3.yml` covers both paths:

- `test-docker-image` (`ghcr.io/pytorch/test-infra:cpu-x86_64-latest`) asserts `id -u` is 0, pinning the root path that must not require sudo.
- `test-non-root-docker-image` is new, on `ghcr.io/pytorch/ci-image:pytorch-linux-jammy-py3.10-clang21` — a uid 1000 `USER jenkins` image. It asserts a non-root user, probes that the workspace is writable, and checks the checkout produced a git repo. It fails on `main` today.

Authored with Claude Code.