### PR TITLE
Add an AI_NOT_RELATED bucket for advisor-cleared failures

### DIFF
--- a/torchci/lib/advisor/advisorSuppression.ts
+++ b/torchci/lib/advisor/advisorSuppression.ts
@@ -1,0 +1,189 @@
+// Decides which NEW/unclassified failures the AI CI Advisor has cleared well
+// enough to stop blocking a merge.
+//
+// Deliberately separate from advisorComment.ts. That module renders a display
+// line and is gated by a display flag; this one moves a failure out of the
+// blocking set, so it gets its own flag and a strictly narrower predicate.
+// Everything here is fail-safe: any missing, stale, ambiguous or low-confidence
+// verdict leaves the job blocking.
+
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import { drciSignalKeyForJob } from "lib/advisor/advisorBadge";
+import { isAdvisorEnabled } from "lib/advisor/advisorConfig";
+import { AdvisorVerdictRow } from "lib/advisorVerdictUtils";
+import { isTime0 } from "lib/bot/utils";
+import { queryClickhouseSaved } from "lib/clickhouse";
+import { RecentWorkflowsData } from "lib/types";
+
+dayjs.extend(utc);
+
+// The only verdict that stops a failure from blocking. `infra_issue` is
+// excluded on purpose: it means CI broke before producing a test outcome, so
+// suppressing it would convert untested into green.
+export const SUPPRESSIBLE_VERDICT = "not_related";
+
+// The badge scale's `high` bucket. The UI already labels anything below this
+// "probably not related" or "not related (uncertain)", and an uncertain verdict
+// is not a basis for skipping a gate.
+export const MIN_SUPPRESSION_CONFIDENCE = 0.89;
+
+// A verdict describes one execution of a job, but is keyed only by (sha, job
+// name), so a rerun at the same head would otherwise inherit the previous run's
+// verdict. Requiring the verdict to be strictly newer than the job's completion
+// rejects the common case: the rerun finishes after the old verdict was
+// written, so the job blocks until a fresh analysis lands. Equality is treated
+// as stale because these timestamps are truncated and a tie cannot be told
+// apart from the unsafe ordering.
+//
+// KNOWN GAP, and the reason this ships behind a flag: a verdict for execution A
+// that lands after execution B has finished still passes this test. Closing it
+// needs the analyzed job id recorded on the verdict row -- the row's `run_id`
+// is the advisor's own dispatch run, not the job's.
+function verdictDescribesThisRun(
+  job: RecentWorkflowsData,
+  verdictTimestamp: string
+): boolean {
+  // isTime0 covers the epoch sentinel AND unparseable input (it NaN-checks), so
+  // a malformed timestamp on either side blocks rather than passing.
+  if (isTime0(job.completed_at) || isTime0(verdictTimestamp)) {
+    return false;
+  }
+  return dayjs.utc(verdictTimestamp).isAfter(dayjs.utc(job.completed_at));
+}
+
+// Only a conclusive `failure` is eligible. `cancelled`, `timed_out`,
+// `action_required` and friends did not produce a test outcome, and the advisor
+// labels much of that class `not_related` anyway -- see the shadow-mode
+// adjudication. This narrows that exposure; it does not close it, because a
+// job can also fail without a real outcome (runner lost, driver fault) while
+// still concluding `failure`. That residue is what the manual adjudication
+// before enforcement is for.
+export function producedATestOutcome(job: RecentWorkflowsData): boolean {
+  return job.conclusion === "failure";
+}
+
+export function advisorSuppressionEnabled(
+  owner: string,
+  repo: string
+): boolean {
+  return (
+    process.env.DRCI_ADVISOR_SUPPRESSION_ENABLED === "true" &&
+    isAdvisorEnabled(owner, repo)
+  );
+}
+
+/**
+ * Pick the verdict for one signal key, keeping "ambiguous" distinct from
+ * "absent". Rows tied at the newest timestamp with different verdicts mean an
+ * answer arrived and is unusable, so the job keeps blocking rather than taking
+ * whichever row sorted first. Tied rows that agree on the verdict but differ on
+ * confidence resolve to the LOWEST, since confidence is part of the safety
+ * decision too.
+ *
+ * Sorts rather than trusting the caller: the saved query orders by timestamp
+ * with no tie-breaker, and "whatever ClickHouse returned first" is not a basis
+ * for skipping a merge gate.
+ */
+export function resolveVerdict(
+  rows: AdvisorVerdictRow[]
+): { verdict: string; confidence: number; timestamp: string } | null {
+  if (rows.length === 0) {
+    return null;
+  }
+  const newestTimestamp = rows
+    .map((r) => r.timestamp)
+    .reduce((a, b) => (a > b ? a : b));
+  const tied = rows.filter((r) => r.timestamp === newestTimestamp);
+  if (tied.some((r) => r.verdict !== tied[0].verdict)) {
+    return null;
+  }
+  return {
+    verdict: tied[0].verdict,
+    confidence: Math.min(...tied.map((r) => r.confidence)),
+    timestamp: newestTimestamp,
+  };
+}
+
+/** Whether one job's verdict clears it to stop blocking. Pure, for testing. */
+export function isSuppressible(
+  job: RecentWorkflowsData,
+  rows: AdvisorVerdictRow[]
+): boolean {
+  if (!producedATestOutcome(job)) {
+    return false;
+  }
+  const resolved = resolveVerdict(rows);
+  if (resolved === null) {
+    return false;
+  }
+  return (
+    resolved.verdict === SUPPRESSIBLE_VERDICT &&
+    resolved.confidence >= MIN_SUPPRESSION_CONFIDENCE &&
+    verdictDescribesThisRun(job, resolved.timestamp)
+  );
+}
+
+/**
+ * Job ids among `jobs` that the advisor has cleared. Returns an empty set when
+ * the flag is off, so the caller needs no separate check. The caller must also
+ * wrap this: a ClickHouse error can never be allowed to break the comment.
+ */
+export async function fetchSuppressibleJobIds(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  headSha: string,
+  jobs: RecentWorkflowsData[]
+): Promise<Set<number>> {
+  if (!advisorSuppressionEnabled(owner, repo) || jobs.length === 0) {
+    return new Set();
+  }
+
+  const allRows = (await queryClickhouseSaved("advisor_verdicts_for_pr", {
+    repo: `${owner}/${repo}`,
+    prNumber,
+  })) as AdvisorVerdictRow[];
+
+  // Rows arrive newest-first; keep only this head's, grouped by signal key.
+  const rowsByKey = new Map<string, AdvisorVerdictRow[]>();
+  for (const row of allRows) {
+    if (row.sha.trim() !== headSha) {
+      continue;
+    }
+    const key = row.signal_key;
+    rowsByKey.set(key, (rowsByKey.get(key) ?? []).concat(row));
+  }
+
+  const suppressible = new Set<number>();
+  for (const job of jobs) {
+    if (!job.name) {
+      continue;
+    }
+    const rows = rowsByKey.get(drciSignalKeyForJob(job.name)) ?? [];
+    if (isSuppressible(job, rows)) {
+      suppressible.add(job.id);
+    }
+  }
+  return suppressible;
+}
+
+/**
+ * Move cleared jobs out of `blocking` and return them, mutating the array in
+ * place. In place because drci.ts hands the same array object to both the
+ * failures dict and the comment renderer, and CRCR L4 pushes into it later --
+ * rebinding would silently desync those.
+ */
+export function extractSuppressed(
+  blocking: RecentWorkflowsData[],
+  suppressibleIds: Set<number>
+): RecentWorkflowsData[] {
+  const extracted: RecentWorkflowsData[] = [];
+  for (let i = blocking.length - 1; i >= 0; i--) {
+    if (suppressibleIds.has(blocking[i].id)) {
+      extracted.unshift(blocking[i]);
+      blocking.splice(i, 1);
+    }
+  }
+  return extracted;
+}

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -4,6 +4,10 @@ import utc from "dayjs/plugin/utc";
 import { ADVISOR_PENDING_ALT_ATTR } from "lib/advisor/advisorBadge";
 import { buildAdvisorVerdictLines } from "lib/advisor/advisorComment";
 import { autoDispatchAdvisorForNewFailures } from "lib/advisor/advisorDispatch";
+import {
+  extractSuppressed,
+  fetchSuppressibleJobIds,
+} from "lib/advisor/advisorSuppression";
 import { fetchJSON, isTime0 } from "lib/bot/utils";
 import { queryClickhouse, queryClickhouseSaved } from "lib/clickhouse";
 import {
@@ -321,6 +325,38 @@ export async function updateDrciComments(
         );
       }
 
+      // Move failures the advisor cleared as `not_related` into their own
+      // bucket, so they leave the NEW/UNCLASSIFIED sections and stop blocking
+      // the merge. Runs BEFORE the CRCR block below on purpose: CRCR L4 jobs
+      // are pushed into failedJobs there and were never advisor-analyzed, so
+      // they must not be eligible. Wrapped so a ClickHouse error can never
+      // break the comment -- and failing to an empty set keeps everything
+      // blocking, which is the safe direction.
+      const aiNotRelatedJobs: RecentWorkflowsData[] = [];
+      try {
+        const suppressible = await fetchSuppressibleJobIds(
+          owner,
+          repo,
+          pr_info.pr_number,
+          pr_info.head_sha,
+          [...failedJobs, ...unknownJobs]
+        );
+        aiNotRelatedJobs.push(
+          ...extractSuppressed(failedJobs, suppressible),
+          ...extractSuppressed(unknownJobs, suppressible)
+        );
+      } catch (e) {
+        console.error(
+          "advisor suppression lookup threw for PR",
+          pr_info.pr_number,
+          e
+        );
+      }
+
+      if (aiNotRelatedJobs.length > 0) {
+        failures[pr_info.pr_number].AI_NOT_RELATED = aiNotRelatedJobs;
+      }
+
       // Classify CRCR downstream CI jobs (L3 = non-blocking, L4 = blocking).
       // These jobs live in oot_workflow_job, not workflow_job, so they are fetched
       // separately and classified based on their downstream_repo_level.
@@ -356,6 +392,7 @@ export async function updateDrciComments(
         unknownJobs,
         awaitingApprovalJobs,
         crcrL3Jobs,
+        aiNotRelatedJobs,
         relatedJobs,
         relatedIssues,
         relatedInfo,
@@ -836,6 +873,7 @@ export function constructResultsComment(
   unknownJobs: RecentWorkflowsData[],
   awaitingApprovalJobs: RecentWorkflowsData[],
   crcrL3Jobs: RecentWorkflowsData[],
+  aiNotRelatedJobs: RecentWorkflowsData[],
   relatedJobs: Map<number, RecentWorkflowsData>,
   relatedIssues: Map<number, IssueData[]>,
   relatedInfo: Map<number, string>,
@@ -858,6 +896,7 @@ export function constructResultsComment(
     .concat(brokenTrunkJobs)
     .concat(unstableJobs)
     .concat(crcrL3Jobs)
+    .concat(aiNotRelatedJobs)
     .filter((job) => !isPending(job))
     .value().length;
   const newFailedJobs: RecentWorkflowsData[] = failedJobs.filter(
@@ -982,10 +1021,11 @@ export function constructResultsComment(
     );
   }
 
-  // advisorLines is threaded only into the NEW FAILURES and UNCLASSIFIED
-  // sections below -- those are the only failures the advisor dispatches on.
-  // Broken-trunk / flaky / unstable / awaiting-approval jobs are already
-  // explained by their own section, so they intentionally get no verdict line.
+  // advisorLines is threaded only into the NEW FAILURES, UNCLASSIFIED and
+  // advisor-cleared sections -- those are the only failures the advisor
+  // dispatches on. Broken-trunk / flaky / unstable / awaiting-approval jobs are
+  // already explained by their own section, so they intentionally get no
+  // verdict line.
   if (newFailedJobs.length) {
     output += constructResultsJobsSections(
       hudBaseUrl,
@@ -1125,6 +1165,32 @@ export function constructResultsComment(
     relatedJobs,
     relatedIssues,
     relatedInfo
+  );
+  output += constructResultsJobsSections(
+    hudBaseUrl,
+    owner,
+    repo,
+    prNumber,
+    "NOT RELATED TO THIS PR (non-blocking)",
+    `The following ${pluralize(
+      "job",
+      aiNotRelatedJobs.length
+    )} failed but the AI CI Advisor judged ${pluralize(
+      "it",
+      aiNotRelatedJobs.length,
+      "them"
+    )} unrelated to this PR, so ${pluralize(
+      "it is",
+      aiNotRelatedJobs.length,
+      "they are"
+    )} non-blocking`,
+    aiNotRelatedJobs,
+    "",
+    true,
+    relatedJobs,
+    relatedIssues,
+    relatedInfo,
+    advisorLines
   );
   return output;
 }

--- a/torchci/test/advisorSuppression.test.ts
+++ b/torchci/test/advisorSuppression.test.ts
@@ -1,0 +1,166 @@
+import {
+  extractSuppressed,
+  isSuppressible,
+  MIN_SUPPRESSION_CONFIDENCE,
+  resolveVerdict,
+} from "lib/advisor/advisorSuppression";
+import { AdvisorVerdictRow } from "lib/advisorVerdictUtils";
+import { RecentWorkflowsData } from "lib/types";
+
+const HEAD_SHA = "a".repeat(40);
+const JOB_DONE_AT = "2026-08-28 12:00:00.000";
+const AFTER_JOB = "2026-08-28 12:05:00.000";
+const BEFORE_JOB = "2026-08-28 11:55:00.000";
+
+function job(
+  overrides: Partial<RecentWorkflowsData> = {}
+): RecentWorkflowsData {
+  return {
+    id: 1,
+    name: "pull / linux-jammy-py3.10-gcc11 / test",
+    conclusion: "failure",
+    completed_at: JOB_DONE_AT,
+    ...overrides,
+  } as unknown as RecentWorkflowsData;
+}
+
+function row(overrides: Partial<AdvisorVerdictRow> = {}): AdvisorVerdictRow {
+  return {
+    sha: HEAD_SHA,
+    signal_key: "dr_ci_pull / linux-jammy-py3.10-gcc11 / test",
+    verdict: "not_related",
+    confidence: 0.95,
+    timestamp: AFTER_JOB,
+    ...overrides,
+  } as unknown as AdvisorVerdictRow;
+}
+
+describe("resolveVerdict", () => {
+  test("no rows is absent, not a verdict", () => {
+    expect(resolveVerdict([])).toBeNull();
+  });
+
+  test("newest row wins", () => {
+    const resolved = resolveVerdict([
+      row({ verdict: "not_related", timestamp: AFTER_JOB }),
+      row({ verdict: "related", timestamp: BEFORE_JOB }),
+    ]);
+    expect(resolved?.verdict).toBe("not_related");
+  });
+
+  test("conflicting rows tied at the newest timestamp resolve to null", () => {
+    expect(
+      resolveVerdict([
+        row({ verdict: "not_related", timestamp: AFTER_JOB }),
+        row({ verdict: "related", timestamp: AFTER_JOB }),
+      ])
+    ).toBeNull();
+  });
+
+  test("agreeing rows tied at the newest timestamp still resolve", () => {
+    expect(
+      resolveVerdict([
+        row({ timestamp: AFTER_JOB }),
+        row({ timestamp: AFTER_JOB }),
+      ])?.verdict
+    ).toBe("not_related");
+  });
+
+  test("tied rows that disagree on confidence resolve to the lowest", () => {
+    expect(
+      resolveVerdict([
+        row({ timestamp: AFTER_JOB, confidence: 0.95 }),
+        row({ timestamp: AFTER_JOB, confidence: 0.4 }),
+      ])?.confidence
+    ).toBe(0.4);
+  });
+
+  test("does not trust the caller's ordering", () => {
+    const resolved = resolveVerdict([
+      row({ verdict: "not_related", timestamp: BEFORE_JOB }),
+      row({ verdict: "related", timestamp: AFTER_JOB }),
+    ]);
+    expect(resolved?.verdict).toBe("related");
+  });
+});
+
+describe("isSuppressible", () => {
+  test("a confident, fresh not_related verdict clears the job", () => {
+    expect(isSuppressible(job(), [row()])).toBe(true);
+  });
+
+  test("no verdict keeps the job blocking", () => {
+    expect(isSuppressible(job(), [])).toBe(false);
+  });
+
+  test.each(["related", "revert", "unsure", "garbage", "infra_issue"])(
+    "%s keeps the job blocking",
+    (verdict) => {
+      expect(isSuppressible(job(), [row({ verdict })])).toBe(false);
+    }
+  );
+
+  test("confidence below the high bucket keeps the job blocking", () => {
+    expect(
+      isSuppressible(job(), [
+        row({ confidence: MIN_SUPPRESSION_CONFIDENCE - 0.01 }),
+      ])
+    ).toBe(false);
+  });
+
+  test("a verdict older than the job's completion is a stale rerun verdict", () => {
+    expect(isSuppressible(job(), [row({ timestamp: BEFORE_JOB })])).toBe(false);
+  });
+
+  test("a verdict exactly at the job's completion is ambiguous, so it blocks", () => {
+    expect(isSuppressible(job(), [row({ timestamp: JOB_DONE_AT })])).toBe(
+      false
+    );
+  });
+
+  test("an unparseable timestamp keeps the job blocking", () => {
+    expect(isSuppressible(job(), [row({ timestamp: "not a date" })])).toBe(
+      false
+    );
+    expect(isSuppressible(job({ completed_at: "not a date" }), [row()])).toBe(
+      false
+    );
+  });
+
+  test.each(["cancelled", "timed_out", "action_required", "neutral"])(
+    "a %s job never produced a test outcome, so it keeps blocking",
+    (conclusion) => {
+      expect(isSuppressible(job({ conclusion }), [row()])).toBe(false);
+    }
+  );
+
+  test("a zero completed_at keeps the job blocking", () => {
+    expect(
+      isSuppressible(job({ completed_at: "1970-01-01 00:00:00.000000000" }), [
+        row(),
+      ])
+    ).toBe(false);
+  });
+});
+
+describe("extractSuppressed", () => {
+  test("removes cleared jobs in place and returns them in order", () => {
+    const blocking = [job({ id: 1 }), job({ id: 2 }), job({ id: 3 })];
+    const extracted = extractSuppressed(blocking, new Set([1, 3]));
+    expect(extracted.map((j) => j.id)).toEqual([1, 3]);
+    expect(blocking.map((j) => j.id)).toEqual([2]);
+  });
+
+  test("mutates the caller's array rather than replacing it", () => {
+    const blocking = [job({ id: 1 })];
+    const sameRef = blocking;
+    extractSuppressed(blocking, new Set([1]));
+    expect(sameRef).toHaveLength(0);
+  });
+
+  test("an empty suppressible set is a no-op", () => {
+    const blocking = [job({ id: 1 }), job({ id: 2 })];
+    expect(extractSuppressed(blocking, new Set())).toEqual([]);
+    expect(blocking).toHaveLength(2);
+  });
+});

--- a/torchci/test/drci.test.ts
+++ b/torchci/test/drci.test.ts
@@ -268,6 +268,7 @@ function constructResultsCommentHelper({
   unknownJobs = [],
   awaitingApprovalJobs = [],
   crcrL3Jobs = [],
+  aiNotRelatedJobs = [],
   sha = "random sha",
   merge_base = "random_merge_base_sha",
   merge_base_date = "2023-08-08 06:03:21",
@@ -285,6 +286,7 @@ function constructResultsCommentHelper({
   unknownJobs?: RecentWorkflowsData[];
   awaitingApprovalJobs?: RecentWorkflowsData[];
   crcrL3Jobs?: RecentWorkflowsData[];
+  aiNotRelatedJobs?: RecentWorkflowsData[];
   sha?: string;
   merge_base?: string;
   merge_base_date?: string;
@@ -303,6 +305,7 @@ function constructResultsCommentHelper({
     unknownJobs,
     awaitingApprovalJobs,
     crcrL3Jobs,
+    aiNotRelatedJobs,
     new Map(),
     new Map(),
     new Map(),


### PR DESCRIPTION
✴️ iz2: closing — this was created in error. It duplicates #8671 exactly (same single commit, same 4 files); a `ghstack` run aborted partway and re-submitted the same commit under a second ghstack number. No review needed here.