### PR TITLE
[BE] Update `actions/github-script` to v9 in `_claude-code.yml`

### DIFF
--- a/.github/workflows/_claude-code.yml
+++ b/.github/workflows/_claude-code.yml
@@ -89,7 +89,7 @@ jobs:
       id-token: write
     steps:
       - name: Verify write access
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const allowedBots = ['pytorch-auto-revert[bot]'];
@@ -116,7 +116,7 @@ jobs:
 
       - name: Check for ghstack PR
         id: ghstack-check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             // Only applies to issue_comment events on pull requests
@@ -174,7 +174,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Set commit author to invoking user
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const actor = context.actor;


### PR DESCRIPTION
Moves the three `actions/github-script` steps in `.github/workflows/_claude-code.yml` from `v7` to `v9`. v7 is two majors behind and pins the action to the Node 20 runtime, which GitHub is winding down.

`.github/actions/cross-repo-ci-relay-callback/action.yml` is the repo's only other call site and is already being moved to v9 by #8675, so it is left alone here to avoid a conflict. Once both land, no `@v7` references remain.

## Breaking-change review

Checked every documented breakage against the three scripts. **None apply.**

**v8.0.0** — Node runtime moved to 24.x, with a hard floor of runner **v2.327.1**. This is the only real constraint; these steps run on the standard pool.

**v9.0.0** — three script-level breakages, all stemming from `@actions/github` v9 becoming ESM-only:

- `require('@actions/github')` fails at runtime
- `getOctokit` is now an injected function parameter, so a script declaring `const getOctokit = ...` or `let getOctokit = ...` raises `SyntaxError`
- other `@actions/github` internals may need updating

All three scripts use only the injected `github.rest.*`, `context.*` and `core.*` surface, unchanged across v7 → v9. Repo-wide there are no occurrences of `require('@actions/github')`, `const getOctokit` or `let getOctokit` under `.github/`. The `getOctokit` matches elsewhere in the tree are inside vendored `dist/` bundles of unrelated actions (`checkout`, `setup-ssh`, `upload-artifact-s3`), not github-script scripts.

Kept as the floating `@v9` tag to match how the other call sites reference this action. SHA-pinning all of them is worth doing separately rather than introducing a second convention in one file.

## Test plan

- Diff is three `uses:` lines; no script bodies changed.
- Verified the only remaining `@v7` in the repo is the one #8675 already covers.
- The scripts exercise `github.rest.repos.getCollaboratorPermissionLevel`, `github.rest.pulls.get`, `github.rest.users.getByUsername`, plus `core.setOutput` / `core.setFailed` / `core.exportVariable` and `context.repo` / `context.payload` / `context.actor` — all stable in v9.
- `_claude-code.yml` is a `workflow_call` reusable workflow triggered by `@claude` mentions, so PR CI does not exercise it; the first real run is the next Claude Code invocation.
