### PR TITLE
linux_job_v3: refresh the HF cache unattended, and honour the label off a PR

### DIFF
--- a/.github/workflows/linux_job_v3.yml
+++ b/.github/workflows/linux_job_v3.yml
@@ -223,9 +223,40 @@ jobs:
       # mount; the sync step below pushes it back to S3. Otherwise leave the mount.
       - name: Resolve HF cache mode
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EVENT_HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'ci-refresh-hf-cache') }}
         run: |
           set -euo pipefail
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'ci-refresh-hf-cache') }}" == "true" ]]; then
+
+          # Reads a GitHub REST path, authenticated if the token can, otherwise
+          # anonymously. Never fails the step: no answer means no refresh.
+          gh_get() {
+            curl -fsSL -H "Accept: application/vnd.github+json" \
+                 -H "Authorization: Bearer ${GH_TOKEN}" "https://api.github.com/$1" 2>/dev/null \
+              || curl -fsSL -H "Accept: application/vnd.github+json" \
+                   "https://api.github.com/$1" 2>/dev/null \
+              || true
+          }
+
+          REFRESH=0
+          if [[ "${GITHUB_EVENT_NAME}" == "schedule" || "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            # An unattended refresh, matching pytorch's _linux-test.yml. This is
+            # what keeps the shared cache seeded: without it the only way to add a
+            # model is for someone to label a pull request.
+            REFRESH=1
+          elif [[ "${EVENT_HAS_LABEL}" == "true" ]]; then
+            REFRESH=1
+          elif [[ "${GITHUB_REF_NAME:-}" =~ ^ciflow/[^/]+/([0-9]+)$ ]]; then
+            # A tag run carries no labels, but a ciflow tag names its pull request,
+            # as pytorch's filter_test_configs.py also relies on.
+            case "$(gh_get "repos/${REPO}/issues/${BASH_REMATCH[1]}/labels")" in
+              *'"ci-refresh-hf-cache"'*) REFRESH=1 ;;
+            esac
+          fi
+
+          if [[ "${REFRESH}" == "1" ]]; then
             {
               echo "HF_CACHE_REFRESH=1"
               echo "TRANSFORMERS_OFFLINE=0"

--- a/.github/workflows/test_linux_job_v3.yml
+++ b/.github/workflows/test_linux_job_v3.yml
@@ -248,6 +248,11 @@ jobs:
       script: |
         set -x
         echo "HF_CACHE_REFRESH=${HF_CACHE_REFRESH:-<unset>} HF_HOME=${HF_HOME:-<unset>}"
+        # This workflow's own trigger says which branch to expect: a dispatch run
+        # refreshes unconditionally, a pull request only with the label.
+        if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+          [[ "${HF_CACHE_REFRESH:-}" == "1" ]] || { echo "workflow_dispatch must refresh"; exit 1; }
+        fi
         if [[ "${HF_CACHE_REFRESH:-}" == "1" ]]; then
           # Refresh branch: HF must be repointed at writable RUNNER_TEMP and online.
           [[ "${HF_HOME}" == "${RUNNER_TEMP}/hf_cache" ]] || { echo "HF_HOME not repointed"; exit 1; }


### PR DESCRIPTION
The refresh label is read from `github.event.pull_request.labels`, which only exists on a `pull_request` event. So the `ciflow` tag run sitting next to a labelled PR ignores it, writes at the read-only `/mnt/hf_cache` mount, and dies on any model the seeded cache does not carry:

```
OSError: [Errno 30] Read-only file system: '/mnt/hf_cache/hub/models--timm--inception_v4.tf_in1k'
```

Example: a [tag run](https://github.com/pytorch/executorch/actions/runs/33449895877/job/99677334824) reporting `HF_CACHE_REFRESH: 0` on a labelled PR's own commit.

Two changes, both following pytorch's `_linux-test.yml`:

- A ciflow tag names its PR, so resolve the label off that — the same resolution `filter_test_configs.py` does.
- `schedule` and `workflow_dispatch` refresh unconditionally. This is what keeps the cache seeded; otherwise the only way to add a model is to label a PR, which is also the only way to find out one was needed.

Anything else, a plain push included, does not refresh, so the read-only mount stays the default.

## Tests

`test-hf-cache-mode` in `test_linux_job_v3.yml` already asserted whichever mode it was given; it now also requires that a `workflow_dispatch` run took the refresh branch, covering the unattended path.

The ciflow tag path has no coverage — test-infra has no ciflow tags to run against. I verified it by hand against pytorch/executorch: `ciflow/trunk/22247` (labelled) resolves to refresh, `ciflow/trunk/22106` (unlabelled) does not.

Authored with Claude Code.