### PR TITLE
Stop reviewing reverted PRs and revoke their approvals

### DIFF
--- a/.github/workflows/greenlight-review.yml
+++ b/.github/workflows/greenlight-review.yml
@@ -65,8 +65,9 @@ jobs:
     runs-on: ubuntu-latest
     # Protected environment holding the Green Light App key: GREENLIGHT_APP_ID and
     # GREENLIGHT_APP_PRIVATE_KEY. The App must be installed on pytorch/test-infra with
-    # Actions: write and Pull requests: read so the minted token can dispatch the
-    # reviewer workflow and read PRs across pytorch/pytorch and pytorch/test-infra.
+    # Actions: write and Pull requests: write so the minted token can dispatch the
+    # reviewer workflow, read PRs across pytorch/pytorch and pytorch/test-infra, and
+    # revoke greenlight's own approval on a reverted PR.
     environment: greenlight-record
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
@@ -74,27 +75,11 @@ jobs:
         with:
           working_directory: greenlight
 
-      # Least privilege: the listing scan only reads PRs, so it mints a pull-requests:read token.
-      # The --pr recheck may post a refusal comment, so it mints pull-requests:write instead.
-      # Exactly one of these runs per invocation (keyed on whether a PR number was given); both
-      # keep actions:write to dispatch the reviewer workflow.
-      - name: Mint Green Light app token (read-only listing scan)
-        id: app-token-ro
-        if: inputs.pr == ''
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349  # v2.2.2
-        with:
-          app-id: ${{ secrets.GREENLIGHT_APP_ID }}
-          private-key: ${{ secrets.GREENLIGHT_APP_PRIVATE_KEY }}
-          owner: pytorch
-          repositories: pytorch,test-infra
-          permission-pull-requests: read
-          permission-actions: write
-          permission-contents: read
-          permission-members: read
-
-      - name: Mint Green Light app token (recheck, can comment)
-        id: app-token-rw
-        if: inputs.pr != ''
+      # pull-requests:write on every invocation, not just the --pr recheck: the listing scan
+      # dismisses greenlight's approving review on any PR that has been reverted. Keep the
+      # permission set in sync with _TOKEN_PERMISSIONS in greenlight/src/greenlight/lambda_handler.py.
+      - name: Mint Green Light app token
+        id: app-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349  # v2.2.2
         with:
           app-id: ${{ secrets.GREENLIGHT_APP_ID }}
@@ -119,12 +104,11 @@ jobs:
 
       - name: Scan and dispatch
         env:
-          # Whichever token step ran (exactly one does): read-only for the listing scan,
-          # pull-requests:write for a --pr recheck so it can post a refusal comment.
-          PYTORCH_GREENLIGHT_GITHUB_TOKEN: ${{ steps.app-token-ro.outputs.token || steps.app-token-rw.outputs.token }}
-          # The App's bot login (<slug>[bot]) author-scopes the recheck-refusal comment. Only the
-          # write token step exposes app-slug, so this is empty on the read-only listing scan.
-          BOT_LOGIN: ${{ steps.app-token-rw.outputs.app-slug && format('{0}[bot]', steps.app-token-rw.outputs.app-slug) || '' }}
+          PYTORCH_GREENLIGHT_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # The App's bot login (<slug>[bot]) author-scopes the recheck-refusal comment and picks
+          # out greenlight's own approvals to revoke on a reverted PR. An empty app-slug yields the
+          # bare "[bot]", which the CLI rejects as not App-shaped rather than silently matching nothing.
+          BOT_LOGIN: ${{ steps.app-token.outputs.app-slug }}[bot]
           CLICKHOUSE_ENDPOINT: ${{ secrets.CLICKHOUSE_HUD_USER_URL }}
           CLICKHOUSE_USERNAME: ${{ secrets.CLICKHOUSE_HUD_USER_USERNAME }}
           CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_HUD_USER_PASSWORD }}

--- a/greenlight/CHEATSHEET.md
+++ b/greenlight/CHEATSHEET.md
@@ -12,7 +12,11 @@ one-shot `verdict` and `drci-poke` subcommands:
 - `review` — scan the open PRs from a fixed set of trusted authors in `pytorch/pytorch`;
   for each, compute its fingerprint (`eval_hash`), read its latest state from
   `misc.greenlight_pr_state`, and dispatch the reviewer workflow
-  (`greenlight-pr-review.yml` on `pytorch/test-infra`) for new or changed PRs. Draft PRs are
+  (`greenlight-pr-review.yml` on `pytorch/test-infra`) for new or changed PRs. A reverted PR —
+  labeled `Reverted`, or with a `REVERTED` row already recorded — is excluded permanently on every
+  path: greenlight revokes its own approving review, records the `REVERTED` row unless it is
+  already the PR's latest, and drops the PR. Removing the label does not restore eligibility, and `@greenlight recheck` is not exempt (it
+  is skipped silently, with no comment). Needs PR write and the App's `BOT_LOGIN`. Draft PRs are
   dropped from the listing scan entirely — never fingerprinted or dispatched — though an explicit
   `@greenlight recheck` (the `--pr` path) still reviews a draft. A PR whose
   `updated_at` is older than `PYTORCH_GREENLIGHT_REVIEW_WINDOW_HOURS` (default 24), or that carries
@@ -109,13 +113,14 @@ runs each iteration, and on SIGTERM/SIGINT stops cleanly after the current
 iteration (`INFO greenlight.runner daemon stopped`, exit `0`). Signals are observed
 only between iterations.
 
-Config comes from `PYTORCH_GREENLIGHT_*` env vars; CLI flags `--interval`, `--log-level`,
-and `--lock-path` override the matching env vars, and `review` adds the scan flags `--pr`,
-`--max`, `--ref`, and `--timeout-minutes`.
+Config comes from `PYTORCH_GREENLIGHT_*` env vars plus the unprefixed `BOT_LOGIN`; CLI flags
+`--interval`, `--log-level`, and `--lock-path` override the matching env vars, and `review` adds
+the scan flags `--pr`, `--max`, `--ref`, and `--timeout-minutes`.
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `PYTORCH_GREENLIGHT_GITHUB_TOKEN` | unset | GitHub token; `review` needs Actions: write (`workflow_dispatch`) on `pytorch/test-infra` plus PR read on `pytorch/pytorch` |
+| `BOT_LOGIN` | unset | The App's own `<slug>[bot]` login; author-scopes the recheck-refusal comment and picks out greenlight's approvals to revoke on a reverted PR. Must be App-shaped when set; the reverted-PR path refuses the scan without it |
+| `PYTORCH_GREENLIGHT_GITHUB_TOKEN` | unset | GitHub token; `review` needs Actions: write (`workflow_dispatch`) on `pytorch/test-infra` plus PR write on `pytorch/pytorch` (to revoke its approval on a reverted PR) |
 | `PYTORCH_GREENLIGHT_INTERVAL_SECONDS` | `60` | Seconds between iterations in `--loop` mode |
 | `PYTORCH_GREENLIGHT_LOG_LEVEL` | `INFO` | Logging level (`INFO`, `DEBUG`, ...) |
 | `PYTORCH_GREENLIGHT_LOCK_PATH` | unset | Single-instance lock file (unset = no lock) |
@@ -148,8 +153,12 @@ the other lambda zips -> pin that tag in the `pytorch-gha-infra-2` `runners/comm
 The end-to-end flow, per trusted-author PR:
 
 1. `review` scans the open PRs, dropping any draft PR from the listing outright — never
-   fingerprinted or dispatched, though `@greenlight recheck` via `--pr` still reviews a draft. For
-   each remaining PR it computes its fingerprint (`eval_hash`) — unless
+   fingerprinted or dispatched, though `@greenlight recheck` via `--pr` still reviews a draft. It
+   also drops any reverted PR (labeled `Reverted`, or with a `REVERTED` row already recorded),
+   first revoking greenlight's own approving review and recording the `REVERTED` row unless it is
+   already the PR's latest, then poking Dr. CI if either changed anything. That exclusion is permanent, survives
+   removal of the label, and is not waived by `@greenlight recheck` (which is skipped silently).
+   For each remaining PR it computes its fingerprint (`eval_hash`) — unless
    the PR's `updated_at` is older than `PYTORCH_GREENLIGHT_REVIEW_WINDOW_HOURS` (default 24) or it
    carries the `Stale` label, and it has no in-flight or retry-eligible (cancelled/failed) review,
    or a human has already decided it (approved by a `merge_rules.yaml` approver with bots excluded,

--- a/greenlight/CLAUDE.md
+++ b/greenlight/CLAUDE.md
@@ -52,13 +52,17 @@ PyTorch Green Light has one unit of work — the `review` phase:
   `pytorch/pytorch` (the trusted-author set is the match rule); for each PR it computes the
   fingerprint (`eval_hash`), reads the PR's latest state from `misc.greenlight_pr_state`,
   and dispatches the reviewer workflow (`greenlight-pr-review.yml` on `pytorch/test-infra`)
-  for new or changed PRs, dropping draft PRs outright (never fingerprinted or dispatched by the
+  for new or changed PRs, excluding reverted PRs permanently (`Reverted` label or a recorded
+  `REVERTED` row: greenlight revokes its own approval, records the row, and drops the PR on every
+  path — the label can be removed, the exclusion cannot, and `--pr` is skipped silently),
+  dropping draft PRs outright (never fingerprinted or dispatched by the
   listing scan), and skipping any PR untouched beyond `PYTORCH_GREENLIGHT_REVIEW_WINDOW_HOURS`
   (default 24) or carrying the `Stale` label that has no in-flight or retry-eligible
   (cancelled/failed) review, and skipping — without fingerprinting or dispatching — any PR a human
   has already decided (approved by a `merge_rules.yaml` approver, bots excluded, or changes
   requested by any non-bot reviewer).
-  Requires `PYTORCH_GREENLIGHT_GITHUB_TOKEN` and `CLICKHOUSE_*` read access.
+  Requires `PYTORCH_GREENLIGHT_GITHUB_TOKEN` (PR write, for the revocation), `BOT_LOGIN`, and
+  `CLICKHOUSE_*` read access.
 
 Approving or rejecting a PR lives in the dispatched reviewer workflow (through `verdict`),
 not in the `review` scan itself.

--- a/greenlight/README.md
+++ b/greenlight/README.md
@@ -27,7 +27,14 @@ trusted authors in `pytorch/pytorch` and, for each one, computes its fingerprint
 (`eval_hash`), reads the PR's latest recorded state from ClickHouse
 `misc.greenlight_pr_state`, and dispatches the reviewer workflow
 (`greenlight-pr-review.yml` on `pytorch/test-infra`) for PRs that are new or changed since
-their last review. Draft PRs are dropped from the listing scan entirely — never fingerprinted or
+their last review. A reverted PR is dropped from every path, permanently: greenlight revokes its
+own approving review, records a `REVERTED` row, and never reviews the PR again. A PR counts as
+reverted once it carries the `Reverted` label (matched case-insensitively) or has ever recorded a
+`REVERTED` row — removing the label does not restore eligibility, and an explicit `@greenlight
+recheck` (the `--pr` path) is not exempt, it is skipped silently with no comment posted. The
+revocation needs `BOT_LOGIN` and PR write access; a `BOT_LOGIN` that is not the App's
+`<slug>[bot]` fails the scan rather than silently revoking nothing.
+Draft PRs are dropped from the listing scan entirely — never fingerprinted or
 dispatched — though an explicit `@greenlight recheck` (the `--pr` path) still reviews a draft.
 A PR whose `updated_at` is older than
 `PYTORCH_GREENLIGHT_REVIEW_WINDOW_HOURS` (default 24), or that carries the `Stale` label, is
@@ -175,11 +182,13 @@ are needed here; `verdict` needs `PYTORCH_GREENLIGHT_GITHUB_TOKEN` to post `LAND
 and `--dry-run` needs nothing. `--bot-login` (the greenlight GitHub App's `<slug>[bot]`
 account) is required for `NO_LAND`.
 
-Configuration is read from the environment via `PYTORCH_GREENLIGHT_*` variables:
+Configuration is read from the environment via `PYTORCH_GREENLIGHT_*` variables, plus the
+unprefixed `BOT_LOGIN`:
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `PYTORCH_GREENLIGHT_GITHUB_TOKEN` | unset | GitHub token used by `review` and `verdict`; `review` needs Actions: write (`workflow_dispatch`) on `pytorch/test-infra`, PR read on `pytorch/pytorch`, and org Members: read (`read:org`) to expand `merge_rules.yaml` team refs |
+| `BOT_LOGIN` | unset | The App's own `<slug>[bot]` login. Author-scopes the `--pr` recheck-refusal comment, and picks out greenlight's own approvals to revoke on a reverted PR. Must be App-shaped when set; the reverted-PR path refuses the whole scan without it |
+| `PYTORCH_GREENLIGHT_GITHUB_TOKEN` | unset | GitHub token used by `review` and `verdict`; `review` needs Actions: write (`workflow_dispatch`) on `pytorch/test-infra`, PR write on `pytorch/pytorch` (to revoke its approval on a reverted PR), and org Members: read (`read:org`) to expand `merge_rules.yaml` team refs |
 | `PYTORCH_GREENLIGHT_INTERVAL_SECONDS` | `60` | Seconds between iterations in `--loop` mode |
 | `PYTORCH_GREENLIGHT_LOG_LEVEL` | `INFO` | Logging level (e.g. `INFO`, `DEBUG`) |
 | `PYTORCH_GREENLIGHT_LOCK_PATH` | unset | Lock file path guarding against concurrent runs (unset = no lock) |
@@ -210,7 +219,8 @@ In production the scheduled scan runs as an AWS Lambda, `greenlight-scan`, in th
 schedule. The function runs `python3.13` with handler `greenlight.lambda_handler.handler`, a
 300 s timeout, and `reserved_concurrent_executions = 1`. It runs the same one-shot
 `execute_once` / `review.run` path as `greenlight review` — no scan-logic change — after minting a
-least-privilege GitHub App installation token in-process and reading the App PEM and ClickHouse
+least-privilege GitHub App installation token in-process, resolving `BOT_LOGIN` from the App's own
+`GET /app` slug, and reading the App PEM and ClickHouse
 password from AWS Secrets Manager (`pytorch-greenlight-secrets`) at runtime. The handler sets
 `PYTORCH_GREENLIGHT_MAX_RUNTIME_SECONDS=0`, so it runs with no single-instance lock and both
 hang-guard layers off (the SIGALRM soft timeout and the `os._exit` hard watchdog, which is wrong
@@ -303,7 +313,13 @@ on failure, and clean signal shutdown — all built and tested. `review` scans t
 from a fixed set of trusted authors in `pytorch/pytorch`, computes each PR's fingerprint
 (`eval_hash`), reads the PR's latest recorded state from `misc.greenlight_pr_state`, and
 dispatches the reviewer workflow (`greenlight-pr-review.yml` on `pytorch/test-infra`) for
-PRs that are new or changed. Draft PRs are dropped from the listing scan entirely — never
+PRs that are new or changed. Reverted PRs — those carrying the `Reverted` label or with a
+`REVERTED` row already recorded — are excluded permanently on every path: greenlight revokes its
+own approving review, records the `REVERTED` row unless it is already the PR's latest row, and
+pokes Dr. CI when either changed. The
+exclusion survives removal of the label, and `@greenlight recheck` is not exempt (it is skipped
+silently). This is the one path where `review` writes to `pytorch/pytorch`, so it needs PR write
+and the App's `BOT_LOGIN`. Draft PRs are dropped from the listing scan entirely — never
 fingerprinted or dispatched — though an explicit `@greenlight recheck` (the `--pr` path) still
 reviews a draft. PRs whose `updated_at` is older than the review window
 (`PYTORCH_GREENLIGHT_REVIEW_WINDOW_HOURS`, default 24), or that carry the `Stale` label, are

--- a/greenlight/src/greenlight/candidate_filter.py
+++ b/greenlight/src/greenlight/candidate_filter.py
@@ -1,0 +1,75 @@
+"""Prune the listed PRs the review scan can safely leave alone this iteration.
+
+Extracted from ``review`` so both modules stay within the per-file line limit. ``review.run``
+lists the candidates and their labels; this module decides which of them are worth the cost of
+a fingerprint, from the recency window and the ``Stale`` label.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from greenlight.constants import TERMINAL_STATUSES
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from datetime import datetime, timedelta
+
+    from greenlight.state import PRState
+
+logger = logging.getLogger(__name__)
+
+
+def labeled_with(labels_by_number: Mapping[int, Sequence[str]], wanted: frozenset[str]) -> frozenset[int]:
+    """Return the PR numbers carrying at least one of ``wanted``, matched exactly.
+
+    GitHub label names are case-sensitive, and pytorch's stale bot tests ``Stale`` case-sensitively
+    too, so a differently-cased label is a different label and must not prune anything.
+    """
+    return frozenset(number for number, labels in labels_by_number.items() if not wanted.isdisjoint(labels))
+
+
+def _within_recency_window(updated_at: datetime | None, now: datetime, window: timedelta) -> bool:
+    # A missing updated_at is never treated as stale: absence must not hide recent activity.
+    if updated_at is None:
+        return True
+    return now - updated_at < window
+
+
+def recency_filter(
+    pr_numbers: Sequence[int],
+    updated_at_by_number: dict[int, datetime | None],
+    states: dict[int, PRState],
+    stale_labeled_numbers: frozenset[int],
+    *,
+    now: datetime,
+    window: timedelta,
+) -> list[int]:
+    """Drop PRs the scan can safely leave alone this iteration.
+
+    A PR is kept when it was updated within ``window`` AND is not ``Stale``-labeled, OR its
+    recorded state is non-terminal (in-flight or retry-eligible), so ``decide`` can still
+    re-dispatch it on timeout/retry. A PR is skipped without fingerprinting when it is stale or
+    ``Stale``-labeled and either terminal (its eval_hash cannot have changed) or never reviewed
+    (an untouched PR is not worth a first review). The ``Stale`` label matters because the pytorch
+    stale bot bumps ``updated_at`` when it applies the label, which would otherwise drag an
+    abandoned never-reviewed PR back into the window.
+    """
+    kept: list[int] = []
+    for number in pr_numbers:
+        active = _within_recency_window(updated_at_by_number.get(number), now, window)
+        stale_labeled = number in stale_labeled_numbers
+        if active and not stale_labeled:
+            kept.append(number)
+            continue
+        recorded = states.get(number)
+        if recorded is not None and recorded.status not in TERMINAL_STATUSES:
+            kept.append(number)
+            continue
+        detail = recorded.status if recorded is not None else "never reviewed"
+        if stale_labeled:
+            logger.info("skipping PR #%d: Stale label (%s)", number, detail)
+        else:
+            logger.info("skipping stale PR #%d: no recent activity (%s)", number, detail)
+    return kept

--- a/greenlight/src/greenlight/cli.py
+++ b/greenlight/src/greenlight/cli.py
@@ -239,10 +239,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         parser.error("--force requires --pr")
     if args.force and args.loop:
         parser.error("--force cannot be combined with --loop")
-    # The bot login is the App's <slug>[bot] account, supplied via BOT_LOGIN (empty on the
-    # read-only listing scan, set only on the write-capable --pr recheck). It author-scopes the
-    # recheck-refusal comment; when set it must be App-shaped, or a copied marker in a third
-    # party's comment could be hijacked. An empty value is allowed and handled downstream.
+    # The bot login is the App's <slug>[bot] account, supplied via BOT_LOGIN. It author-scopes the
+    # recheck-refusal comment and identifies greenlight's own approvals for the reverted-PR
+    # dismissal; when set it must be App-shaped, or a copied marker in a third party's comment could
+    # be hijacked. An empty value parses (the reverted-PR path refuses it where it would matter).
     bot_login = os.environ.get("BOT_LOGIN", "").strip()
     if bot_login and not is_app_login(bot_login):
         parser.error(

--- a/greenlight/src/greenlight/constants.py
+++ b/greenlight/src/greenlight/constants.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 STATUS_LAND = "LAND"
 STATUS_NO_LAND = "NO_LAND"
@@ -10,6 +14,10 @@ STATUS_CANCELLED = "CANCELLED"
 STATUS_FAILED = "FAILED"
 STATUS_AI_REVIEW_STARTED = "AI_REVIEW_STARTED"
 STATUS_AI_REVIEW_DISPATCHED = "AI_REVIEW_DISPATCHED"
+# REVERTED is deliberately a member of none of the groupings below. That keeps it out of
+# VERDICT_STATUSES (the verdict CLI can never emit it) and out of decide()'s status branches, which
+# must therefore match it explicitly rather than let it reach the unknown-status DISPATCH fallback.
+STATUS_REVERTED = "REVERTED"
 
 TERMINAL_STATUSES: frozenset[str] = frozenset({STATUS_LAND, STATUS_NO_LAND})
 IN_FLIGHT_STATUSES: frozenset[str] = frozenset({STATUS_AI_REVIEW_STARTED, STATUS_AI_REVIEW_DISPATCHED})
@@ -20,9 +28,24 @@ RETRY_STATUSES: frozenset[str] = frozenset({STATUS_CANCELLED, STATUS_FAILED})
 SCAN_ONLY_STATUSES: frozenset[str] = frozenset({STATUS_AI_REVIEW_DISPATCHED})
 VERDICT_STATUSES: frozenset[str] = (TERMINAL_STATUSES | IN_FLIGHT_STATUSES | RETRY_STATUSES) - SCAN_ONLY_STATUSES
 
-# GitHub labels are case-sensitive; the pytorch stale bot uses the exact name "Stale".
+# GitHub labels are case-sensitive; pytorch's stale.yml both applies and case-sensitively tests
+# the exact name "Stale", so folding it here would diverge from the bot this filter tracks.
 STALE_LABEL = "Stale"
 EXCLUDED_LABELS: frozenset[str] = frozenset({STALE_LABEL})
+
+# The revert label is matched case-insensitively instead: pytorch's trymerge applies it as
+# lowercase "reverted" and GitHub resolves that to whichever canonical label the repo holds, so the
+# casing greenlight reads back is the label registry's, not the caller's. Folding cannot conflate
+# two distinct labels either -- GitHub rejects names differing only in case.
+REVERTED_LABEL = "Reverted"
+REVERTED_LABELS: frozenset[str] = frozenset({REVERTED_LABEL})
+
+
+def carries_any_label(labels: Iterable[str], wanted: Iterable[str]) -> bool:
+    """True when any name in ``labels`` matches one in ``wanted``, compared case-insensitively."""
+    folded = {name.casefold() for name in wanted}
+    return any(label.casefold() in folded for label in labels)
+
 
 # The reviewer and record workflows already write greenlight state rows to this bucket via
 # ``aws s3 cp``; the scan's direct boto3 upload targets the same bucket, single-sourced here.
@@ -61,9 +84,11 @@ def normalize_repo(repo: str) -> str:
 # Entries are folded at construction, so a mixed-case addition cannot silently never match.
 DRCI_STATUS_COMMENT_REPOS: frozenset[str] = frozenset(normalize_repo(repo) for repo in (TARGET_REPO,))
 
-# A GitHub App acts through a bot account whose login is ``<app-slug>[bot]``. Both the verdict
-# writer and the scan's recheck-refusal poster author-scope their comment writes to this login,
-# so it must be App-shaped or a copied marker in a third party's comment could be hijacked.
+# A GitHub App acts through a bot account whose login is ``<app-slug>[bot]``. The verdict writer
+# and the scan's recheck-refusal poster author-scope their comment writes to this login, so it must
+# be App-shaped or a copied marker in a third party's comment could be hijacked; the scan also
+# matches greenlight's own approving reviews by it before revoking them on a reverted PR, where a
+# login that is not App-shaped would match nothing while reporting success.
 BOT_LOGIN_SUFFIX = "[bot]"
 
 

--- a/greenlight/src/greenlight/decision.py
+++ b/greenlight/src/greenlight/decision.py
@@ -11,7 +11,7 @@ import enum
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from greenlight.constants import IN_FLIGHT_STATUSES, RETRY_STATUSES, TERMINAL_STATUSES
+from greenlight.constants import IN_FLIGHT_STATUSES, RETRY_STATUSES, STATUS_REVERTED, TERMINAL_STATUSES
 
 if TYPE_CHECKING:
     from datetime import datetime, timedelta
@@ -44,6 +44,12 @@ def decide(
 ) -> Outcome:
     if latest_status is None:
         return Outcome(Decision.DISPATCH, "never_reviewed")
+
+    # A reverted PR is never re-reviewed, whatever its fingerprint now says. The scan drops it
+    # long before this, so reaching here means that guard was bypassed -- and the fallthrough for
+    # an unrecognised status is DISPATCH, which would put a reverted PR straight back in review.
+    if latest_status == STATUS_REVERTED:
+        return Outcome(Decision.SKIP, "reverted")
 
     if latest_status in TERMINAL_STATUSES:
         if latest_eval_hash == current_eval_hash:

--- a/greenlight/src/greenlight/github_types.py
+++ b/greenlight/src/greenlight/github_types.py
@@ -115,6 +115,13 @@ if TYPE_CHECKING:
     class _VerdictRepo(Protocol):
         def get_pull(self, number: int) -> VerdictPR: ...
 
+    class _LabelledPR(Protocol):
+        @property
+        def labels(self) -> Iterable[_Label]: ...
+
+    class _LabelRepo(Protocol):
+        def get_pull(self, number: int) -> _LabelledPR: ...
+
 
 class VerdictClient(Protocol):
     """Structural GitHub client for the verdict path; the real ``github.Github`` satisfies it."""
@@ -126,3 +133,9 @@ class ScanClient(Protocol):
     """Structural GitHub client for the scan/fingerprint path; the real ``github.Github`` satisfies it."""
 
     def get_repo(self, full_name_or_id: str) -> _ScanRepo: ...
+
+
+class LabelClient(Protocol):
+    """Structural GitHub client for a single PR's label read; the real ``github.Github`` satisfies it."""
+
+    def get_repo(self, full_name_or_id: str) -> _LabelRepo: ...

--- a/greenlight/src/greenlight/lambda_handler.py
+++ b/greenlight/src/greenlight/lambda_handler.py
@@ -1,10 +1,10 @@
 """AWS Lambda entry point for the greenlight review scan.
 
 Fetches the GitHub App private key and ClickHouse password from AWS Secrets Manager,
-mints a least-privilege App installation token, and runs one ``review`` scan through the
-same CLI used on the command line. The Lambda function timeout is the runtime backstop, so
-the in-process guards are disabled here (their hard watchdog force-exits via ``os._exit``,
-which is wrong under the Lambda runtime).
+mints a least-privilege App installation token, resolves the App's own ``<slug>[bot]`` login,
+and runs one ``review`` scan through the same CLI used on the command line. The Lambda function
+timeout is the runtime backstop, so the in-process guards are disabled here (their hard watchdog
+force-exits via ``os._exit``, which is wrong under the Lambda runtime).
 """
 
 from __future__ import annotations
@@ -13,20 +13,26 @@ import base64
 import json
 import logging
 import os
+from typing import TYPE_CHECKING
 
 from greenlight import cli
+from greenlight.constants import BOT_LOGIN_SUFFIX, is_app_login
 from greenlight.exit_codes import EXIT_ALREADY_RUNNING, EXIT_OK
+
+if TYPE_CHECKING:
+    from github import GithubIntegration
 
 logger = logging.getLogger(__name__)
 
 _AWS_REGION = "us-east-1"
 
 # Least-privilege scope for the installation token: only the repos and permissions the scan
-# needs, even though the App itself holds broader org-level grants.
+# needs, even though the App itself holds broader org-level grants. pull_requests is write, not
+# read: the scan revokes greenlight's own approval on a reverted PR.
 # Keep in sync with the actions/create-github-app-token scope in .github/workflows/greenlight-review.yml.
 _TOKEN_PERMISSIONS = {
     "actions": "write",
-    "pull_requests": "read",
+    "pull_requests": "write",
     "contents": "read",
     "members": "read",
 }
@@ -60,19 +66,38 @@ def _load_secret(secret_store_name: str) -> dict[str, str]:
     return secret
 
 
-def _mint_installation_token(app_id: str, pem: str, installation_id: int) -> str:
+def _github_integration(app_id: str, pem: str) -> GithubIntegration:
     import github  # lazy: keeps this module importable without PyGithub
 
+    return github.GithubIntegration(auth=github.Auth.AppAuth(app_id, pem))
+
+
+def _mint_installation_token(integration: GithubIntegration, installation_id: int) -> str:
     # PyGithub 2.9.1's GithubIntegration.get_access_token sends only ``permissions`` and cannot
     # scope ``repositories``; the token is minted through the integration's public requester
     # (its documented escape hatch for endpoints PyGithub does not model) so both are applied.
-    integration = github.GithubIntegration(auth=github.Auth.AppAuth(app_id, pem))
     _, data = integration.requester.requestJsonAndCheck(
         "POST",
         f"/app/installations/{installation_id}/access_tokens",
         input={"permissions": _TOKEN_PERMISSIONS, "repositories": _TOKEN_REPOSITORIES},
     )
     return _require_key(data, "token", "installation token response")
+
+
+def _resolve_bot_login(integration: GithubIntegration) -> str:
+    """Return the App's own ``<slug>[bot]`` account login, read from ``GET /app``.
+
+    The scan matches greenlight's own approving reviews by this login before revoking them on a
+    reverted PR, so a wrong or empty one would dismiss nothing while reporting success. Anything
+    that is not ``<slug>[bot]`` raises here rather than reaching the scan.
+    """
+    slug = integration.get_app().slug
+    # PyGithub annotates GithubApp.slug as str but returns None when the response omits it (the
+    # unset attribute's .value), and interpolating that yields the App-shaped literal "None[bot]".
+    login = f"{slug}{BOT_LOGIN_SUFFIX}" if slug else ""
+    if not is_app_login(login):
+        raise ValueError(f"GET /app returned an unusable app slug {slug!r} for the greenlight bot login")
+    return login
 
 
 def handler(event: dict[str, object], context: object) -> dict[str, str]:  # noqa: ARG001
@@ -87,7 +112,9 @@ def handler(event: dict[str, object], context: object) -> dict[str, str]:  # noq
     pem_b64 = _require_key(secret, "GITHUB_APP_SECRET", secret_source)
     pem = base64.b64decode(pem_b64).decode("utf-8")
     os.environ["CLICKHOUSE_PASSWORD"] = _require_key(secret, "CLICKHOUSE_PASSWORD", secret_source)
-    os.environ["PYTORCH_GREENLIGHT_GITHUB_TOKEN"] = _mint_installation_token(app_id, pem, installation_id)
+    integration = _github_integration(app_id, pem)
+    os.environ["PYTORCH_GREENLIGHT_GITHUB_TOKEN"] = _mint_installation_token(integration, installation_id)
+    os.environ["BOT_LOGIN"] = _resolve_bot_login(integration)
 
     # The Lambda function timeout is the runtime backstop; a zero max-runtime disables both the
     # SIGALRM soft timeout and the hard watchdog (whose os._exit would abort the runtime uncleanly).

--- a/greenlight/src/greenlight/revert_guard.py
+++ b/greenlight/src/greenlight/revert_guard.py
@@ -1,0 +1,182 @@
+"""Permanently exclude reverted pytorch/pytorch PRs from review.
+
+A PR is excluded when it carries the ``Reverted`` label OR has ever recorded a ``REVERTED`` row.
+The label can be taken off again, the row cannot, so the row is what makes the exclusion
+permanent. Every scan re-runs the same steps for each excluded PR -- revoke greenlight's own
+approval, record the row unless one already wins, poke Dr. CI if either changed anything -- and
+then drops the PR before it is fingerprinted or dispatched. Re-running is not redundant: a review
+already in flight when the revert landed can still post a LAND approval afterwards.
+
+Exclusion and recording deliberately ask different questions of the table. Exclusion keys on a
+``REVERTED`` row *existing*, which no later row can outrank -- that is what makes it permanent.
+Recording keys on the *latest* row not being ``REVERTED``, because that row is the one Dr. CI
+renders: a review that lands its verdict after the exclusion was recorded carries the real
+``github.run_id`` and outranks it, and only re-recording puts the exclusion back on top.
+
+Two orderings are load-bearing:
+
+- The dismissal runs BEFORE the row is written, and the row is skipped when the dismissal raises.
+  The row is what stops later scans retrying, so writing it after a failed dismissal would freeze
+  a live approval on a reverted PR.
+- A missing row is never read as "no approval". The reviewer workflow posts its approving review a
+  step before it uploads the row, so a lost upload, a cancelled job, or replication lag all leave a
+  live approval with nothing recorded -- hence the dismissal is attempted whatever the state says.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from greenlight import constants
+from greenlight.constants import REVERTED_LABELS, STATUS_REVERTED, TARGET_REPO
+from greenlight.github_client import is_rate_limit_error
+from greenlight.guards import IterationTimeout
+from greenlight.state import next_run_id
+
+if TYPE_CHECKING:
+    import threading
+    from collections.abc import Callable, Mapping, Sequence
+
+    from github import Github
+
+    from greenlight.github_types import LabelClient, VerdictPR
+    from greenlight.state import PRState
+
+logger = logging.getLogger(__name__)
+
+_DISMISS_MESSAGE = "This pull request was reverted; greenlight's approval no longer applies."
+
+
+def fetch_pr_labels(client: LabelClient, repo: str, pr_number: int) -> tuple[str, ...]:
+    """Read one PR's label names.
+
+    The listing scan gets every PR's labels free from the open-PR payload; the ``--pr`` path has no
+    listing, so its single PR is fetched here.
+    """
+    return tuple(label.name for label in client.get_repo(repo).get_pull(pr_number).labels)
+
+
+def _carries_reverted_label(
+    client: Github,
+    number: int,
+    known_labels: Mapping[int, Sequence[str]],
+    fetch_labels: Callable[[Github, str, int], tuple[str, ...]],
+) -> bool:
+    labels = known_labels.get(number)
+    if labels is None:
+        labels = fetch_labels(client, TARGET_REPO, number)
+    return constants.carries_any_label(labels, REVERTED_LABELS)
+
+
+def _revoke_and_record(
+    client: Github,
+    number: int,
+    *,
+    recorded_state: PRState | None,
+    bot_login: str,
+    get_pr: Callable[[Github, str, int], VerdictPR],
+    dismiss: Callable[..., list[int]],
+    emit: Callable[..., None],
+    poke: Callable[[int], None],
+    failed: list[int],
+    cancel_event: threading.Event,
+) -> None:
+    """Revoke greenlight's approval on one reverted PR, then record its row unless one already wins.
+
+    The row is stamped with ``state.next_run_id``, so Dr. CI -- which renders a PR's latest row --
+    shows the exclusion. Writing whenever the latest row is not ``REVERTED`` is self-limiting: the
+    row it writes then *is* the latest, so a settled exclusion writes nothing, and one outranked by
+    a later verdict is rewritten exactly once.
+    """
+    try:
+        pr = get_pr(client, TARGET_REPO, number)
+        dismissed = dismiss(pr, bot_login=bot_login, message=_DISMISS_MESSAGE)
+    except IterationTimeout:
+        raise
+    except Exception as exc:
+        if is_rate_limit_error(exc):
+            cancel_event.set()
+        logger.error("failed to revoke greenlight approval on reverted PR #%d: %s", number, exc, exc_info=True)
+        failed.append(number)
+        return
+    if dismissed:
+        logger.info("dismissed %d greenlight approval(s) on reverted PR #%d", len(dismissed), number)
+    if recorded_state is not None and recorded_state.status == STATUS_REVERTED:
+        # Dr. CI already renders this PR's REVERTED row, so a settled exclusion is worth a rebuild
+        # only when an approval was actually revoked this pass.
+        if dismissed:
+            poke(number)
+        return
+    try:
+        emit(
+            repo=TARGET_REPO,
+            pr_number=number,
+            head_sha=pr.head.sha,
+            run_id=next_run_id(recorded_state),
+        )
+    except IterationTimeout:
+        raise
+    except Exception as exc:
+        logger.error("failed to record REVERTED for PR #%d: %s", number, exc, exc_info=True)
+        failed.append(number)
+        return
+    logger.info("recorded REVERTED for PR #%d", number)
+    poke(number)
+
+
+def exclude_reverted(
+    client: Github,
+    pr_numbers: Sequence[int],
+    *,
+    known_labels: Mapping[int, Sequence[str]],
+    states: Mapping[int, PRState],
+    bot_login: str,
+    read_reverted: Callable[[str, Sequence[int]], set[int]],
+    fetch_labels: Callable[[Github, str, int], tuple[str, ...]],
+    get_pr: Callable[[Github, str, int], VerdictPR],
+    dismiss: Callable[..., list[int]],
+    emit: Callable[..., None],
+    poke: Callable[[int], None],
+    failed: list[int],
+    cancel_event: threading.Event,
+) -> frozenset[int]:
+    """Act on every reverted PR in ``pr_numbers`` and return the set the caller must drop.
+
+    ``known_labels`` holds the labels the caller already has; a PR absent from it has its labels
+    read from GitHub, which is how the ``--pr`` path (no listing, so no labels) is covered too. A
+    per-PR failure is collected into ``failed`` so the scan still fails closed, and a rate limit
+    additionally trips ``cancel_event`` so the fingerprint fan-out does not run on a throttled
+    token. Either way the PR is still dropped -- an exclusion never lapses because a step failed.
+    """
+    recorded = read_reverted(TARGET_REPO, pr_numbers)
+    excluded = [
+        number
+        for number in pr_numbers
+        if number in recorded or _carries_reverted_label(client, number, known_labels, fetch_labels)
+    ]
+    if not excluded:
+        return frozenset()
+    # Dismissal matches greenlight's own reviews by login, so an empty or non-App login silently
+    # dismisses nothing while reporting success -- which would then let the row be written and
+    # suppress every retry. Refuse the whole scan instead of writing anything.
+    if not constants.is_app_login(bot_login):
+        raise ValueError(
+            f"BOT_LOGIN must be the greenlight App login (<app-slug>{constants.BOT_LOGIN_SUFFIX}) to revoke "
+            f"approvals on reverted PR(s) {excluded}; got {bot_login!r}"
+        )
+    logger.info("excluding %d reverted PR(s) from review: %s", len(excluded), excluded)
+    for number in excluded:
+        _revoke_and_record(
+            client,
+            number,
+            recorded_state=states.get(number),
+            bot_login=bot_login,
+            get_pr=get_pr,
+            dismiss=dismiss,
+            emit=emit,
+            poke=poke,
+            failed=failed,
+            cancel_event=cancel_event,
+        )
+    return frozenset(excluded)

--- a/greenlight/src/greenlight/review.py
+++ b/greenlight/src/greenlight/review.py
@@ -7,6 +7,9 @@ one-shot and ``--loop`` paths behave identically -- nothing is remembered in mem
 between scans. All GitHub, ClickHouse, and dispatch I/O sits behind injectable keyword
 seams so the loop is testable without any of them.
 
+Reverted PRs are excluded before any of that, on both the listing and ``--pr`` paths: greenlight
+revokes its own approval, records the exclusion, and drops the PR (see ``revert_guard``).
+
 The fingerprint step can also short-circuit: when a human has already decided a PR (an
 approval from a merge-authorized login, or changes requested by anyone), the scan skips
 its fingerprint and dispatch. On the listing path an approval or changes-requested skips;
@@ -24,14 +27,13 @@ import threading
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
+from greenlight import candidate_filter, drci_poke, github_client, revert_guard, scan_runner, state, state_emit
 from greenlight import dispatch as dispatch_module
-from greenlight import drci_poke, github_client, scan_runner, state, state_emit
 from greenlight.constants import (
     DEFAULT_DISPATCH_REF,
     DEFAULT_TIMEOUT_MINUTES,
     EXCLUDED_LABELS,
     TARGET_REPO,
-    TERMINAL_STATUSES,
 )
 
 if TYPE_CHECKING:
@@ -125,67 +127,24 @@ def _close_client(client: Github) -> None:
 
 def _candidate_numbers(
     client: Github, *, pr: int | None, fetch: Callable[[Github], list[OpenPR]]
-) -> tuple[list[int], dict[int, datetime | None], frozenset[int]]:
+) -> tuple[list[int], dict[int, datetime | None], dict[int, tuple[str, ...]]]:
+    """Return the candidate PR numbers with their ``updated_at`` and, from the listing, their labels.
+
+    The ``--pr`` path has no listing to read labels from, so it returns none and leaves the one
+    caller that needs them (``revert_guard``) to fetch that single PR's.
+    """
     if pr is not None:
         logger.info("targeting single PR #%d in %s", pr, TARGET_REPO)
-        return [pr], {}, frozenset()
+        return [pr], {}, {}
     open_prs = fetch(client)
     logger.info("found %d open PR(s) from %d author(s) in %s", len(open_prs), len(TRUSTED_AUTHORS), TARGET_REPO)
     for open_pr in open_prs:
         logger.info("open PR #%d by %s: %s (%s)", open_pr.number, open_pr.author, open_pr.title, open_pr.url)
-    stale_labeled_numbers = frozenset(
-        open_pr.number for open_pr in open_prs if not EXCLUDED_LABELS.isdisjoint(open_pr.labels)
-    )
     return (
         [open_pr.number for open_pr in open_prs],
         {open_pr.number: open_pr.updated_at for open_pr in open_prs},
-        stale_labeled_numbers,
+        {open_pr.number: open_pr.labels for open_pr in open_prs},
     )
-
-
-def _within_recency_window(updated_at: datetime | None, now: datetime, window: timedelta) -> bool:
-    # A missing updated_at is never treated as stale: absence must not hide recent activity.
-    if updated_at is None:
-        return True
-    return now - updated_at < window
-
-
-def _recency_filter(
-    pr_numbers: Sequence[int],
-    updated_at_by_number: dict[int, datetime | None],
-    states: dict[int, PRState],
-    stale_labeled_numbers: frozenset[int],
-    *,
-    now: datetime,
-    window: timedelta,
-) -> list[int]:
-    """Drop PRs the scan can safely leave alone this iteration.
-
-    A PR is kept when it was updated within ``window`` AND is not ``Stale``-labeled, OR its
-    recorded state is non-terminal (in-flight or retry-eligible), so ``decide`` can still
-    re-dispatch it on timeout/retry. A PR is skipped without fingerprinting when it is stale or
-    ``Stale``-labeled and either terminal (its eval_hash cannot have changed) or never reviewed
-    (an untouched PR is not worth a first review). The ``Stale`` label matters because the pytorch
-    stale bot bumps ``updated_at`` when it applies the label, which would otherwise drag an
-    abandoned never-reviewed PR back into the window.
-    """
-    kept: list[int] = []
-    for number in pr_numbers:
-        active = _within_recency_window(updated_at_by_number.get(number), now, window)
-        stale_labeled = number in stale_labeled_numbers
-        if active and not stale_labeled:
-            kept.append(number)
-            continue
-        recorded = states.get(number)
-        if recorded is not None and recorded.status not in TERMINAL_STATUSES:
-            kept.append(number)
-            continue
-        detail = recorded.status if recorded is not None else "never reviewed"
-        if stale_labeled:
-            logger.info("skipping PR #%d: Stale label (%s)", number, detail)
-        else:
-            logger.info("skipping stale PR #%d: no recent activity (%s)", number, detail)
-    return kept
 
 
 def run(
@@ -202,12 +161,16 @@ def run(
     build_github: _BuildClient = github_client.build_client,
     fetch: Callable[[Github], list[OpenPR]] = _default_fetch,
     fetch_author: Callable[[Github, int], str | None] = _default_fetch_author,
+    fetch_labels: Callable[[Github, str, int], tuple[str, ...]] = revert_guard.fetch_pr_labels,
     fingerprint: FingerprintFn = _default_fingerprint,
     read_state: Callable[[str, Sequence[int]], dict[int, PRState]] = state.read_latest_states,
+    read_reverted: Callable[[str, Sequence[int]], set[int]] = state.read_reverted_pr_numbers,
     dispatch: Callable[[Github, int, str, str, str], None] = dispatch_module.dispatch_review,
     emit_dispatched: Callable[..., None] = state_emit.emit_ai_review_dispatched,
+    emit_reverted: Callable[..., None] = state_emit.emit_reverted,
     poke_drci: Callable[[str, int, Config], None] = drci_poke.poke,
     get_pr: Callable[[Github, str, int], VerdictPR] = github_client.get_pr,
+    dismiss_approvals: Callable[..., list[int]] = github_client.dismiss_prior_greenlight_approvals,
     upsert_comment: Callable[..., None] = github_client.upsert_issue_comment,
     resolve_authorized: Callable[[], frozenset[str]],
     now: Callable[[], datetime] = _utcnow,
@@ -240,26 +203,10 @@ def run(
         # exits non-zero, daemon backs off) rather than silently revert to hashing all human comments.
         authorized_logins = resolve_authorized()
         logger.info("filtering fingerprint comments to %d merge-authorized login(s)", len(authorized_logins))
-        pr_numbers, updated_at_by_number, stale_labeled_numbers = _candidate_numbers(client, pr=pr, fetch=fetch)
+        pr_numbers, updated_at_by_number, labels_by_number = _candidate_numbers(client, pr=pr, fetch=fetch)
         states = read_state(TARGET_REPO, pr_numbers)
         evaluated_at = now()
         timeout = timedelta(minutes=timeout_minutes)
-        # A human approval skips only the listing scan; on --pr the recheck reviews anyway (an
-        # approval must never suppress a manual recheck). Changes-requested still skips on both.
-        skip_on_approval = pr is None
-        if pr is None:
-            # A single --pr target is always evaluated; the recency window only prunes the
-            # listed scan, where a stale untouched PR would waste a fingerprint.
-            fingerprint_numbers = _recency_filter(
-                pr_numbers,
-                updated_at_by_number,
-                states,
-                stale_labeled_numbers,
-                now=evaluated_at,
-                window=timedelta(hours=config.review_window_hours),
-            )
-        else:
-            fingerprint_numbers = pr_numbers
         failed: list[int] = []
         abandoned: list[int] = []
         skips: list[tuple[int, ReviewSkip]] = []
@@ -268,6 +215,43 @@ def run(
         # is broader than a non-empty `abandoned` -- a rate limit on the last task leaves nothing to
         # cancel (abandoned stays empty) yet must still skip dispatch.
         cancel_event = threading.Event()
+        # drci_poke's configured delay covers the verdict path's gap between writing the row to /tmp
+        # and a later workflow step uploading it. Both emits below have already PUT the object to S3
+        # before returning, and neither loop is capped, so keeping the wait would only multiply one
+        # sleep per PR into the Lambda's function timeout.
+        poke_config = dataclasses.replace(config, drci_poke_delay_seconds=0.0)
+        excluded = revert_guard.exclude_reverted(
+            client,
+            pr_numbers,
+            known_labels=labels_by_number,
+            states=states,
+            bot_login=bot_login,
+            read_reverted=read_reverted,
+            fetch_labels=fetch_labels,
+            get_pr=get_pr,
+            dismiss=dismiss_approvals,
+            emit=emit_reverted,
+            poke=lambda number: poke_drci(TARGET_REPO, number, poke_config),
+            failed=failed,
+            cancel_event=cancel_event,
+        )
+        pr_numbers = [number for number in pr_numbers if number not in excluded]
+        # A human approval skips only the listing scan; on --pr the recheck reviews anyway (an
+        # approval must never suppress a manual recheck). Changes-requested still skips on both.
+        skip_on_approval = pr is None
+        if pr is None:
+            # A single --pr target is always evaluated; the recency window only prunes the
+            # listed scan, where a stale untouched PR would waste a fingerprint.
+            fingerprint_numbers = candidate_filter.recency_filter(
+                pr_numbers,
+                updated_at_by_number,
+                states,
+                candidate_filter.labeled_with(labels_by_number, EXCLUDED_LABELS),
+                now=evaluated_at,
+                window=timedelta(hours=config.review_window_hours),
+            )
+        else:
+            fingerprint_numbers = pr_numbers
         worker_count = min(_FINGERPRINT_WORKERS, len(fingerprint_numbers))
         # PyGithub is not thread-safe, so each concurrent task borrows a client for its
         # exclusive use; sizing the pool to the worker count keeps queue.get non-blocking
@@ -326,11 +310,6 @@ def run(
                 len(pending),
             )
         else:
-            # drci_poke's configured delay covers the verdict path's gap between writing the row to
-            # /tmp and a later workflow step uploading it. Here emit_dispatched has already PUT the
-            # object to S3 before returning, and this loop is uncapped, so keeping the wait would
-            # only multiply one sleep per dispatch into the Lambda's function timeout.
-            poke_config = dataclasses.replace(config, drci_poke_delay_seconds=0.0)
             dispatch_failed = scan_runner._dispatch_pending(
                 client,
                 pending,

--- a/greenlight/src/greenlight/scan_runner.py
+++ b/greenlight/src/greenlight/scan_runner.py
@@ -20,6 +20,7 @@ from greenlight.decision import Decision, decide
 from greenlight.github_client import is_rate_limit_error
 from greenlight.guards import IterationTimeout
 from greenlight.review_gate import CHANGES_REQUESTED, ReviewSkip
+from greenlight.state import next_run_id
 
 if TYPE_CHECKING:
     import queue
@@ -255,20 +256,16 @@ def _fingerprint_until_dispatchable(
 def _emit_dispatch_marker(
     candidate: _Candidate, emit_dispatched: Callable[..., None], poke: Callable[[int], None]
 ) -> None:
-    # run_id is prior_run_id + 1 so this AI_REVIEW_DISPATCHED row supersedes the PR's prior row,
-    # while the reviewer run's own later, higher github.run_id supersedes it in turn once that run
-    # starts. A None state (never-reviewed PR) has no prior run, so it bases at 0 -> run_id 1.
     # The workflow was already fired, so an emit failure is logged and swallowed: a missing marker
     # self-heals (next scan re-dispatches, the reviewer's per-PR concurrency group cancels the dup),
     # and must not fail the scan or block dispatching the remaining candidates.
-    prior_run_id = candidate.state.run_id if candidate.state else 0
     try:
         emit_dispatched(
             repo=constants.TARGET_REPO,
             pr_number=candidate.pr_number,
             head_sha=candidate.head_sha,
             eval_hash=candidate.eval_hash,
-            run_id=prior_run_id + 1,
+            run_id=next_run_id(candidate.state),
         )
     except IterationTimeout:
         raise

--- a/greenlight/src/greenlight/state.py
+++ b/greenlight/src/greenlight/state.py
@@ -1,7 +1,12 @@
-"""Read the authoritative per-PR greenlight state from ClickHouse.
+"""Read per-PR greenlight state from ClickHouse.
 
-The scanner is read-only: it observes the authoritative ``misc.greenlight_pr_state`` row
-per PR to decide whether to dispatch a review. Writes go through the S3 -> replicator path
+Two reads live here. ``read_latest_states`` observes the authoritative
+``misc.greenlight_pr_state`` row per PR to decide whether to dispatch a review;
+``read_reverted_pr_numbers`` asks a separate question -- has this PR *ever* recorded a
+``REVERTED`` row -- which deliberately does not depend on that row winning the
+authoritative-row selection below.
+
+Writes go through the S3 -> replicator path
 (see ``verdict``), never a direct INSERT. The table keeps every emit as history: the
 ``SharedReplacingMergeTree`` never collapses rows because the sort key
 ``(repo, pr_number, run_id, emit_id)`` ends in a per-emit-unique ``emit_id``. So the
@@ -10,6 +15,9 @@ time: ``ORDER BY pr_number, run_id DESC, version DESC LIMIT 1 BY pr_number`` kee
 highest ``run_id`` and, within that run, the latest ``version``. Ordering by ``run_id``
 ahead of ``version`` is race-proof: a superseded slower dispatch that happens to finish
 with a later ``version`` still loses to the newer dispatch's higher ``run_id``.
+
+``next_run_id`` is the write-side counterpart of that selection: it is what every scan-written
+row stamps to become the row these reads return.
 """
 
 from __future__ import annotations
@@ -19,6 +27,7 @@ from datetime import UTC
 from typing import TYPE_CHECKING
 
 from greenlight import clickhouse_client
+from greenlight.constants import STATUS_REVERTED
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -26,13 +35,16 @@ if TYPE_CHECKING:
 
     from clickhouse_connect.driver.client import Client
 
-__all__ = ["PRState", "naive_utc", "read_latest_states"]
+__all__ = ["PRState", "naive_utc", "next_run_id", "read_latest_states", "read_reverted_pr_numbers"]
 
 _QUERY = (
     "SELECT pr_number, status, eval_hash, head_sha, version, run_id FROM misc.greenlight_pr_state WHERE repo = %(repo)s"
 )
 _PR_FILTER = " AND pr_number IN %(pr_numbers)s"
 _ORDER_LIMIT = " ORDER BY pr_number, run_id DESC, version DESC LIMIT 1 BY pr_number"
+_REVERTED_QUERY = (
+    "SELECT DISTINCT pr_number FROM misc.greenlight_pr_state WHERE repo = %(repo)s AND status = %(status)s"
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -43,6 +55,16 @@ class PRState:
     head_sha: str
     version: datetime
     run_id: int
+
+
+def next_run_id(recorded: PRState | None) -> int:
+    """The ``run_id`` a scan-written row must carry to supersede ``recorded`` as the latest row.
+
+    One above the prior row's, so it wins the ``run_id DESC`` selection above; a PR with no prior
+    row has no prior run and so bases at 0, giving 1. The reviewer run's own ``github.run_id`` is
+    far higher and supersedes the scan's marker in turn once that run starts.
+    """
+    return (recorded.run_id if recorded is not None else 0) + 1
 
 
 def naive_utc(value: datetime) -> datetime:
@@ -90,3 +112,34 @@ def read_latest_states(
         )
         for row in result.named_results()
     }
+
+
+def read_reverted_pr_numbers(
+    repo: str,
+    pr_numbers: Sequence[int] | None = None,
+    *,
+    connect: Callable[[], Client] = clickhouse_client.connect,
+) -> set[int]:
+    """Return the PRs of ``repo`` that have ever recorded a ``REVERTED`` row.
+
+    Existence, not recency: a later ``AI_REVIEW_STARTED`` row carries the real
+    ``github.run_id`` and outranks any ``REVERTED`` row in ``read_latest_states``' selection,
+    so keying the permanent exclusion on the authoritative row would let it lapse.
+
+    ``pr_numbers`` is None to scan every PR for ``repo``, or a sequence to restrict the read
+    to those PRs. An empty sequence returns ``set()`` without a query. Query and connection
+    errors propagate; the connection is always closed.
+    """
+    if pr_numbers is not None and not pr_numbers:
+        return set()
+    query = _REVERTED_QUERY
+    params: dict[str, object] = {"repo": repo, "status": STATUS_REVERTED}
+    if pr_numbers is not None:
+        query += _PR_FILTER
+        params["pr_numbers"] = tuple(pr_numbers)
+    client = connect()
+    try:
+        result = client.query(query, parameters=params)
+    finally:
+        client.close()
+    return {int(row["pr_number"]) for row in result.named_results()}

--- a/greenlight/src/greenlight/state_emit.py
+++ b/greenlight/src/greenlight/state_emit.py
@@ -4,9 +4,11 @@ Two producers write state rows and MUST agree byte-for-byte on the JSONEachRow f
 order/values and the object-key layout, or the positional S3 -> ClickHouse replicator
 silently drops rows. This module is that single source: ``emit_row`` serializes the row and
 ``object_key`` computes its bucket-relative key. The ``verdict`` command feeds its rows
-through here; the scan calls ``emit_ai_review_dispatched`` the instant it fires the reviewer
-workflow, so a queued run (which can sit in GitHub's Actions queue well past a scan interval)
-is recorded as in-flight immediately and never re-dispatched while it waits.
+through here; the scan emits two marker rows of its own. ``emit_ai_review_dispatched`` fires
+the instant the reviewer workflow is dispatched, so a queued run (which can sit in GitHub's
+Actions queue well past a scan interval) is recorded as in-flight immediately and never
+re-dispatched while it waits. ``emit_reverted`` records that a PR is permanently out of
+review, so the exclusion outlives the ``Reverted`` label that triggered it.
 
 ``verdict`` writes the row to a fixed local path that its workflow ``aws s3 cp``s after a
 ``success()`` gate; the scan has no such gate, so its default ``upload`` puts the object to
@@ -22,12 +24,12 @@ import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Protocol, cast
 
-from greenlight.constants import S3_BUCKET, S3_KEY_PREFIX, STATUS_AI_REVIEW_DISPATCHED
+from greenlight.constants import S3_BUCKET, S3_KEY_PREFIX, STATUS_AI_REVIEW_DISPATCHED, STATUS_REVERTED
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-__all__ = ["default_emit_id", "emit_ai_review_dispatched", "emit_row", "object_key"]
+__all__ = ["default_emit_id", "emit_ai_review_dispatched", "emit_reverted", "emit_row", "object_key"]
 
 
 class _S3Putter(Protocol):
@@ -110,6 +112,34 @@ def _default_upload(row_gzip: bytes, key: str) -> None:
     _s3_client().put_object(Bucket=S3_BUCKET, Key=key, Body=row_gzip)
 
 
+def _emit_marker(
+    *,
+    repo: str,
+    pr_number: int,
+    head_sha: str,
+    status: str,
+    eval_hash: str,
+    run_id: int,
+    upload: Callable[[bytes, str], None] | None,
+) -> None:
+    """Emit one scan-written marker row: reason/message and the job URLs are always empty."""
+    emit_row(
+        repo=repo,
+        pr_number=pr_number,
+        head_sha=head_sha,
+        status=status,
+        reason="",
+        eval_hash=eval_hash,
+        message="",
+        eval_job="",
+        agent_job="",
+        run_id=run_id,
+        now=_utcnow,
+        emit=upload if upload is not None else _default_upload,
+        new_emit_id=default_emit_id,
+    )
+
+
 def emit_ai_review_dispatched(
     *,
     repo: str,
@@ -121,22 +151,41 @@ def emit_ai_review_dispatched(
 ) -> None:
     """Emit an ``AI_REVIEW_DISPATCHED`` row the instant the scan fires the reviewer workflow.
 
-    ``run_id`` is supplied by the caller (the scan computes the next run id); reason/message and
-    the job URLs are empty, matching the ``AI_REVIEW_STARTED`` marker. ``upload`` is an injectable
+    ``run_id`` is supplied by the caller (the scan computes the next run id); the empty
+    reason/message and job URLs match the ``AI_REVIEW_STARTED`` marker. ``upload`` is an injectable
     ``(gzip_bytes, key)`` seam for tests; the default puts the object via boto3.
     """
-    emit_row(
+    _emit_marker(
         repo=repo,
         pr_number=pr_number,
         head_sha=head_sha,
         status=STATUS_AI_REVIEW_DISPATCHED,
-        reason="",
         eval_hash=eval_hash,
-        message="",
-        eval_job="",
-        agent_job="",
         run_id=run_id,
-        now=_utcnow,
-        emit=upload if upload is not None else _default_upload,
-        new_emit_id=default_emit_id,
+        upload=upload,
+    )
+
+
+def emit_reverted(
+    *,
+    repo: str,
+    pr_number: int,
+    head_sha: str,
+    run_id: int,
+    upload: Callable[[bytes, str], None] | None = None,
+) -> None:
+    """Emit the ``REVERTED`` row that permanently excludes a PR from review.
+
+    ``eval_hash`` is empty: no fingerprint is computed for an excluded PR, and an empty hash can
+    never match one a land-time verifier recomputes. ``run_id`` and ``upload`` behave as for
+    ``emit_ai_review_dispatched``.
+    """
+    _emit_marker(
+        repo=repo,
+        pr_number=pr_number,
+        head_sha=head_sha,
+        status=STATUS_REVERTED,
+        eval_hash="",
+        run_id=run_id,
+        upload=upload,
     )

--- a/greenlight/tests/test_decision.py
+++ b/greenlight/tests/test_decision.py
@@ -127,3 +127,14 @@ def test_retry_past_timeout_dispatches_retry(status):
 
 def test_unknown_status_dispatches_unknown_status():
     assert _decide("SOMETHING_WEIRD", version=FRESH) == Outcome(Decision.DISPATCH, "unknown_status")
+
+
+def test_reverted_skips_reverted():
+    # REVERTED belongs to none of the status groupings, so without its own branch it would reach
+    # the unknown-status fallthrough and DISPATCH a reverted PR straight back into review.
+    assert _decide(constants.STATUS_REVERTED, version=FRESH) == Outcome(Decision.SKIP, "reverted")
+
+
+def test_reverted_skips_even_when_hash_changed():
+    # A push after the revert changes the fingerprint; the exclusion still holds.
+    assert _decide(constants.STATUS_REVERTED, latest=HASH_A, current=HASH_B) == Outcome(Decision.SKIP, "reverted")

--- a/greenlight/tests/test_lambda_handler.py
+++ b/greenlight/tests/test_lambda_handler.py
@@ -20,10 +20,11 @@ _TOKEN = "ghs_minted_installation_token"
 _SECRET_STORE = "greenlight/prod"
 _APP_ID = "123456"
 _INSTALLATION_ID = 42
+_APP_SLUG = "pytorchgreenlight"
 _EXPECTED_ARGV = ["review", "--ref", "main"]
 _EXPECTED_PERMISSIONS = {
     "actions": "write",
-    "pull_requests": "read",
+    "pull_requests": "write",
     "contents": "read",
     "members": "read",
 }
@@ -57,6 +58,7 @@ def fakes(monkeypatch):
         {},
         {"token": _TOKEN},
     )
+    fake_github.GithubIntegration.return_value.get_app.return_value.slug = _APP_SLUG
 
     monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
     # Ensure the real github module is in sys.modules before replacing it, so monkeypatch restores
@@ -91,8 +93,30 @@ def test_handler_happy_path(monkeypatch, fakes):
     )
     assert os.environ["PYTORCH_GREENLIGHT_GITHUB_TOKEN"] == _TOKEN
     assert os.environ["PYTORCH_GREENLIGHT_MAX_RUNTIME_SECONDS"] == "0"
+    # pull_requests is write, not read: the scan revokes greenlight's own approval on a reverted PR,
+    # and identifies it by the <slug>[bot] login resolved from GET /app on the same integration.
+    assert os.environ["BOT_LOGIN"] == f"{_APP_SLUG}[bot]"
+    fake_github.GithubIntegration.return_value.get_app.assert_called_once_with()
 
     main_mock.assert_called_once_with(_EXPECTED_ARGV)
+
+
+@pytest.mark.parametrize("slug", [pytest.param("", id="empty"), pytest.param(None, id="absent")])
+def test_handler_unusable_app_slug_raises(monkeypatch, fakes, slug):
+    _fake_boto3, fake_github = fakes
+    fake_github.GithubIntegration.return_value.get_app.return_value.slug = slug
+    main_mock = Mock()
+    monkeypatch.setattr(cli, "main", main_mock)
+
+    # An empty or missing slug yields a login that matches none of greenlight's reviews, so the
+    # dismissal would report success having revoked nothing. The scheduled path fails loudly here
+    # instead of handing the scan a login it cannot act on. None is the value PyGithub hands back
+    # for an absent slug, and it is the dangerous one: "None[bot]" is App-shaped.
+    with pytest.raises(ValueError, match="unusable app slug"):
+        lambda_handler.handler({}, object())
+
+    assert "BOT_LOGIN" not in os.environ
+    main_mock.assert_not_called()
 
 
 def test_handler_decodes_base64_pem(monkeypatch, fakes):

--- a/greenlight/tests/test_render_sync.py
+++ b/greenlight/tests/test_render_sync.py
@@ -126,6 +126,22 @@ def test_status_constants_match_python() -> None:
     )
 
 
+def test_every_status_is_branched_on_by_typescript() -> None:
+    source = _read(_TS_RENDER)
+    # A branched status names its constant at least once past the declaration line.
+    unwired = sorted(
+        name for name in _ts_statuses() if len(re.findall(rf"\bGREENLIGHT_STATUS_{re.escape(name)}\b", source)) < 2
+    )
+    assert not unwired, _drift(
+        _TS_RENDER,
+        _PY_CONSTANTS,
+        f"declared but never branched on: {unwired}. Declaring the constant is all "
+        f"test_status_constants_match_python asks for, so a status can satisfy it and still fall "
+        f'through renderGreenlightSection to "" -- which buildGreenlightSections drops, taking '
+        f"the whole GREEN LIGHT section out of the Dr. CI comment rather than showing the state.",
+    )
+
+
 _HEADLINES = {
     "GREENLIGHT_LAND_HEADLINE": comment_format.LAND_HEADLINE,
     "GREENLIGHT_NO_LAND_HEADLINE": comment_format.NO_LAND_HEADLINE,

--- a/greenlight/tests/test_revert_guard.py
+++ b/greenlight/tests/test_revert_guard.py
@@ -1,0 +1,382 @@
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import TYPE_CHECKING, NoReturn, cast
+
+import pytest
+
+from greenlight import revert_guard
+from greenlight.constants import STATUS_AI_REVIEW_STARTED, STATUS_LAND, STATUS_REVERTED, TARGET_REPO
+from greenlight.guards import IterationTimeout
+from greenlight.state import PRState
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from github import Github
+
+# Every seam below is faked, so the client is never inspected -- a bare sentinel is enough.
+_CLIENT = cast("Github", object())
+_BOT = "pytorchgreenlight[bot]"
+_VERSION = datetime(2026, 7, 31, 12, 0, 0)
+
+
+@dataclass(frozen=True)
+class _FakeHead:
+    sha: str
+
+
+@dataclass(frozen=True)
+class _FakePR:
+    number: int
+    head: _FakeHead
+
+
+def _state(number: int, status: str = STATUS_LAND, run_id: int = 0) -> PRState:
+    return PRState(
+        pr_number=number, status=status, eval_hash="a" * 64, head_sha=f"rec{number}", version=_VERSION, run_id=run_id
+    )
+
+
+@dataclass
+class _Guard:
+    excluded: frozenset[int]
+    failed: list[int] = field(default_factory=list)
+    label_fetches: list[int] = field(default_factory=list)
+    got_pr: list[int] = field(default_factory=list)
+    dismissals: list[tuple[int, str, str]] = field(default_factory=list)
+    emitted: list[tuple[str, int, str, int]] = field(default_factory=list)
+    poked: list[int] = field(default_factory=list)
+    events: list[str] = field(default_factory=list)
+    cancelled: bool = False
+
+
+def _exclude(
+    pr_numbers: Sequence[int],
+    *,
+    recorded: frozenset[int] = frozenset(),
+    known_labels: Mapping[int, Sequence[str]] | None = None,
+    fetched_labels: Mapping[int, Sequence[str]] | None = None,
+    states: Mapping[int, PRState] | None = None,
+    bot_login: str = _BOT,
+    dismissed_ids: Mapping[int, list[int]] | None = None,
+    dismiss_errors: Mapping[int, Exception] | None = None,
+    emit_errors: Mapping[int, Exception] | None = None,
+    get_pr_errors: Mapping[int, Exception] | None = None,
+) -> _Guard:
+    known_labels = {} if known_labels is None else known_labels
+    fetched_labels = {} if fetched_labels is None else fetched_labels
+    states = {} if states is None else states
+    dismissed_ids = {} if dismissed_ids is None else dismissed_ids
+    dismiss_errors = {} if dismiss_errors is None else dismiss_errors
+    emit_errors = {} if emit_errors is None else emit_errors
+    get_pr_errors = {} if get_pr_errors is None else get_pr_errors
+    result = _Guard(frozenset())
+    cancel_event = threading.Event()
+
+    def fake_read_reverted(_repo, numbers):
+        return {n for n in numbers if n in recorded}
+
+    def fake_fetch_labels(_client, _repo, number):
+        result.label_fetches.append(number)
+        return tuple(fetched_labels.get(number, ()))
+
+    def fake_get_pr(_client, _repo, number):
+        result.got_pr.append(number)
+        error = get_pr_errors.get(number)
+        if error is not None:
+            raise error
+        return _FakePR(number, _FakeHead(f"headsha{number}"))
+
+    def fake_dismiss(pr, *, bot_login, message):
+        result.dismissals.append((pr.number, bot_login, message))
+        result.events.append(f"dismiss:{pr.number}")
+        error = dismiss_errors.get(pr.number)
+        if error is not None:
+            raise error
+        return list(dismissed_ids.get(pr.number, ()))
+
+    def fake_emit(*, repo, pr_number, head_sha, run_id):
+        result.events.append(f"emit:{pr_number}")
+        error = emit_errors.get(pr_number)
+        if error is not None:
+            raise error
+        result.emitted.append((repo, pr_number, head_sha, run_id))
+
+    def fake_poke(number):
+        result.poked.append(number)
+        result.events.append(f"poke:{number}")
+
+    result.excluded = revert_guard.exclude_reverted(
+        _CLIENT,
+        pr_numbers,
+        known_labels=known_labels,
+        states=states,
+        bot_login=bot_login,
+        read_reverted=fake_read_reverted,
+        fetch_labels=fake_fetch_labels,
+        get_pr=fake_get_pr,
+        dismiss=fake_dismiss,
+        emit=fake_emit,
+        poke=fake_poke,
+        failed=result.failed,
+        cancel_event=cancel_event,
+    )
+    result.cancelled = cancel_event.is_set()
+    return result
+
+
+def test_fetch_pr_labels_reads_the_names_off_the_pr():
+    class _Label:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+    class _PR:
+        def __init__(self) -> None:
+            self.labels = [_Label("Reverted"), _Label("open source")]
+
+    class _Repo:
+        def get_pull(self, number: int) -> _PR:
+            asked.append(number)
+            return _PR()
+
+    class _Client:
+        def get_repo(self, full_name_or_id: str) -> _Repo:
+            asked.append(full_name_or_id)
+            return _Repo()
+
+    asked: list[object] = []
+
+    assert revert_guard.fetch_pr_labels(_Client(), TARGET_REPO, 7) == ("Reverted", "open source")
+    assert asked == [TARGET_REPO, 7]
+
+
+def test_clean_pr_is_not_excluded_and_nothing_is_touched():
+    guard = _exclude([1], known_labels={1: ("open source", "Merged")}, bot_login="")
+
+    # No reverted PR means no writes at all -- and no BOT_LOGIN demand either, so the ordinary
+    # listing scan is unaffected by a login it never needs.
+    assert guard.excluded == frozenset()
+    assert guard.got_pr == []
+    assert guard.dismissals == []
+    assert guard.emitted == []
+    assert guard.poked == []
+
+
+def test_label_excludes_dismisses_records_and_pokes():
+    guard = _exclude([1], known_labels={1: ("Reverted",)}, dismissed_ids={1: [901]})
+
+    assert guard.excluded == frozenset({1})
+    assert guard.dismissals == [(1, _BOT, revert_guard._DISMISS_MESSAGE)]
+    # head_sha comes from the PR read at dismissal time, and the first row for a PR with no prior
+    # state is run_id 1.
+    assert guard.emitted == [(TARGET_REPO, 1, "headsha1", 1)]
+    assert guard.poked == [1]
+    # The dismissal runs BEFORE the row: the row is what stops later scans retrying, so writing it
+    # after a failed dismissal would freeze a live approval on a reverted PR.
+    assert guard.events == ["dismiss:1", "emit:1", "poke:1"]
+
+
+@pytest.mark.parametrize("label", ["Reverted", "reverted", "REVERTED"])
+def test_reverted_label_matched_case_insensitively(label):
+    # Unlike Stale (matched exactly), a case variant of the revert label still excludes.
+    assert _exclude([1], known_labels={1: (label,)}).excluded == frozenset({1})
+
+
+def test_recorded_row_excludes_after_the_label_is_removed():
+    guard = _exclude([1], recorded=frozenset({1}), known_labels={1: ()}, dismissed_ids={1: [901]})
+
+    # The no-escape guarantee: taking the label off does not restore eligibility, because the row
+    # -- not the label -- is what the exclusion is keyed on from then on.
+    assert guard.excluded == frozenset({1})
+    assert guard.dismissals == [(1, _BOT, revert_guard._DISMISS_MESSAGE)]
+
+
+def test_winning_row_is_not_rewritten():
+    guard = _exclude(
+        [1], recorded=frozenset({1}), states={1: _state(1, STATUS_REVERTED, run_id=7)}, dismissed_ids={1: [901]}
+    )
+
+    # The row is written once; a settled exclusion re-run writes nothing further.
+    assert guard.emitted == []
+    assert guard.poked == [1]
+
+
+def test_outranked_row_is_rewritten_above_the_row_that_beat_it_and_then_settles():
+    first = _exclude([1], recorded=frozenset({1}), states={1: _state(1, STATUS_LAND, run_id=19283746)})
+
+    # A review still in flight when the revert landed posts its verdict at the real github.run_id,
+    # which outranks the REVERTED row written at prior+1 -- so Dr. CI would go on rendering LAND on a
+    # reverted PR. Recording again at one above it puts the exclusion back on top.
+    assert first.emitted == [(TARGET_REPO, 1, "headsha1", 19283747)]
+    assert first.poked == [1]
+
+    second = _exclude([1], recorded=frozenset({1}), states={1: _state(1, STATUS_REVERTED, run_id=19283747)})
+
+    # Bounded, because the rewrite is what makes the row win: the following scan writes nothing.
+    assert second.emitted == []
+    assert second.poked == []
+
+
+def test_settled_exclusion_does_not_poke_when_nothing_changed():
+    guard = _exclude([1], recorded=frozenset({1}), states={1: _state(1, STATUS_REVERTED)})
+
+    # Dr. CI already renders this PR's REVERTED row, so a rebuild is only worth requesting when an
+    # approval was actually revoked this pass.
+    assert guard.dismissals == [(1, _BOT, revert_guard._DISMISS_MESSAGE)]
+    assert guard.emitted == []
+    assert guard.poked == []
+
+
+@pytest.mark.parametrize(
+    ("recorded", "states"),
+    [
+        pytest.param(frozenset(), None, id="no-row-at-all"),
+        pytest.param(frozenset({1}), None, id="reverted-row-but-no-authoritative-state"),
+        pytest.param(frozenset(), {1: _state(1, STATUS_AI_REVIEW_STARTED)}, id="in-flight-review"),
+    ],
+)
+def test_dismissal_is_attempted_whatever_the_state_says(recorded, states):
+    # A missing row is never read as "no approval": the reviewer posts its approving review a step
+    # before it uploads the row, so a lost upload or replication lag leaves a live approval with
+    # nothing recorded.
+    guard = _exclude([1], recorded=recorded, known_labels={1: ("Reverted",)}, states=states)
+
+    assert guard.dismissals == [(1, _BOT, revert_guard._DISMISS_MESSAGE)]
+
+
+def test_row_supersedes_the_prior_row_by_run_id():
+    guard = _exclude([1], known_labels={1: ("Reverted",)}, states={1: _state(1, run_id=7)})
+
+    # Dr. CI renders a PR's latest row, so the exclusion must outrank the prior one.
+    assert guard.emitted == [(TARGET_REPO, 1, "headsha1", 8)]
+
+
+def test_failed_dismissal_writes_no_row_and_still_drops_the_pr(caplog):
+    with caplog.at_level(logging.ERROR, logger="greenlight"):
+        guard = _exclude([1], known_labels={1: ("Reverted",)}, dismiss_errors={1: RuntimeError("dismiss boom")})
+
+    # No row is written, so the next scan re-reads the label, finds no REVERTED row, and retries the
+    # dismissal. The PR is still dropped this pass -- an exclusion never lapses because a step failed.
+    assert guard.emitted == []
+    assert guard.poked == []
+    assert guard.failed == [1]
+    assert guard.excluded == frozenset({1})
+    assert "failed to revoke greenlight approval on reverted PR #1" in caplog.text
+    assert any(record.exc_info is not None for record in caplog.records)
+
+
+def test_failed_pr_read_is_handled_as_a_dismissal_failure(caplog):
+    with caplog.at_level(logging.ERROR, logger="greenlight"):
+        guard = _exclude([1], known_labels={1: ("Reverted",)}, get_pr_errors={1: RuntimeError("get_pr boom")})
+
+    assert guard.dismissals == []
+    assert guard.emitted == []
+    assert guard.failed == [1]
+    assert guard.excluded == frozenset({1})
+
+
+def test_failed_emit_records_the_failure_and_does_not_poke(caplog):
+    with caplog.at_level(logging.ERROR, logger="greenlight"):
+        guard = _exclude([1], known_labels={1: ("Reverted",)}, emit_errors={1: RuntimeError("emit boom")})
+
+    assert guard.emitted == []
+    assert guard.poked == []
+    assert guard.failed == [1]
+    assert guard.excluded == frozenset({1})
+    assert "failed to record REVERTED for PR #1" in caplog.text
+
+
+def test_rate_limited_dismissal_trips_the_cancel_event():
+    from github import RateLimitExceededException
+
+    guard = _exclude([1], known_labels={1: ("Reverted",)}, dismiss_errors={1: RateLimitExceededException(403)})
+
+    # Classified exactly as the fingerprint stage classifies it: the event gates the fan-out and the
+    # dispatch phase so neither runs on a throttled token.
+    assert guard.cancelled
+    assert guard.failed == [1]
+
+
+def test_non_rate_limit_dismissal_failure_leaves_the_cancel_event_clear():
+    guard = _exclude([1], known_labels={1: ("Reverted",)}, dismiss_errors={1: RuntimeError("dismiss boom")})
+
+    assert not guard.cancelled
+
+
+@pytest.mark.parametrize("stage", ["dismiss", "emit"])
+def test_iteration_timeout_propagates(stage):
+    errors = {1: IterationTimeout("iteration exceeded")}
+
+    # The soft per-iteration control signal is not a per-PR failure: it must halt the scan rather
+    # than be swallowed into `failed`.
+    with pytest.raises(IterationTimeout):
+        _exclude(
+            [1],
+            known_labels={1: ("Reverted",)},
+            dismiss_errors=errors if stage == "dismiss" else None,
+            emit_errors=errors if stage == "emit" else None,
+        )
+
+
+@pytest.mark.parametrize("bot_login", ["", "[bot]", "greenlight"])
+def test_non_app_bot_login_refuses_the_whole_scan(bot_login):
+    # Dismissal matches greenlight's own reviews by login, so a login that is not <slug>[bot]
+    # silently dismisses nothing while reporting success -- which would then let the row be written
+    # and suppress every retry.
+    with pytest.raises(ValueError, match="BOT_LOGIN must be the greenlight App login"):
+        _exclude([1], known_labels={1: ("Reverted",)}, bot_login=bot_login)
+
+
+def test_non_app_bot_login_refuses_before_any_write():
+    def boom(*_args: object, **_kwargs: object) -> NoReturn:
+        raise AssertionError("nothing may be written before the BOT_LOGIN check")
+
+    with pytest.raises(ValueError, match="BOT_LOGIN must be the greenlight App login"):
+        revert_guard.exclude_reverted(
+            _CLIENT,
+            [1],
+            known_labels={1: ("Reverted",)},
+            states={},
+            bot_login="",
+            read_reverted=lambda _repo, _numbers: set(),
+            fetch_labels=lambda _client, _repo, _number: (),
+            get_pr=boom,
+            dismiss=boom,
+            emit=boom,
+            poke=boom,
+            failed=[],
+            cancel_event=threading.Event(),
+        )
+
+
+def test_labels_are_only_fetched_for_prs_the_caller_has_none_for():
+    guard = _exclude([1, 2], known_labels={1: ("Reverted",)}, fetched_labels={2: ("Reverted",)})
+
+    # The listing scan gets labels free from the open-PR payload; only a PR absent from that map
+    # (the --pr path, which has no listing) costs an extra read.
+    assert guard.label_fetches == [2]
+    assert guard.excluded == frozenset({1, 2})
+
+
+def test_each_reverted_pr_is_acted_on_independently():
+    guard = _exclude(
+        [1, 2, 3],
+        known_labels={1: ("Reverted",), 2: (), 3: ("Reverted",)},
+        dismiss_errors={1: RuntimeError("dismiss boom")},
+    )
+
+    # PR1's failure isolates: PR3 is still dismissed and recorded, and clean PR2 is left alone.
+    assert guard.excluded == frozenset({1, 3})
+    assert guard.failed == [1]
+    assert guard.emitted == [(TARGET_REPO, 3, "headsha3", 1)]
+
+
+def test_no_candidates_returns_empty_without_reading_labels():
+    guard = _exclude([])
+
+    assert guard.excluded == frozenset()
+    assert guard.label_fetches == []

--- a/greenlight/tests/test_review.py
+++ b/greenlight/tests/test_review.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from greenlight import drci_poke, github_client, review, scan_runner, state_emit
+from greenlight import clickhouse_client, drci_poke, github_client, revert_guard, review, scan_runner, state_emit
 from greenlight.comment_format import RECHECK_REFUSAL_MARKER
 from greenlight.constants import (
     DEFAULT_DISPATCH_REF,
@@ -19,6 +19,7 @@ from greenlight.constants import (
     STATUS_CANCELLED,
     STATUS_FAILED,
     STATUS_LAND,
+    STATUS_REVERTED,
     TARGET_REPO,
 )
 from greenlight.github_client import OpenPR
@@ -70,6 +71,21 @@ def _boom_poke(repo: str, pr_number: int, poke_config: Config) -> NoReturn:
     raise AssertionError(f"poke should not be called for {repo}#{pr_number}")
 
 
+def _no_reverted(_repo: str, _numbers: Sequence[int]) -> set[int]:
+    return set()
+
+
+@dataclass(frozen=True)
+class _FakeHead:
+    sha: str
+
+
+@dataclass(frozen=True)
+class _FakePR:
+    number: int
+    head: _FakeHead
+
+
 def _state(number: int, status: str, eval_hash: str, version: datetime, run_id: int = 0) -> PRState:
     return PRState(
         pr_number=number, status=status, eval_hash=eval_hash, head_sha=f"rec{number}", version=version, run_id=run_id
@@ -97,6 +113,17 @@ def _no_real_drci_post(monkeypatch):
     monkeypatch.setattr(urllib3, "PoolManager", unreachable)
 
 
+@pytest.fixture(autouse=True)
+def _no_real_clickhouse_read(monkeypatch):
+    # Same guard for review.run's default read_reverted seam, which SELECTs from ClickHouse. That
+    # default and read_reverted_pr_numbers' own `connect` default are both bound at import, so the
+    # only interceptable layer is inside connect() itself. Every test injects its own read_reverted.
+    def unreachable() -> str:
+        raise AssertionError("a test reached the live ClickHouse endpoint")
+
+    monkeypatch.setattr(clickhouse_client, "_host_from_env", unreachable)
+
+
 @dataclass
 class _Scan:
     dispatched: list[tuple[int, str, str, str]]
@@ -111,6 +138,9 @@ class _Scan:
     emitted: list[tuple[str, int, str, str, int]]
     poked: list[tuple[str, int, Config]]
     events: list[str]
+    label_fetches: list[int]
+    dismissals: list[tuple[int, str, str]]
+    reverted_emitted: list[tuple[str, int, str, int]]
 
 
 def _run_scan(
@@ -131,8 +161,15 @@ def _run_scan(
     author: str | None = "albanD",
     bot_login: str = "",
     config_kwargs: dict[str, object] | None = None,
+    reverted: frozenset[int] = frozenset(),
+    fetched_labels: dict[int, tuple[str, ...]] | None = None,
+    dismissed_ids: dict[int, list[int]] | None = None,
+    dismiss_errors: dict[int, Exception] | None = None,
 ) -> _Scan:
     states = states or {}
+    fetched_labels = fetched_labels or {}
+    dismissed_ids = dismissed_ids or {}
+    dismiss_errors = dismiss_errors or {}
     dispatched: list[tuple[int, str, str, str]] = []
     read_calls: list[tuple[str, list[int]]] = []
     fingerprinted: list[int] = []
@@ -145,6 +182,9 @@ def _run_scan(
     emitted: list[tuple[str, int, str, str, int]] = []
     poked: list[tuple[str, int, Config]] = []
     events: list[str] = []
+    label_fetches: list[int] = []
+    dismissals: list[tuple[int, str, str]] = []
+    reverted_emitted: list[tuple[str, int, str, int]] = []
 
     def fake_fetch(_client):
         listed_calls.append(1)
@@ -174,11 +214,12 @@ def _run_scan(
         return author
 
     def fake_get_pr(_client, _repo, number):
-        # The comment upsert is faked, so the "PR" object need only carry its number back.
-        return number
+        # The comment upsert and the review dismissal are both faked, so the "PR" object need only
+        # carry back its number and the head_sha the reverted-PR row is written from.
+        return _FakePR(number, _FakeHead(f"headsha{number}"))
 
     def fake_upsert(pr, *, marker, body, author_login, run_id=None):
-        refusals.append((pr, marker, body, author_login))
+        refusals.append((pr.number, marker, body, author_login))
 
     def fake_emit(*, repo, pr_number, head_sha, eval_hash, run_id):
         emitted.append((repo, pr_number, head_sha, eval_hash, run_id))
@@ -187,6 +228,25 @@ def _run_scan(
     def fake_poke(repo, pr_number, poke_config):
         poked.append((repo, pr_number, poke_config))
         events.append(f"poke:{pr_number}")
+
+    def fake_read_reverted(_repo, numbers):
+        return {n for n in numbers if n in reverted}
+
+    def fake_fetch_labels(_client, _repo, number):
+        label_fetches.append(number)
+        return fetched_labels.get(number, ())
+
+    def fake_dismiss(pr, *, bot_login, message):
+        dismissals.append((pr.number, bot_login, message))
+        events.append(f"dismiss:{pr.number}")
+        error = dismiss_errors.get(pr.number)
+        if error is not None:
+            raise error
+        return list(dismissed_ids.get(pr.number, ()))
+
+    def fake_emit_reverted(*, repo, pr_number, head_sha, run_id):
+        reverted_emitted.append((repo, pr_number, head_sha, run_id))
+        events.append(f"emit_reverted:{pr_number}")
 
     review.run(
         make_config(github_token="t", **(config_kwargs or {})),
@@ -201,12 +261,16 @@ def _run_scan(
         build_github=lambda _token, **_kwargs: _CLIENT,
         fetch=fake_fetch,
         fetch_author=fake_fetch_author,
+        fetch_labels=fake_fetch_labels,
         fingerprint=fake_fingerprint,
         read_state=fake_read_state,
+        read_reverted=fake_read_reverted,
         dispatch=fake_dispatch,
         emit_dispatched=fake_emit,
+        emit_reverted=fake_emit_reverted,
         poke_drci=fake_poke,
         get_pr=fake_get_pr,
+        dismiss_approvals=fake_dismiss,
         upsert_comment=fake_upsert,
         resolve_authorized=fake_resolve_authorized,
         now=lambda: now,
@@ -224,6 +288,9 @@ def _run_scan(
         emitted,
         poked,
         events,
+        label_fetches,
+        dismissals,
+        reverted_emitted,
     )
 
 
@@ -585,6 +652,112 @@ def test_stale_label_pr_target_is_exempt(make_config):
     assert scan.dispatched == [(5, "headsha5", _HASH_A, DEFAULT_DISPATCH_REF)]
 
 
+def test_reverted_label_drops_pr_before_fingerprinting(make_config, caplog):
+    with caplog.at_level(logging.INFO, logger="greenlight"):
+        scan = _run_scan(
+            make_config,
+            listed=[_open_pr(1, updated_at=_NEW, labels=("Reverted",)), _open_pr(2, updated_at=_NEW)],
+            fingerprints={1: ("headsha1", _HASH_A), 2: ("headsha2", _HASH_A)},
+            bot_login="greenlight-app[bot]",
+            dismissed_ids={1: [901]},
+        )
+
+    # The reverted PR is dropped before the fingerprint stage -- its approval revoked, its exclusion
+    # recorded, Dr. CI poked -- while the healthy PR2 in the same batch is unaffected.
+    assert scan.fingerprinted == [2]
+    assert [number for number, *_ in scan.dispatched] == [2]
+    assert scan.dismissals == [(1, "greenlight-app[bot]", revert_guard._DISMISS_MESSAGE)]
+    assert scan.reverted_emitted == [(TARGET_REPO, 1, "headsha1", 1)]
+    assert 1 in [pr_number for _repo, pr_number, _config in scan.poked]
+    assert "excluding 1 reverted PR(s) from review: [1]" in caplog.text
+
+
+def test_reverted_row_still_excludes_after_the_label_is_removed(make_config):
+    scan = _run_scan(
+        make_config,
+        listed=[_open_pr(1, updated_at=_NEW)],
+        fingerprints={1: ("headsha1", _HASH_A)},
+        states={1: _state(1, STATUS_REVERTED, _HASH_A, _NEW, run_id=3)},
+        reverted=frozenset({1}),
+        bot_login="greenlight-app[bot]",
+    )
+
+    # The no-escape guarantee: with the label gone the recorded row alone keeps the PR out, and the
+    # settled exclusion is not rewritten.
+    assert scan.fingerprinted == []
+    assert scan.dispatched == []
+    assert scan.reverted_emitted == []
+    assert scan.poked == []
+
+
+def test_reverted_pr_target_is_not_exempt_and_is_dropped_silently(make_config):
+    scan = _run_scan(
+        make_config,
+        pr=5,
+        fingerprints={5: ("headsha5", _HASH_A)},
+        fetched_labels={5: ("Reverted",)},
+        bot_login="greenlight-app[bot]",
+    )
+
+    # Unlike Stale, a revert is not waived by an explicit recheck. The --pr path has no listing to
+    # read labels from, so it fetches them for its one target; the PR is then dropped with no
+    # refusal comment -- the recheck is simply a no-op.
+    assert scan.label_fetches == [5]
+    assert scan.fingerprinted == []
+    assert scan.dispatched == []
+    assert scan.refusals == []
+    assert scan.reverted_emitted == [(TARGET_REPO, 5, "headsha5", 1)]
+
+
+def test_reverted_dismissal_failure_fails_the_scan_and_writes_no_row(make_config, caplog):
+    with (
+        caplog.at_level(logging.ERROR, logger="greenlight"),
+        pytest.raises(RuntimeError, match=r"1 PR\(s\) failed during scan: \[1\]"),
+    ):
+        _run_scan(
+            make_config,
+            listed=[_open_pr(1, updated_at=_NEW, labels=("Reverted",))],
+            fingerprints={1: ("headsha1", _HASH_A)},
+            bot_login="greenlight-app[bot]",
+            dismiss_errors={1: RuntimeError("dismiss boom")},
+        )
+
+    # No row is written, so the next scan retries the dismissal; the scan still fails closed.
+    assert "failed to revoke greenlight approval on reverted PR #1" in caplog.text
+
+
+def test_reverted_rate_limit_defers_the_fanout_and_the_dispatch_phase(make_config, caplog):
+    from github import RateLimitExceededException
+
+    with caplog.at_level(logging.WARNING, logger="greenlight"), pytest.raises(RuntimeError) as excinfo:
+        _run_scan(
+            make_config,
+            listed=[_open_pr(1, updated_at=_NEW, labels=("Reverted",)), _open_pr(2, updated_at=_NEW)],
+            fingerprints={2: ("headsha2", _HASH_A)},
+            bot_login="greenlight-app[bot]",
+            dismiss_errors={1: RateLimitExceededException(403)},
+        )
+
+    # A rate limit here is classified exactly as one in the fingerprint stage: it trips the same
+    # shared cancel event, so PR2 is abandoned unfingerprinted and the dispatch phase is skipped.
+    message = str(excinfo.value)
+    assert "1 PR(s) failed during scan: [1]" in message
+    assert "1 PR(s) abandoned due to rate limit: [2]" in message
+    assert "abandoned 1 of 1" in caplog.text
+
+
+def test_reverted_without_app_bot_login_raises(make_config):
+    # BOT_LOGIN is load-bearing for the dismissal, so the scheduled path fails loudly rather than
+    # "dismissing" nothing and then recording an exclusion that suppresses every retry.
+    with pytest.raises(ValueError, match="BOT_LOGIN must be the greenlight App login"):
+        _run_scan(
+            make_config,
+            listed=[_open_pr(1, updated_at=_NEW, labels=("Reverted",))],
+            fingerprints={1: ("headsha1", _HASH_A)},
+            bot_login="",
+        )
+
+
 def test_max_caps_only_dispatches(make_config):
     scan = _run_scan(
         make_config,
@@ -697,6 +870,7 @@ def test_max_fingerprint_failure_still_raises(make_config, caplog):
             fetch=lambda _client: [_open_pr(n) for n in numbers],
             fingerprint=boom_fingerprint,
             read_state=lambda _repo, _numbers: {},
+            read_reverted=_no_reverted,
             dispatch=fake_dispatch,
             resolve_authorized=lambda: _AUTHORIZED,
             now=lambda: _NOW,
@@ -934,8 +1108,10 @@ def test_force_fingerprint_failure_still_raises(make_config, caplog):
             build_github=lambda _token, **_kwargs: _CLIENT,
             fetch=lambda _client: [],
             fetch_author=lambda _client, _number: "albanD",
+            fetch_labels=lambda _client, _repo, _number: (),
             fingerprint=boom_fingerprint,
             read_state=lambda _repo, _numbers: {},
+            read_reverted=_no_reverted,
             dispatch=fake_dispatch,
             resolve_authorized=lambda: _AUTHORIZED,
             now=lambda: _NOW,
@@ -1034,6 +1210,7 @@ def test_poison_pill_isolates_pr_but_scan_still_raises(make_config, caplog):
             fetch=lambda _client: [_open_pr(1), _open_pr(2), _open_pr(3)],
             fingerprint=boom_fingerprint,
             read_state=lambda _repo, _numbers: {2: _state(2, STATUS_LAND, _HASH_A, _NEW)},
+            read_reverted=_no_reverted,
             dispatch=fake_dispatch,
             resolve_authorized=lambda: _AUTHORIZED,
             now=lambda: _NOW,
@@ -1068,6 +1245,7 @@ def test_concurrent_fingerprint_failures_aggregate_sorted(make_config, caplog):
             fetch=lambda _client: [_open_pr(3), _open_pr(1), _open_pr(2)],
             fingerprint=boom_fingerprint,
             read_state=lambda _repo, _numbers: {},
+            read_reverted=_no_reverted,
             dispatch=fake_dispatch,
             resolve_authorized=lambda: _AUTHORIZED,
             now=lambda: _NOW,
@@ -1099,6 +1277,7 @@ def test_dispatch_failure_isolated_others_still_dispatched(make_config, caplog):
             fetch=lambda _client: [_open_pr(1), _open_pr(2), _open_pr(3)],
             fingerprint=lambda _client, number, _authorized, _skip: (f"headsha{number}", _HASH_A),
             read_state=lambda _repo, _numbers: {},
+            read_reverted=_no_reverted,
             dispatch=boom_dispatch,
             resolve_authorized=lambda: _AUTHORIZED,
             now=lambda: _NOW,
@@ -1128,6 +1307,7 @@ def test_all_dispatch_failures_all_attempted_then_raise(make_config, caplog):
             fetch=lambda _client: [_open_pr(1), _open_pr(2), _open_pr(3)],
             fingerprint=lambda _client, number, _authorized, _skip: (f"headsha{number}", _HASH_A),
             read_state=lambda _repo, _numbers: {},
+            read_reverted=_no_reverted,
             dispatch=boom_dispatch,
             resolve_authorized=lambda: _AUTHORIZED,
             now=lambda: _NOW,
@@ -1153,6 +1333,7 @@ def test_dispatch_iteration_timeout_propagates_and_halts(make_config):
             fetch=lambda _client: [_open_pr(1), _open_pr(2), _open_pr(3)],
             fingerprint=lambda _client, number, _authorized, _skip: (f"headsha{number}", _HASH_A),
             read_state=lambda _repo, _numbers: {},
+            read_reverted=_no_reverted,
             dispatch=timeout_dispatch,
             resolve_authorized=lambda: _AUTHORIZED,
             now=lambda: _NOW,
@@ -1184,6 +1365,7 @@ def test_fingerprint_and_dispatch_failures_surface_together(make_config, caplog)
             fetch=lambda _client: [_open_pr(1), _open_pr(2), _open_pr(3)],
             fingerprint=boom_fingerprint,
             read_state=lambda _repo, _numbers: {},
+            read_reverted=_no_reverted,
             dispatch=boom_dispatch,
             resolve_authorized=lambda: _AUTHORIZED,
             now=lambda: _NOW,
@@ -1232,6 +1414,7 @@ def test_fingerprints_run_concurrently_across_workers(make_config):
         fetch=lambda _client: [_open_pr(n) for n in numbers],
         fingerprint=barrier_fingerprint,
         read_state=lambda _repo, _numbers: {},
+        read_reverted=_no_reverted,
         dispatch=fake_dispatch,
         resolve_authorized=lambda: _AUTHORIZED,
         now=lambda: _NOW,
@@ -1274,6 +1457,7 @@ def test_worker_clients_are_isolated_and_exclude_main_client(make_config):
         fetch=lambda _client: [_open_pr(n) for n in numbers],
         fingerprint=recording_fingerprint,
         read_state=lambda _repo, _numbers: {},
+        read_reverted=_no_reverted,
         dispatch=fake_dispatch,
         resolve_authorized=lambda: _AUTHORIZED,
         now=lambda: _NOW,
@@ -1313,6 +1497,7 @@ def test_run_closes_main_and_worker_clients(make_config):
         fetch=lambda _client: [_open_pr(1), _open_pr(2)],
         fingerprint=lambda _client, number, _authorized, _skip: (f"headsha{number}", _HASH_A),
         read_state=lambda _repo, _numbers: {},
+        read_reverted=_no_reverted,
         dispatch=lambda *_args: None,
         resolve_authorized=lambda: _AUTHORIZED,
         now=lambda: _NOW,
@@ -1395,6 +1580,7 @@ def test_rate_limit_abandons_remaining_fingerprints(make_config, monkeypatch, ca
             fetch=lambda _client: [_open_pr(1), _open_pr(2), _open_pr(3)],
             fingerprint=fingerprint,
             read_state=lambda _repo, _numbers: {},
+            read_reverted=_no_reverted,
             dispatch=fake_dispatch,
             resolve_authorized=lambda: _AUTHORIZED,
             now=lambda: _NOW,
@@ -1437,6 +1623,7 @@ def test_rate_limit_defers_completed_candidate_without_dispatching(make_config, 
             fetch=lambda _client: [_open_pr(1), _open_pr(2), _open_pr(3)],
             fingerprint=fingerprint,
             read_state=lambda _repo, _numbers: {},
+            read_reverted=_no_reverted,
             dispatch=fake_dispatch,
             poke_drci=_boom_poke,
             resolve_authorized=lambda: _AUTHORIZED,
@@ -1486,6 +1673,7 @@ def test_rate_limit_on_last_task_skips_dispatch_with_no_abandoned(make_config, m
             fetch=lambda _client: [_open_pr(1), _open_pr(2), _open_pr(3)],
             fingerprint=fingerprint,
             read_state=lambda _repo, _numbers: {},
+            read_reverted=_no_reverted,
             dispatch=fake_dispatch,
             resolve_authorized=lambda: _AUTHORIZED,
             now=lambda: _NOW,
@@ -1527,6 +1715,7 @@ def test_rate_limit_abandonment_breaks_max_dispatch_batches(make_config, monkeyp
             fetch=lambda _client: [_open_pr(1), _open_pr(2), _open_pr(3)],
             fingerprint=fingerprint,
             read_state=lambda _repo, _numbers: {},
+            read_reverted=_no_reverted,
             dispatch=fake_dispatch,
             resolve_authorized=lambda: _AUTHORIZED,
             now=lambda: _NOW,
@@ -1561,6 +1750,7 @@ def test_normal_scan_dispatches_when_not_rate_limited(make_config, monkeypatch, 
             fetch=lambda _client: [_open_pr(1), _open_pr(2), _open_pr(3)],
             fingerprint=fingerprint,
             read_state=lambda _repo, _numbers: {},
+            read_reverted=_no_reverted,
             dispatch=fake_dispatch,
             resolve_authorized=lambda: _AUTHORIZED,
             now=lambda: _NOW,
@@ -1585,6 +1775,7 @@ def test_fetch_failure_still_closes_main_client(make_config):
             fetch=boom_fetch,
             fingerprint=lambda _client, number, _authorized, _skip: (f"headsha{number}", _HASH_A),
             read_state=lambda _repo, _numbers: {},
+            read_reverted=_no_reverted,
             dispatch=lambda *_args: None,
             resolve_authorized=lambda: _AUTHORIZED,
             now=lambda: _NOW,
@@ -1658,6 +1849,7 @@ def test_run_cold_authorized_failure_propagates(make_config):
             fetch=lambda _client: [_open_pr(1)],
             fingerprint=lambda _client, number, _authorized, _skip: (f"headsha{number}", _HASH_A),
             read_state=lambda _repo, _numbers: {},
+            read_reverted=_no_reverted,
             dispatch=lambda *_args: None,
             resolve_authorized=boom_resolve,
             now=lambda: _NOW,

--- a/greenlight/tests/test_state.py
+++ b/greenlight/tests/test_state.py
@@ -207,6 +207,99 @@ def test_query_error_propagates_and_closes_connection():
     assert client.closed == 1
 
 
+def test_reverted_query_asks_for_existence_not_the_authoritative_row():
+    client = _FakeClient([])
+    connect, _ = _connect_seam(client)
+
+    state.read_reverted_pr_numbers(_REPO, connect=connect)
+
+    query, params = client.queries[0]
+    # Existence, not recency: a later AI_REVIEW_STARTED row outranks a REVERTED one in
+    # read_latest_states' selection, so this read must carry none of that ordering/limit.
+    assert "SELECT DISTINCT pr_number" in query
+    assert "status = %(status)s" in query
+    assert "ORDER BY" not in query
+    assert "LIMIT" not in query
+    assert "pr_number IN" not in query
+    assert params == {"repo": _REPO, "status": "REVERTED"}
+
+
+def test_reverted_pr_filter_and_tuple_param_applied_only_when_pr_numbers_given():
+    client = _FakeClient([])
+    connect, _ = _connect_seam(client)
+
+    state.read_reverted_pr_numbers(_REPO, [7, 9], connect=connect)
+
+    query, params = client.queries[0]
+    assert "pr_number IN %(pr_numbers)s" in query
+    assert params == {"repo": _REPO, "status": "REVERTED", "pr_numbers": (7, 9)}
+
+
+def test_reverted_rows_map_to_a_set_of_ints():
+    client = _FakeClient([{"pr_number": 7}, {"pr_number": "9"}])
+    connect, _ = _connect_seam(client)
+
+    assert state.read_reverted_pr_numbers(_REPO, [7, 9], connect=connect) == {7, 9}
+
+
+def test_reverted_empty_rows_returns_empty_set():
+    client = _FakeClient([])
+    connect, _ = _connect_seam(client)
+
+    assert state.read_reverted_pr_numbers(_REPO, [7], connect=connect) == set()
+
+
+def test_reverted_empty_pr_numbers_returns_empty_set_without_connecting():
+    client = _FakeClient([{"pr_number": 7}])
+    connect, calls = _connect_seam(client)
+
+    assert state.read_reverted_pr_numbers(_REPO, [], connect=connect) == set()
+    assert calls["count"] == 0
+    assert client.queries == []
+
+
+def test_reverted_connection_is_closed_after_read():
+    client = _FakeClient([])
+    connect, _ = _connect_seam(client)
+
+    state.read_reverted_pr_numbers(_REPO, [7], connect=connect)
+
+    assert client.closed == 1
+
+
+def test_reverted_query_error_propagates_and_closes_connection():
+    client = _RaisingClient([])
+    connect, _ = _connect_seam(client)
+
+    # The read gates a permanent exclusion, so a failed query must fail the scan rather than
+    # silently read as "nothing was ever reverted".
+    with pytest.raises(RuntimeError, match="query boom"):
+        state.read_reverted_pr_numbers(_REPO, [7], connect=connect)
+
+    assert client.closed == 1
+
+
+@pytest.mark.parametrize(
+    ("recorded", "expected"),
+    [
+        pytest.param(None, 1, id="never-reviewed-bases-at-zero"),
+        pytest.param(0, 1, id="legacy-zero-run-id"),
+        pytest.param(4, 5, id="supersedes-prior-row"),
+        pytest.param(19283746, 19283747, id="supersedes-a-real-github-run-id"),
+    ],
+)
+def test_next_run_id_is_one_above_the_prior_row(recorded, expected):
+    # The write-side counterpart of the ORDER BY run_id DESC selection: one above the prior row is
+    # what makes a scan-written row the one read_latest_states returns.
+    prior = (
+        None
+        if recorded is None
+        else PRState(pr_number=1, status="LAND", eval_hash="a" * 64, head_sha="sha", version=_V1, run_id=recorded)
+    )
+
+    assert state.next_run_id(prior) == expected
+
+
 def test_prstate_is_frozen():
     st = PRState(pr_number=1, status="LAND", eval_hash="a" * 64, head_sha="sha", version=_V1, run_id=3)
 

--- a/greenlight/tests/test_state_emit.py
+++ b/greenlight/tests/test_state_emit.py
@@ -166,6 +166,40 @@ def test_two_dispatched_emits_get_distinct_emit_ids():
     assert all(_EMIT_ID_RE.fullmatch(value) for value in ids)
 
 
+def test_emit_reverted_builds_row_with_empty_eval_hash(monkeypatch):
+    monkeypatch.setattr(state_emit, "_utcnow", lambda: _FIXED)
+    cap = _Capture()
+
+    state_emit.emit_reverted(repo="pytorch/pytorch", pr_number=42, head_sha="deadbeef", run_id=4, upload=cap)
+
+    row = cap.decoded()
+    assert cap.key == state_emit.object_key("pytorch/pytorch", 42, _VERSION, str(row["emit_id"]))
+    assert list(row.keys()) == _ROW_KEYS
+    assert row["status"] == constants.STATUS_REVERTED == "REVERTED"
+    assert row["repo"] == "pytorch/pytorch"
+    assert row["pr_number"] == 42
+    assert row["head_sha"] == "deadbeef"
+    assert row["run_id"] == 4
+    # No fingerprint is computed for an excluded PR, and an empty hash can never match one a
+    # land-time verifier recomputes.
+    assert row["eval_hash"] == ""
+    assert row["reason"] == ""
+    assert row["message"] == ""
+    assert row["eval_job"] == ""
+    assert row["agent_job"] == ""
+
+
+def test_emit_reverted_defaults_to_boto3_upload(monkeypatch):
+    cap = _Capture()
+    monkeypatch.setattr(state_emit, "_default_upload", cap)
+
+    state_emit.emit_reverted(repo="o/r", pr_number=1, head_sha="h", run_id=2)
+
+    assert cap.key is not None
+    assert cap.key.startswith("greenlight_pr_state/o/r/1/")
+    assert cap.decoded()["status"] == constants.STATUS_REVERTED
+
+
 def test_emit_ai_review_dispatched_defaults_to_boto3_upload(monkeypatch):
     # With no upload seam, the default boto3 uploader is used.
     cap = _Capture()

--- a/torchci/lib/greenlight/greenlightRender.ts
+++ b/torchci/lib/greenlight/greenlightRender.ts
@@ -31,8 +31,11 @@ export const GREENLIGHT_INCOMPLETE_HEADLINE =
 export const GREENLIGHT_REVERTED_HEADLINE =
   "PR was reverted - re-landing requires human review";
 export const GREENLIGHT_REVIEWING_BODY = "Green Light is reviewing this PR.";
+// Says only what the row itself establishes. The row is recorded for every reverted
+// candidate, including one Green Light never approved and one whose revocation
+// failed, so a body claiming the approval was dismissed would be wrong on both.
 export const GREENLIGHT_REVERTED_BODY =
-  "Green Light dismissed its approval and will not review this PR again, on this or any later commit; re-landing it needs a human approval.";
+  "Green Light will not review this PR again, on this or any later commit; re-landing it needs a human approval.";
 
 // Leads the summary line whenever the verdict was reached on a commit that is no
 // longer the PR's head. The scan writes no new row once a human has decided,

--- a/torchci/lib/greenlight/greenlightRender.ts
+++ b/torchci/lib/greenlight/greenlightRender.ts
@@ -20,6 +20,7 @@ export const GREENLIGHT_STATUS_AI_REVIEW_STARTED = "AI_REVIEW_STARTED";
 export const GREENLIGHT_STATUS_AI_REVIEW_DISPATCHED = "AI_REVIEW_DISPATCHED";
 export const GREENLIGHT_STATUS_CANCELLED = "CANCELLED";
 export const GREENLIGHT_STATUS_FAILED = "FAILED";
+export const GREENLIGHT_STATUS_REVERTED = "REVERTED";
 
 export const GREENLIGHT_LAND_HEADLINE =
   "PR approved to be merged without human review";
@@ -27,7 +28,11 @@ export const GREENLIGHT_NO_LAND_HEADLINE = "PR requires human review";
 export const GREENLIGHT_REVIEWING_HEADLINE = "Green Light review in progress";
 export const GREENLIGHT_INCOMPLETE_HEADLINE =
   "Green Light review did not complete";
+export const GREENLIGHT_REVERTED_HEADLINE =
+  "PR was reverted - re-landing requires human review";
 export const GREENLIGHT_REVIEWING_BODY = "Green Light is reviewing this PR.";
+export const GREENLIGHT_REVERTED_BODY =
+  "Green Light dismissed its approval and will not review this PR again, on this or any later commit; re-landing it needs a human approval.";
 
 // Leads the summary line whenever the verdict was reached on a commit that is no
 // longer the PR's head. The scan writes no new row once a human has decided,
@@ -322,6 +327,21 @@ export function renderGreenlightSection(
       evalJob,
       false,
       outdated
+    );
+  }
+
+  // A revert excludes the PR outright rather than judging one commit: it holds
+  // for the current head and every later one, and the row carries no reason,
+  // message or job of its own. Both the outdated marker and the reviewed-commit
+  // line would frame it as superseded by the next push, which is the one reading
+  // that leaves an author waiting on a re-review that never comes.
+  if (status === GREENLIGHT_STATUS_REVERTED) {
+    return renderSection(
+      GREENLIGHT_REVERTED_HEADLINE,
+      [GREENLIGHT_REVERTED_BODY],
+      evalJob,
+      false,
+      false
     );
   }
 

--- a/torchci/test/greenlightRender.test.ts
+++ b/torchci/test/greenlightRender.test.ts
@@ -8,6 +8,8 @@ import {
   GREENLIGHT_NO_LAND_HEADLINE,
   GREENLIGHT_OUTDATED_HEADLINE_PREFIX,
   GREENLIGHT_PENDING_ALT_ATTR,
+  GREENLIGHT_REVERTED_BODY,
+  GREENLIGHT_REVERTED_HEADLINE,
   GREENLIGHT_REVIEWING_HEADLINE,
   GreenlightState,
   INLINE_BREAKERS_RE,
@@ -398,6 +400,23 @@ describe("renderGreenlightSection statuses", () => {
     expect(failed).toContain("reason: `failed`");
   });
 
+  // The scan writes this row with no reason, message or job of its own, so the
+  // blank-field handling the retry statuses get applies here too: a rendered
+  // `reason: ``` or an empty fence would be noise the reader has to expand to.
+  it("renders REVERTED with its own headline and body, and no blank fields", () => {
+    const out = render(
+      state({ status: "REVERTED", reason: "", message: "", evalJob: "" }),
+      FRESH_NOW
+    );
+
+    expect(summaryLine(out)).toContain(GREENLIGHT_REVERTED_HEADLINE);
+    expect(out).toContain(GREENLIGHT_REVERTED_BODY);
+    expect(out).not.toContain(GREENLIGHT_LAND_HEADLINE);
+    expect(out).not.toContain(GREENLIGHT_INCOMPLETE_HEADLINE);
+    expect(out).not.toContain("reason:");
+    expect(out).not.toContain("```");
+  });
+
   it("returns empty for statuses it cannot render", () => {
     expect(render(state({ status: "" }), FRESH_NOW)).toBe("");
     expect(render(state({ status: "SOMETHING_NEW" }), FRESH_NOW)).toBe("");
@@ -543,7 +562,7 @@ describe("renderGreenlightSection pending sentinel", () => {
         GREENLIGHT_PENDING_ALT_ATTR
       );
     }
-    for (const status of ["LAND", "NO_LAND", "CANCELLED", "FAILED"]) {
+    for (const status of [...TERMINAL_STATUSES, "REVERTED"]) {
       expect(render(state({ status }), FRESH_NOW)).not.toContain(
         GREENLIGHT_PENDING_ALT_ATTR
       );
@@ -814,6 +833,24 @@ describe("renderGreenlightSection outdated verdict", () => {
     expect(summaryLine(out)).toContain(
       `${GREENLIGHT_OUTDATED_HEADLINE_PREFIX}${GREENLIGHT_LAND_HEADLINE}`
     );
+  });
+
+  // The one status the marker must never reach. A revert stands whatever is
+  // pushed next, so calling it outdated once the author fixes the PR reads as an
+  // invitation to wait for the re-review that greenlight will never run -- and
+  // the reviewed-commit line, which says the same thing in longer form below the
+  // fold, has to go with it.
+  it("never marks REVERTED outdated, however far the head has moved on", () => {
+    const out = renderGreenlightSection(
+      state({ status: "REVERTED" }),
+      FRESH_NOW,
+      OTHER_SHA
+    );
+
+    expect(out).toContain(GREENLIGHT_REVERTED_HEADLINE);
+    expect(out).not.toContain(GREENLIGHT_OUTDATED_HEADLINE_PREFIX);
+    expect(out).not.toContain("Reviewed commit:");
+    expect(out).not.toContain("NOT the current head");
   });
 
   it("leaves a verdict on the current head unmarked", () => {

--- a/torchci/test/greenlightRender.test.ts
+++ b/torchci/test/greenlightRender.test.ts
@@ -415,6 +415,9 @@ describe("renderGreenlightSection statuses", () => {
     expect(out).not.toContain(GREENLIGHT_INCOMPLETE_HEADLINE);
     expect(out).not.toContain("reason:");
     expect(out).not.toContain("```");
+    // The row says nothing about a dismissal having happened, and is written for
+    // PRs Green Light never approved, so the body may not assert one.
+    expect(GREENLIGHT_REVERTED_BODY).not.toMatch(/dismiss/i);
   });
 
   it("returns empty for statuses it cannot render", () => {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #8669
* #8668
* #8667

**Impact:** pytorch/pytorch PRs from trusted authors that have been reverted
**Risk:** medium

## What
A PR that carries the `Reverted` label, or has ever recorded a `REVERTED` row, is
dropped from review permanently. On each scan greenlight dismisses its own approving
review on such a PR, records the state once, and refreshes the Dr. CI comment.

## Why
`@pytorchbot revert` reopens the PR, so a reverted PR re-enters the scan with
greenlight's approval still standing — and that approval alone satisfies a merge rule
for any path. Three pytorch/pytorch PRs are in exactly that state right now, each
mergeable with no human review. Re-landing a reverted change should need a person to
look at it.

# Notes
Exclusion keys on whether a `REVERTED` row exists, not on it being the newest row, so
it survives the label being removed and cannot be outranked by a later verdict. The
dismissal runs before the row is written — a row written after a failed dismissal
would suppress the retry while the approval was still live.

Known residual: a review already in flight when the revert lands can still post an
approval afterwards, which the next scan revokes, so there is a window of up to one
scan interval. Reverted PRs that are draft, closed, or whose author leaves the
trusted list fall outside the scan's listing and are not swept.