### PR TITLE
Await the webhook signature verification so it can actually reject

### DIFF
--- a/terraform-aws-github-runner/modules/webhook/lambdas/webhook/src/webhook/handler.test.ts
+++ b/terraform-aws-github-runner/modules/webhook/lambdas/webhook/src/webhook/handler.test.ts
@@ -1,3 +1,5 @@
+import { createHmac } from 'crypto';
+
 import { handle } from './handler';
 import check_run_event from '../../test/resources/github_check_run_event.json';
 
@@ -10,11 +12,34 @@ jest.mock('../kms', () => ({
   }),
 }));
 
+const TEST_SECRET = 'TEST_SECRET';
+
+const sign = (payload: string, algorithm: 'sha256' | 'sha1' = 'sha256'): string =>
+  `${algorithm}=${createHmac(algorithm, TEST_SECRET).update(payload).digest('hex')}`;
+
+const signedHeaders = (payload: string, event = 'push') => ({
+  'X-Hub-Signature-256': sign(payload),
+  'X-GitHub-Event': event,
+});
+
+// A workflow_job/queued event IS actionable, so `sendActionRequest` assertions below are
+// only meaningful when the payload is this one — see the positive control test.
+const queuedWorkflowJob = JSON.stringify({
+  action: 'queued',
+  installation: { id: 42 },
+  repository: { name: 'pytorch', owner: { login: 'pytorch' } },
+  workflow_job: {
+    id: 1234,
+    labels: ['linux.2xlarge'],
+    html_url: 'https://github.com/pytorch/pytorch/actions/runs/1',
+  },
+});
+
 describe('handler', () => {
   let originalError: Console['error'];
 
   beforeEach(() => {
-    process.env.GITHUB_APP_WEBHOOK_SECRET = 'TEST_SECRET';
+    process.env.GITHUB_APP_WEBHOOK_SECRET = TEST_SECRET;
     originalError = console.error;
     console.error = jest.fn();
     jest.clearAllMocks();
@@ -29,31 +54,92 @@ describe('handler', () => {
     expect(resp).toBe(500);
   });
 
-  it('does not handle other events', async () => {
+  // Positive control: proves the actionable path really does fire when the signature is valid,
+  // which is what makes every `not.toBeCalled()` assertion below non-vacuous.
+  it('enqueues a correctly signed queued workflow_job', async () => {
+    const resp = await handle(signedHeaders(queuedWorkflowJob, 'workflow_job'), queuedWorkflowJob);
+    expect(resp).toBe(200);
+    expect(sendActionRequest).toBeCalledTimes(1);
+  });
+
+  it('returns 401 and does not enqueue when the signature does not match the payload', async () => {
     const resp = await handle(
-      { 'X-Hub-Signature': 'sha1=4a82d2f60346e16dab3546eb3b56d8dde4d5b659', 'X-GitHub-Event': 'push' },
-      JSON.stringify(check_run_event),
+      { 'X-Hub-Signature-256': `sha256=${'0'.repeat(64)}`, 'X-GitHub-Event': 'workflow_job' },
+      queuedWorkflowJob,
     );
+    expect(resp).toBe(401);
+    expect(sendActionRequest).not.toBeCalled();
+  });
+
+  it('returns 401 and does not enqueue when the payload was tampered with after signing', async () => {
+    const headers = signedHeaders(queuedWorkflowJob, 'workflow_job');
+    const tampered = JSON.stringify({ ...JSON.parse(queuedWorkflowJob), workflow_job: { id: 9999, labels: ['huge'] } });
+    const resp = await handle(headers, tampered);
+    expect(resp).toBe(401);
+    expect(sendActionRequest).not.toBeCalled();
+  });
+
+  it('returns 401 and does not enqueue when the signature was made with a different secret', async () => {
+    const foreign = `sha256=${createHmac('sha256', 'NOT_THE_SECRET').update(queuedWorkflowJob).digest('hex')}`;
+    const resp = await handle({ 'X-Hub-Signature-256': foreign, 'X-GitHub-Event': 'workflow_job' }, queuedWorkflowJob);
+    expect(resp).toBe(401);
+    expect(sendActionRequest).not.toBeCalled();
+  });
+
+  it('returns 401 when the signature header is not a recognisable digest', async () => {
+    const resp = await handle(
+      { 'X-Hub-Signature-256': 'not-a-signature', 'X-GitHub-Event': 'workflow_job' },
+      queuedWorkflowJob,
+    );
+    expect(resp).toBe(401);
+    expect(sendActionRequest).not.toBeCalled();
+  });
+
+  // The verifier throws (rather than returning false) on an empty payload; the handler must
+  // turn that into a 401 instead of an unhandled rejection.
+  it('returns 401 rather than throwing when the verifier rejects', async () => {
+    const resp = await handle({ 'X-Hub-Signature-256': sign(''), 'X-GitHub-Event': 'workflow_job' }, '');
+    expect(resp).toBe(401);
+    expect(sendActionRequest).not.toBeCalled();
+  });
+
+  // sha256 is preferred, so a bad sha256 must NOT be rescued by a valid legacy sha1 header.
+  it('rejects an invalid sha256 signature even when a valid sha1 header is present', async () => {
+    const resp = await handle(
+      {
+        'X-Hub-Signature-256': `sha256=${'0'.repeat(64)}`,
+        'X-Hub-Signature': sign(queuedWorkflowJob, 'sha1'),
+        'X-GitHub-Event': 'workflow_job',
+      },
+      queuedWorkflowJob,
+    );
+    expect(resp).toBe(401);
+    expect(sendActionRequest).not.toBeCalled();
+  });
+
+  it('accepts the legacy sha1 signature header when no sha256 header is sent', async () => {
+    const payload = JSON.stringify(check_run_event);
+    const resp = await handle({ 'X-Hub-Signature': sign(payload, 'sha1'), 'X-GitHub-Event': 'push' }, payload);
+    expect(resp).toBe(200);
+  });
+
+  it('does not handle other events', async () => {
+    const payload = JSON.stringify(check_run_event);
+    const resp = await handle(signedHeaders(payload), payload);
     expect(resp).toBe(200);
     expect(sendActionRequest).not.toBeCalled();
   });
 
   it('does not handle check_run events with actions other than created', async () => {
-    const event = { ...check_run_event, action: 'completed' };
-    const resp = await handle(
-      { 'X-Hub-Signature': 'sha1=891749859807857017f7ee56a429e8fcead6f3e1', 'X-GitHub-Event': 'push' },
-      JSON.stringify(event),
-    );
+    const payload = JSON.stringify({ ...check_run_event, action: 'completed' });
+    const resp = await handle(signedHeaders(payload), payload);
     expect(resp).toBe(200);
     expect(sendActionRequest).not.toBeCalled();
   });
 
   it('does not handle check_run events with status other than queued', async () => {
-    const event = { ...check_run_event, check_run: { id: 1234, status: 'completed' } };
-    const resp = await handle(
-      { 'X-Hub-Signature': 'sha1=73dfae4aa56de5b038af8921b40d7a412ce7ca19', 'X-GitHub-Event': 'push' },
-      JSON.stringify(event),
-    );
+    const payload = JSON.stringify({ ...check_run_event, check_run: { id: 1234, status: 'completed' } });
+    const resp = await handle(signedHeaders(payload), payload);
     expect(resp).toBe(200);
     expect(sendActionRequest).not.toBeCalled();
   });

--- a/terraform-aws-github-runner/modules/webhook/lambdas/webhook/src/webhook/handler.ts
+++ b/terraform-aws-github-runner/modules/webhook/lambdas/webhook/src/webhook/handler.ts
@@ -13,7 +13,8 @@ export const handle = async (headers: IncomingHttpHeaders, payload: any): Promis
     headers[key.toLowerCase()] = headers[key];
   }
 
-  const signature = headers['x-hub-signature'] as string;
+  // Prefer the SHA-256 signature; GitHub still sends the legacy SHA-1 header alongside it.
+  const signature = (headers['x-hub-signature-256'] ?? headers['x-hub-signature']) as string;
   if (!signature) {
     console.error("Github event doesn't have signature. This webhook requires a secret to be configured.");
     return 500;
@@ -32,7 +33,15 @@ export const handle = async (headers: IncomingHttpHeaders, payload: any): Promis
   const webhooks = new Webhooks({
     secret: secret,
   });
-  if (!webhooks.verify(payload, signature)) {
+  // `verify` is async — without the await this is an always-truthy Promise and the check never rejects.
+  let verified: boolean;
+  try {
+    verified = await webhooks.verify(payload, signature);
+  } catch (e) {
+    console.error(`Unable to verify signature: ${e}`);
+    return 401;
+  }
+  if (!verified) {
     console.error('Unable to verify signature!');
     return 401;
   }


### PR DESCRIPTION
✴️ iz2: filed on behalf of @izaitsevfb.

## What's wrong

In the vendored `terraform-aws-github-runner` webhook lambda, the signature check is:

```ts
if (!webhooks.verify(payload, signature)) {
  console.error('Unable to verify signature!');
  return 401;
}
```

`Webhooks#verify` from `@octokit/webhooks` v12 is **async** — the constructor binds it straight to
the `async function verify(secret, eventPayload, signature)` in `@octokit/webhooks-methods`. So the
call returns a Promise, a Promise is always truthy, `!Promise` is always `false`, and the `401`
branch is dead code. Any request carrying a non-empty `x-hub-signature` header passes the check.

A synchronous throw inside an async function becomes a rejected Promise rather than a falsy value,
so nothing recovers the check on the error path either.

## Why CI didn't catch it

`handler.test.ts` had no test asserting `401` on an invalid signature. Its cases passed hardcoded
`sha1=…` values and asserted `200` — they passed *because* verification was bypassed, so a green
suite was actively evidence for the wrong conclusion.

## The change

- `await` the verification result.
- Prefer `x-hub-signature-256`, falling back to the legacy `x-hub-signature`. GitHub sends both;
  the handler previously only ever read the sha1 one. `??` rather than `||` is deliberate: a
  present-but-invalid sha256 header must not be downgraded to sha1.
- Wrap the call so a throwing verifier returns `401` instead of an unhandled rejection.

## Tests

Adds the negative coverage that was missing, and a positive control:

- signature does not match the payload → 401, nothing enqueued
- payload tampered with after signing → 401, nothing enqueued
- signature made with a different secret → 401, nothing enqueued
- unrecognisable digest → 401
- verifier throws → 401 rather than an unhandled rejection
- invalid sha256 **plus** a valid sha1 header → still 401 (precedence)
- valid sha1 alone, with no sha256 header → 200 (back-compat)
- correctly signed `workflow_job`/`queued` → 200 **and enqueued**

That last one is the positive control: it proves the actionable path really does fire when the
signature is valid, which is what makes every `not.toBeCalled()` assertion above non-vacuous.

Verified locally: 12/12 pass; `prettier --check` and `eslint` clean; `tsc --noEmit` reports no
errors outside `node_modules`. Mutation control — restoring the missing `await` makes the suite
fail, and it is exactly the new negative tests that fail, so they genuinely detect the defect.

## Deploying this

This turns a check that never ran into one that does, so **confirm the configured
`GITHUB_APP_WEBHOOK_SECRET` for each deployment actually matches the webhook secret on the
corresponding GitHub App before rolling out.** Because verification has never executed, a stale or
mismatched secret cannot have shown up as an error until now — it would surface for the first time
as a 401 on every delivery once this lands. Roll out per-environment and watch the 4xx rate rather
than deploying everywhere at once.

Two adjacent gaps left deliberately out of scope, both pre-existing:

- A missing signature still returns `500` where `400`/`401` would be more accurate. Unchanged to
  keep this diff minimal and avoid perturbing existing alerting.
- Signed deliveries are replayable: `X-GitHub-Delivery` is not recorded and workflow-job IDs are not
  deduplicated downstream.
