### PR TITLE
Let the greenlight scan dismiss its own reviews

### DIFF
--- a/.github/workflows/greenlight-review.yml
+++ b/.github/workflows/greenlight-review.yml
@@ -65,8 +65,9 @@ jobs:
     runs-on: ubuntu-latest
     # Protected environment holding the Green Light App key: GREENLIGHT_APP_ID and
     # GREENLIGHT_APP_PRIVATE_KEY. The App must be installed on pytorch/test-infra with
-    # Actions: write and Pull requests: read so the minted token can dispatch the
-    # reviewer workflow and read PRs across pytorch/pytorch and pytorch/test-infra.
+    # Actions: write and Pull requests: write so the minted token can dispatch the
+    # reviewer workflow, read PRs across pytorch/pytorch and pytorch/test-infra, and
+    # revoke greenlight's own approval on a reverted PR.
     environment: greenlight-record
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
@@ -74,27 +75,11 @@ jobs:
         with:
           working_directory: greenlight
 
-      # Least privilege: the listing scan only reads PRs, so it mints a pull-requests:read token.
-      # The --pr recheck may post a refusal comment, so it mints pull-requests:write instead.
-      # Exactly one of these runs per invocation (keyed on whether a PR number was given); both
-      # keep actions:write to dispatch the reviewer workflow.
-      - name: Mint Green Light app token (read-only listing scan)
-        id: app-token-ro
-        if: inputs.pr == ''
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349  # v2.2.2
-        with:
-          app-id: ${{ secrets.GREENLIGHT_APP_ID }}
-          private-key: ${{ secrets.GREENLIGHT_APP_PRIVATE_KEY }}
-          owner: pytorch
-          repositories: pytorch,test-infra
-          permission-pull-requests: read
-          permission-actions: write
-          permission-contents: read
-          permission-members: read
-
-      - name: Mint Green Light app token (recheck, can comment)
-        id: app-token-rw
-        if: inputs.pr != ''
+      # pull-requests:write on every invocation, not just the --pr recheck: the listing scan
+      # dismisses greenlight's approving review on any PR that has been reverted. Keep the
+      # permission set in sync with _TOKEN_PERMISSIONS in greenlight/src/greenlight/lambda_handler.py.
+      - name: Mint Green Light app token
+        id: app-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349  # v2.2.2
         with:
           app-id: ${{ secrets.GREENLIGHT_APP_ID }}
@@ -119,12 +104,11 @@ jobs:
 
       - name: Scan and dispatch
         env:
-          # Whichever token step ran (exactly one does): read-only for the listing scan,
-          # pull-requests:write for a --pr recheck so it can post a refusal comment.
-          PYTORCH_GREENLIGHT_GITHUB_TOKEN: ${{ steps.app-token-ro.outputs.token || steps.app-token-rw.outputs.token }}
-          # The App's bot login (<slug>[bot]) author-scopes the recheck-refusal comment. Only the
-          # write token step exposes app-slug, so this is empty on the read-only listing scan.
-          BOT_LOGIN: ${{ steps.app-token-rw.outputs.app-slug && format('{0}[bot]', steps.app-token-rw.outputs.app-slug) || '' }}
+          PYTORCH_GREENLIGHT_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # The App's bot login (<slug>[bot]) author-scopes the recheck-refusal comment and picks
+          # out greenlight's own approvals to revoke on a reverted PR. An empty app-slug yields the
+          # bare "[bot]", which the CLI rejects as not App-shaped rather than silently matching nothing.
+          BOT_LOGIN: ${{ steps.app-token.outputs.app-slug }}[bot]
           CLICKHOUSE_ENDPOINT: ${{ secrets.CLICKHOUSE_HUD_USER_URL }}
           CLICKHOUSE_USERNAME: ${{ secrets.CLICKHOUSE_HUD_USER_USERNAME }}
           CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_HUD_USER_PASSWORD }}

--- a/greenlight/src/greenlight/cli.py
+++ b/greenlight/src/greenlight/cli.py
@@ -239,10 +239,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         parser.error("--force requires --pr")
     if args.force and args.loop:
         parser.error("--force cannot be combined with --loop")
-    # The bot login is the App's <slug>[bot] account, supplied via BOT_LOGIN (empty on the
-    # read-only listing scan, set only on the write-capable --pr recheck). It author-scopes the
-    # recheck-refusal comment; when set it must be App-shaped, or a copied marker in a third
-    # party's comment could be hijacked. An empty value is allowed and handled downstream.
+    # The bot login is the App's <slug>[bot] account, supplied via BOT_LOGIN. It author-scopes the
+    # recheck-refusal comment and identifies greenlight's own approvals for the reverted-PR
+    # dismissal; when set it must be App-shaped, or a copied marker in a third party's comment could
+    # be hijacked. An empty value parses (the reverted-PR path refuses it where it would matter).
     bot_login = os.environ.get("BOT_LOGIN", "").strip()
     if bot_login and not is_app_login(bot_login):
         parser.error(

--- a/greenlight/src/greenlight/constants.py
+++ b/greenlight/src/greenlight/constants.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 STATUS_LAND = "LAND"
 STATUS_NO_LAND = "NO_LAND"
@@ -10,6 +14,10 @@ STATUS_CANCELLED = "CANCELLED"
 STATUS_FAILED = "FAILED"
 STATUS_AI_REVIEW_STARTED = "AI_REVIEW_STARTED"
 STATUS_AI_REVIEW_DISPATCHED = "AI_REVIEW_DISPATCHED"
+# REVERTED is deliberately a member of none of the groupings below. That keeps it out of
+# VERDICT_STATUSES (the verdict CLI can never emit it) and out of decide()'s status branches, which
+# must therefore match it explicitly rather than let it reach the unknown-status DISPATCH fallback.
+STATUS_REVERTED = "REVERTED"
 
 TERMINAL_STATUSES: frozenset[str] = frozenset({STATUS_LAND, STATUS_NO_LAND})
 IN_FLIGHT_STATUSES: frozenset[str] = frozenset({STATUS_AI_REVIEW_STARTED, STATUS_AI_REVIEW_DISPATCHED})
@@ -20,9 +28,24 @@ RETRY_STATUSES: frozenset[str] = frozenset({STATUS_CANCELLED, STATUS_FAILED})
 SCAN_ONLY_STATUSES: frozenset[str] = frozenset({STATUS_AI_REVIEW_DISPATCHED})
 VERDICT_STATUSES: frozenset[str] = (TERMINAL_STATUSES | IN_FLIGHT_STATUSES | RETRY_STATUSES) - SCAN_ONLY_STATUSES
 
-# GitHub labels are case-sensitive; the pytorch stale bot uses the exact name "Stale".
+# GitHub labels are case-sensitive; pytorch's stale.yml both applies and case-sensitively tests
+# the exact name "Stale", so folding it here would diverge from the bot this filter tracks.
 STALE_LABEL = "Stale"
 EXCLUDED_LABELS: frozenset[str] = frozenset({STALE_LABEL})
+
+# The revert label is matched case-insensitively instead: pytorch's trymerge applies it as
+# lowercase "reverted" and GitHub resolves that to whichever canonical label the repo holds, so the
+# casing greenlight reads back is the label registry's, not the caller's. Folding cannot conflate
+# two distinct labels either -- GitHub rejects names differing only in case.
+REVERTED_LABEL = "Reverted"
+REVERTED_LABELS: frozenset[str] = frozenset({REVERTED_LABEL})
+
+
+def carries_any_label(labels: Iterable[str], wanted: Iterable[str]) -> bool:
+    """True when any name in ``labels`` matches one in ``wanted``, compared case-insensitively."""
+    folded = {name.casefold() for name in wanted}
+    return any(label.casefold() in folded for label in labels)
+
 
 # The reviewer and record workflows already write greenlight state rows to this bucket via
 # ``aws s3 cp``; the scan's direct boto3 upload targets the same bucket, single-sourced here.
@@ -61,9 +84,11 @@ def normalize_repo(repo: str) -> str:
 # Entries are folded at construction, so a mixed-case addition cannot silently never match.
 DRCI_STATUS_COMMENT_REPOS: frozenset[str] = frozenset(normalize_repo(repo) for repo in (TARGET_REPO,))
 
-# A GitHub App acts through a bot account whose login is ``<app-slug>[bot]``. Both the verdict
-# writer and the scan's recheck-refusal poster author-scope their comment writes to this login,
-# so it must be App-shaped or a copied marker in a third party's comment could be hijacked.
+# A GitHub App acts through a bot account whose login is ``<app-slug>[bot]``. The verdict writer
+# and the scan's recheck-refusal poster author-scope their comment writes to this login, so it must
+# be App-shaped or a copied marker in a third party's comment could be hijacked; the scan also
+# matches greenlight's own approving reviews by it before revoking them on a reverted PR, where a
+# login that is not App-shaped would match nothing while reporting success.
 BOT_LOGIN_SUFFIX = "[bot]"
 
 

--- a/greenlight/src/greenlight/decision.py
+++ b/greenlight/src/greenlight/decision.py
@@ -11,7 +11,7 @@ import enum
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from greenlight.constants import IN_FLIGHT_STATUSES, RETRY_STATUSES, TERMINAL_STATUSES
+from greenlight.constants import IN_FLIGHT_STATUSES, RETRY_STATUSES, STATUS_REVERTED, TERMINAL_STATUSES
 
 if TYPE_CHECKING:
     from datetime import datetime, timedelta
@@ -44,6 +44,12 @@ def decide(
 ) -> Outcome:
     if latest_status is None:
         return Outcome(Decision.DISPATCH, "never_reviewed")
+
+    # A reverted PR is never re-reviewed, whatever its fingerprint now says. The scan drops it
+    # long before this, so reaching here means that guard was bypassed -- and the fallthrough for
+    # an unrecognised status is DISPATCH, which would put a reverted PR straight back in review.
+    if latest_status == STATUS_REVERTED:
+        return Outcome(Decision.SKIP, "reverted")
 
     if latest_status in TERMINAL_STATUSES:
         if latest_eval_hash == current_eval_hash:

--- a/greenlight/src/greenlight/lambda_handler.py
+++ b/greenlight/src/greenlight/lambda_handler.py
@@ -1,10 +1,10 @@
 """AWS Lambda entry point for the greenlight review scan.
 
 Fetches the GitHub App private key and ClickHouse password from AWS Secrets Manager,
-mints a least-privilege App installation token, and runs one ``review`` scan through the
-same CLI used on the command line. The Lambda function timeout is the runtime backstop, so
-the in-process guards are disabled here (their hard watchdog force-exits via ``os._exit``,
-which is wrong under the Lambda runtime).
+mints a least-privilege App installation token, resolves the App's own ``<slug>[bot]`` login,
+and runs one ``review`` scan through the same CLI used on the command line. The Lambda function
+timeout is the runtime backstop, so the in-process guards are disabled here (their hard watchdog
+force-exits via ``os._exit``, which is wrong under the Lambda runtime).
 """
 
 from __future__ import annotations
@@ -13,20 +13,26 @@ import base64
 import json
 import logging
 import os
+from typing import TYPE_CHECKING
 
 from greenlight import cli
+from greenlight.constants import BOT_LOGIN_SUFFIX, is_app_login
 from greenlight.exit_codes import EXIT_ALREADY_RUNNING, EXIT_OK
+
+if TYPE_CHECKING:
+    from github import GithubIntegration
 
 logger = logging.getLogger(__name__)
 
 _AWS_REGION = "us-east-1"
 
 # Least-privilege scope for the installation token: only the repos and permissions the scan
-# needs, even though the App itself holds broader org-level grants.
+# needs, even though the App itself holds broader org-level grants. pull_requests is write, not
+# read: the scan revokes greenlight's own approval on a reverted PR.
 # Keep in sync with the actions/create-github-app-token scope in .github/workflows/greenlight-review.yml.
 _TOKEN_PERMISSIONS = {
     "actions": "write",
-    "pull_requests": "read",
+    "pull_requests": "write",
     "contents": "read",
     "members": "read",
 }
@@ -60,19 +66,38 @@ def _load_secret(secret_store_name: str) -> dict[str, str]:
     return secret
 
 
-def _mint_installation_token(app_id: str, pem: str, installation_id: int) -> str:
+def _github_integration(app_id: str, pem: str) -> GithubIntegration:
     import github  # lazy: keeps this module importable without PyGithub
 
+    return github.GithubIntegration(auth=github.Auth.AppAuth(app_id, pem))
+
+
+def _mint_installation_token(integration: GithubIntegration, installation_id: int) -> str:
     # PyGithub 2.9.1's GithubIntegration.get_access_token sends only ``permissions`` and cannot
     # scope ``repositories``; the token is minted through the integration's public requester
     # (its documented escape hatch for endpoints PyGithub does not model) so both are applied.
-    integration = github.GithubIntegration(auth=github.Auth.AppAuth(app_id, pem))
     _, data = integration.requester.requestJsonAndCheck(
         "POST",
         f"/app/installations/{installation_id}/access_tokens",
         input={"permissions": _TOKEN_PERMISSIONS, "repositories": _TOKEN_REPOSITORIES},
     )
     return _require_key(data, "token", "installation token response")
+
+
+def _resolve_bot_login(integration: GithubIntegration) -> str:
+    """Return the App's own ``<slug>[bot]`` account login, read from ``GET /app``.
+
+    The scan matches greenlight's own approving reviews by this login before revoking them on a
+    reverted PR, so a wrong or empty one would dismiss nothing while reporting success. Anything
+    that is not ``<slug>[bot]`` raises here rather than reaching the scan.
+    """
+    slug = integration.get_app().slug
+    # PyGithub annotates GithubApp.slug as str but returns None when the response omits it (the
+    # unset attribute's .value), and interpolating that yields the App-shaped literal "None[bot]".
+    login = f"{slug}{BOT_LOGIN_SUFFIX}" if slug else ""
+    if not is_app_login(login):
+        raise ValueError(f"GET /app returned an unusable app slug {slug!r} for the greenlight bot login")
+    return login
 
 
 def handler(event: dict[str, object], context: object) -> dict[str, str]:  # noqa: ARG001
@@ -87,7 +112,9 @@ def handler(event: dict[str, object], context: object) -> dict[str, str]:  # noq
     pem_b64 = _require_key(secret, "GITHUB_APP_SECRET", secret_source)
     pem = base64.b64decode(pem_b64).decode("utf-8")
     os.environ["CLICKHOUSE_PASSWORD"] = _require_key(secret, "CLICKHOUSE_PASSWORD", secret_source)
-    os.environ["PYTORCH_GREENLIGHT_GITHUB_TOKEN"] = _mint_installation_token(app_id, pem, installation_id)
+    integration = _github_integration(app_id, pem)
+    os.environ["PYTORCH_GREENLIGHT_GITHUB_TOKEN"] = _mint_installation_token(integration, installation_id)
+    os.environ["BOT_LOGIN"] = _resolve_bot_login(integration)
 
     # The Lambda function timeout is the runtime backstop; a zero max-runtime disables both the
     # SIGALRM soft timeout and the hard watchdog (whose os._exit would abort the runtime uncleanly).

--- a/greenlight/src/greenlight/scan_runner.py
+++ b/greenlight/src/greenlight/scan_runner.py
@@ -20,6 +20,7 @@ from greenlight.decision import Decision, decide
 from greenlight.github_client import is_rate_limit_error
 from greenlight.guards import IterationTimeout
 from greenlight.review_gate import CHANGES_REQUESTED, ReviewSkip
+from greenlight.state import next_run_id
 
 if TYPE_CHECKING:
     import queue
@@ -255,20 +256,16 @@ def _fingerprint_until_dispatchable(
 def _emit_dispatch_marker(
     candidate: _Candidate, emit_dispatched: Callable[..., None], poke: Callable[[int], None]
 ) -> None:
-    # run_id is prior_run_id + 1 so this AI_REVIEW_DISPATCHED row supersedes the PR's prior row,
-    # while the reviewer run's own later, higher github.run_id supersedes it in turn once that run
-    # starts. A None state (never-reviewed PR) has no prior run, so it bases at 0 -> run_id 1.
     # The workflow was already fired, so an emit failure is logged and swallowed: a missing marker
     # self-heals (next scan re-dispatches, the reviewer's per-PR concurrency group cancels the dup),
     # and must not fail the scan or block dispatching the remaining candidates.
-    prior_run_id = candidate.state.run_id if candidate.state else 0
     try:
         emit_dispatched(
             repo=constants.TARGET_REPO,
             pr_number=candidate.pr_number,
             head_sha=candidate.head_sha,
             eval_hash=candidate.eval_hash,
-            run_id=prior_run_id + 1,
+            run_id=next_run_id(candidate.state),
         )
     except IterationTimeout:
         raise

--- a/greenlight/src/greenlight/state.py
+++ b/greenlight/src/greenlight/state.py
@@ -1,7 +1,12 @@
-"""Read the authoritative per-PR greenlight state from ClickHouse.
+"""Read per-PR greenlight state from ClickHouse.
 
-The scanner is read-only: it observes the authoritative ``misc.greenlight_pr_state`` row
-per PR to decide whether to dispatch a review. Writes go through the S3 -> replicator path
+Two reads live here. ``read_latest_states`` observes the authoritative
+``misc.greenlight_pr_state`` row per PR to decide whether to dispatch a review;
+``read_reverted_pr_numbers`` asks a separate question -- has this PR *ever* recorded a
+``REVERTED`` row -- which deliberately does not depend on that row winning the
+authoritative-row selection below.
+
+Writes go through the S3 -> replicator path
 (see ``verdict``), never a direct INSERT. The table keeps every emit as history: the
 ``SharedReplacingMergeTree`` never collapses rows because the sort key
 ``(repo, pr_number, run_id, emit_id)`` ends in a per-emit-unique ``emit_id``. So the
@@ -10,6 +15,9 @@ time: ``ORDER BY pr_number, run_id DESC, version DESC LIMIT 1 BY pr_number`` kee
 highest ``run_id`` and, within that run, the latest ``version``. Ordering by ``run_id``
 ahead of ``version`` is race-proof: a superseded slower dispatch that happens to finish
 with a later ``version`` still loses to the newer dispatch's higher ``run_id``.
+
+``next_run_id`` is the write-side counterpart of that selection: it is what every scan-written
+row stamps to become the row these reads return.
 """
 
 from __future__ import annotations
@@ -19,6 +27,7 @@ from datetime import UTC
 from typing import TYPE_CHECKING
 
 from greenlight import clickhouse_client
+from greenlight.constants import STATUS_REVERTED
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -26,13 +35,16 @@ if TYPE_CHECKING:
 
     from clickhouse_connect.driver.client import Client
 
-__all__ = ["PRState", "naive_utc", "read_latest_states"]
+__all__ = ["PRState", "naive_utc", "next_run_id", "read_latest_states", "read_reverted_pr_numbers"]
 
 _QUERY = (
     "SELECT pr_number, status, eval_hash, head_sha, version, run_id FROM misc.greenlight_pr_state WHERE repo = %(repo)s"
 )
 _PR_FILTER = " AND pr_number IN %(pr_numbers)s"
 _ORDER_LIMIT = " ORDER BY pr_number, run_id DESC, version DESC LIMIT 1 BY pr_number"
+_REVERTED_QUERY = (
+    "SELECT DISTINCT pr_number FROM misc.greenlight_pr_state WHERE repo = %(repo)s AND status = %(status)s"
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -43,6 +55,16 @@ class PRState:
     head_sha: str
     version: datetime
     run_id: int
+
+
+def next_run_id(recorded: PRState | None) -> int:
+    """The ``run_id`` a scan-written row must carry to supersede ``recorded`` as the latest row.
+
+    One above the prior row's, so it wins the ``run_id DESC`` selection above; a PR with no prior
+    row has no prior run and so bases at 0, giving 1. The reviewer run's own ``github.run_id`` is
+    far higher and supersedes the scan's marker in turn once that run starts.
+    """
+    return (recorded.run_id if recorded is not None else 0) + 1
 
 
 def naive_utc(value: datetime) -> datetime:
@@ -90,3 +112,34 @@ def read_latest_states(
         )
         for row in result.named_results()
     }
+
+
+def read_reverted_pr_numbers(
+    repo: str,
+    pr_numbers: Sequence[int] | None = None,
+    *,
+    connect: Callable[[], Client] = clickhouse_client.connect,
+) -> set[int]:
+    """Return the PRs of ``repo`` that have ever recorded a ``REVERTED`` row.
+
+    Existence, not recency: a later ``AI_REVIEW_STARTED`` row carries the real
+    ``github.run_id`` and outranks any ``REVERTED`` row in ``read_latest_states``' selection,
+    so keying the permanent exclusion on the authoritative row would let it lapse.
+
+    ``pr_numbers`` is None to scan every PR for ``repo``, or a sequence to restrict the read
+    to those PRs. An empty sequence returns ``set()`` without a query. Query and connection
+    errors propagate; the connection is always closed.
+    """
+    if pr_numbers is not None and not pr_numbers:
+        return set()
+    query = _REVERTED_QUERY
+    params: dict[str, object] = {"repo": repo, "status": STATUS_REVERTED}
+    if pr_numbers is not None:
+        query += _PR_FILTER
+        params["pr_numbers"] = tuple(pr_numbers)
+    client = connect()
+    try:
+        result = client.query(query, parameters=params)
+    finally:
+        client.close()
+    return {int(row["pr_number"]) for row in result.named_results()}

--- a/greenlight/src/greenlight/state_emit.py
+++ b/greenlight/src/greenlight/state_emit.py
@@ -4,9 +4,11 @@ Two producers write state rows and MUST agree byte-for-byte on the JSONEachRow f
 order/values and the object-key layout, or the positional S3 -> ClickHouse replicator
 silently drops rows. This module is that single source: ``emit_row`` serializes the row and
 ``object_key`` computes its bucket-relative key. The ``verdict`` command feeds its rows
-through here; the scan calls ``emit_ai_review_dispatched`` the instant it fires the reviewer
-workflow, so a queued run (which can sit in GitHub's Actions queue well past a scan interval)
-is recorded as in-flight immediately and never re-dispatched while it waits.
+through here; the scan emits two marker rows of its own. ``emit_ai_review_dispatched`` fires
+the instant the reviewer workflow is dispatched, so a queued run (which can sit in GitHub's
+Actions queue well past a scan interval) is recorded as in-flight immediately and never
+re-dispatched while it waits. ``emit_reverted`` records that a PR is permanently out of
+review, so the exclusion outlives the ``Reverted`` label that triggered it.
 
 ``verdict`` writes the row to a fixed local path that its workflow ``aws s3 cp``s after a
 ``success()`` gate; the scan has no such gate, so its default ``upload`` puts the object to
@@ -22,12 +24,12 @@ import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Protocol, cast
 
-from greenlight.constants import S3_BUCKET, S3_KEY_PREFIX, STATUS_AI_REVIEW_DISPATCHED
+from greenlight.constants import S3_BUCKET, S3_KEY_PREFIX, STATUS_AI_REVIEW_DISPATCHED, STATUS_REVERTED
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-__all__ = ["default_emit_id", "emit_ai_review_dispatched", "emit_row", "object_key"]
+__all__ = ["default_emit_id", "emit_ai_review_dispatched", "emit_reverted", "emit_row", "object_key"]
 
 
 class _S3Putter(Protocol):
@@ -110,6 +112,34 @@ def _default_upload(row_gzip: bytes, key: str) -> None:
     _s3_client().put_object(Bucket=S3_BUCKET, Key=key, Body=row_gzip)
 
 
+def _emit_marker(
+    *,
+    repo: str,
+    pr_number: int,
+    head_sha: str,
+    status: str,
+    eval_hash: str,
+    run_id: int,
+    upload: Callable[[bytes, str], None] | None,
+) -> None:
+    """Emit one scan-written marker row: reason/message and the job URLs are always empty."""
+    emit_row(
+        repo=repo,
+        pr_number=pr_number,
+        head_sha=head_sha,
+        status=status,
+        reason="",
+        eval_hash=eval_hash,
+        message="",
+        eval_job="",
+        agent_job="",
+        run_id=run_id,
+        now=_utcnow,
+        emit=upload if upload is not None else _default_upload,
+        new_emit_id=default_emit_id,
+    )
+
+
 def emit_ai_review_dispatched(
     *,
     repo: str,
@@ -121,22 +151,41 @@ def emit_ai_review_dispatched(
 ) -> None:
     """Emit an ``AI_REVIEW_DISPATCHED`` row the instant the scan fires the reviewer workflow.
 
-    ``run_id`` is supplied by the caller (the scan computes the next run id); reason/message and
-    the job URLs are empty, matching the ``AI_REVIEW_STARTED`` marker. ``upload`` is an injectable
+    ``run_id`` is supplied by the caller (the scan computes the next run id); the empty
+    reason/message and job URLs match the ``AI_REVIEW_STARTED`` marker. ``upload`` is an injectable
     ``(gzip_bytes, key)`` seam for tests; the default puts the object via boto3.
     """
-    emit_row(
+    _emit_marker(
         repo=repo,
         pr_number=pr_number,
         head_sha=head_sha,
         status=STATUS_AI_REVIEW_DISPATCHED,
-        reason="",
         eval_hash=eval_hash,
-        message="",
-        eval_job="",
-        agent_job="",
         run_id=run_id,
-        now=_utcnow,
-        emit=upload if upload is not None else _default_upload,
-        new_emit_id=default_emit_id,
+        upload=upload,
+    )
+
+
+def emit_reverted(
+    *,
+    repo: str,
+    pr_number: int,
+    head_sha: str,
+    run_id: int,
+    upload: Callable[[bytes, str], None] | None = None,
+) -> None:
+    """Emit the ``REVERTED`` row that permanently excludes a PR from review.
+
+    ``eval_hash`` is empty: no fingerprint is computed for an excluded PR, and an empty hash can
+    never match one a land-time verifier recomputes. ``run_id`` and ``upload`` behave as for
+    ``emit_ai_review_dispatched``.
+    """
+    _emit_marker(
+        repo=repo,
+        pr_number=pr_number,
+        head_sha=head_sha,
+        status=STATUS_REVERTED,
+        eval_hash="",
+        run_id=run_id,
+        upload=upload,
     )

--- a/greenlight/tests/test_decision.py
+++ b/greenlight/tests/test_decision.py
@@ -127,3 +127,14 @@ def test_retry_past_timeout_dispatches_retry(status):
 
 def test_unknown_status_dispatches_unknown_status():
     assert _decide("SOMETHING_WEIRD", version=FRESH) == Outcome(Decision.DISPATCH, "unknown_status")
+
+
+def test_reverted_skips_reverted():
+    # REVERTED belongs to none of the status groupings, so without its own branch it would reach
+    # the unknown-status fallthrough and DISPATCH a reverted PR straight back into review.
+    assert _decide(constants.STATUS_REVERTED, version=FRESH) == Outcome(Decision.SKIP, "reverted")
+
+
+def test_reverted_skips_even_when_hash_changed():
+    # A push after the revert changes the fingerprint; the exclusion still holds.
+    assert _decide(constants.STATUS_REVERTED, latest=HASH_A, current=HASH_B) == Outcome(Decision.SKIP, "reverted")

--- a/greenlight/tests/test_lambda_handler.py
+++ b/greenlight/tests/test_lambda_handler.py
@@ -20,10 +20,11 @@ _TOKEN = "ghs_minted_installation_token"
 _SECRET_STORE = "greenlight/prod"
 _APP_ID = "123456"
 _INSTALLATION_ID = 42
+_APP_SLUG = "pytorchgreenlight"
 _EXPECTED_ARGV = ["review", "--ref", "main"]
 _EXPECTED_PERMISSIONS = {
     "actions": "write",
-    "pull_requests": "read",
+    "pull_requests": "write",
     "contents": "read",
     "members": "read",
 }
@@ -57,6 +58,7 @@ def fakes(monkeypatch):
         {},
         {"token": _TOKEN},
     )
+    fake_github.GithubIntegration.return_value.get_app.return_value.slug = _APP_SLUG
 
     monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
     # Ensure the real github module is in sys.modules before replacing it, so monkeypatch restores
@@ -91,8 +93,30 @@ def test_handler_happy_path(monkeypatch, fakes):
     )
     assert os.environ["PYTORCH_GREENLIGHT_GITHUB_TOKEN"] == _TOKEN
     assert os.environ["PYTORCH_GREENLIGHT_MAX_RUNTIME_SECONDS"] == "0"
+    # pull_requests is write, not read: the scan revokes greenlight's own approval on a reverted PR,
+    # and identifies it by the <slug>[bot] login resolved from GET /app on the same integration.
+    assert os.environ["BOT_LOGIN"] == f"{_APP_SLUG}[bot]"
+    fake_github.GithubIntegration.return_value.get_app.assert_called_once_with()
 
     main_mock.assert_called_once_with(_EXPECTED_ARGV)
+
+
+@pytest.mark.parametrize("slug", [pytest.param("", id="empty"), pytest.param(None, id="absent")])
+def test_handler_unusable_app_slug_raises(monkeypatch, fakes, slug):
+    _fake_boto3, fake_github = fakes
+    fake_github.GithubIntegration.return_value.get_app.return_value.slug = slug
+    main_mock = Mock()
+    monkeypatch.setattr(cli, "main", main_mock)
+
+    # An empty or missing slug yields a login that matches none of greenlight's reviews, so the
+    # dismissal would report success having revoked nothing. The scheduled path fails loudly here
+    # instead of handing the scan a login it cannot act on. None is the value PyGithub hands back
+    # for an absent slug, and it is the dangerous one: "None[bot]" is App-shaped.
+    with pytest.raises(ValueError, match="unusable app slug"):
+        lambda_handler.handler({}, object())
+
+    assert "BOT_LOGIN" not in os.environ
+    main_mock.assert_not_called()
 
 
 def test_handler_decodes_base64_pem(monkeypatch, fakes):

--- a/greenlight/tests/test_render_sync.py
+++ b/greenlight/tests/test_render_sync.py
@@ -126,6 +126,22 @@ def test_status_constants_match_python() -> None:
     )
 
 
+def test_every_status_is_branched_on_by_typescript() -> None:
+    source = _read(_TS_RENDER)
+    # A branched status names its constant at least once past the declaration line.
+    unwired = sorted(
+        name for name in _ts_statuses() if len(re.findall(rf"\bGREENLIGHT_STATUS_{re.escape(name)}\b", source)) < 2
+    )
+    assert not unwired, _drift(
+        _TS_RENDER,
+        _PY_CONSTANTS,
+        f"declared but never branched on: {unwired}. Declaring the constant is all "
+        f"test_status_constants_match_python asks for, so a status can satisfy it and still fall "
+        f'through renderGreenlightSection to "" -- which buildGreenlightSections drops, taking '
+        f"the whole GREEN LIGHT section out of the Dr. CI comment rather than showing the state.",
+    )
+
+
 _HEADLINES = {
     "GREENLIGHT_LAND_HEADLINE": comment_format.LAND_HEADLINE,
     "GREENLIGHT_NO_LAND_HEADLINE": comment_format.NO_LAND_HEADLINE,

--- a/greenlight/tests/test_state.py
+++ b/greenlight/tests/test_state.py
@@ -207,6 +207,99 @@ def test_query_error_propagates_and_closes_connection():
     assert client.closed == 1
 
 
+def test_reverted_query_asks_for_existence_not_the_authoritative_row():
+    client = _FakeClient([])
+    connect, _ = _connect_seam(client)
+
+    state.read_reverted_pr_numbers(_REPO, connect=connect)
+
+    query, params = client.queries[0]
+    # Existence, not recency: a later AI_REVIEW_STARTED row outranks a REVERTED one in
+    # read_latest_states' selection, so this read must carry none of that ordering/limit.
+    assert "SELECT DISTINCT pr_number" in query
+    assert "status = %(status)s" in query
+    assert "ORDER BY" not in query
+    assert "LIMIT" not in query
+    assert "pr_number IN" not in query
+    assert params == {"repo": _REPO, "status": "REVERTED"}
+
+
+def test_reverted_pr_filter_and_tuple_param_applied_only_when_pr_numbers_given():
+    client = _FakeClient([])
+    connect, _ = _connect_seam(client)
+
+    state.read_reverted_pr_numbers(_REPO, [7, 9], connect=connect)
+
+    query, params = client.queries[0]
+    assert "pr_number IN %(pr_numbers)s" in query
+    assert params == {"repo": _REPO, "status": "REVERTED", "pr_numbers": (7, 9)}
+
+
+def test_reverted_rows_map_to_a_set_of_ints():
+    client = _FakeClient([{"pr_number": 7}, {"pr_number": "9"}])
+    connect, _ = _connect_seam(client)
+
+    assert state.read_reverted_pr_numbers(_REPO, [7, 9], connect=connect) == {7, 9}
+
+
+def test_reverted_empty_rows_returns_empty_set():
+    client = _FakeClient([])
+    connect, _ = _connect_seam(client)
+
+    assert state.read_reverted_pr_numbers(_REPO, [7], connect=connect) == set()
+
+
+def test_reverted_empty_pr_numbers_returns_empty_set_without_connecting():
+    client = _FakeClient([{"pr_number": 7}])
+    connect, calls = _connect_seam(client)
+
+    assert state.read_reverted_pr_numbers(_REPO, [], connect=connect) == set()
+    assert calls["count"] == 0
+    assert client.queries == []
+
+
+def test_reverted_connection_is_closed_after_read():
+    client = _FakeClient([])
+    connect, _ = _connect_seam(client)
+
+    state.read_reverted_pr_numbers(_REPO, [7], connect=connect)
+
+    assert client.closed == 1
+
+
+def test_reverted_query_error_propagates_and_closes_connection():
+    client = _RaisingClient([])
+    connect, _ = _connect_seam(client)
+
+    # The read gates a permanent exclusion, so a failed query must fail the scan rather than
+    # silently read as "nothing was ever reverted".
+    with pytest.raises(RuntimeError, match="query boom"):
+        state.read_reverted_pr_numbers(_REPO, [7], connect=connect)
+
+    assert client.closed == 1
+
+
+@pytest.mark.parametrize(
+    ("recorded", "expected"),
+    [
+        pytest.param(None, 1, id="never-reviewed-bases-at-zero"),
+        pytest.param(0, 1, id="legacy-zero-run-id"),
+        pytest.param(4, 5, id="supersedes-prior-row"),
+        pytest.param(19283746, 19283747, id="supersedes-a-real-github-run-id"),
+    ],
+)
+def test_next_run_id_is_one_above_the_prior_row(recorded, expected):
+    # The write-side counterpart of the ORDER BY run_id DESC selection: one above the prior row is
+    # what makes a scan-written row the one read_latest_states returns.
+    prior = (
+        None
+        if recorded is None
+        else PRState(pr_number=1, status="LAND", eval_hash="a" * 64, head_sha="sha", version=_V1, run_id=recorded)
+    )
+
+    assert state.next_run_id(prior) == expected
+
+
 def test_prstate_is_frozen():
     st = PRState(pr_number=1, status="LAND", eval_hash="a" * 64, head_sha="sha", version=_V1, run_id=3)
 

--- a/greenlight/tests/test_state_emit.py
+++ b/greenlight/tests/test_state_emit.py
@@ -166,6 +166,40 @@ def test_two_dispatched_emits_get_distinct_emit_ids():
     assert all(_EMIT_ID_RE.fullmatch(value) for value in ids)
 
 
+def test_emit_reverted_builds_row_with_empty_eval_hash(monkeypatch):
+    monkeypatch.setattr(state_emit, "_utcnow", lambda: _FIXED)
+    cap = _Capture()
+
+    state_emit.emit_reverted(repo="pytorch/pytorch", pr_number=42, head_sha="deadbeef", run_id=4, upload=cap)
+
+    row = cap.decoded()
+    assert cap.key == state_emit.object_key("pytorch/pytorch", 42, _VERSION, str(row["emit_id"]))
+    assert list(row.keys()) == _ROW_KEYS
+    assert row["status"] == constants.STATUS_REVERTED == "REVERTED"
+    assert row["repo"] == "pytorch/pytorch"
+    assert row["pr_number"] == 42
+    assert row["head_sha"] == "deadbeef"
+    assert row["run_id"] == 4
+    # No fingerprint is computed for an excluded PR, and an empty hash can never match one a
+    # land-time verifier recomputes.
+    assert row["eval_hash"] == ""
+    assert row["reason"] == ""
+    assert row["message"] == ""
+    assert row["eval_job"] == ""
+    assert row["agent_job"] == ""
+
+
+def test_emit_reverted_defaults_to_boto3_upload(monkeypatch):
+    cap = _Capture()
+    monkeypatch.setattr(state_emit, "_default_upload", cap)
+
+    state_emit.emit_reverted(repo="o/r", pr_number=1, head_sha="h", run_id=2)
+
+    assert cap.key is not None
+    assert cap.key.startswith("greenlight_pr_state/o/r/1/")
+    assert cap.decoded()["status"] == constants.STATUS_REVERTED
+
+
 def test_emit_ai_review_dispatched_defaults_to_boto3_upload(monkeypatch):
     # With no upload seam, the default boto3 uploader is used.
     cap = _Capture()

--- a/torchci/lib/greenlight/greenlightRender.ts
+++ b/torchci/lib/greenlight/greenlightRender.ts
@@ -31,8 +31,11 @@ export const GREENLIGHT_INCOMPLETE_HEADLINE =
 export const GREENLIGHT_REVERTED_HEADLINE =
   "PR was reverted - re-landing requires human review";
 export const GREENLIGHT_REVIEWING_BODY = "Green Light is reviewing this PR.";
+// Says only what the row itself establishes. The row is recorded for every reverted
+// candidate, including one Green Light never approved and one whose revocation
+// failed, so a body claiming the approval was dismissed would be wrong on both.
 export const GREENLIGHT_REVERTED_BODY =
-  "Green Light dismissed its approval and will not review this PR again, on this or any later commit; re-landing it needs a human approval.";
+  "Green Light will not review this PR again, on this or any later commit; re-landing it needs a human approval.";
 
 // Leads the summary line whenever the verdict was reached on a commit that is no
 // longer the PR's head. The scan writes no new row once a human has decided,

--- a/torchci/lib/greenlight/greenlightRender.ts
+++ b/torchci/lib/greenlight/greenlightRender.ts
@@ -20,6 +20,7 @@ export const GREENLIGHT_STATUS_AI_REVIEW_STARTED = "AI_REVIEW_STARTED";
 export const GREENLIGHT_STATUS_AI_REVIEW_DISPATCHED = "AI_REVIEW_DISPATCHED";
 export const GREENLIGHT_STATUS_CANCELLED = "CANCELLED";
 export const GREENLIGHT_STATUS_FAILED = "FAILED";
+export const GREENLIGHT_STATUS_REVERTED = "REVERTED";
 
 export const GREENLIGHT_LAND_HEADLINE =
   "PR approved to be merged without human review";
@@ -27,7 +28,11 @@ export const GREENLIGHT_NO_LAND_HEADLINE = "PR requires human review";
 export const GREENLIGHT_REVIEWING_HEADLINE = "Green Light review in progress";
 export const GREENLIGHT_INCOMPLETE_HEADLINE =
   "Green Light review did not complete";
+export const GREENLIGHT_REVERTED_HEADLINE =
+  "PR was reverted - re-landing requires human review";
 export const GREENLIGHT_REVIEWING_BODY = "Green Light is reviewing this PR.";
+export const GREENLIGHT_REVERTED_BODY =
+  "Green Light dismissed its approval and will not review this PR again, on this or any later commit; re-landing it needs a human approval.";
 
 // Leads the summary line whenever the verdict was reached on a commit that is no
 // longer the PR's head. The scan writes no new row once a human has decided,
@@ -322,6 +327,21 @@ export function renderGreenlightSection(
       evalJob,
       false,
       outdated
+    );
+  }
+
+  // A revert excludes the PR outright rather than judging one commit: it holds
+  // for the current head and every later one, and the row carries no reason,
+  // message or job of its own. Both the outdated marker and the reviewed-commit
+  // line would frame it as superseded by the next push, which is the one reading
+  // that leaves an author waiting on a re-review that never comes.
+  if (status === GREENLIGHT_STATUS_REVERTED) {
+    return renderSection(
+      GREENLIGHT_REVERTED_HEADLINE,
+      [GREENLIGHT_REVERTED_BODY],
+      evalJob,
+      false,
+      false
     );
   }
 

--- a/torchci/test/greenlightRender.test.ts
+++ b/torchci/test/greenlightRender.test.ts
@@ -8,6 +8,8 @@ import {
   GREENLIGHT_NO_LAND_HEADLINE,
   GREENLIGHT_OUTDATED_HEADLINE_PREFIX,
   GREENLIGHT_PENDING_ALT_ATTR,
+  GREENLIGHT_REVERTED_BODY,
+  GREENLIGHT_REVERTED_HEADLINE,
   GREENLIGHT_REVIEWING_HEADLINE,
   GreenlightState,
   INLINE_BREAKERS_RE,
@@ -398,6 +400,23 @@ describe("renderGreenlightSection statuses", () => {
     expect(failed).toContain("reason: `failed`");
   });
 
+  // The scan writes this row with no reason, message or job of its own, so the
+  // blank-field handling the retry statuses get applies here too: a rendered
+  // `reason: ``` or an empty fence would be noise the reader has to expand to.
+  it("renders REVERTED with its own headline and body, and no blank fields", () => {
+    const out = render(
+      state({ status: "REVERTED", reason: "", message: "", evalJob: "" }),
+      FRESH_NOW
+    );
+
+    expect(summaryLine(out)).toContain(GREENLIGHT_REVERTED_HEADLINE);
+    expect(out).toContain(GREENLIGHT_REVERTED_BODY);
+    expect(out).not.toContain(GREENLIGHT_LAND_HEADLINE);
+    expect(out).not.toContain(GREENLIGHT_INCOMPLETE_HEADLINE);
+    expect(out).not.toContain("reason:");
+    expect(out).not.toContain("```");
+  });
+
   it("returns empty for statuses it cannot render", () => {
     expect(render(state({ status: "" }), FRESH_NOW)).toBe("");
     expect(render(state({ status: "SOMETHING_NEW" }), FRESH_NOW)).toBe("");
@@ -543,7 +562,7 @@ describe("renderGreenlightSection pending sentinel", () => {
         GREENLIGHT_PENDING_ALT_ATTR
       );
     }
-    for (const status of ["LAND", "NO_LAND", "CANCELLED", "FAILED"]) {
+    for (const status of [...TERMINAL_STATUSES, "REVERTED"]) {
       expect(render(state({ status }), FRESH_NOW)).not.toContain(
         GREENLIGHT_PENDING_ALT_ATTR
       );
@@ -814,6 +833,24 @@ describe("renderGreenlightSection outdated verdict", () => {
     expect(summaryLine(out)).toContain(
       `${GREENLIGHT_OUTDATED_HEADLINE_PREFIX}${GREENLIGHT_LAND_HEADLINE}`
     );
+  });
+
+  // The one status the marker must never reach. A revert stands whatever is
+  // pushed next, so calling it outdated once the author fixes the PR reads as an
+  // invitation to wait for the re-review that greenlight will never run -- and
+  // the reviewed-commit line, which says the same thing in longer form below the
+  // fold, has to go with it.
+  it("never marks REVERTED outdated, however far the head has moved on", () => {
+    const out = renderGreenlightSection(
+      state({ status: "REVERTED" }),
+      FRESH_NOW,
+      OTHER_SHA
+    );
+
+    expect(out).toContain(GREENLIGHT_REVERTED_HEADLINE);
+    expect(out).not.toContain(GREENLIGHT_OUTDATED_HEADLINE_PREFIX);
+    expect(out).not.toContain("Reviewed commit:");
+    expect(out).not.toContain("NOT the current head");
   });
 
   it("leaves a verdict on the current head unmarked", () => {

--- a/torchci/test/greenlightRender.test.ts
+++ b/torchci/test/greenlightRender.test.ts
@@ -415,6 +415,9 @@ describe("renderGreenlightSection statuses", () => {
     expect(out).not.toContain(GREENLIGHT_INCOMPLETE_HEADLINE);
     expect(out).not.toContain("reason:");
     expect(out).not.toContain("```");
+    // The row says nothing about a dismissal having happened, and is written for
+    // PRs Green Light never approved, so the body may not assert one.
+    expect(GREENLIGHT_REVERTED_BODY).not.toMatch(/dismiss/i);
   });
 
   it("returns empty for statuses it cannot render", () => {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #8669
* __->__ #8668
* #8667

**Impact:** the scheduled greenlight-scan Lambda and the manual scan workflow
**Risk:** medium

## What
Raises the scan's App token from `pull_requests: read` to `write`, and resolves
`BOT_LOGIN` from the App itself so both scheduled paths carry it. Nothing exercises
the new permission yet.

## Why
Dismissing a review needs `pull_requests: write`, and the dismissal matches reviews
by comparing logins. `BOT_LOGIN` was empty on both scheduled paths, so a dismissal
there would have matched nothing while reporting success — the failure mode is
silence, which is why the handler now refuses an absent or unusable App slug rather
than building a plausible-looking login from it.

# Notes
The App installation already holds Pull requests: write — the reviewer workflow's
record job mints exactly that today — so no org approval is pending and the mint
will not 422. The trade is real though: the scheduled scan can now post reviews,
not only read them, where previously only the short-lived record job could.