### PR TITLE
[CRCR] Fix inconsistent pass rate colors on summary page

### DIFF
--- a/torchci/pages/crcr/index.tsx
+++ b/torchci/pages/crcr/index.tsx
@@ -101,8 +101,8 @@ const CRCR_HEALTH_REPO = "pytorch/crcr-test";
 
 function PassRateChip({ rate }: { rate: number }) {
   const pct = (rate * 100).toFixed(1) + "%";
-  if (rate >= 0.95) return <Chip label={pct} color="success" size="small" />;
-  if (rate >= 0.8) return <Chip label={pct} color="warning" size="small" />;
+  if (rate >= 1.0) return <Chip label={pct} color="success" size="small" />;
+  if (rate >= 0.9) return <Chip label={pct} color="warning" size="small" />;
   return <Chip label={pct} color="error" size="small" />;
 }
 
@@ -353,9 +353,9 @@ function NightlyTable({
                       height: 8,
                       borderRadius: "50%",
                       bgcolor:
-                        row.pass_rate >= 0.95
+                        row.pass_rate >= 1.0
                           ? "success.main"
-                          : row.pass_rate >= 0.8
+                          : row.pass_rate >= 0.9
                           ? "warning.main"
                           : "error.main",
                       display: "inline-block",


### PR DESCRIPTION
## Summary

The CRCR summary page (`/crcr`) and per-repo page (`/crcr/[org]/[repo]`) used different color thresholds for pass rate, causing the same value to show different colors on different pages.

| Threshold | Summary page (before) | Per-repo page | Summary page (after) |
|-----------|----------------------|---------------|---------------------|
| Green | >= 95% | >= 100% | >= 100% |
| Orange | >= 80% | >= 90% | >= 90% |
| Red | < 80% | < 90% | < 90% |

This fixes both the `PassRateChip` component and the status dot indicator in the repo table to use the same thresholds as the per-repo page.

Fixes #8690

## Test plan

- Verify a 96.9% pass rate shows orange on both the summary page and per-repo page
- Verify 100% shows green on both pages
- Verify < 90% shows red on both pages