### PR TITLE
[CRCR] Fix nightly dashboard partial rows at time-window boundary

### DIFF
--- a/torchci/clickhouse_queries/crcr_nightly_dashboard/query.sql
+++ b/torchci/clickhouse_queries/crcr_nightly_dashboard/query.sql
@@ -54,7 +54,11 @@ WHERE
     AND event_type = 'nightly'
     AND run_id IN (SELECT run_id FROM eligible_runs)
     AND (run_id, job_name, run_attempt) IN (
-        SELECT run_id, job_name, max_attempt FROM latest_attempts
+        SELECT
+            run_id,
+            job_name,
+            max_attempt
+        FROM latest_attempts
     )
 ORDER BY
     started_at DESC

--- a/torchci/clickhouse_queries/crcr_nightly_dashboard/query.sql
+++ b/torchci/clickhouse_queries/crcr_nightly_dashboard/query.sql
@@ -1,3 +1,30 @@
+-- Identify runs where at least one job started within the time window.
+-- Using run-level filtering ensures complete nightly rows: when a pipeline's
+-- jobs start at different times (build first, tests later), per-job
+-- started_at filtering would clip earlier jobs from the last run, producing
+-- partial rows with missing cells.
+WITH eligible_runs AS (
+    SELECT DISTINCT run_id
+    FROM default.crcr_workflow_job FINAL
+    WHERE
+        downstream_repo = {repo: String}
+        AND started_at > now() - INTERVAL {days: UInt64} DAY
+        AND event_type = 'nightly'
+),
+
+latest_attempts AS (
+    SELECT
+        run_id,
+        job_name,
+        max(run_attempt) AS max_attempt
+    FROM default.crcr_workflow_job FINAL
+    WHERE
+        downstream_repo = {repo: String}
+        AND event_type = 'nightly'
+        AND run_id IN (SELECT run_id FROM eligible_runs)
+    GROUP BY run_id, job_name
+)
+
 SELECT
     upstream_repo,
     pytorch_head_sha,
@@ -24,19 +51,10 @@ FROM
     default.crcr_workflow_job FINAL
 WHERE
     downstream_repo = {repo: String}
-    AND started_at > now() - INTERVAL {days: UInt64} DAY
     AND event_type = 'nightly'
+    AND run_id IN (SELECT run_id FROM eligible_runs)
     AND (run_id, job_name, run_attempt) IN (
-        SELECT
-            run_id,
-            job_name,
-            max(run_attempt) AS max_attempt
-        FROM default.crcr_workflow_job FINAL
-        WHERE
-            downstream_repo = {repo: String}
-            AND started_at > now() - INTERVAL {days: UInt64} DAY
-            AND event_type = 'nightly'
-        GROUP BY run_id, job_name
+        SELECT run_id, job_name, max_attempt FROM latest_attempts
     )
 ORDER BY
     started_at DESC


### PR DESCRIPTION
## Summary

Fixes the "no signal" cells appearing on the last row of the nightly dashboard, and partially addresses the jobs count discrepancy reported in #8691.

**Root cause:** The nightly dashboard query filtered by per-job `started_at > now() - INTERVAL {days} DAY`. In a nightly pipeline, jobs execute sequentially — build starts first, then tests start 1-2 hours later. When the time window clips through a run at the boundary, earlier-starting jobs (build) age out while later-starting jobs (tests) remain. This produces partial SHA rows with empty cells for the disappeared jobs.

**Fix:** Switch to run-level filtering using a CTE. First, identify `eligible_runs` where at least one job started within the window. Then include ALL jobs from those runs, regardless of individual `started_at`. This ensures complete nightly rows at the boundary — no more jobs disappearing one-by-one from the last row.

**Before:**
```sql
WHERE started_at > now() - INTERVAL {days} DAY  -- per-job cutoff
```

**After:**
```sql
WITH eligible_runs AS (
    SELECT DISTINCT run_id ... WHERE started_at > now() - INTERVAL {days} DAY
)
WHERE run_id IN (SELECT run_id FROM eligible_runs)  -- run-level cutoff
```

Ref #8691

## Test plan

- [ ] Verify nightly dashboard loads without errors
- [ ] Confirm the last SHA row now shows complete data (no "no signal" cells for jobs that were part of the same run)
- [ ] CI passes

Closes https://github.com/pytorch/test-infra/issues/8691 (partial)

Fixes https://github.com/pytorch/test-infra/issues/8691 (partial — companion: #8696)