### PR TITLE
Add an AI_NOT_RELATED bucket for advisor-cleared failures

### DIFF
--- a/torchci/lib/advisor/advisorComment.ts
+++ b/torchci/lib/advisor/advisorComment.ts
@@ -10,34 +10,29 @@ import {
   AdvisorLineVerdict,
   selectAdvisorLines,
 } from "lib/advisor/advisorBadge";
-import { isAdvisorEnabled } from "lib/advisor/advisorConfig";
 import {
   readDispatchStates,
   signalKeyForJob,
 } from "lib/advisor/advisorDispatch";
+import { advisorCommentEnabled } from "lib/advisor/advisorFlags";
 import {
   AdvisorVerdictRow,
-  deduplicateVerdicts,
+  headRowsBySignalKey,
+  resolveVerdict,
 } from "lib/advisorVerdictUtils";
-import { queryClickhouseSaved } from "lib/clickhouse";
 import { RecentWorkflowsData } from "lib/types";
-
-// Gate the inline verdict rendering behind its own flag so it ships dark and
-// can be enabled per deployment (Vercel env var), independently of the
-// auto-dispatch flag. Display-only, so it doesn't also require VERCEL_ENV
-// (unlike auto-dispatch, which fires real workflow_dispatches).
-export function advisorCommentEnabled(owner: string, repo: string): boolean {
-  return (
-    process.env.DRCI_ADVISOR_COMMENT_ENABLED === "true" &&
-    isAdvisorEnabled(owner, repo)
-  );
-}
 
 /**
  * Build the per-job "AI verdict:" line for a PR's new/unclassified failures.
  * Returns job.id -> rendered HTML (empty map when the comment flag is off, the
  * repo isn't advisor-enabled, or there are no jobs). The caller wraps this so a
  * ClickHouse error can never break the Dr.CI comment.
+ *
+ * Takes the PR's verdict rows rather than reading them, so this line and the
+ * suppression gate describe the same rows resolved the same way. A signal key
+ * whose newest rows disagree resolves to nothing here too, and the job falls
+ * through to the pending/in-progress treatment below -- an unusable answer
+ * should not render as a confident badge.
  */
 export async function buildAdvisorVerdictLines(
   hudBaseUrl: string,
@@ -45,24 +40,22 @@ export async function buildAdvisorVerdictLines(
   repo: string,
   prNumber: number,
   headSha: string,
-  jobs: RecentWorkflowsData[]
+  jobs: RecentWorkflowsData[],
+  verdictRows: AdvisorVerdictRow[]
 ): Promise<Map<number, string>> {
   if (!advisorCommentEnabled(owner, repo) || jobs.length === 0) {
     return new Map();
   }
 
   // Finalized verdicts for this PR, keyed by signal_key for the head commit.
-  const verdictRows = (await queryClickhouseSaved("advisor_verdicts_for_pr", {
-    repo: `${owner}/${repo}`,
-    prNumber,
-  })) as AdvisorVerdictRow[];
   const verdictByKey = new Map<string, AdvisorLineVerdict>();
-  for (const v of deduplicateVerdicts(verdictRows)) {
-    if (v.sha === headSha) {
-      verdictByKey.set(v.signalKey, {
-        verdict: v.verdict,
-        confidence: v.confidence,
-        summary: v.summary,
+  for (const [signalKey, rows] of headRowsBySignalKey(verdictRows, headSha)) {
+    const resolved = resolveVerdict(rows);
+    if (resolved !== null) {
+      verdictByKey.set(signalKey, {
+        verdict: resolved.verdict,
+        confidence: resolved.confidence,
+        summary: resolved.summary,
       });
     }
   }

--- a/torchci/lib/advisor/advisorFlags.ts
+++ b/torchci/lib/advisor/advisorFlags.ts
@@ -20,15 +20,23 @@ export function advisorCommentEnabled(owner: string, repo: string): boolean {
   );
 }
 
-// Move advisor-cleared failures out of the blocking set. Separate from the
+// Move advisor-cleared failures out of the blocking set. Kept separate from the
 // display flag above because this one decides whether a merge is allowed, not
-// just what the comment says.
+// just what the comment says, so the display half can be enabled on its own
+// while the merge gate stays off.
+//
+// REQUIRES the comment flag, and is inert without it. Suppression with the
+// comment off would move a job into the non-blocking section while
+// buildAdvisorVerdictLines returns nothing, so the reader is told the AI
+// cleared the job but never which verdict cleared it or why. That combination
+// has no use -- a merge gate the comment cannot account for -- so it is
+// unreachable by construction rather than left to deployment discipline.
 export function advisorSuppressionEnabled(
   owner: string,
   repo: string
 ): boolean {
   return (
     process.env.DRCI_ADVISOR_SUPPRESSION_ENABLED === "true" &&
-    isAdvisorEnabled(owner, repo)
+    advisorCommentEnabled(owner, repo)
   );
 }

--- a/torchci/lib/advisor/advisorFlags.ts
+++ b/torchci/lib/advisor/advisorFlags.ts
@@ -1,0 +1,34 @@
+// Deployment flags for the two Dr.CI advisor consumers.
+//
+// Separate from advisorConfig.ts because that module is pure data with no
+// server-only behavior and is imported by React components; these read
+// process.env, which a client caller would see as unset. Separate from the
+// consumers themselves so that deciding whether to read verdicts at all costs
+// no import of the modules that consume them -- advisorComment reaches the AWS
+// SDK through its dispatch-state dependency.
+
+import { isAdvisorEnabled } from "lib/advisor/advisorConfig";
+
+// Render the inline "AI verdict:" line in the Dr.CI comment. Its own flag so it
+// ships dark and can be enabled per deployment (Vercel env var), independently
+// of the auto-dispatch flag. Display-only, so it doesn't also require
+// VERCEL_ENV (unlike auto-dispatch, which fires real workflow_dispatches).
+export function advisorCommentEnabled(owner: string, repo: string): boolean {
+  return (
+    process.env.DRCI_ADVISOR_COMMENT_ENABLED === "true" &&
+    isAdvisorEnabled(owner, repo)
+  );
+}
+
+// Move advisor-cleared failures out of the blocking set. Separate from the
+// display flag above because this one decides whether a merge is allowed, not
+// just what the comment says.
+export function advisorSuppressionEnabled(
+  owner: string,
+  repo: string
+): boolean {
+  return (
+    process.env.DRCI_ADVISOR_SUPPRESSION_ENABLED === "true" &&
+    isAdvisorEnabled(owner, repo)
+  );
+}

--- a/torchci/lib/advisor/advisorSuppression.ts
+++ b/torchci/lib/advisor/advisorSuppression.ts
@@ -1,0 +1,189 @@
+// Decides which NEW/unclassified failures the AI CI Advisor has cleared well
+// enough to stop blocking a merge.
+//
+// Deliberately separate from advisorComment.ts. That module renders a display
+// line and is gated by a display flag; this one moves a failure out of the
+// blocking set, so it gets its own flag and a strictly narrower predicate.
+// Everything here is fail-safe: any missing, stale, ambiguous or low-confidence
+// verdict leaves the job blocking.
+
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import { drciSignalKeyForJob } from "lib/advisor/advisorBadge";
+import { isAdvisorEnabled } from "lib/advisor/advisorConfig";
+import { AdvisorVerdictRow } from "lib/advisorVerdictUtils";
+import { isTime0 } from "lib/bot/utils";
+import { queryClickhouseSaved } from "lib/clickhouse";
+import { RecentWorkflowsData } from "lib/types";
+
+dayjs.extend(utc);
+
+// The only verdict that stops a failure from blocking. `infra_issue` is
+// excluded on purpose: it means CI broke before producing a test outcome, so
+// suppressing it would convert untested into green.
+export const SUPPRESSIBLE_VERDICT = "not_related";
+
+// The badge scale's `high` bucket. The UI already labels anything below this
+// "probably not related" or "not related (uncertain)", and an uncertain verdict
+// is not a basis for skipping a gate.
+export const MIN_SUPPRESSION_CONFIDENCE = 0.89;
+
+// A verdict describes one execution of a job, but is keyed only by (sha, job
+// name), so a rerun at the same head would otherwise inherit the previous run's
+// verdict. Requiring the verdict to be strictly newer than the job's completion
+// rejects the common case: the rerun finishes after the old verdict was
+// written, so the job blocks until a fresh analysis lands. Equality is treated
+// as stale because these timestamps are truncated and a tie cannot be told
+// apart from the unsafe ordering.
+//
+// KNOWN GAP, and the reason this ships behind a flag: a verdict for execution A
+// that lands after execution B has finished still passes this test. Closing it
+// needs the analyzed job id recorded on the verdict row -- the row's `run_id`
+// is the advisor's own dispatch run, not the job's.
+function verdictDescribesThisRun(
+  job: RecentWorkflowsData,
+  verdictTimestamp: string
+): boolean {
+  // isTime0 covers the epoch sentinel AND unparseable input (it NaN-checks), so
+  // a malformed timestamp on either side blocks rather than passing.
+  if (isTime0(job.completed_at) || isTime0(verdictTimestamp)) {
+    return false;
+  }
+  return dayjs.utc(verdictTimestamp).isAfter(dayjs.utc(job.completed_at));
+}
+
+// Only a conclusive `failure` is eligible. `cancelled`, `timed_out`,
+// `action_required` and friends did not produce a test outcome, and the advisor
+// labels much of that class `not_related` anyway -- see the shadow-mode
+// adjudication. This narrows that exposure; it does not close it, because a
+// job can also fail without a real outcome (runner lost, driver fault) while
+// still concluding `failure`. That residue is what the manual adjudication
+// before enforcement is for.
+export function producedATestOutcome(job: RecentWorkflowsData): boolean {
+  return job.conclusion === "failure";
+}
+
+export function advisorSuppressionEnabled(
+  owner: string,
+  repo: string
+): boolean {
+  return (
+    process.env.DRCI_ADVISOR_SUPPRESSION_ENABLED === "true" &&
+    isAdvisorEnabled(owner, repo)
+  );
+}
+
+/**
+ * Pick the verdict for one signal key, keeping "ambiguous" distinct from
+ * "absent". Rows tied at the newest timestamp with different verdicts mean an
+ * answer arrived and is unusable, so the job keeps blocking rather than taking
+ * whichever row sorted first. Tied rows that agree on the verdict but differ on
+ * confidence resolve to the LOWEST, since confidence is part of the safety
+ * decision too.
+ *
+ * Sorts rather than trusting the caller: the saved query orders by timestamp
+ * with no tie-breaker, and "whatever ClickHouse returned first" is not a basis
+ * for skipping a merge gate.
+ */
+export function resolveVerdict(
+  rows: AdvisorVerdictRow[]
+): { verdict: string; confidence: number; timestamp: string } | null {
+  if (rows.length === 0) {
+    return null;
+  }
+  const newestTimestamp = rows
+    .map((r) => r.timestamp)
+    .reduce((a, b) => (a > b ? a : b));
+  const tied = rows.filter((r) => r.timestamp === newestTimestamp);
+  if (tied.some((r) => r.verdict !== tied[0].verdict)) {
+    return null;
+  }
+  return {
+    verdict: tied[0].verdict,
+    confidence: Math.min(...tied.map((r) => r.confidence)),
+    timestamp: newestTimestamp,
+  };
+}
+
+/** Whether one job's verdict clears it to stop blocking. Pure, for testing. */
+export function isSuppressible(
+  job: RecentWorkflowsData,
+  rows: AdvisorVerdictRow[]
+): boolean {
+  if (!producedATestOutcome(job)) {
+    return false;
+  }
+  const resolved = resolveVerdict(rows);
+  if (resolved === null) {
+    return false;
+  }
+  return (
+    resolved.verdict === SUPPRESSIBLE_VERDICT &&
+    resolved.confidence >= MIN_SUPPRESSION_CONFIDENCE &&
+    verdictDescribesThisRun(job, resolved.timestamp)
+  );
+}
+
+/**
+ * Job ids among `jobs` that the advisor has cleared. Returns an empty set when
+ * the flag is off, so the caller needs no separate check. The caller must also
+ * wrap this: a ClickHouse error can never be allowed to break the comment.
+ */
+export async function fetchSuppressibleJobIds(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  headSha: string,
+  jobs: RecentWorkflowsData[]
+): Promise<Set<number>> {
+  if (!advisorSuppressionEnabled(owner, repo) || jobs.length === 0) {
+    return new Set();
+  }
+
+  const allRows = (await queryClickhouseSaved("advisor_verdicts_for_pr", {
+    repo: `${owner}/${repo}`,
+    prNumber,
+  })) as AdvisorVerdictRow[];
+
+  // Rows arrive newest-first; keep only this head's, grouped by signal key.
+  const rowsByKey = new Map<string, AdvisorVerdictRow[]>();
+  for (const row of allRows) {
+    if (row.sha.trim() !== headSha) {
+      continue;
+    }
+    const key = row.signal_key;
+    rowsByKey.set(key, (rowsByKey.get(key) ?? []).concat(row));
+  }
+
+  const suppressible = new Set<number>();
+  for (const job of jobs) {
+    if (!job.name) {
+      continue;
+    }
+    const rows = rowsByKey.get(drciSignalKeyForJob(job.name)) ?? [];
+    if (isSuppressible(job, rows)) {
+      suppressible.add(job.id);
+    }
+  }
+  return suppressible;
+}
+
+/**
+ * Move cleared jobs out of `blocking` and return them, mutating the array in
+ * place. In place because drci.ts hands the same array object to both the
+ * failures dict and the comment renderer, and CRCR L4 pushes into it later --
+ * rebinding would silently desync those.
+ */
+export function extractSuppressed(
+  blocking: RecentWorkflowsData[],
+  suppressibleIds: Set<number>
+): RecentWorkflowsData[] {
+  const extracted: RecentWorkflowsData[] = [];
+  for (let i = blocking.length - 1; i >= 0; i--) {
+    if (suppressibleIds.has(blocking[i].id)) {
+      extracted.unshift(blocking[i]);
+      blocking.splice(i, 1);
+    }
+  }
+  return extracted;
+}

--- a/torchci/lib/advisor/advisorSuppression.ts
+++ b/torchci/lib/advisor/advisorSuppression.ts
@@ -51,9 +51,10 @@ dayjs.extend(utc);
 // `infra_issue` is where that lands. `producedATestOutcome` below narrows this
 // -- it gates on the job's own conclusion rather than the advisor's opinion, so
 // an infra fault that left the job `cancelled` never reaches here -- but it does
-// not close it, since a job can conclude `failure` having tested nothing. The
-// remaining exposure is bounded by the merge-side cap on how many gates one
-// merge may skip, and by this shipping behind a flag.
+// not close it, since a job can conclude `failure` having tested nothing.
+// Nothing on this side bounds how many such jobs one merge may skip; a
+// per-merge cap is proposed in pytorch/pytorch#195503. Unless such a cap is
+// deployed, the flag being off is what holds this residue.
 const VERDICT_DISPOSITION: Record<AdvisorVerdictType, "clear" | "block"> = {
   not_related: "clear",
   infra_issue: "clear",
@@ -71,8 +72,16 @@ export const SUPPRESSIBLE_VERDICTS: ReadonlySet<string> = new Set(
 
 // Clear only what the badge scale calls high confidence. Asks advisorBadge for
 // the bucket rather than restating its threshold, so retuning the scale moves
-// the gate with it instead of leaving the comment saying "probably not related"
-// while this still suppresses.
+// the gate with it.
+//
+// That keeps badge and gate in step for `not_related` -- the only cleared
+// verdict whose label is hedged by confidence, so it is the only one that could
+// read "probably not related" while this suppressed. `verdictBadge` returns for
+// `garbage` and `infra_issue` before it consults the bucket, so those labels
+// never hedge: a sub-threshold `infra_issue` shows a flat "infra issue" beside a
+// job that still blocks, and about 6% of `infra_issue` rows in a recent 30-day
+// sample sit below the bar. Fixing that means changing labels in advisorBadge.ts,
+// which is on the already-live comment path -- a follow-up, not this change.
 export function confidentEnoughToSuppress(confidence: number): boolean {
   return confidenceBucket(confidence) === "high";
 }
@@ -136,9 +145,12 @@ export function isSuppressible(
  * the flag is off, so the caller needs no separate check.
  *
  * Takes the PR's verdict rows rather than reading them: drci.ts reads once and
- * shares them with the badge line, so the comment and the gate cannot disagree
- * about a job. Rows for any other commit are dropped here, so a verdict from an
- * earlier head can never clear a job at this one.
+ * shares them with the badge line, so the two cannot resolve the same job to
+ * different verdicts. They can still reach different DISPOSITIONS -- the gate
+ * adds the confidence, freshness and conclusion tests the badge does not, so a
+ * confident-looking badge beside a still-blocking job is expected. Rows for any
+ * other commit are dropped here, so a verdict from an earlier head can never
+ * clear a job at this one.
  */
 export function suppressibleJobIds(
   owner: string,

--- a/torchci/lib/advisor/advisorSuppression.ts
+++ b/torchci/lib/advisor/advisorSuppression.ts
@@ -9,11 +9,17 @@
 
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
-import { drciSignalKeyForJob } from "lib/advisor/advisorBadge";
-import { isAdvisorEnabled } from "lib/advisor/advisorConfig";
-import { AdvisorVerdictRow } from "lib/advisorVerdictUtils";
+import {
+  confidenceBucket,
+  drciSignalKeyForJob,
+} from "lib/advisor/advisorBadge";
+import { advisorSuppressionEnabled } from "lib/advisor/advisorFlags";
+import {
+  AdvisorVerdictRow,
+  headRowsBySignalKey,
+  resolveVerdict,
+} from "lib/advisorVerdictUtils";
 import { isTime0 } from "lib/bot/utils";
-import { queryClickhouseSaved } from "lib/clickhouse";
 import { RecentWorkflowsData } from "lib/types";
 
 dayjs.extend(utc);
@@ -23,10 +29,13 @@ dayjs.extend(utc);
 // suppressing it would convert untested into green.
 export const SUPPRESSIBLE_VERDICT = "not_related";
 
-// The badge scale's `high` bucket. The UI already labels anything below this
-// "probably not related" or "not related (uncertain)", and an uncertain verdict
-// is not a basis for skipping a gate.
-export const MIN_SUPPRESSION_CONFIDENCE = 0.89;
+// Clear only what the badge scale calls high confidence. Asks advisorBadge for
+// the bucket rather than restating its threshold, so retuning the scale moves
+// the gate with it instead of leaving the comment saying "probably not related"
+// while this still suppresses.
+export function confidentEnoughToSuppress(confidence: number): boolean {
+  return confidenceBucket(confidence) === "high";
+}
 
 // A verdict describes one execution of a job, but is keyed only by (sha, job
 // name), so a rerun at the same head would otherwise inherit the previous run's
@@ -63,48 +72,6 @@ export function producedATestOutcome(job: RecentWorkflowsData): boolean {
   return job.conclusion === "failure";
 }
 
-export function advisorSuppressionEnabled(
-  owner: string,
-  repo: string
-): boolean {
-  return (
-    process.env.DRCI_ADVISOR_SUPPRESSION_ENABLED === "true" &&
-    isAdvisorEnabled(owner, repo)
-  );
-}
-
-/**
- * Pick the verdict for one signal key, keeping "ambiguous" distinct from
- * "absent". Rows tied at the newest timestamp with different verdicts mean an
- * answer arrived and is unusable, so the job keeps blocking rather than taking
- * whichever row sorted first. Tied rows that agree on the verdict but differ on
- * confidence resolve to the LOWEST, since confidence is part of the safety
- * decision too.
- *
- * Sorts rather than trusting the caller: the saved query orders by timestamp
- * with no tie-breaker, and "whatever ClickHouse returned first" is not a basis
- * for skipping a merge gate.
- */
-export function resolveVerdict(
-  rows: AdvisorVerdictRow[]
-): { verdict: string; confidence: number; timestamp: string } | null {
-  if (rows.length === 0) {
-    return null;
-  }
-  const newestTimestamp = rows
-    .map((r) => r.timestamp)
-    .reduce((a, b) => (a > b ? a : b));
-  const tied = rows.filter((r) => r.timestamp === newestTimestamp);
-  if (tied.some((r) => r.verdict !== tied[0].verdict)) {
-    return null;
-  }
-  return {
-    verdict: tied[0].verdict,
-    confidence: Math.min(...tied.map((r) => r.confidence)),
-    timestamp: newestTimestamp,
-  };
-}
-
 /** Whether one job's verdict clears it to stop blocking. Pure, for testing. */
 export function isSuppressible(
   job: RecentWorkflowsData,
@@ -119,41 +86,32 @@ export function isSuppressible(
   }
   return (
     resolved.verdict === SUPPRESSIBLE_VERDICT &&
-    resolved.confidence >= MIN_SUPPRESSION_CONFIDENCE &&
+    confidentEnoughToSuppress(resolved.confidence) &&
     verdictDescribesThisRun(job, resolved.timestamp)
   );
 }
 
 /**
  * Job ids among `jobs` that the advisor has cleared. Returns an empty set when
- * the flag is off, so the caller needs no separate check. The caller must also
- * wrap this: a ClickHouse error can never be allowed to break the comment.
+ * the flag is off, so the caller needs no separate check.
+ *
+ * Takes the PR's verdict rows rather than reading them: drci.ts reads once and
+ * shares them with the badge line, so the comment and the gate cannot disagree
+ * about a job. Rows for any other commit are dropped here, so a verdict from an
+ * earlier head can never clear a job at this one.
  */
-export async function fetchSuppressibleJobIds(
+export function suppressibleJobIds(
   owner: string,
   repo: string,
-  prNumber: number,
   headSha: string,
-  jobs: RecentWorkflowsData[]
-): Promise<Set<number>> {
+  jobs: RecentWorkflowsData[],
+  verdictRows: AdvisorVerdictRow[]
+): Set<number> {
   if (!advisorSuppressionEnabled(owner, repo) || jobs.length === 0) {
     return new Set();
   }
 
-  const allRows = (await queryClickhouseSaved("advisor_verdicts_for_pr", {
-    repo: `${owner}/${repo}`,
-    prNumber,
-  })) as AdvisorVerdictRow[];
-
-  // Rows arrive newest-first; keep only this head's, grouped by signal key.
-  const rowsByKey = new Map<string, AdvisorVerdictRow[]>();
-  for (const row of allRows) {
-    if (row.sha.trim() !== headSha) {
-      continue;
-    }
-    const key = row.signal_key;
-    rowsByKey.set(key, (rowsByKey.get(key) ?? []).concat(row));
-  }
+  const rowsByKey = headRowsBySignalKey(verdictRows, headSha);
 
   const suppressible = new Set<number>();
   for (const job of jobs) {

--- a/torchci/lib/advisor/advisorSuppression.ts
+++ b/torchci/lib/advisor/advisorSuppression.ts
@@ -16,6 +16,7 @@ import {
 import { advisorSuppressionEnabled } from "lib/advisor/advisorFlags";
 import {
   AdvisorVerdictRow,
+  AdvisorVerdictType,
   headRowsBySignalKey,
   resolveVerdict,
 } from "lib/advisorVerdictUtils";
@@ -24,10 +25,49 @@ import { RecentWorkflowsData } from "lib/types";
 
 dayjs.extend(utc);
 
-// The only verdict that stops a failure from blocking. `infra_issue` is
-// excluded on purpose: it means CI broke before producing a test outcome, so
-// suppressing it would convert untested into green.
-export const SUPPRESSIBLE_VERDICT = "not_related";
+// Every advisor verdict and whether it stops a failure from blocking.
+//
+// Written as a TOTAL map rather than a list of the cleared ones: adding a member
+// to AdvisorVerdictType then fails to compile here until someone decides which
+// side it falls on, which is the decision most likely to be skipped.
+//
+//   not_related  the failure exists independently of this change
+//   infra_issue  the environment broke -- credentials, image pull, runner loss
+//   garbage      the signal itself is noise: it flips red/green across unrelated
+//                commits, and the baselines fail the same way
+//   related      the opposite claim -- this change caused it
+//   revert       the trunk-side spelling of `related`
+//   unsure       no claim was reached
+//
+// `garbage` sits with the cleared ones rather than with `unsure` because it is
+// an EVIDENCED claim about the signal, not an absence of one: the advisor
+// reaches it by comparing the job against its own baselines. `unsure` is the
+// real "cannot tell", and it blocks.
+//
+// LIMIT, stated because the confidence and freshness gates do not cover it: a
+// verdict says the failure looks environmental, not that the PR is innocent of
+// causing it. A change to CI config, a Dockerfile, or a submodule pin can
+// produce a genuine infrastructure-shaped failure that IS the PR's fault, and
+// `infra_issue` is where that lands. `producedATestOutcome` below narrows this
+// -- it gates on the job's own conclusion rather than the advisor's opinion, so
+// an infra fault that left the job `cancelled` never reaches here -- but it does
+// not close it, since a job can conclude `failure` having tested nothing. The
+// remaining exposure is bounded by the merge-side cap on how many gates one
+// merge may skip, and by this shipping behind a flag.
+const VERDICT_DISPOSITION: Record<AdvisorVerdictType, "clear" | "block"> = {
+  not_related: "clear",
+  infra_issue: "clear",
+  garbage: "clear",
+  related: "block",
+  revert: "block",
+  unsure: "block",
+};
+
+export const SUPPRESSIBLE_VERDICTS: ReadonlySet<string> = new Set(
+  Object.entries(VERDICT_DISPOSITION)
+    .filter(([, disposition]) => disposition === "clear")
+    .map(([verdict]) => verdict)
+);
 
 // Clear only what the badge scale calls high confidence. Asks advisorBadge for
 // the bucket rather than restating its threshold, so retuning the scale moves
@@ -85,7 +125,7 @@ export function isSuppressible(
     return false;
   }
   return (
-    resolved.verdict === SUPPRESSIBLE_VERDICT &&
+    SUPPRESSIBLE_VERDICTS.has(resolved.verdict) &&
     confidentEnoughToSuppress(resolved.confidence) &&
     verdictDescribesThisRun(job, resolved.timestamp)
   );

--- a/torchci/lib/advisor/advisorVerdictSource.ts
+++ b/torchci/lib/advisor/advisorVerdictSource.ts
@@ -1,0 +1,46 @@
+// The single read of a PR's advisor verdicts.
+//
+// Both consumers in the Dr.CI request -- the inline badge line and the
+// suppression gate -- need the same rows for the same PR and head. Reading
+// twice cost a ClickHouse round trip per PR and, worse, let a verdict landing
+// between the two reads make the comment and the merge gate describe the same
+// job differently. drci.ts reads once here and hands the rows to both.
+
+import {
+  advisorCommentEnabled,
+  advisorSuppressionEnabled,
+} from "lib/advisor/advisorFlags";
+import { AdvisorVerdictRow } from "lib/advisorVerdictUtils";
+import { queryClickhouseSaved } from "lib/clickhouse";
+import { RecentWorkflowsData } from "lib/types";
+
+/**
+ * Whether this PR is worth a verdict read at all.
+ *
+ * Both consumers bail on an empty job list, so a PR with no new or
+ * unclassified failures -- the common case -- must not cost a query. Each
+ * consumer re-checks its own flag; this only decides whether to read.
+ */
+export function shouldReadAdvisorVerdicts(
+  owner: string,
+  repo: string,
+  jobs: RecentWorkflowsData[]
+): boolean {
+  if (jobs.length === 0) {
+    return false;
+  }
+  return (
+    advisorCommentEnabled(owner, repo) || advisorSuppressionEnabled(owner, repo)
+  );
+}
+
+export async function fetchAdvisorVerdictRows(
+  owner: string,
+  repo: string,
+  prNumber: number
+): Promise<AdvisorVerdictRow[]> {
+  return (await queryClickhouseSaved("advisor_verdicts_for_pr", {
+    repo: `${owner}/${repo}`,
+    prNumber,
+  })) as AdvisorVerdictRow[];
+}

--- a/torchci/lib/advisorVerdictUtils.ts
+++ b/torchci/lib/advisorVerdictUtils.ts
@@ -80,6 +80,73 @@ export function deduplicateVerdicts(
 }
 
 /**
+ * Group one commit's rows by signal key, dropping every other commit's.
+ *
+ * `sha` is trimmed because the column is FixedString-padded, and the caller's
+ * head sha is not.
+ */
+export function headRowsBySignalKey(
+  rows: AdvisorVerdictRow[],
+  headSha: string
+): Map<string, AdvisorVerdictRow[]> {
+  const byKey = new Map<string, AdvisorVerdictRow[]>();
+  for (const row of rows) {
+    if (row.sha.trim() !== headSha) {
+      continue;
+    }
+    byKey.set(row.signal_key, (byKey.get(row.signal_key) ?? []).concat(row));
+  }
+  return byKey;
+}
+
+/**
+ * Pick the row that speaks for one signal key, keeping "ambiguous" distinct
+ * from "absent" by returning null for both. Rows tied at the newest timestamp
+ * with different verdicts mean an answer arrived and is unusable, so callers
+ * get nothing rather than whichever row sorted first. Among tied rows that
+ * agree, the LEAST confident one represents them: confidence drives a merge
+ * gate, and the comment should describe the same row the gate judged.
+ *
+ * Picks the newest itself rather than trusting the caller's ordering: the saved
+ * query orders by timestamp with no tie-breaker, and "whatever ClickHouse
+ * returned first" is not a basis for skipping a merge gate. Rows that tie on
+ * timestamp, verdict AND confidence are interchangeable for every decision
+ * either caller makes, so which of those is returned is left unspecified.
+ *
+ * Shared by the Dr.CI badge line and the suppression gate so the two cannot
+ * describe the same job differently.
+ */
+export function resolveVerdict(
+  rows: AdvisorVerdictRow[]
+): AdvisorVerdictRow | null {
+  if (rows.length === 0) {
+    return null;
+  }
+  const newestTimestamp = rows
+    .map((r) => r.timestamp)
+    .reduce((a, b) => (a > b ? a : b));
+  const tied = rows.filter((r) => r.timestamp === newestTimestamp);
+  if (tied.some((r) => r.verdict !== tied[0].verdict)) {
+    return null;
+  }
+  // A confidence that is not a real number in [0, 1] means the row cannot be
+  // compared, and picking "the least confident" among incomparable values
+  // silently drops the bad row instead of the good one -- NaN loses every
+  // comparison, so a NaN row beside a 0.95 row would resolve to 0.95 and
+  // suppress. Refuse the whole key instead: unusable input is ambiguous, and
+  // ambiguous blocks.
+  if (
+    !tied.every(
+      (r) =>
+        Number.isFinite(r.confidence) && r.confidence >= 0 && r.confidence <= 1
+    )
+  ) {
+    return null;
+  }
+  return tied.reduce((a, b) => (a.confidence <= b.confidence ? a : b));
+}
+
+/**
  * Build a lookup map: sha -> array of verdicts for that commit.
  */
 export function buildVerdictsBySha(

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -1082,6 +1082,30 @@ export function constructResultsComment(
     );
   }
 
+  // Directly after NEW FAILURES: these are the jobs lifted out of it, so they
+  // read as that section's footnote rather than as an unrelated bucket.
+  output += constructResultsJobsSections(
+    hudBaseUrl,
+    owner,
+    repo,
+    prNumber,
+    "NEW FAILURES SUPPRESSED BY AI (non-blocking)",
+    `The following ${pluralize(
+      "job",
+      aiNotRelatedJobs.length
+    )} failed, but the AI CI Advisor judged the ${pluralize(
+      "failure",
+      aiNotRelatedJobs.length
+    )} unrelated to the change`,
+    aiNotRelatedJobs,
+    "",
+    true,
+    relatedJobs,
+    relatedIssues,
+    relatedInfo,
+    advisorLines
+  );
+
   if (unknownJobs.length) {
     output += constructResultsJobsSections(
       hudBaseUrl,
@@ -1201,34 +1225,6 @@ export function constructResultsComment(
     relatedJobs,
     relatedIssues,
     relatedInfo
-  );
-  output += constructResultsJobsSections(
-    hudBaseUrl,
-    owner,
-    repo,
-    prNumber,
-    // Covers three advisor verdicts, not just `not_related` -- see
-    // SUPPRESSIBLE_VERDICTS. Naming only one of them here would state something
-    // false about a job cleared as an infra fault or an unusable signal.
-    "CLEARED BY THE AI CI ADVISOR (non-blocking)",
-    `The following ${pluralize(
-      "job",
-      aiNotRelatedJobs.length
-    )} failed, but the AI CI Advisor judged the ${pluralize(
-      "failure",
-      aiNotRelatedJobs.length
-    )} not to be evidence against this PR -- unrelated to the change, a CI infrastructure fault, or an unusable signal -- so ${pluralize(
-      "it is",
-      aiNotRelatedJobs.length,
-      "they are"
-    )} non-blocking. The verdict on each job is shown beside it.`,
-    aiNotRelatedJobs,
-    "",
-    true,
-    relatedJobs,
-    relatedIssues,
-    relatedInfo,
-    advisorLines
   );
   return output;
 }

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -6,8 +6,13 @@ import { buildAdvisorVerdictLines } from "lib/advisor/advisorComment";
 import { autoDispatchAdvisorForNewFailures } from "lib/advisor/advisorDispatch";
 import {
   extractSuppressed,
-  fetchSuppressibleJobIds,
+  suppressibleJobIds,
 } from "lib/advisor/advisorSuppression";
+import {
+  fetchAdvisorVerdictRows,
+  shouldReadAdvisorVerdicts,
+} from "lib/advisor/advisorVerdictSource";
+import { AdvisorVerdictRow } from "lib/advisorVerdictUtils";
 import { fetchJSON, isTime0 } from "lib/bot/utils";
 import { queryClickhouse, queryClickhouseSaved } from "lib/clickhouse";
 import {
@@ -304,9 +309,39 @@ export async function updateDrciComments(
         );
       }
 
-      // Look up AI advisor verdicts / in-progress dispatches for this PR's new
-      // and unclassified failures, rendered as an inline "AI verdict:" line per
-      // job. Wrapped so an advisor / ClickHouse error can never break the comment.
+      // The failures either advisor consumer can say anything about.
+      const advisorJobs = [...failedJobs, ...unknownJobs];
+
+      // One read of this PR's advisor verdicts, shared by the inline "AI
+      // verdict:" line and the suppression gate below. Reading per consumer
+      // would let a verdict landing between the two reads make the badge and
+      // the merge gate describe the same job differently.
+      //
+      // A read that is skipped or fails yields an empty array, which both
+      // consumers treat as "no verdict": nothing is suppressed, so every job
+      // keeps blocking. Note the comment can still render an "analyzing" line
+      // for a job with a dispatch in flight, since that state is read
+      // separately and does not depend on these rows.
+      let advisorVerdictRows: AdvisorVerdictRow[] = [];
+      if (shouldReadAdvisorVerdicts(owner, repo, advisorJobs)) {
+        try {
+          advisorVerdictRows = await fetchAdvisorVerdictRows(
+            owner,
+            repo,
+            pr_info.pr_number
+          );
+        } catch (e) {
+          console.error(
+            "advisor verdict fetch threw for PR",
+            pr_info.pr_number,
+            e
+          );
+        }
+      }
+
+      // Render the verdicts for this PR's new and unclassified failures as an
+      // inline line per job. Wrapped so an advisor error can never break the
+      // comment.
       let advisorLines: Map<number, string> = new Map();
       try {
         advisorLines = await buildAdvisorVerdictLines(
@@ -315,7 +350,8 @@ export async function updateDrciComments(
           repo,
           pr_info.pr_number,
           pr_info.head_sha,
-          [...failedJobs, ...unknownJobs]
+          advisorJobs,
+          advisorVerdictRows
         );
       } catch (e) {
         console.error(
@@ -329,17 +365,17 @@ export async function updateDrciComments(
       // bucket, so they leave the NEW/UNCLASSIFIED sections and stop blocking
       // the merge. Runs BEFORE the CRCR block below on purpose: CRCR L4 jobs
       // are pushed into failedJobs there and were never advisor-analyzed, so
-      // they must not be eligible. Wrapped so a ClickHouse error can never
+      // they must not be eligible. Wrapped so an unexpected error can never
       // break the comment -- and failing to an empty set keeps everything
       // blocking, which is the safe direction.
       const aiNotRelatedJobs: RecentWorkflowsData[] = [];
       try {
-        const suppressible = await fetchSuppressibleJobIds(
+        const suppressible = suppressibleJobIds(
           owner,
           repo,
-          pr_info.pr_number,
           pr_info.head_sha,
-          [...failedJobs, ...unknownJobs]
+          advisorJobs,
+          advisorVerdictRows
         );
         aiNotRelatedJobs.push(
           ...extractSuppressed(failedJobs, suppressible),

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -1090,13 +1090,18 @@ export function constructResultsComment(
     repo,
     prNumber,
     "NEW FAILURES SUPPRESSED BY AI (non-blocking)",
+    // "not evidence against this change" is the only claim true of all three
+    // cleared verdicts -- see SUPPRESSIBLE_VERDICTS. `infra_issue` says the
+    // environment broke, which a PR can itself cause, and `garbage` judges the
+    // signal rather than the change, so "unrelated to the change" would be
+    // false for both. Keep the umbrella wording if this gets shortened again.
     `The following ${pluralize(
       "job",
       aiNotRelatedJobs.length
     )} failed, but the AI CI Advisor judged the ${pluralize(
       "failure",
       aiNotRelatedJobs.length
-    )} unrelated to the change`,
+    )} not to be evidence against this change`,
     aiNotRelatedJobs,
     "",
     true,

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -4,6 +4,10 @@ import utc from "dayjs/plugin/utc";
 import { ADVISOR_PENDING_ALT_ATTR } from "lib/advisor/advisorBadge";
 import { buildAdvisorVerdictLines } from "lib/advisor/advisorComment";
 import { autoDispatchAdvisorForNewFailures } from "lib/advisor/advisorDispatch";
+import {
+  extractSuppressed,
+  fetchSuppressibleJobIds,
+} from "lib/advisor/advisorSuppression";
 import { fetchJSON, isTime0 } from "lib/bot/utils";
 import { queryClickhouse, queryClickhouseSaved } from "lib/clickhouse";
 import {
@@ -321,6 +325,38 @@ export async function updateDrciComments(
         );
       }
 
+      // Move failures the advisor cleared as `not_related` into their own
+      // bucket, so they leave the NEW/UNCLASSIFIED sections and stop blocking
+      // the merge. Runs BEFORE the CRCR block below on purpose: CRCR L4 jobs
+      // are pushed into failedJobs there and were never advisor-analyzed, so
+      // they must not be eligible. Wrapped so a ClickHouse error can never
+      // break the comment -- and failing to an empty set keeps everything
+      // blocking, which is the safe direction.
+      const aiNotRelatedJobs: RecentWorkflowsData[] = [];
+      try {
+        const suppressible = await fetchSuppressibleJobIds(
+          owner,
+          repo,
+          pr_info.pr_number,
+          pr_info.head_sha,
+          [...failedJobs, ...unknownJobs]
+        );
+        aiNotRelatedJobs.push(
+          ...extractSuppressed(failedJobs, suppressible),
+          ...extractSuppressed(unknownJobs, suppressible)
+        );
+      } catch (e) {
+        console.error(
+          "advisor suppression lookup threw for PR",
+          pr_info.pr_number,
+          e
+        );
+      }
+
+      if (aiNotRelatedJobs.length > 0) {
+        failures[pr_info.pr_number].AI_NOT_RELATED = aiNotRelatedJobs;
+      }
+
       // Classify CRCR downstream CI jobs (L3 = non-blocking, L4 = blocking).
       // These jobs live in oot_workflow_job, not workflow_job, so they are fetched
       // separately and classified based on their downstream_repo_level.
@@ -356,6 +392,7 @@ export async function updateDrciComments(
         unknownJobs,
         awaitingApprovalJobs,
         crcrL3Jobs,
+        aiNotRelatedJobs,
         relatedJobs,
         relatedIssues,
         relatedInfo,
@@ -836,6 +873,7 @@ export function constructResultsComment(
   unknownJobs: RecentWorkflowsData[],
   awaitingApprovalJobs: RecentWorkflowsData[],
   crcrL3Jobs: RecentWorkflowsData[],
+  aiNotRelatedJobs: RecentWorkflowsData[],
   relatedJobs: Map<number, RecentWorkflowsData>,
   relatedIssues: Map<number, IssueData[]>,
   relatedInfo: Map<number, string>,
@@ -858,6 +896,7 @@ export function constructResultsComment(
     .concat(brokenTrunkJobs)
     .concat(unstableJobs)
     .concat(crcrL3Jobs)
+    .concat(aiNotRelatedJobs)
     .filter((job) => !isPending(job))
     .value().length;
   const newFailedJobs: RecentWorkflowsData[] = failedJobs.filter(
@@ -982,10 +1021,11 @@ export function constructResultsComment(
     );
   }
 
-  // advisorLines is threaded only into the NEW FAILURES and UNCLASSIFIED
-  // sections below -- those are the only failures the advisor dispatches on.
-  // Broken-trunk / flaky / unstable / awaiting-approval jobs are already
-  // explained by their own section, so they intentionally get no verdict line.
+  // advisorLines is threaded only into the NEW FAILURES, UNCLASSIFIED and
+  // advisor-cleared sections -- those are the only failures the advisor
+  // dispatches on. Broken-trunk / flaky / unstable / awaiting-approval jobs are
+  // already explained by their own section, so they intentionally get no
+  // verdict line.
   if (newFailedJobs.length) {
     output += constructResultsJobsSections(
       hudBaseUrl,
@@ -1125,6 +1165,32 @@ export function constructResultsComment(
     relatedJobs,
     relatedIssues,
     relatedInfo
+  );
+  output += constructResultsJobsSections(
+    hudBaseUrl,
+    owner,
+    repo,
+    prNumber,
+    "NOT RELATED TO THIS PR (non-blocking)",
+    `The following ${pluralize(
+      "job",
+      aiNotRelatedJobs.length
+    )} failed but the AI CI Advisor judged ${pluralize(
+      "it",
+      aiNotRelatedJobs.length,
+      "them"
+    )} unrelated to this PR, so ${pluralize(
+      "it is",
+      aiNotRelatedJobs.length,
+      "they are"
+    )} non-blocking`,
+    aiNotRelatedJobs,
+    "",
+    true,
+    relatedJobs,
+    relatedIssues,
+    relatedInfo,
+    advisorLines
   );
   return output;
 }

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -1207,19 +1207,21 @@ export function constructResultsComment(
     owner,
     repo,
     prNumber,
-    "NOT RELATED TO THIS PR (non-blocking)",
+    // Covers three advisor verdicts, not just `not_related` -- see
+    // SUPPRESSIBLE_VERDICTS. Naming only one of them here would state something
+    // false about a job cleared as an infra fault or an unusable signal.
+    "CLEARED BY THE AI CI ADVISOR (non-blocking)",
     `The following ${pluralize(
       "job",
       aiNotRelatedJobs.length
-    )} failed but the AI CI Advisor judged ${pluralize(
-      "it",
-      aiNotRelatedJobs.length,
-      "them"
-    )} unrelated to this PR, so ${pluralize(
+    )} failed, but the AI CI Advisor judged the ${pluralize(
+      "failure",
+      aiNotRelatedJobs.length
+    )} not to be evidence against this PR -- unrelated to the change, a CI infrastructure fault, or an unusable signal -- so ${pluralize(
       "it is",
       aiNotRelatedJobs.length,
       "they are"
-    )} non-blocking`,
+    )} non-blocking. The verdict on each job is shown beside it.`,
     aiNotRelatedJobs,
     "",
     true,

--- a/torchci/test/advisorComment.test.ts
+++ b/torchci/test/advisorComment.test.ts
@@ -1,0 +1,122 @@
+import { buildAdvisorVerdictLines } from "lib/advisor/advisorComment";
+import { AdvisorVerdictRow } from "lib/advisorVerdictUtils";
+import { RecentWorkflowsData } from "lib/types";
+
+// Stubbed rather than requireActual'd: the real module reaches lib/lambda.ts,
+// which pulls the AWS SDK into a test that has nothing to do with it. These two
+// exports are all advisorComment uses, and no dispatch is in flight in any case
+// below, so every job's line comes from its verdict alone.
+jest.mock("lib/advisor/advisorDispatch", () => ({
+  readDispatchStates: jest.fn().mockResolvedValue(new Map()),
+  signalKeyForJob: (fullJobName: string) => `dr_ci_${fullJobName}`,
+}));
+
+const HEAD_SHA = "a".repeat(40);
+const OTHER_SHA = "b".repeat(40);
+const JOB_NAME = "pull / linux-jammy-py3.10-gcc11 / test";
+const NEWER = "2026-08-28 12:05:00.000";
+const OLDER = "2026-08-28 11:55:00.000";
+
+function job(
+  overrides: Partial<RecentWorkflowsData> = {}
+): RecentWorkflowsData {
+  return {
+    id: 1,
+    name: JOB_NAME,
+    ...overrides,
+  } as unknown as RecentWorkflowsData;
+}
+
+function row(overrides: Partial<AdvisorVerdictRow> = {}): AdvisorVerdictRow {
+  return {
+    sha: HEAD_SHA,
+    signal_key: `dr_ci_${JOB_NAME}`,
+    verdict: "not_related",
+    confidence: 0.95,
+    summary: "unrelated to this PR",
+    timestamp: NEWER,
+    ...overrides,
+  } as unknown as AdvisorVerdictRow;
+}
+
+async function lines(
+  rows: AdvisorVerdictRow[],
+  jobs: RecentWorkflowsData[] = [job()]
+): Promise<Map<number, string>> {
+  return buildAdvisorVerdictLines(
+    "https://hud.pytorch.org",
+    "pytorch",
+    "pytorch",
+    123,
+    HEAD_SHA,
+    jobs,
+    rows
+  );
+}
+
+describe("buildAdvisorVerdictLines", () => {
+  let saved: string | undefined;
+  beforeEach(() => {
+    saved = process.env.DRCI_ADVISOR_COMMENT_ENABLED;
+    process.env.DRCI_ADVISOR_COMMENT_ENABLED = "true";
+  });
+  afterEach(() => {
+    if (saved === undefined) {
+      delete process.env.DRCI_ADVISOR_COMMENT_ENABLED;
+    } else {
+      process.env.DRCI_ADVISOR_COMMENT_ENABLED = saved;
+    }
+  });
+
+  test("renders the verdict badge for this head", async () => {
+    expect((await lines([row()])).get(1)).toContain("not related");
+  });
+
+  test("the flag being off renders nothing", async () => {
+    process.env.DRCI_ADVISOR_COMMENT_ENABLED = "false";
+    expect(await lines([row()])).toEqual(new Map());
+  });
+
+  test("a verdict for a different head is not rendered", async () => {
+    expect(await lines([row({ sha: OTHER_SHA })])).toEqual(new Map());
+  });
+
+  test("the newest verdict wins over an older one", async () => {
+    const rendered = await lines([
+      row({ verdict: "not_related", timestamp: OLDER }),
+      row({ verdict: "related", timestamp: NEWER }),
+    ]);
+    expect(rendered.get(1)).toContain("related");
+    expect(rendered.get(1)).not.toContain("not related");
+  });
+
+  // The reason the badge and the suppression gate now share one resolver: an
+  // answer that arrived and is unusable must not render as a confident badge on
+  // a job the gate keeps blocking.
+  test("verdicts tied at the newest timestamp that disagree render no badge", async () => {
+    expect(
+      await lines([
+        row({ verdict: "not_related", timestamp: NEWER }),
+        row({ verdict: "related", timestamp: NEWER }),
+      ])
+    ).toEqual(new Map());
+  });
+
+  test("a row keyed to a different job is not rendered on this one", async () => {
+    expect(
+      await lines([row({ signal_key: "dr_ci_pull / some other job / test" })])
+    ).toEqual(new Map());
+  });
+
+  test("tied agreeing verdicts render the least confident row whole", async () => {
+    const rendered = await lines([
+      row({ confidence: 0.95, timestamp: NEWER, summary: "high-conf summary" }),
+      row({ confidence: 0.5, timestamp: NEWER, summary: "low-conf summary" }),
+    ]);
+    // 0.5 is below the badge scale's high bucket, so the label is hedged --
+    // and the summary must come from that same row, not the other one.
+    expect(rendered.get(1)).toContain("not related (uncertain)");
+    expect(rendered.get(1)).toContain("low-conf summary");
+    expect(rendered.get(1)).not.toContain("high-conf summary");
+  });
+});

--- a/torchci/test/advisorSuppression.test.ts
+++ b/torchci/test/advisorSuppression.test.ts
@@ -1,0 +1,166 @@
+import {
+  extractSuppressed,
+  isSuppressible,
+  MIN_SUPPRESSION_CONFIDENCE,
+  resolveVerdict,
+} from "lib/advisor/advisorSuppression";
+import { AdvisorVerdictRow } from "lib/advisorVerdictUtils";
+import { RecentWorkflowsData } from "lib/types";
+
+const HEAD_SHA = "a".repeat(40);
+const JOB_DONE_AT = "2026-08-28 12:00:00.000";
+const AFTER_JOB = "2026-08-28 12:05:00.000";
+const BEFORE_JOB = "2026-08-28 11:55:00.000";
+
+function job(
+  overrides: Partial<RecentWorkflowsData> = {}
+): RecentWorkflowsData {
+  return {
+    id: 1,
+    name: "pull / linux-jammy-py3.10-gcc11 / test",
+    conclusion: "failure",
+    completed_at: JOB_DONE_AT,
+    ...overrides,
+  } as unknown as RecentWorkflowsData;
+}
+
+function row(overrides: Partial<AdvisorVerdictRow> = {}): AdvisorVerdictRow {
+  return {
+    sha: HEAD_SHA,
+    signal_key: "dr_ci_pull / linux-jammy-py3.10-gcc11 / test",
+    verdict: "not_related",
+    confidence: 0.95,
+    timestamp: AFTER_JOB,
+    ...overrides,
+  } as unknown as AdvisorVerdictRow;
+}
+
+describe("resolveVerdict", () => {
+  test("no rows is absent, not a verdict", () => {
+    expect(resolveVerdict([])).toBeNull();
+  });
+
+  test("newest row wins", () => {
+    const resolved = resolveVerdict([
+      row({ verdict: "not_related", timestamp: AFTER_JOB }),
+      row({ verdict: "related", timestamp: BEFORE_JOB }),
+    ]);
+    expect(resolved?.verdict).toBe("not_related");
+  });
+
+  test("conflicting rows tied at the newest timestamp resolve to null", () => {
+    expect(
+      resolveVerdict([
+        row({ verdict: "not_related", timestamp: AFTER_JOB }),
+        row({ verdict: "related", timestamp: AFTER_JOB }),
+      ])
+    ).toBeNull();
+  });
+
+  test("agreeing rows tied at the newest timestamp still resolve", () => {
+    expect(
+      resolveVerdict([
+        row({ timestamp: AFTER_JOB }),
+        row({ timestamp: AFTER_JOB }),
+      ])?.verdict
+    ).toBe("not_related");
+  });
+
+  test("tied rows that disagree on confidence resolve to the lowest", () => {
+    expect(
+      resolveVerdict([
+        row({ timestamp: AFTER_JOB, confidence: 0.95 }),
+        row({ timestamp: AFTER_JOB, confidence: 0.4 }),
+      ])?.confidence
+    ).toBe(0.4);
+  });
+
+  test("does not trust the caller's ordering", () => {
+    const resolved = resolveVerdict([
+      row({ verdict: "not_related", timestamp: BEFORE_JOB }),
+      row({ verdict: "related", timestamp: AFTER_JOB }),
+    ]);
+    expect(resolved?.verdict).toBe("related");
+  });
+});
+
+describe("isSuppressible", () => {
+  test("a confident, fresh not_related verdict clears the job", () => {
+    expect(isSuppressible(job(), [row()])).toBe(true);
+  });
+
+  test("no verdict keeps the job blocking", () => {
+    expect(isSuppressible(job(), [])).toBe(false);
+  });
+
+  test.each(["related", "revert", "unsure", "garbage", "infra_issue"])(
+    "%s keeps the job blocking",
+    (verdict) => {
+      expect(isSuppressible(job(), [row({ verdict })])).toBe(false);
+    }
+  );
+
+  test("confidence below the high bucket keeps the job blocking", () => {
+    expect(
+      isSuppressible(job(), [
+        row({ confidence: MIN_SUPPRESSION_CONFIDENCE - 0.01 }),
+      ])
+    ).toBe(false);
+  });
+
+  test("a verdict older than the job's completion is a stale rerun verdict", () => {
+    expect(isSuppressible(job(), [row({ timestamp: BEFORE_JOB })])).toBe(false);
+  });
+
+  test("a verdict exactly at the job's completion is ambiguous, so it blocks", () => {
+    expect(isSuppressible(job(), [row({ timestamp: JOB_DONE_AT })])).toBe(
+      false
+    );
+  });
+
+  test("an unparseable timestamp keeps the job blocking", () => {
+    expect(isSuppressible(job(), [row({ timestamp: "not a date" })])).toBe(
+      false
+    );
+    expect(isSuppressible(job({ completed_at: "not a date" }), [row()])).toBe(
+      false
+    );
+  });
+
+  test.each(["cancelled", "timed_out", "action_required", "neutral"])(
+    "a %s job never produced a test outcome, so it keeps blocking",
+    (conclusion) => {
+      expect(isSuppressible(job({ conclusion }), [row()])).toBe(false);
+    }
+  );
+
+  test("a zero completed_at keeps the job blocking", () => {
+    expect(
+      isSuppressible(job({ completed_at: "1970-01-01 00:00:00.000000000" }), [
+        row(),
+      ])
+    ).toBe(false);
+  });
+});
+
+describe("extractSuppressed", () => {
+  test("removes cleared jobs in place and returns them in order", () => {
+    const blocking = [job({ id: 1 }), job({ id: 2 }), job({ id: 3 })];
+    const extracted = extractSuppressed(blocking, new Set([1, 3]));
+    expect(extracted.map((j) => j.id)).toEqual([1, 3]);
+    expect(blocking.map((j) => j.id)).toEqual([2]);
+  });
+
+  test("mutates the caller's array rather than replacing it", () => {
+    const blocking = [job({ id: 1 })];
+    const sameRef = blocking;
+    extractSuppressed(blocking, new Set([1]));
+    expect(sameRef).toHaveLength(0);
+  });
+
+  test("an empty suppressible set is a no-op", () => {
+    const blocking = [job({ id: 1 }), job({ id: 2 })];
+    expect(extractSuppressed(blocking, new Set())).toEqual([]);
+    expect(blocking).toHaveLength(2);
+  });
+});

--- a/torchci/test/advisorSuppression.test.ts
+++ b/torchci/test/advisorSuppression.test.ts
@@ -1,10 +1,11 @@
+import { confidenceBucket } from "lib/advisor/advisorBadge";
 import {
+  confidentEnoughToSuppress,
   extractSuppressed,
   isSuppressible,
-  MIN_SUPPRESSION_CONFIDENCE,
-  resolveVerdict,
+  suppressibleJobIds,
 } from "lib/advisor/advisorSuppression";
-import { AdvisorVerdictRow } from "lib/advisorVerdictUtils";
+import { AdvisorVerdictRow, resolveVerdict } from "lib/advisorVerdictUtils";
 import { RecentWorkflowsData } from "lib/types";
 
 const HEAD_SHA = "a".repeat(40);
@@ -82,6 +83,45 @@ describe("resolveVerdict", () => {
     ]);
     expect(resolved?.verdict).toBe("related");
   });
+
+  // "Least confident wins" is a comparison, and NaN loses every comparison, so
+  // an unusable row would be discarded in favour of the usable one -- the
+  // opposite of the safe direction. Both orderings are checked because the
+  // reducer is order-sensitive in exactly the way that would hide this.
+  test.each([
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["above 1", 1.5],
+    ["negative", -0.2],
+  ])("a tied row with %s confidence makes the key ambiguous", (_label, bad) => {
+    expect(
+      resolveVerdict([
+        row({ timestamp: AFTER_JOB, confidence: bad }),
+        row({ timestamp: AFTER_JOB, confidence: 0.95 }),
+      ])
+    ).toBeNull();
+    expect(
+      resolveVerdict([
+        row({ timestamp: AFTER_JOB, confidence: 0.95 }),
+        row({ timestamp: AFTER_JOB, confidence: bad }),
+      ])
+    ).toBeNull();
+  });
+
+  test("a lone row with an unusable confidence is ambiguous too", () => {
+    expect(
+      resolveVerdict([row({ timestamp: AFTER_JOB, confidence: Number.NaN })])
+    ).toBeNull();
+  });
+
+  test("an older row with an unusable confidence does not poison a good newest row", () => {
+    expect(
+      resolveVerdict([
+        row({ timestamp: BEFORE_JOB, confidence: Number.NaN }),
+        row({ timestamp: AFTER_JOB, confidence: 0.95 }),
+      ])?.confidence
+    ).toBe(0.95);
+  });
 });
 
 describe("isSuppressible", () => {
@@ -100,12 +140,31 @@ describe("isSuppressible", () => {
     }
   );
 
-  test("confidence below the high bucket keeps the job blocking", () => {
-    expect(
-      isSuppressible(job(), [
-        row({ confidence: MIN_SUPPRESSION_CONFIDENCE - 0.01 }),
-      ])
-    ).toBe(false);
+  test.each([0.88, 0.71, 0.5])(
+    "confidence %s is below the badge scale's high bucket, so the job keeps blocking",
+    (confidence) => {
+      // Assert the premise: if the scale is retuned so this is `high` after
+      // all, the case below stops testing anything and should fail loudly.
+      expect(confidenceBucket(confidence)).not.toBe("high");
+      expect(isSuppressible(job(), [row({ confidence })])).toBe(false);
+    }
+  );
+
+  test("the gate follows the badge scale rather than a copied threshold", () => {
+    // The lowest confidence advisorBadge still labels "not related".
+    const lowestHigh = 0.89;
+    expect(confidenceBucket(lowestHigh)).toBe("high");
+    expect(isSuppressible(job(), [row({ confidence: lowestHigh })])).toBe(true);
+  });
+
+  // Deriving the gate from the badge scale is deliberate -- the comment must not
+  // say "not related" while the gate disagrees -- but it does mean a change to a
+  // UI scale moves a merge gate. Pin the number here so that change cannot be
+  // silent: retuning `confidenceBucket` turns this red and whoever does it has
+  // to decide the merge question on purpose.
+  test("the merge gate's effective floor is 0.89 -- retuning the badge scale must be deliberate", () => {
+    expect(confidentEnoughToSuppress(0.89)).toBe(true);
+    expect(confidentEnoughToSuppress(0.8899)).toBe(false);
   });
 
   test("a verdict older than the job's completion is a stale rerun verdict", () => {
@@ -140,6 +199,86 @@ describe("isSuppressible", () => {
         row(),
       ])
     ).toBe(false);
+  });
+});
+
+describe("suppressibleJobIds", () => {
+  const OWNER = "pytorch";
+  const REPO = "pytorch";
+  const OTHER_SHA = "b".repeat(40);
+
+  let savedFlag: string | undefined;
+  beforeEach(() => {
+    savedFlag = process.env.DRCI_ADVISOR_SUPPRESSION_ENABLED;
+    process.env.DRCI_ADVISOR_SUPPRESSION_ENABLED = "true";
+  });
+  afterEach(() => {
+    if (savedFlag === undefined) {
+      delete process.env.DRCI_ADVISOR_SUPPRESSION_ENABLED;
+    } else {
+      process.env.DRCI_ADVISOR_SUPPRESSION_ENABLED = savedFlag;
+    }
+  });
+
+  function ids(
+    jobs: RecentWorkflowsData[],
+    rows: AdvisorVerdictRow[],
+    headSha = HEAD_SHA
+  ): number[] {
+    return [...suppressibleJobIds(OWNER, REPO, headSha, jobs, rows)].sort(
+      (a, b) => a - b
+    );
+  }
+
+  test("a cleared job is returned when the flag is on", () => {
+    expect(ids([job()], [row()])).toEqual([1]);
+  });
+
+  test("the flag being off clears nothing", () => {
+    process.env.DRCI_ADVISOR_SUPPRESSION_ENABLED = "false";
+    expect(ids([job()], [row()])).toEqual([]);
+  });
+
+  test("an advisor-disabled repo clears nothing even with the flag on", () => {
+    expect([
+      ...suppressibleJobIds(
+        OWNER,
+        "not-an-advisor-repo",
+        HEAD_SHA,
+        [job()],
+        [row()]
+      ),
+    ]).toEqual([]);
+  });
+
+  test("a verdict for a different head does not clear this head's job", () => {
+    expect(ids([job()], [row({ sha: OTHER_SHA })])).toEqual([]);
+  });
+
+  test("a FixedString-padded sha still matches the head", () => {
+    expect(ids([job()], [row({ sha: `${HEAD_SHA}    ` })])).toEqual([1]);
+  });
+
+  test("rows are matched to jobs by the dr_ci_ signal key, not the bare name", () => {
+    // Same verdict, keyed by the raw job name instead of `dr_ci_<name>`.
+    expect(ids([job()], [row({ signal_key: job().name })])).toEqual([]);
+  });
+
+  test("a verdict for one job does not clear a different job", () => {
+    const cleared = job({ id: 1 });
+    const other = job({
+      id: 2,
+      name: "pull / linux-jammy-py3.10-gcc11 / build",
+    });
+    expect(ids([cleared, other], [row()])).toEqual([1]);
+  });
+
+  test("no rows at all clears nothing", () => {
+    expect(ids([job()], [])).toEqual([]);
+  });
+
+  test("an unnamed job is skipped rather than throwing", () => {
+    expect(ids([job({ name: undefined })], [row()])).toEqual([]);
   });
 });
 

--- a/torchci/test/advisorSuppression.test.ts
+++ b/torchci/test/advisorSuppression.test.ts
@@ -232,16 +232,26 @@ describe("suppressibleJobIds", () => {
   const REPO = "pytorch";
   const OTHER_SHA = "b".repeat(40);
 
-  let savedFlag: string | undefined;
+  // Suppression requires BOTH flags, so the default here is both on and the
+  // truth table below is what pins that.
+  let savedSuppression: string | undefined;
+  let savedComment: string | undefined;
   beforeEach(() => {
-    savedFlag = process.env.DRCI_ADVISOR_SUPPRESSION_ENABLED;
+    savedSuppression = process.env.DRCI_ADVISOR_SUPPRESSION_ENABLED;
+    savedComment = process.env.DRCI_ADVISOR_COMMENT_ENABLED;
     process.env.DRCI_ADVISOR_SUPPRESSION_ENABLED = "true";
+    process.env.DRCI_ADVISOR_COMMENT_ENABLED = "true";
   });
   afterEach(() => {
-    if (savedFlag === undefined) {
-      delete process.env.DRCI_ADVISOR_SUPPRESSION_ENABLED;
-    } else {
-      process.env.DRCI_ADVISOR_SUPPRESSION_ENABLED = savedFlag;
+    for (const [name, saved] of [
+      ["DRCI_ADVISOR_SUPPRESSION_ENABLED", savedSuppression],
+      ["DRCI_ADVISOR_COMMENT_ENABLED", savedComment],
+    ] as const) {
+      if (saved === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = saved;
+      }
     }
   });
 
@@ -255,12 +265,24 @@ describe("suppressibleJobIds", () => {
     );
   }
 
-  test("a cleared job is returned when the flag is on", () => {
-    expect(ids([job()], [row()])).toEqual([1]);
-  });
+  // The whole flag surface, because the interesting cell is the last one: a
+  // merge gate must not open while the comment that accounts for it is dark.
+  test.each([
+    ["true", "true", [1]],
+    ["true", "false", []],
+    ["false", "true", []],
+    ["false", "false", []],
+  ])(
+    "suppression=%s comment=%s clears %p",
+    (suppression, comment, expected) => {
+      process.env.DRCI_ADVISOR_SUPPRESSION_ENABLED = suppression;
+      process.env.DRCI_ADVISOR_COMMENT_ENABLED = comment;
+      expect(ids([job()], [row()])).toEqual(expected);
+    }
+  );
 
-  test("the flag being off clears nothing", () => {
-    process.env.DRCI_ADVISOR_SUPPRESSION_ENABLED = "false";
+  test("an unset comment flag is as good as off", () => {
+    delete process.env.DRCI_ADVISOR_COMMENT_ENABLED;
     expect(ids([job()], [row()])).toEqual([]);
   });
 

--- a/torchci/test/advisorSuppression.test.ts
+++ b/torchci/test/advisorSuppression.test.ts
@@ -3,6 +3,7 @@ import {
   confidentEnoughToSuppress,
   extractSuppressed,
   isSuppressible,
+  SUPPRESSIBLE_VERDICTS,
   suppressibleJobIds,
 } from "lib/advisor/advisorSuppression";
 import { AdvisorVerdictRow, resolveVerdict } from "lib/advisorVerdictUtils";
@@ -125,18 +126,42 @@ describe("resolveVerdict", () => {
 });
 
 describe("isSuppressible", () => {
-  test("a confident, fresh not_related verdict clears the job", () => {
-    expect(isSuppressible(job(), [row()])).toBe(true);
-  });
+  test.each(["not_related", "infra_issue", "garbage"])(
+    "a confident, fresh %s verdict clears the job",
+    (verdict) => {
+      expect(isSuppressible(job(), [row({ verdict })])).toBe(true);
+    }
+  );
 
   test("no verdict keeps the job blocking", () => {
     expect(isSuppressible(job(), [])).toBe(false);
   });
 
-  test.each(["related", "revert", "unsure", "garbage", "infra_issue"])(
+  test.each(["related", "revert", "unsure"])(
     "%s keeps the job blocking",
     (verdict) => {
       expect(isSuppressible(job(), [row({ verdict })])).toBe(false);
+    }
+  );
+
+  // The set is the whole policy, so pin it: adding a verdict to
+  // AdvisorVerdictType without deciding which side it falls on turns this red.
+  test("the suppressible set is exactly the three cleared verdicts", () => {
+    expect([...SUPPRESSIBLE_VERDICTS].sort()).toEqual([
+      "garbage",
+      "infra_issue",
+      "not_related",
+    ]);
+  });
+
+  // Widening the verdict set must not widen the outcome gate with it: an infra
+  // fault that stopped the job before it concluded `failure` still blocks.
+  test.each(["cancelled", "timed_out", "action_required", "neutral"])(
+    "an infra_issue verdict on a %s job still keeps it blocking",
+    (conclusion) => {
+      expect(
+        isSuppressible(job({ conclusion }), [row({ verdict: "infra_issue" })])
+      ).toBe(false);
     }
   );
 

--- a/torchci/test/advisorVerdictSource.test.ts
+++ b/torchci/test/advisorVerdictSource.test.ts
@@ -1,0 +1,72 @@
+import { shouldReadAdvisorVerdicts } from "lib/advisor/advisorVerdictSource";
+import { RecentWorkflowsData } from "lib/types";
+
+const JOBS = [
+  { id: 1, name: "pull / build" },
+] as unknown as RecentWorkflowsData[];
+const NO_JOBS: RecentWorkflowsData[] = [];
+
+// pytorch/pytorch is advisor-enabled in advisorConfig; this one is not.
+const OFF_REPO = "not-an-advisor-repo";
+
+function withFlags(
+  comment: string | undefined,
+  suppression: string | undefined,
+  fn: () => void
+) {
+  const savedC = process.env.DRCI_ADVISOR_COMMENT_ENABLED;
+  const savedS = process.env.DRCI_ADVISOR_SUPPRESSION_ENABLED;
+  const set = (k: string, v: string | undefined) =>
+    v === undefined ? delete process.env[k] : (process.env[k] = v);
+  set("DRCI_ADVISOR_COMMENT_ENABLED", comment);
+  set("DRCI_ADVISOR_SUPPRESSION_ENABLED", suppression);
+  try {
+    fn();
+  } finally {
+    set("DRCI_ADVISOR_COMMENT_ENABLED", savedC);
+    set("DRCI_ADVISOR_SUPPRESSION_ENABLED", savedS);
+  }
+}
+
+describe("shouldReadAdvisorVerdicts", () => {
+  test("both flags off means no read", () => {
+    withFlags("false", "false", () => {
+      expect(shouldReadAdvisorVerdicts("pytorch", "pytorch", JOBS)).toBe(false);
+    });
+  });
+
+  test("the comment flag alone is enough to read", () => {
+    withFlags("true", "false", () => {
+      expect(shouldReadAdvisorVerdicts("pytorch", "pytorch", JOBS)).toBe(true);
+    });
+  });
+
+  test("the suppression flag alone is enough to read", () => {
+    withFlags("false", "true", () => {
+      expect(shouldReadAdvisorVerdicts("pytorch", "pytorch", JOBS)).toBe(true);
+    });
+  });
+
+  // The regression this guard exists for: most PRs have no new or unclassified
+  // failures, and both consumers bail on an empty list, so reading for them
+  // would be a ClickHouse round trip per PR that nothing can use.
+  test("no eligible jobs means no read even with both flags on", () => {
+    withFlags("true", "true", () => {
+      expect(shouldReadAdvisorVerdicts("pytorch", "pytorch", NO_JOBS)).toBe(
+        false
+      );
+    });
+  });
+
+  test("an advisor-disabled repo means no read", () => {
+    withFlags("true", "true", () => {
+      expect(shouldReadAdvisorVerdicts("pytorch", OFF_REPO, JOBS)).toBe(false);
+    });
+  });
+
+  test("an unset flag is off, not on", () => {
+    withFlags(undefined, undefined, () => {
+      expect(shouldReadAdvisorVerdicts("pytorch", "pytorch", JOBS)).toBe(false);
+    });
+  });
+});

--- a/torchci/test/advisorVerdictSource.test.ts
+++ b/torchci/test/advisorVerdictSource.test.ts
@@ -41,9 +41,12 @@ describe("shouldReadAdvisorVerdicts", () => {
     });
   });
 
-  test("the suppression flag alone is enough to read", () => {
+  // "Suppression alone" is not a reachable state: advisorSuppressionEnabled
+  // requires the comment flag, so this reads nothing rather than reading for a
+  // gate that would then be inert anyway.
+  test("the suppression flag alone reads nothing", () => {
     withFlags("false", "true", () => {
-      expect(shouldReadAdvisorVerdicts("pytorch", "pytorch", JOBS)).toBe(true);
+      expect(shouldReadAdvisorVerdicts("pytorch", "pytorch", JOBS)).toBe(false);
     });
   });
 

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -268,6 +268,7 @@ function constructResultsCommentHelper({
   unknownJobs = [],
   awaitingApprovalJobs = [],
   crcrL3Jobs = [],
+  aiNotRelatedJobs = [],
   sha = "random sha",
   merge_base = "random_merge_base_sha",
   merge_base_date = "2023-08-08 06:03:21",
@@ -285,6 +286,7 @@ function constructResultsCommentHelper({
   unknownJobs?: RecentWorkflowsData[];
   awaitingApprovalJobs?: RecentWorkflowsData[];
   crcrL3Jobs?: RecentWorkflowsData[];
+  aiNotRelatedJobs?: RecentWorkflowsData[];
   sha?: string;
   merge_base?: string;
   merge_base_date?: string;
@@ -303,6 +305,7 @@ function constructResultsCommentHelper({
     unknownJobs,
     awaitingApprovalJobs,
     crcrL3Jobs,
+    aiNotRelatedJobs,
     new Map(),
     new Map(),
     new Map(),


### PR DESCRIPTION
✴️ iz2: opened on behalf of @izaitsevfb.

The AI CI Advisor already analyzes NEW and Unclassified failures and renders its verdict inline in the pytorchbot comment, but the verdict currently changes nothing: the job still sits in the NEW FAILURES section and still blocks the merge.

This moves the failures the advisor has cleared into their own non-blocking bucket, `AI_NOT_RELATED`, in the same place and shape as the existing `CRCR_L3` block. Two things fall out of that for free:

* **The comment.** `newFailedJobs` and the "N New Failures" header both derive from `failedJobs`, so cleared jobs leave the NEW section automatically. They get their own collapsed section, still carrying their `AI verdict:` line, and count toward "Unrelated".
* **Merge.** `failures[pr]` is both the `/api/drci/drci` response and the `Dr.CI` check-run summary, so `trymerge.py` can read the new category with no extra request and no new auth surface. The merge-bot side is pytorch/pytorch#195503; nothing in this PR affects merges on its own.

## Which verdicts are cleared

`not_related`, `infra_issue` and `garbage`, at high confidence. All three make the same claim about the PR under review — this failure is not evidence against it — and they are encoded as a **total map** over `AdvisorVerdictType`, so adding a verdict fails to compile until someone decides which side it falls on.

`garbage` sits with the cleared ones rather than with `unsure` because it is an *evidenced* claim about the signal, not the absence of one: the advisor reaches it by comparing the job against its own baselines and finding the red flips across unrelated commits. `unsure` is the real "cannot tell", and it keeps blocking, as do `related` and `revert`.

Measured over 30 days on PR-side verdicts at high confidence, joined to each job's own conclusion: `not_related` 1179 jobs, `infra_issue` 976, `garbage` 1.

## The two flags, and why suppression depends on the comment

Two deployment flags, not one:

* `DRCI_ADVISOR_COMMENT_ENABLED` — render the inline `AI verdict:` line. Display only.
* `DRCI_ADVISOR_SUPPRESSION_ENABLED` — move cleared failures out of the blocking set.

**Suppression requires the comment flag and is inert without it.** Suppression with the comment dark would move a job into the non-blocking section while `buildAdvisorVerdictLines` returns nothing, so the reader is told the AI cleared the job but never which verdict cleared it or why — and trymerge would stop blocking on a flag that says nothing about merges. That combination has no use, so it is unreachable by construction rather than left to deployment discipline.

They stay two flags rather than one because the display half can be enabled on its own while the merge gate stays off, which is the intended rollout order. The whole flag surface is pinned by a truth table.

## The rest of the predicate

Every branch fails toward blocking:

* **Confidence in the `high` bucket.** Asked of `confidenceBucket` rather than restating its threshold, so retuning the badge scale cannot leave the comment saying "probably not related" while this still suppresses. A test pins the effective floor so that retune cannot be silent either.
* **The verdict must be strictly newer than the job's `completed_at`.** Verdicts are keyed by `(sha, job name)` with no run identity, so a rerun at the same head would otherwise inherit the previous run's verdict.
* **The job must have concluded `failure`.** A cancelled or timed-out job produced no outcome to clear. This gate is what keeps an infra fault that stopped the job before it concluded from being cleared.
* **Absent, ambiguous or unusable is not a verdict.** Rows tied at the newest timestamp that disagree resolve to "no answer"; tied rows that agree resolve to the least confident of them; and a confidence that is not a real number in `[0, 1]` makes the whole key ambiguous.

## One read, one resolver

The saved query `advisor_verdicts_for_pr` used to run twice per PR per pass — once for the inline badge, once for the gate — and the two callers resolved the current verdict by *different* rules, so rows tied at the newest timestamp could render a green "not related" badge on a job the gate kept blocking. `drci.ts` now reads once and hands the rows to both, through a shared `resolveVerdict`. The read is also skipped entirely when the PR has no new or unclassified failures, which is most PRs.

`resolveVerdict` picks the newest row by comparing the `timestamp` strings directly. That is safe rather than incidental: `misc.autorevert_advisor_verdicts.timestamp` is `DateTime64(3)` on a UTC server, so every row in a response renders fixed-width `YYYY-MM-DD HH:MM:SS.mmm` and lexicographic order is chronological order. `dayjs` is used in the one place the formats actually differ — comparing a ClickHouse timestamp against GitHub's ISO-8601 `completed_at` in the freshness gate.

## Known limitations

* **Rerun freshness.** The freshness check rejects the common stale-verdict ordering but not all of it: a verdict for run A that lands *after* a rerun B has finished still passes. Closing that needs the analyzed job id on the verdict row — the row's `run_id` is the advisor's own dispatch run, not the job's.
* **The badge does not apply that freshness check**, only the gate does, so a stale verdict can render a confident badge on a job that is still blocking. Pre-existing and deliberate — the display module and the gate are separate by design — but worth deciding before the flag goes on.
* **An `infra_issue` verdict says a failure looks environmental, not that the PR did not cause it.** A change to a submodule pin, workflow YAML, a Dockerfile or a dependency pin can produce a genuine infrastructure-shaped failure that *is* the PR's fault. pytorch/pytorch#195502 addresses this in the advisor prompt by making `related` outrank every dismissal.

All three are conditions on enabling, not on landing the code.

## Safety

No-op unless **both** `DRCI_ADVISOR_SUPPRESSION_ENABLED=true` and `DRCI_ADVISOR_COMMENT_ENABLED=true`, and the repo is advisor-enabled. A ClickHouse error falls back to an empty set, so the worst case is today's behaviour. The lookup runs before the CRCR block so CRCR L4 jobs, which are pushed into `failedJobs` there and are never advisor-analyzed, cannot be eligible; extraction mutates the arrays in place because the same objects back both the failures dict and the comment renderer.

## Test plan

* `torchci/test/advisorSuppression.test.ts` — every predicate branch, the verdict set, verdict ambiguity, non-finite and out-of-range confidence in both orderings, timestamp staleness, the head-commit row filter, the `dr_ci_<name>` key mapping, the repo gate, and a truth table over both flags including the unset-is-off case.
* `torchci/test/advisorComment.test.ts` — the badge side of the shared resolver, including that a conflicting tie renders no badge and that a tied pair renders the least-confident row whole.
* `torchci/test/advisorVerdictSource.test.ts` — the read guard, including that a PR with no eligible jobs costs no query and that the suppression flag alone reads nothing.
* Mutation-tested: each new test file was run against deliberate mutations with a positive control and a vacuity control, and every mutation was caught.
* `tsc --noEmit`, prettier and `next lint` clean. Full jest run green: all 62 suites pass.
* Reviewed cross-model at high effort over several rounds. Findings applied include the duplicate read and tie divergence above, a fail-open bug where a `NaN` confidence would have been discarded in favour of a usable one, a needless query on PRs with no failures, and the section wording, which said "NOT RELATED TO THIS PR" and would have been false for a job cleared as an infra fault.

**Not covered:** the `drci.ts` orchestration block itself has no automated test. Its constituent decisions are extracted and unit-tested instead; covering the orchestration itself would mean importing `drci.ts` and its whole dependency graph. Worth deciding before the flag goes on.
