### PR TITLE
Grant actions: write to the lambda release caller job

### DIFF
--- a/.github/workflows/lambda-release-tag-runners.yml
+++ b/.github/workflows/lambda-release-tag-runners.yml
@@ -60,6 +60,7 @@ jobs:
   call-release:
     permissions:
       contents: write
+      actions: write
     needs: tag
     uses: ./.github/workflows/_lambda-do-release-runners.yml
     with:


### PR DESCRIPTION
**Impact:** CI only — the lambda release pipeline in test-infra
**Risk:** low

## What
Adds `actions: write` to the `call-release` job in `lambda-release-tag-runners.yml`, so the reusable `_lambda-do-release-runners.yml` workflow actually receives that scope.

## Why
#8674 added a `gh workflow run update-crcr-terrafile.yml` step to the `release` job and declared `actions: write` on it. A reusable workflow can only narrow the permissions it gets from the caller, never widen them — the caller only granted `contents: write`, so the dispatch step would fail with a 403.

Signed-off-by: Jean Schmidt <contato@jschmidt.me>