### PR TITLE
[CRCR] Add L3 promotion/demotion readiness panel with fixed evaluation windows

### DIFF
--- a/torchci/clickhouse_queries/crcr_l3_summary/params.json
+++ b/torchci/clickhouse_queries/crcr_l3_summary/params.json
@@ -1,0 +1,10 @@
+{
+  "params": {
+    "days": "UInt64"
+  },
+  "tests": [
+    {
+      "days": "30"
+    }
+  ]
+}

--- a/torchci/clickhouse_queries/crcr_l3_summary/query.sql
+++ b/torchci/clickhouse_queries/crcr_l3_summary/query.sql
@@ -1,0 +1,90 @@
+-- All-repo variant of crcr_backend_summary for the L3 readiness panel and
+-- the /crcr at-a-glance readiness column. `days` here is the L3 evaluation
+-- window (promotion/demotion) chosen by that panel — deliberately not the
+-- page's Time Range selector, so the verdict doesn't change depending on
+-- which dropdown value a reviewer happened to have.
+WITH deduped AS (
+    SELECT
+        downstream_repo,
+        pr_number,
+        job_name,
+        conclusion,
+        queue_time,
+        execution_time,
+        run_id,
+        started_at,
+        completed_at,
+        ROW_NUMBER() OVER (
+            PARTITION BY downstream_repo, run_id, job_name
+            ORDER BY run_attempt DESC
+        ) AS rn
+    FROM
+        default.crcr_workflow_job FINAL
+    WHERE
+        started_at > now() - INTERVAL {days: UInt64} DAY
+        AND status = 'completed'
+        AND pr_number > 0
+),
+
+base AS (
+    SELECT
+        downstream_repo,
+        conclusion,
+        job_name,
+        pr_number,
+        queue_time,
+        execution_time,
+        -- Partition by (downstream_repo, run_id): run_id (github.run_id) is
+        -- only unique within a single downstream repo, and this query spans
+        -- all repos (unlike crcr_backend_summary, which filters to one).
+        max(queue_time) OVER (PARTITION BY downstream_repo, run_id) AS run_queue_time_s,
+        dateDiff(
+            'second',
+            min(started_at) OVER (PARTITION BY downstream_repo, run_id),
+            max(completed_at) OVER (PARTITION BY downstream_repo, run_id)
+        ) AS run_span_s,
+        row_number() OVER (
+            PARTITION BY downstream_repo, run_id ORDER BY job_name
+        ) AS run_rn
+    FROM deduped
+    WHERE rn = 1
+)
+
+SELECT
+    downstream_repo AS repo,
+    countIf(
+        conclusion = 'success'
+        OR (
+            downstream_repo = 'pytorch/crcr-test'
+            AND (
+                (job_name LIKE '%xfail%' AND conclusion = 'failure')
+                OR (job_name LIKE '%xcancel%' AND conclusion = 'cancelled')
+                OR (job_name LIKE '%xtimeout%' AND conclusion = 'timed_out')
+            )
+        )
+    ) AS successes,
+    countIf(
+        conclusion = 'timed_out'
+        AND NOT (
+            downstream_repo = 'pytorch/crcr-test'
+            AND job_name LIKE '%xtimeout%'
+            AND conclusion = 'timed_out'
+        )
+    ) AS timed_out,
+    count() AS total_jobs,
+    if(total_jobs > 0, successes / total_jobs, 0) AS pass_rate,
+    avg(queue_time) AS avg_queue_time_s,
+    max(execution_time) AS max_exec_time_s,
+    -- E2E time is per-run; run_rn = 1 keeps one sample per run.
+    quantileExactIf(0.5)(
+        run_queue_time_s + run_span_s,
+        run_rn = 1 AND run_queue_time_s IS NOT NULL
+    ) AS median_e2e_time_s,
+    if(
+        total_jobs > 0,
+        timed_out / total_jobs,
+        0
+    ) AS timeout_rate
+FROM base
+GROUP BY
+    repo

--- a/torchci/clickhouse_queries/crcr_l3_summary/query.sql
+++ b/torchci/clickhouse_queries/crcr_l3_summary/query.sql
@@ -74,7 +74,9 @@ SELECT
     count() AS total_jobs,
     if(total_jobs > 0, successes / total_jobs, 0) AS pass_rate,
     avg(queue_time) AS avg_queue_time_s,
-    max(execution_time) AS max_exec_time_s,
+    -- Excludes timed-out jobs: their execution_time reflects the timeout
+    -- ceiling, not genuine run time, and would inflate this otherwise.
+    maxIf(execution_time, conclusion != 'timed_out') AS max_exec_time_s,
     -- E2E time is per-run; run_rn = 1 keeps one sample per run.
     quantileExactIf(0.5)(
         run_queue_time_s + run_span_s,

--- a/torchci/components/crcr/CrcrL3Readiness.tsx
+++ b/torchci/components/crcr/CrcrL3Readiness.tsx
@@ -1,0 +1,253 @@
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import {
+  Box,
+  Chip,
+  Collapse,
+  Paper,
+  Skeleton,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { durationDisplay } from "components/common/TimeUtils";
+import L3SummaryChip from "components/crcr/L3SummaryChip";
+import { fetcherHandleError } from "lib/GeneralUtils";
+import {
+  buildCriteriaRows,
+  buildDemotionRows,
+  CriterionRow,
+  L3Metrics,
+  mergeCriteriaRows,
+  useTenure,
+} from "lib/crcr/l3Readiness";
+import {
+  L3_DEMOTION_WINDOW_DAYS,
+  L3_PROMOTION_WINDOW_DAYS,
+  useL3VerdictColors,
+} from "lib/crcr/l3Thresholds";
+import { useMemo, useState } from "react";
+import useSWR from "swr";
+
+function formatMeasured(row: CriterionRow): string {
+  if (row.measured == null) return "–";
+  switch (row.format) {
+    case "days":
+      return row.detail
+        ? `${row.measured.toFixed(0)} days (${row.detail})`
+        : `${row.measured.toFixed(0)} days`;
+    case "duration":
+      return durationDisplay(Math.round(row.measured));
+    case "percent":
+      return `${(row.measured * 100).toFixed(1)}%`;
+  }
+}
+
+// Measured value colored by verdict — the value itself carries the signal,
+// no separate checkmark column needed. Each column only highlights the
+// state worth acting on: Promotion turns green when a criterion qualifies
+// (the notable event — go promote), Demotion turns red when a criterion
+// would trigger demotion (the notable event — go fix it). The unremarkable
+// state in either column (not yet promotable / not at risk) stays the
+// default text color instead of also being colored.
+function VerdictValue({
+  row,
+  variant,
+}: {
+  row: CriterionRow | null;
+  variant: "promotion" | "demotion";
+}) {
+  const { pass, fail } = useL3VerdictColors();
+  if (!row) {
+    return (
+      <Typography variant="body2" color="text.disabled">
+        n/a
+      </Typography>
+    );
+  }
+  if (row.verdict == null) {
+    return (
+      <Typography variant="body2" color="text.disabled">
+        {formatMeasured(row)}
+      </Typography>
+    );
+  }
+  const notable = variant === "promotion" ? row.verdict : !row.verdict;
+  const color = notable ? (variant === "promotion" ? pass : fail) : undefined;
+  return (
+    <Typography variant="body2" sx={{ color, fontWeight: notable ? 600 : 400 }}>
+      {formatMeasured(row)}
+    </Typography>
+  );
+}
+
+// crcr_backend_summary, filtered server-side to one repo — a bloom filter
+// index on downstream_repo makes this cheap. Avoids crcr_l3_summary (the
+// all-repo query the /crcr at-a-glance column needs) here, which would
+// scan every registered repo's data just to keep the one row this panel
+// actually uses. Same query + params SummaryCards above uses for the
+// promotion window, so SWR dedupes that fetch too.
+function useL3Summary(days: number, repoFullName: string) {
+  const url = `/api/clickhouse/crcr_backend_summary?parameters=${encodeURIComponent(
+    JSON.stringify({ repo: repoFullName, days: String(days) })
+  )}`;
+  const { data, error } = useSWR<L3Metrics[]>(url, fetcherHandleError, {
+    refreshInterval: 60_000,
+  });
+  const summary = useMemo(() => data?.[0] ?? null, [data]);
+  return { summary, loaded: !!data || !!error };
+}
+
+export default function CrcrL3Readiness({
+  repoFullName,
+}: {
+  repoFullName: string;
+}) {
+  // Promotion and demotion shown as one table (same criteria, same
+  // thresholds where they overlap) instead of a toggle or two separate
+  // tables — each column is just evaluated over its own fixed window.
+  const promotion = useL3Summary(L3_PROMOTION_WINDOW_DAYS, repoFullName);
+  const demotion = useL3Summary(L3_DEMOTION_WINDOW_DAYS, repoFullName);
+  const tenure = useTenure(repoFullName);
+  const [expanded, setExpanded] = useState(false);
+
+  if (!promotion.loaded || !demotion.loaded || !tenure.loaded) {
+    return <Skeleton variant="rectangular" height={80} />;
+  }
+
+  const promotionRows = buildCriteriaRows(promotion.summary, tenure.tenure);
+  const demotionRows = buildDemotionRows(demotion.summary);
+  const rows = mergeCriteriaRows(promotionRows, demotionRows);
+
+  return (
+    <Paper elevation={1} sx={{ p: 2 }}>
+      <Stack spacing={1.5}>
+        <Box
+          display="flex"
+          justifyContent="space-between"
+          alignItems="center"
+          flexWrap="wrap"
+          gap={1}
+          sx={{ cursor: "pointer" }}
+          onClick={() => setExpanded((e) => !e)}
+        >
+          <Stack spacing={0.5}>
+            <Typography variant="h6">L3 Readiness</Typography>
+            <Chip
+              label={expanded ? "Hide details" : "Details"}
+              size="small"
+              color="primary"
+              variant={expanded ? "filled" : "outlined"}
+              clickable
+              onClick={(e) => {
+                e.stopPropagation();
+                setExpanded((v) => !v);
+              }}
+              deleteIcon={
+                <ExpandMoreIcon
+                  sx={{
+                    transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
+                    transition: "transform 0.2s",
+                  }}
+                />
+              }
+              onDelete={(e) => {
+                e.stopPropagation();
+                setExpanded((v) => !v);
+              }}
+              sx={{ width: "fit-content" }}
+            />
+          </Stack>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <L3SummaryChip
+              label="Promotion"
+              rows={promotionRows}
+              variant="promotion"
+            />
+            <L3SummaryChip
+              label="Demotion"
+              rows={demotionRows}
+              variant="demotion"
+            />
+          </Stack>
+        </Box>
+
+        <Collapse in={expanded} timeout="auto" unmountOnExit>
+          <Stack spacing={1.5}>
+            <Typography variant="caption" color="text.secondary">
+              Promotion is evaluated over the last {L3_PROMOTION_WINDOW_DAYS}{" "}
+              days, demotion over the last {L3_DEMOTION_WINDOW_DAYS} days.
+            </Typography>
+
+            <TableContainer>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>
+                      <strong>Criterion</strong>
+                    </TableCell>
+                    <TableCell align="right">
+                      <strong>Target</strong>
+                    </TableCell>
+                    <TableCell align="right">
+                      <strong>Promotion ({L3_PROMOTION_WINDOW_DAYS}d)</strong>
+                    </TableCell>
+                    <TableCell align="right">
+                      <strong>Demotion ({L3_DEMOTION_WINDOW_DAYS}d)</strong>
+                    </TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {rows.map((r) => (
+                    <TableRow key={r.key}>
+                      <TableCell>
+                        {r.criterion}
+                        {r.provisional && (
+                          <Tooltip title="Provisional — value pending a future spec amendment">
+                            <Typography
+                              component="span"
+                              variant="caption"
+                              color="text.secondary"
+                              sx={{ ml: 0.5, cursor: "help" }}
+                            >
+                              (provisional)
+                            </Typography>
+                          </Tooltip>
+                        )}
+                        {r.key === "tenureAtL2Days" &&
+                          r.promotion.measured == null && (
+                            <Tooltip title="No tenure data for this repo yet">
+                              <Typography
+                                component="span"
+                                variant="caption"
+                                color="text.secondary"
+                                sx={{ ml: 0.5, cursor: "help" }}
+                              >
+                                (no data)
+                              </Typography>
+                            </Tooltip>
+                          )}
+                      </TableCell>
+                      <TableCell align="right">{r.targetLabel}</TableCell>
+                      <TableCell align="right">
+                        <VerdictValue row={r.promotion} variant="promotion" />
+                      </TableCell>
+                      <TableCell align="right">
+                        <VerdictValue row={r.demotion} variant="demotion" />
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Stack>
+        </Collapse>
+      </Stack>
+    </Paper>
+  );
+}

--- a/torchci/components/crcr/L3SummaryChip.tsx
+++ b/torchci/components/crcr/L3SummaryChip.tsx
@@ -1,0 +1,41 @@
+import { Chip } from "@mui/material";
+import { CriterionRow, summarizeReadiness } from "lib/crcr/l3Readiness";
+import { useL3VerdictColors } from "lib/crcr/l3Thresholds";
+
+// Shared by the per-repo CrcrL3Readiness panel and the /crcr at-a-glance
+// readiness column so both summarize a repo's rows the same way.
+export default function L3SummaryChip({
+  label,
+  rows,
+  variant,
+}: {
+  label: string;
+  rows: CriterionRow[];
+  variant: "promotion" | "demotion";
+}) {
+  const { pass, fail } = useL3VerdictColors();
+  const { judgedCount, metCount, totalCount, ready } = summarizeReadiness(rows);
+  const triggeredCount = rows.filter((r) => r.verdict === false).length;
+
+  // The chip's number is the *notable* count, matching the row coloring:
+  // for Promotion that's how many criteria are met (want it to climb to
+  // totalCount); for Demotion that's how many are currently triggering
+  // (want it to stay at 0) — showing "met count" there instead would read
+  // backwards, since a bigger number looks like more problems.
+  const notableCount = variant === "promotion" ? metCount : triggeredCount;
+  const suffix = variant === "promotion" ? "met" : "at risk";
+  const notable = variant === "promotion" ? ready : triggeredCount > 0;
+  const color = notable ? (variant === "promotion" ? pass : fail) : undefined;
+  return (
+    <Chip
+      label={
+        judgedCount === 0
+          ? `${label}: no data`
+          : `${label}: ${notableCount}/${totalCount} ${suffix}`
+      }
+      size="small"
+      variant="outlined"
+      sx={{ color, borderColor: color }}
+    />
+  );
+}

--- a/torchci/lib/crcr/l3Readiness.ts
+++ b/torchci/lib/crcr/l3Readiness.ts
@@ -102,37 +102,65 @@ function buildRow(
   };
 }
 
+// The five summary-derived metrics (everything but tenure).
+const METRICS: {
+  threshold: (typeof L3_THRESHOLDS)[keyof typeof L3_THRESHOLDS];
+  format: L3MeasuredFormat;
+  getMeasured: (summary: L3Metrics | null) => number | null;
+}[] = [
+  {
+    threshold: L3_THRESHOLDS.e2eTimeS,
+    format: "duration",
+    getMeasured: (s) => s?.median_e2e_time_s ?? null,
+  },
+  {
+    threshold: L3_THRESHOLDS.maxExecTimeS,
+    format: "duration",
+    getMeasured: (s) => s?.max_exec_time_s ?? null,
+  },
+  {
+    threshold: L3_THRESHOLDS.avgQueueTimeS,
+    format: "duration",
+    getMeasured: (s) => s?.avg_queue_time_s ?? null,
+  },
+  {
+    threshold: L3_THRESHOLDS.timeoutRate,
+    format: "percent",
+    getMeasured: (s) => (s ? s.timeout_rate : null),
+  },
+  {
+    threshold: L3_THRESHOLDS.passRate,
+    format: "percent",
+    getMeasured: (s) => (s ? s.pass_rate : null),
+  },
+];
+
 // L3 Promotion — tenure + five metrics, evaluated over the 2-week
 // promotion window (L3_PROMOTION_WINDOW_DAYS).
 export function buildCriteriaRows(
   summary: L3Metrics | null,
   tenure: TenureInfo | null
 ): CriterionRow[] {
-  const t = L3_THRESHOLDS;
   return [
     buildRow(
-      t.tenureAtL2Days,
+      L3_THRESHOLDS.tenureAtL2Days,
       tenure?.tenureDays ?? null,
       "days",
       tenure?.currentLevel
     ),
-    buildRow(t.e2eTimeS, summary?.median_e2e_time_s ?? null, "duration"),
-    buildRow(t.maxExecTimeS, summary?.max_exec_time_s ?? null, "duration"),
-    buildRow(t.avgQueueTimeS, summary?.avg_queue_time_s ?? null, "duration"),
-    buildRow(t.timeoutRate, summary ? summary.timeout_rate : null, "percent"),
-    buildRow(t.passRate, summary ? summary.pass_rate : null, "percent"),
+    ...METRICS.map((m) =>
+      buildRow(m.threshold, m.getMeasured(summary), m.format)
+    ),
   ];
 }
 
-// L3 Demotion — a *subset* of three metrics (no tenure, no max exec/avg
-// queue), evaluated over the 1-week demotion window.
+// L3 Demotion — the subset of metrics flagged `demotionRelevant` (no
+// tenure, no max exec/avg queue), evaluated over the 1-week demotion
+// window.
 export function buildDemotionRows(summary: L3Metrics | null): CriterionRow[] {
-  const t = L3_THRESHOLDS;
-  return [
-    buildRow(t.e2eTimeS, summary?.median_e2e_time_s ?? null, "duration"),
-    buildRow(t.timeoutRate, summary ? summary.timeout_rate : null, "percent"),
-    buildRow(t.passRate, summary ? summary.pass_rate : null, "percent"),
-  ];
+  return METRICS.filter((m) => m.threshold.demotionRelevant).map((m) =>
+    buildRow(m.threshold, m.getMeasured(summary), m.format)
+  );
 }
 
 // One row per criterion, promotion and demotion verdicts side by side —

--- a/torchci/lib/crcr/l3Readiness.ts
+++ b/torchci/lib/crcr/l3Readiness.ts
@@ -1,0 +1,181 @@
+import { fetcherHandleError } from "lib/GeneralUtils";
+import { evaluateL3Threshold, L3_THRESHOLDS } from "lib/crcr/l3Thresholds";
+import { useMemo } from "react";
+import useSWR from "swr";
+
+// Shared between the per-repo CrcrL3Readiness panel and the /crcr
+// at-a-glance readiness column so both compute the same verdict off the
+// same shared thresholds.
+
+// Shape shared by crcr_backend_summary (single repo, filtered server-side)
+// and crcr_l3_summary (all repos, grouped) — the fields buildCriteriaRows
+// et al. actually read. crcr_l3_summary rows additionally carry `repo` to
+// tell them apart (see L3SummaryRow below); a single-repo query has no
+// need for that since the filter already picked the one row.
+export interface L3Metrics {
+  successes: number;
+  timed_out: number;
+  total_jobs: number;
+  pass_rate: number;
+  avg_queue_time_s: number | null;
+  max_exec_time_s: number | null;
+  median_e2e_time_s: number | null;
+  timeout_rate: number;
+}
+
+// crcr_l3_summary's output — one row per repo, for views that need every
+// repo at once (the /crcr at-a-glance readiness column). The per-repo
+// panel should prefer the repo-filtered crcr_backend_summary instead of
+// fetching this and discarding all but one row.
+export interface L3SummaryRow extends L3Metrics {
+  repo: string;
+}
+
+// Shape of the crcr_repo_tenure query's output.
+export interface RepoTenure {
+  current_level: string;
+  level_since: string;
+  first_seen: string;
+  last_seen: string;
+}
+
+export interface TenureInfo {
+  currentLevel: string;
+  tenureDays: number;
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export function tenureInfoFromRow(
+  row: RepoTenure | null | undefined
+): TenureInfo | null {
+  if (!row || !row.current_level) return null;
+  return {
+    currentLevel: row.current_level,
+    tenureDays: (Date.now() - new Date(row.level_since).getTime()) / MS_PER_DAY,
+  };
+}
+
+// Same crcr_repo_tenure query + params used by the per-repo panel, the
+// at-a-glance readiness column, and the page header's own "L2 since ..."
+// text — SWR dedupes the identical key across all of them, so sharing this
+// hook doesn't add extra requests.
+export function useTenure(repoFullName: string) {
+  const url = `/api/clickhouse/crcr_repo_tenure?parameters=${encodeURIComponent(
+    JSON.stringify({ repo: repoFullName })
+  )}`;
+  const { data, error } = useSWR<RepoTenure[]>(url, fetcherHandleError, {
+    refreshInterval: 60_000,
+  });
+  const tenure = useMemo(() => tenureInfoFromRow(data?.[0]), [data]);
+  return { tenure, loaded: !!data || !!error };
+}
+
+export type L3MeasuredFormat = "days" | "duration" | "percent";
+
+export interface CriterionRow {
+  key: string;
+  criterion: string;
+  measured: number | null;
+  format: L3MeasuredFormat;
+  detail?: string;
+  targetLabel: string;
+  verdict: boolean | null;
+  provisional: boolean;
+}
+
+function buildRow(
+  threshold: (typeof L3_THRESHOLDS)[keyof typeof L3_THRESHOLDS],
+  measured: number | null,
+  format: L3MeasuredFormat,
+  detail?: string
+): CriterionRow {
+  return {
+    key: threshold.key,
+    criterion: threshold.label,
+    measured,
+    format,
+    detail,
+    targetLabel: threshold.targetLabel,
+    verdict: evaluateL3Threshold(threshold, measured),
+    provisional: threshold.provisional,
+  };
+}
+
+// L3 Promotion — tenure + five metrics, evaluated over the 2-week
+// promotion window (L3_PROMOTION_WINDOW_DAYS).
+export function buildCriteriaRows(
+  summary: L3Metrics | null,
+  tenure: TenureInfo | null
+): CriterionRow[] {
+  const t = L3_THRESHOLDS;
+  return [
+    buildRow(
+      t.tenureAtL2Days,
+      tenure?.tenureDays ?? null,
+      "days",
+      tenure?.currentLevel
+    ),
+    buildRow(t.e2eTimeS, summary?.median_e2e_time_s ?? null, "duration"),
+    buildRow(t.maxExecTimeS, summary?.max_exec_time_s ?? null, "duration"),
+    buildRow(t.avgQueueTimeS, summary?.avg_queue_time_s ?? null, "duration"),
+    buildRow(t.timeoutRate, summary ? summary.timeout_rate : null, "percent"),
+    buildRow(t.passRate, summary ? summary.pass_rate : null, "percent"),
+  ];
+}
+
+// L3 Demotion — a *subset* of three metrics (no tenure, no max exec/avg
+// queue), evaluated over the 1-week demotion window.
+export function buildDemotionRows(summary: L3Metrics | null): CriterionRow[] {
+  const t = L3_THRESHOLDS;
+  return [
+    buildRow(t.e2eTimeS, summary?.median_e2e_time_s ?? null, "duration"),
+    buildRow(t.timeoutRate, summary ? summary.timeout_rate : null, "percent"),
+    buildRow(t.passRate, summary ? summary.pass_rate : null, "percent"),
+  ];
+}
+
+// One row per criterion, promotion and demotion verdicts side by side —
+// demotion is a subset of promotion's criteria, so `demotion` is null for
+// rows that aren't part of the demotion trigger list.
+export interface MergedCriterionRow {
+  key: string;
+  criterion: string;
+  targetLabel: string;
+  provisional: boolean;
+  promotion: CriterionRow;
+  demotion: CriterionRow | null;
+}
+
+export function mergeCriteriaRows(
+  promotionRows: CriterionRow[],
+  demotionRows: CriterionRow[]
+): MergedCriterionRow[] {
+  const demotionByKey = new Map(demotionRows.map((r) => [r.key, r]));
+  return promotionRows.map((p) => ({
+    key: p.key,
+    criterion: p.criterion,
+    targetLabel: p.targetLabel,
+    provisional: p.provisional,
+    promotion: p,
+    demotion: demotionByKey.get(p.key) ?? null,
+  }));
+}
+
+export interface ReadinessSummary {
+  judgedCount: number;
+  metCount: number;
+  totalCount: number;
+  ready: boolean;
+}
+
+export function summarizeReadiness(rows: CriterionRow[]): ReadinessSummary {
+  const judged = rows.filter((r) => r.verdict != null);
+  const met = judged.filter((r) => r.verdict).length;
+  return {
+    judgedCount: judged.length,
+    metCount: met,
+    totalCount: rows.length,
+    ready: judged.length > 0 && met === rows.length,
+  };
+}

--- a/torchci/lib/crcr/l3Thresholds.ts
+++ b/torchci/lib/crcr/l3Thresholds.ts
@@ -1,0 +1,100 @@
+import { useTheme } from "@mui/material";
+
+/**
+ * Single source of truth for the L3 promotion/demotion criteria. The
+ * CrcrL3Readiness panel and its summary chip must read from here instead
+ * of hardcoding a number, otherwise the two drift.
+ *
+ * There are six L3 promotion criteria: tenure + five metrics
+ * (end-to-end time, max execution time, avg queue time, timeout rate, job
+ * pass rate).
+ */
+
+export type L3ComparisonDirection = "atLeast" | "below";
+
+export interface L3Threshold {
+  key: string;
+  label: string;
+  /** Human-readable target, e.g. "< 30 min" or "≥ 1 month". */
+  targetLabel: string;
+  target: number;
+  direction: L3ComparisonDirection;
+  provisional: boolean;
+}
+
+// L3 promotion/demotion infrastructure gates.
+export const L3_THRESHOLDS = {
+  tenureAtL2Days: {
+    key: "tenureAtL2Days",
+    label: "Time at L2",
+    targetLabel: "≥ 1 month",
+    target: 30,
+    direction: "atLeast",
+    provisional: false,
+  },
+  e2eTimeS: {
+    key: "e2eTimeS",
+    label: "End-to-End Time (P50)",
+    targetLabel: "< 3 h",
+    target: 3 * 3600,
+    direction: "below",
+    provisional: false,
+  },
+  maxExecTimeS: {
+    key: "maxExecTimeS",
+    label: "Max Execution Time",
+    targetLabel: "< 3 h",
+    target: 3 * 3600,
+    direction: "below",
+    provisional: false,
+  },
+  avgQueueTimeS: {
+    key: "avgQueueTimeS",
+    label: "Avg Queue Time",
+    targetLabel: "< 30 min",
+    target: 30 * 60,
+    direction: "below",
+    provisional: false,
+  },
+  timeoutRate: {
+    key: "timeoutRate",
+    label: "Timeout Rate",
+    targetLabel: "< 1%",
+    target: 0.01,
+    direction: "below",
+    provisional: false,
+  },
+  passRate: {
+    key: "passRate",
+    label: "Job Pass Rate",
+    targetLabel: "> 90%",
+    target: 0.9,
+    direction: "atLeast",
+    provisional: false,
+  },
+} as const satisfies Record<string, L3Threshold>;
+
+/** true = meets the criterion, false = fails it, null = no data to judge. */
+export function evaluateL3Threshold(
+  threshold: L3Threshold,
+  measured: number | null | undefined
+): boolean | null {
+  if (measured == null || Number.isNaN(measured)) return null;
+  return threshold.direction === "below"
+    ? measured < threshold.target
+    : measured >= threshold.target;
+}
+
+// Verdict colors shared by the readiness panel and its summary chip,
+// sourced from the theme (not a hardcoded hex pair) so they stay correct
+// in both light and dark mode.
+export function useL3VerdictColors(): { pass: string; fail: string } {
+  const theme = useTheme();
+  return { pass: theme.palette.success.main, fail: theme.palette.error.main };
+}
+
+// Fixed evaluation windows: promotion metrics must be met throughout the
+// most recent 2-week window; demotion conditions are observed over a
+// 1-week window.
+export const L3_PROMOTION_WINDOW_DAYS = 14;
+export const L3_DEMOTION_WINDOW_DAYS = 7;

--- a/torchci/lib/crcr/l3Thresholds.ts
+++ b/torchci/lib/crcr/l3Thresholds.ts
@@ -67,7 +67,7 @@ export const L3_THRESHOLDS = {
   passRate: {
     key: "passRate",
     label: "Job Pass Rate",
-    targetLabel: "> 90%",
+    targetLabel: "≥ 90%",
     target: 0.9,
     direction: "atLeast",
     provisional: false,

--- a/torchci/lib/crcr/l3Thresholds.ts
+++ b/torchci/lib/crcr/l3Thresholds.ts
@@ -20,6 +20,7 @@ export interface L3Threshold {
   target: number;
   direction: L3ComparisonDirection;
   provisional: boolean;
+  demotionRelevant: boolean;
 }
 
 // L3 promotion/demotion infrastructure gates.
@@ -31,6 +32,7 @@ export const L3_THRESHOLDS = {
     target: 30,
     direction: "atLeast",
     provisional: false,
+    demotionRelevant: false,
   },
   e2eTimeS: {
     key: "e2eTimeS",
@@ -39,6 +41,7 @@ export const L3_THRESHOLDS = {
     target: 3 * 3600,
     direction: "below",
     provisional: false,
+    demotionRelevant: true,
   },
   maxExecTimeS: {
     key: "maxExecTimeS",
@@ -47,6 +50,7 @@ export const L3_THRESHOLDS = {
     target: 3 * 3600,
     direction: "below",
     provisional: false,
+    demotionRelevant: false,
   },
   avgQueueTimeS: {
     key: "avgQueueTimeS",
@@ -55,6 +59,7 @@ export const L3_THRESHOLDS = {
     target: 30 * 60,
     direction: "below",
     provisional: false,
+    demotionRelevant: false,
   },
   timeoutRate: {
     key: "timeoutRate",
@@ -63,6 +68,7 @@ export const L3_THRESHOLDS = {
     target: 0.01,
     direction: "below",
     provisional: false,
+    demotionRelevant: true,
   },
   passRate: {
     key: "passRate",
@@ -71,6 +77,7 @@ export const L3_THRESHOLDS = {
     target: 0.9,
     direction: "atLeast",
     provisional: false,
+    demotionRelevant: true,
   },
 } as const satisfies Record<string, L3Threshold>;
 

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -14,8 +14,10 @@ import {
 } from "@mui/material";
 import { durationDisplay } from "components/common/TimeUtils";
 import TooltipTarget from "components/common/tooltipTarget/TooltipTarget";
+import CrcrL3Readiness from "components/crcr/CrcrL3Readiness";
 import hudStyles from "components/hud.module.css";
 import { getConclusionChar } from "lib/JobClassifierUtil";
+import { L3_PROMOTION_WINDOW_DAYS } from "lib/crcr/l3Thresholds";
 import { Highlight } from "lib/types";
 import Head from "next/head";
 import NextLink from "next/link";
@@ -318,9 +320,17 @@ function isNightlyJobPassing(job: CrcrJobRow): boolean {
 const NIGHTLY_HEALTH_COUNT = 5;
 
 function NightlyHealthCard({ repoFullName }: { repoFullName: string }) {
+  // Window matches L3_PROMOTION_WINDOW_DAYS (the 2-week promotion window)
+  // rather than an independent magic number, so this isn't a third,
+  // inconsistent window alongside the Time Range selector.
   const url =
     `/api/clickhouse/crcr_nightly_dashboard?parameters=` +
-    encodeURIComponent(JSON.stringify({ repo: repoFullName, days: "14" }));
+    encodeURIComponent(
+      JSON.stringify({
+        repo: repoFullName,
+        days: String(L3_PROMOTION_WINDOW_DAYS),
+      })
+    );
   const { data } = useSWR<CrcrJobRow[]>(url, fetcherHandleError, {
     refreshInterval: 60_000,
   });
@@ -1671,6 +1681,8 @@ export default function CrcrBackendPage() {
                 </FormControl>
               </Stack>
             </Box>
+
+            {!isNightly && <CrcrL3Readiness repoFullName={repoFullName} />}
 
             {!isNightly && (
               <>

--- a/torchci/pages/crcr/index.tsx
+++ b/torchci/pages/crcr/index.tsx
@@ -22,7 +22,18 @@ import {
   Typography,
 } from "@mui/material";
 import { durationDisplay } from "components/common/TimeUtils";
+import L3SummaryChip from "components/crcr/L3SummaryChip";
 import { fetcherHandleError } from "lib/GeneralUtils";
+import {
+  buildCriteriaRows,
+  buildDemotionRows,
+  L3SummaryRow,
+  useTenure,
+} from "lib/crcr/l3Readiness";
+import {
+  L3_DEMOTION_WINDOW_DAYS,
+  L3_PROMOTION_WINDOW_DAYS,
+} from "lib/crcr/l3Thresholds";
 import Head from "next/head";
 import NextLink from "next/link";
 import { useMemo, useState } from "react";
@@ -129,14 +140,67 @@ function timeAgo(dateStr: string): string {
   return `${days}d ago`;
 }
 
+// crcr_l3_summary, keyed by repo — the all-repo query the promotion and
+// demotion at-a-glance columns share (fixed windows).
+function useL3SummaryMap(days: number): Map<string, L3SummaryRow> {
+  const url =
+    `/api/clickhouse/crcr_l3_summary?parameters=` +
+    encodeURIComponent(JSON.stringify({ days: String(days) }));
+  const { data } = useSWR<L3SummaryRow[]>(url, fetcherHandleError, {
+    refreshInterval: 60_000,
+  });
+  return useMemo(() => {
+    const map = new Map<string, L3SummaryRow>();
+    if (!data) return map;
+    for (const row of data) {
+      map.set(row.repo, row);
+    }
+    return map;
+  }, [data]);
+}
+
+function ReadinessChip({
+  repo,
+  l3SummaryMap,
+  l3SummaryMapDemotion,
+}: {
+  repo: string;
+  l3SummaryMap: Map<string, L3SummaryRow>;
+  l3SummaryMapDemotion: Map<string, L3SummaryRow>;
+}) {
+  const { tenure } = useTenure(repo);
+  const promotionRows = buildCriteriaRows(
+    l3SummaryMap.get(repo) ?? null,
+    tenure
+  );
+  const demotionRows = buildDemotionRows(
+    l3SummaryMapDemotion.get(repo) ?? null
+  );
+
+  return (
+    <Stack direction="row" spacing={0.5} justifyContent="center">
+      <L3SummaryChip
+        label="Promotion"
+        rows={promotionRows}
+        variant="promotion"
+      />
+      <L3SummaryChip label="Demotion" rows={demotionRows} variant="demotion" />
+    </Stack>
+  );
+}
+
 function CiHealthTable({
   level,
   repos,
   metricsMap,
+  l3SummaryMap,
+  l3SummaryMapDemotion,
 }: {
   level: Level;
   repos: AllowlistEntry[];
   metricsMap: Map<string, CiMetricsRow>;
+  l3SummaryMap: Map<string, L3SummaryRow>;
+  l3SummaryMapDemotion: Map<string, L3SummaryRow>;
 }) {
   return (
     <TableContainer component={Paper} elevation={1}>
@@ -167,6 +231,9 @@ function CiHealthTable({
             </TableCell>
             <TableCell align="right">
               <strong>Last Run</strong>
+            </TableCell>
+            <TableCell align="center">
+              <strong>L3 Readiness</strong>
             </TableCell>
           </TableRow>
         </TableHead>
@@ -258,6 +325,13 @@ function CiHealthTable({
                   ) : (
                     "–"
                   )}
+                </TableCell>
+                <TableCell align="center">
+                  <ReadinessChip
+                    repo={entry.repo}
+                    l3SummaryMap={l3SummaryMap}
+                    l3SummaryMapDemotion={l3SummaryMapDemotion}
+                  />
                 </TableCell>
               </TableRow>
             );
@@ -689,10 +763,15 @@ export default function CrcrSummaryPage() {
     { refreshInterval: 60_000 }
   );
 
+  // Window matches L3_PROMOTION_WINDOW_DAYS (the 2-week promotion window)
+  // rather than an independent magic number.
   const nightlyHealthUrl =
     `/api/clickhouse/crcr_nightly_dashboard?parameters=` +
     encodeURIComponent(
-      JSON.stringify({ repo: "pytorch/crcr-test", days: "14" })
+      JSON.stringify({
+        repo: "pytorch/crcr-test",
+        days: String(L3_PROMOTION_WINDOW_DAYS),
+      })
     );
   const { data: nightlyHealthJobs, error: nightlyHealthError } = useSWR<
     NightlyJobRow[]
@@ -705,6 +784,11 @@ export default function CrcrSummaryPage() {
     [nightlyData],
   );
   const nightlyRepoCount = visibleNightlyData.length;
+
+  // L3 readiness — fixed promotion/demotion windows, independent of the
+  // Time Range selector above.
+  const l3SummaryMap = useL3SummaryMap(L3_PROMOTION_WINDOW_DAYS);
+  const l3SummaryMapDemotion = useL3SummaryMap(L3_DEMOTION_WINDOW_DAYS);
 
   const metricsMap = useMemo(() => {
     const map = new Map<string, CiMetricsRow>();
@@ -957,6 +1041,8 @@ export default function CrcrSummaryPage() {
                       level={level}
                       repos={repos}
                       metricsMap={metricsMap}
+                      l3SummaryMap={l3SummaryMap}
+                      l3SummaryMapDemotion={l3SummaryMapDemotion}
                     />
                   )}
                 </Box>

--- a/torchci/pages/crcr/index.tsx
+++ b/torchci/pages/crcr/index.tsx
@@ -781,7 +781,7 @@ export default function CrcrSummaryPage() {
 
   const visibleNightlyData = useMemo(
     () => nightlyData?.filter((r) => r.repo !== CRCR_HEALTH_REPO) ?? [],
-    [nightlyData],
+    [nightlyData]
   );
   const nightlyRepoCount = visibleNightlyData.length;
 
@@ -1092,10 +1092,7 @@ export default function CrcrSummaryPage() {
                 <Typography variant="h6" sx={{ mt: 2 }}>
                   Nightly CI Runs — Last {days} Days
                 </Typography>
-                <NightlyTable
-                  nightlyData={visibleNightlyData}
-                  days={days}
-                />
+                <NightlyTable nightlyData={visibleNightlyData} days={days} />
               </>
             ) : (
               <Paper

--- a/torchci/test/l3Readiness.test.ts
+++ b/torchci/test/l3Readiness.test.ts
@@ -1,0 +1,144 @@
+import {
+  buildCriteriaRows,
+  L3SummaryRow,
+  RepoTenure,
+  summarizeReadiness,
+  TenureInfo,
+  tenureInfoFromRow,
+} from "../lib/crcr/l3Readiness";
+import { evaluateL3Threshold, L3_THRESHOLDS } from "../lib/crcr/l3Thresholds";
+
+function repoTenure(overrides: Partial<RepoTenure>): RepoTenure {
+  return {
+    current_level: "L2",
+    level_since: "2026-01-01T00:00:00Z",
+    first_seen: "2026-01-01T00:00:00Z",
+    last_seen: "2026-08-30T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("tenureInfoFromRow", () => {
+  it("returns null when there is no row", () => {
+    expect(tenureInfoFromRow(undefined)).toBeNull();
+    expect(tenureInfoFromRow(null)).toBeNull();
+  });
+
+  it("returns null when the repo has no current level", () => {
+    expect(tenureInfoFromRow(repoTenure({ current_level: "" }))).toBeNull();
+  });
+
+  it("carries the current level and computes tenure days from level_since", () => {
+    const tenure = tenureInfoFromRow(
+      repoTenure({
+        current_level: "L2",
+        level_since: new Date(
+          Date.now() - 60 * 24 * 60 * 60 * 1000
+        ).toISOString(),
+      })
+    );
+    expect(tenure?.currentLevel).toBe("L2");
+    expect(tenure?.tenureDays).toBeCloseTo(60, 0);
+  });
+});
+
+describe("evaluateL3Threshold", () => {
+  it("returns null when there is no data", () => {
+    expect(evaluateL3Threshold(L3_THRESHOLDS.passRate, null)).toBeNull();
+    expect(evaluateL3Threshold(L3_THRESHOLDS.passRate, undefined)).toBeNull();
+  });
+
+  it("passes a repo at 93% pass rate", () => {
+    // A prior version of the stat-card coloring flagged 93% pass rate as a
+    // warning even though the target (>90%) says it passes. The shared
+    // threshold must not repeat that drift.
+    expect(evaluateL3Threshold(L3_THRESHOLDS.passRate, 0.93)).toBe(true);
+    expect(evaluateL3Threshold(L3_THRESHOLDS.passRate, 0.89)).toBe(false);
+  });
+
+  it("evaluates a 'below' criterion correctly at the boundary", () => {
+    const t = L3_THRESHOLDS.timeoutRate; // < 1%
+    expect(evaluateL3Threshold(t, 0.009)).toBe(true);
+    expect(evaluateL3Threshold(t, 0.01)).toBe(false);
+    expect(evaluateL3Threshold(t, 0.011)).toBe(false);
+  });
+});
+
+function summaryRow(overrides: Partial<L3SummaryRow>): L3SummaryRow {
+  return {
+    repo: "pytorch/example",
+    successes: 100,
+    timed_out: 0,
+    total_jobs: 100,
+    pass_rate: 1.0,
+    avg_queue_time_s: 60,
+    max_exec_time_s: 3600,
+    median_e2e_time_s: 3600,
+    timeout_rate: 0,
+    ...overrides,
+  };
+}
+
+const goodTenure: TenureInfo = {
+  currentLevel: "L2",
+  tenureDays: 60,
+};
+
+describe("buildCriteriaRows / summarizeReadiness", () => {
+  it("has one row per L3 threshold, in a stable order — six criteria, not seven", () => {
+    // L3 Promotion's prerequisites list tenure + five metrics.
+    const rows = buildCriteriaRows(summaryRow({}), null);
+    expect(rows.map((r) => r.key)).toEqual([
+      "tenureAtL2Days",
+      "e2eTimeS",
+      "maxExecTimeS",
+      "avgQueueTimeS",
+      "timeoutRate",
+      "passRate",
+    ]);
+  });
+
+  it("marks tenure as unjudged (not failed) when tenure is null — e.g. a repo crcr_repo_tenure has no rows for", () => {
+    const rows = buildCriteriaRows(summaryRow({}), null);
+    const tenureRow = rows.find((r) => r.key === "tenureAtL2Days");
+    expect(tenureRow?.verdict).toBeNull();
+  });
+
+  it("is ready only when every criterion is judged and met", () => {
+    const goodSummary = summaryRow({
+      avg_queue_time_s: 60,
+      max_exec_time_s: 1000,
+      median_e2e_time_s: 1000,
+      timeout_rate: 0,
+      pass_rate: 1.0,
+    });
+
+    const readyRows = buildCriteriaRows(goodSummary, goodTenure);
+    expect(summarizeReadiness(readyRows).ready).toBe(true);
+
+    const notReadyRows = buildCriteriaRows(
+      summaryRow({ pass_rate: 0.5 }),
+      goodTenure
+    );
+    const notReady = summarizeReadiness(notReadyRows);
+    expect(notReady.ready).toBe(false);
+    expect(notReady.metCount).toBe(notReady.totalCount - 1);
+  });
+
+  it("is never ready while tenure is null, even with a perfect summary", () => {
+    // A repo with no tenure data at all (crcr_repo_tenure returns no row)
+    // should never read "Ready" outright — only "N/M criteria met".
+    const rows = buildCriteriaRows(summaryRow({}), null);
+    const result = summarizeReadiness(rows);
+    expect(result.judgedCount).toBe(5);
+    expect(result.metCount).toBe(5);
+    expect(result.ready).toBe(false);
+  });
+
+  it("is not ready when data is missing entirely", () => {
+    const rows = buildCriteriaRows(null, null);
+    const result = summarizeReadiness(rows);
+    expect(result.judgedCount).toBe(0);
+    expect(result.ready).toBe(false);
+  });
+});

--- a/torchci/test/l3Readiness.test.ts
+++ b/torchci/test/l3Readiness.test.ts
@@ -1,6 +1,8 @@
 import {
   buildCriteriaRows,
+  buildDemotionRows,
   L3SummaryRow,
+  mergeCriteriaRows,
   RepoTenure,
   summarizeReadiness,
   TenureInfo,
@@ -140,5 +142,79 @@ describe("buildCriteriaRows / summarizeReadiness", () => {
     const result = summarizeReadiness(rows);
     expect(result.judgedCount).toBe(0);
     expect(result.ready).toBe(false);
+  });
+});
+
+describe("buildDemotionRows", () => {
+  it("returns exactly the demotionRelevant subset, in threshold order", () => {
+    // e2e time, timeout rate, pass rate — no tenure, no max exec/avg queue.
+    const rows = buildDemotionRows(summaryRow({}));
+    expect(rows.map((r) => r.key)).toEqual([
+      "e2eTimeS",
+      "timeoutRate",
+      "passRate",
+    ]);
+  });
+
+  it("tracks whichever thresholds are flagged demotionRelevant, not a hardcoded list", () => {
+    // Derives the expected set from L3_THRESHOLDS itself, so this keeps
+    // passing if a future criterion's demotionRelevant flag changes —
+    // it only fails if buildDemotionRows stops honoring the flag.
+    const expectedKeys = Object.values(L3_THRESHOLDS)
+      .filter((t) => t.demotionRelevant)
+      .map((t) => t.key);
+    const rows = buildDemotionRows(summaryRow({}));
+    expect(rows.map((r) => r.key).sort()).toEqual(expectedKeys.sort());
+  });
+
+  it("judges each row against the same thresholds as promotion", () => {
+    const rows = buildDemotionRows(
+      summaryRow({
+        pass_rate: 0.5,
+        timeout_rate: 0.02,
+        median_e2e_time_s: 4 * 3600,
+      })
+    );
+    expect(rows.every((r) => r.verdict === false)).toBe(true);
+  });
+
+  it("leaves every row unjudged when there is no summary data", () => {
+    const rows = buildDemotionRows(null);
+    expect(rows.every((r) => r.verdict === null)).toBe(true);
+  });
+});
+
+describe("mergeCriteriaRows", () => {
+  it("is null for demotion on rows outside the demotionRelevant set, and populated on the rest", () => {
+    const promotionRows = buildCriteriaRows(summaryRow({}), goodTenure);
+    const demotionRows = buildDemotionRows(summaryRow({}));
+    const merged = mergeCriteriaRows(promotionRows, demotionRows);
+
+    expect(merged).toHaveLength(promotionRows.length);
+    for (const row of merged) {
+      const shouldHaveDemotion = demotionRows.some((d) => d.key === row.key);
+      if (shouldHaveDemotion) {
+        expect(row.demotion?.key).toBe(row.key);
+      } else {
+        expect(row.demotion).toBeNull();
+      }
+    }
+    // Tenure and the two demotion-irrelevant metrics never get a demotion verdict.
+    expect(merged.find((r) => r.key === "tenureAtL2Days")?.demotion).toBeNull();
+    expect(merged.find((r) => r.key === "maxExecTimeS")?.demotion).toBeNull();
+    expect(merged.find((r) => r.key === "avgQueueTimeS")?.demotion).toBeNull();
+  });
+
+  it("pairs each demotion-relevant row with its own measurement, not just any row sharing a verdict", () => {
+    const promotionRows = buildCriteriaRows(
+      summaryRow({ pass_rate: 1.0 }),
+      goodTenure
+    );
+    const demotionRows = buildDemotionRows(summaryRow({ pass_rate: 0.5 }));
+    const merged = mergeCriteriaRows(promotionRows, demotionRows);
+
+    const passRateRow = merged.find((r) => r.key === "passRate");
+    expect(passRateRow?.promotion.verdict).toBe(true);
+    expect(passRateRow?.demotion?.verdict).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Implements #8554 (per-repo L3 readiness panel) and the fixed-window piece of #8552 it depends on.

- **`lib/crcr/l3Thresholds.ts`** — single source of truth for the six L3 promotion criteria (tenure + five metrics) and their fixed evaluation windows (14d promotion / 7d demotion). The per-repo stat cards above the panel keep their own existing coloring and still follow the page's Time Range selector, since they intentionally support an arbitrary window and tying their color to a fixed L3 threshold would be misleading outside the panel's own 14d/7d windows.
- **`CrcrL3Readiness`** — one table per repo, Criterion / Target / Promotion / Demotion columns, colored so only the state worth acting on stands out (green = qualifies for promotion, red = would trigger demotion). Collapsed by default; a "Details" chip expands it.
- **`/crcr` index page** — an at-a-glance readiness column (Promotion + Demotion chips) per repo, so maintainers can spot promotion candidates and demotion risks without opening each repo's page.
- Tenure ("time at L2") is wired in via `crcr_repo_tenure` (#8658) on both the panel and the index column, so the two stay consistent.

Demotion reuses the same threshold definitions as promotion (RFC's demotion trigger conditions are the boundary-complement of the promotion targets), evaluated over its own window — no separate threshold set to keep in sync.

The per-repo stat cards above the panel keep their own existing coloring and still follow the page's Time Range selector, since they intentionally support an arbitrary window and tying their color to a fixed L3 threshold would be misleading outside the panel's own 14d/7d windows.

---
