### PR TITLE
[CRCR] Add trigger for update-crcr-terrafile workflow after release

### DIFF
--- a/.github/workflows/_lambda-do-release-runners.yml
+++ b/.github/workflows/_lambda-do-release-runners.yml
@@ -192,6 +192,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -228,3 +229,12 @@ jobs:
           name: ${{ inputs.tag }}
           tag: ${{ inputs.tag }}
           updateOnlyUnreleased: true
+
+      # `release: published` events created with the default GITHUB_TOKEN don't
+      # trigger other workflows (GitHub's anti-recursion rule), so
+      # update-crcr-terrafile.yml would never see this release. workflow_dispatch
+      # is exempt from that rule, so dispatch it directly instead.
+      - name: Trigger update-crcr-terrafile
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run update-crcr-terrafile.yml --repo "${{ github.repository }}" -f tag="${{ inputs.tag }}"


### PR DESCRIPTION
## Summary

- `update-crcr-terrafile.yml` listens for `release: published`, but the lambda release in `_lambda-do-release-runners.yml` is published by `ncipollo/release-action` using the default `GITHUB_TOKEN`. GitHub doesn't spawn new workflow runs for events authored by `GITHUB_TOKEN` (to prevent accidental recursive loops), so `release: published` never actually fired here — 0 runs since the workflow was added, despite dozens of lambda releases going out. Refer to [Triggering a workflow from a workflow](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow)
- `workflow_dispatch` is explicitly exempted from that rule:
  > workflow_dispatch and repository_dispatch events are explicit calls made by the customer and not likely to end up in a loop.
  > [GitHub Changelog, 2022-09-08](https://github.blog/changelog/2022-09-08-github-actions-use-github_token-with-workflow_dispatch-and-repository_dispatch/)
- So instead of relying on the `release` event, dispatch `update-crcr-terrafile.yml` directly (`gh workflow run ... -f tag=...`) as the last step of the release job, using the default `GITHUB_TOKEN` plus a new `actions: write` permission. `update-crcr-terrafile.yml` already had a `workflow_dispatch` input for exactly this.