### PR TITLE
[CRCR] Add write-once guard for nightly/periodic callback finalization

### DIFF
--- a/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/callback/callback_handler.py
@@ -317,7 +317,18 @@ def _handle_nightly_callback(
     trusted = _build_trusted(verified_repo, repo_level)
     untrusted = {"callback_payload": body}
 
-    forward_to_hud(config, trusted, untrusted)
+    try:
+        forward_to_hud(config, trusted, untrusted)
+    except HTTPException as exc:
+        if exc.status_code == 409:
+            logger.info(
+                "nightly callback already finalized (duplicate), "
+                "delivery_id=%s repo=%s",
+                delivery_id,
+                verified_repo,
+            )
+            return {"ok": True, "status": "duplicate"}
+        raise
     logger.info(
         "nightly callback forwarded delivery_id=%s repo=%s event_type=%s",
         delivery_id,
@@ -462,9 +473,20 @@ def handle(config: RelayConfig, body: dict, verified_repo: str) -> dict:
         )
 
     trusted = _build_trusted(verified_repo, repo_level, ci_metrics)
-    # downstream's payload is untrusted — provide it under the "callback_payload"
-    # key so HUD receives it under the expected untrusted namespace.
     untrusted = {"callback_payload": body}
 
-    forward_to_hud(config, trusted, untrusted)
+    try:
+        forward_to_hud(config, trusted, untrusted)
+    except HTTPException as exc:
+        if exc.status_code == 409:
+            logger.info(
+                "callback already finalized (duplicate), "
+                "delivery_id=%s repo=%s run_id=%s job_name=%s",
+                delivery_id,
+                verified_repo,
+                run_id,
+                job_name,
+            )
+            return {"ok": True, "status": "duplicate"}
+        raise
     return {"ok": True, "status": status}

--- a/aws/lambda/cross_repo_ci_relay/tests/test_callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_callback_handler.py
@@ -711,6 +711,20 @@ class TestNightlyCallback(unittest.TestCase):
             untrusted["callback_payload"]["workflow"]["conclusion"], "failure"
         )
 
+    def test_nightly_duplicate_returns_ok_duplicate(self):
+        self.mock_hud.side_effect = HTTPException(409, "Record already finalized")
+
+        result = handle(_cfg(), self._nightly_body(), verified_repo="org/repo")
+
+        self.assertEqual(result, {"ok": True, "status": "duplicate"})
+
+    def test_nightly_hud_non_409_error_propagates(self):
+        self.mock_hud.side_effect = HTTPException(500, "Internal error")
+
+        with self.assertRaises(HTTPException) as ctx:
+            handle(_cfg(), self._nightly_body(), verified_repo="org/repo")
+        self.assertEqual(ctx.exception.status_code, 500)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/aws/lambda/cross_repo_ci_relay/tests/test_callback_handler.py
+++ b/aws/lambda/cross_repo_ci_relay/tests/test_callback_handler.py
@@ -299,6 +299,17 @@ class TestCallbackHandler(unittest.TestCase):
             handle(_cfg(), _body(), verified_repo="org/repo")
         self.assertEqual(ctx.exception.status_code, 422)
 
+    def test_pr_duplicate_returns_ok_duplicate(self):
+        # Write-once guard on HUD returns 409 for completed → completed
+        # replays. PR/push path should treat that as a soft duplicate, same
+        # as the nightly handler (nightly is the primary write-once use case;
+        # this is the matching backstop for the shared HUD API).
+        self.mock_hud.side_effect = HTTPException(409, "Record already finalized")
+
+        result = handle(_cfg(), _body(status="completed"), verified_repo="org/repo")
+
+        self.assertEqual(result, {"ok": True, "status": "duplicate"})
+
     # --- required field validation ---
 
     def test_missing_delivery_id_returns_400(self):

--- a/torchci/lib/crcr/crcrUtils.ts
+++ b/torchci/lib/crcr/crcrUtils.ts
@@ -1,3 +1,4 @@
+import { ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
 import { getDynamoClient } from "lib/dynamo";
 
 const CRCR_TABLE = "torchci-oot-workflow-job";
@@ -273,13 +274,31 @@ export async function writeToDynamo(
     expressionNames[nameAlias] = key;
   }
 
-  await client.update({
-    TableName: CRCR_TABLE,
-    Key: { dynamoKey: record.dynamoKey },
-    UpdateExpression: `SET ${expressionParts.join(", ")}`,
-    ExpressionAttributeValues: expressionValues,
-    ExpressionAttributeNames: expressionNames,
-  });
+  // Write-once guard: reject writes to already-finalized records.
+  // Allows new records (attribute_not_exists) and in_progress → completed
+  // transitions, but blocks completed → completed replays.
+  expressionNames["#guard_status"] = "status";
+  expressionValues[":guard_completed"] = "completed";
+
+  try {
+    await client.update({
+      TableName: CRCR_TABLE,
+      Key: { dynamoKey: record.dynamoKey },
+      UpdateExpression: `SET ${expressionParts.join(", ")}`,
+      ConditionExpression:
+        "attribute_not_exists(#guard_status) OR #guard_status <> :guard_completed",
+      ExpressionAttributeValues: expressionValues,
+      ExpressionAttributeNames: expressionNames,
+    });
+  } catch (err: unknown) {
+    if (err instanceof ConditionalCheckFailedException) {
+      throw new ApiError(
+        409,
+        `Record already finalized (key=${record.dynamoKey})`
+      );
+    }
+    throw err;
+  }
 }
 
 // ---- UI Helpers ----

--- a/torchci/test/crcrUtils.test.ts
+++ b/torchci/test/crcrUtils.test.ts
@@ -5,7 +5,15 @@ import {
   extractDynamoRecord,
   RelayPayload,
   validatePayloadSize,
+  writeToDynamo,
+  CrcrWorkflowJobRecord,
 } from "../lib/crcr/crcrUtils";
+import { ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
+
+const mockUpdate = jest.fn();
+jest.mock("lib/dynamo", () => ({
+  getDynamoClient: () => ({ update: mockUpdate }),
+}));
 
 function makePayload(
   overrides: {
@@ -512,5 +520,85 @@ describe("extractDynamoRecord - failed_tests_detail", () => {
     const parsed = JSON.parse(record.failed_tests_json!);
     expect(parsed[0].name).toBe("");
     expect(parsed[0].classname).toBe("TestNoName");
+  });
+});
+
+describe("writeToDynamo - write-once guard", () => {
+  const baseRecord: CrcrWorkflowJobRecord = {
+    dynamoKey: "repo/delivery/wf/job/cr1",
+    status: "completed",
+    downstream_repo: "Ascend/pytorch",
+    upstream_repo: "pytorch/pytorch",
+    pr_number: 0,
+    pytorch_head_sha: "abc123",
+    delivery_id: "delivery-1",
+    workflow_run_url: "https://example.com",
+    workflow_name: "nightly-ci",
+    job_name: "build-and-test",
+    check_run_id: "cr1",
+    run_id: "100",
+    run_attempt: 1,
+    conclusion: "success",
+  };
+
+  beforeEach(() => {
+    mockUpdate.mockReset();
+  });
+
+  test("includes ConditionExpression in DynamoDB update", async () => {
+    mockUpdate.mockResolvedValueOnce({});
+    await writeToDynamo(baseRecord);
+
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    const args = mockUpdate.mock.calls[0][0];
+    expect(args.ConditionExpression).toBe(
+      "attribute_not_exists(#guard_status) OR #guard_status <> :guard_completed"
+    );
+    expect(args.ExpressionAttributeNames["#guard_status"]).toBe("status");
+    expect(args.ExpressionAttributeValues[":guard_completed"]).toBe(
+      "completed"
+    );
+  });
+
+  test("throws ApiError(409) on ConditionalCheckFailedException", async () => {
+    mockUpdate.mockRejectedValueOnce(
+      new ConditionalCheckFailedException({
+        message: "The conditional request failed",
+        $metadata: {},
+      })
+    );
+
+    await expect(writeToDynamo(baseRecord)).rejects.toThrow(ApiError);
+    try {
+      mockUpdate.mockRejectedValueOnce(
+        new ConditionalCheckFailedException({
+          message: "The conditional request failed",
+          $metadata: {},
+        })
+      );
+      await writeToDynamo(baseRecord);
+    } catch (e: any) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect(e.statusCode).toBe(409);
+      expect(e.message).toContain("already finalized");
+    }
+  });
+
+  test("re-throws non-conditional DynamoDB errors", async () => {
+    const genericError = new Error("DynamoDB unavailable");
+    mockUpdate.mockRejectedValueOnce(genericError);
+
+    await expect(writeToDynamo(baseRecord)).rejects.toThrow(
+      "DynamoDB unavailable"
+    );
+  });
+
+  test("succeeds for in_progress record when no prior exists", async () => {
+    mockUpdate.mockResolvedValueOnce({});
+    const record = { ...baseRecord, status: "in_progress" };
+    delete (record as any).conclusion;
+
+    await expect(writeToDynamo(record)).resolves.toBeUndefined();
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
   });
 });

--- a/torchci/test/crcrUtils.test.ts
+++ b/torchci/test/crcrUtils.test.ts
@@ -1,14 +1,14 @@
+import { ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
 import {
   ApiError,
   conclusionColor,
   conclusionLabel,
+  CrcrWorkflowJobRecord,
   extractDynamoRecord,
   RelayPayload,
   validatePayloadSize,
   writeToDynamo,
-  CrcrWorkflowJobRecord,
 } from "../lib/crcr/crcrUtils";
-import { ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
 
 const mockUpdate = jest.fn();
 jest.mock("lib/dynamo", () => ({


### PR DESCRIPTION
## Summary

Adds replay/overwrite protection for nightly and periodic callbacks by enforcing a DynamoDB write-once guard on finalized records. This closes a gap identified in #8676 — unlike the PR/push flow which uses Redis state tracking, the nightly/periodic path had no protection against duplicate or replayed callbacks silently overwriting completed records.

**Changes:**

**HUD side (`torchci/lib/crcr/crcrUtils.ts`)**
- `writeToDynamo` now includes a `ConditionExpression` that rejects writes when the record already has `status = "completed"`
- `ConditionalCheckFailedException` is caught and surfaced as `ApiError(409)`
- The condition `attribute_not_exists(#guard_status) OR #guard_status <> :guard_completed` allows new records and `in_progress → completed` transitions, but blocks `completed → completed` replays

**Lambda side (`callback/callback_handler.py`)**
- Both `_handle_nightly_callback` and the PR/push `handle` path catch the 409 from HUD and return `{"ok": true, "status": "duplicate"}` instead of failing
- Non-409 errors still propagate normally

**State transition matrix:**

| Current state | Incoming status | Result |
|---|---|---|
| (no record) | in_progress | allowed |
| (no record) | completed | allowed (nightly single-shot) |
| in_progress | completed | allowed |
| completed | completed | **rejected (409)** |

**Tests added:**
- `crcrUtils.test.ts`: Verifies ConditionExpression is present, 409 on duplicate, non-conditional errors propagate
- `test_callback_handler.py`: Verifies nightly duplicate returns `{"ok": true, "status": "duplicate"}` and non-409 errors propagate

Fixes #8676

## Test plan

- [ ] Existing `crcrUtils.test.ts` tests pass (no regression on extraction/validation)
- [ ] New `writeToDynamo` tests verify the condition expression and 409 handling
- [ ] Lambda nightly callback tests verify graceful duplicate handling
- [ ] CI passes