### PR TITLE
[CRCR] Compute nightly summary stats from matrix data instead of raw array

### DIFF
--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -414,7 +414,14 @@ function NightlySummaryCards({
     ).length;
     const total = completed.length;
     const passRate = total > 0 ? successes / total : 0;
-    return { successes, failures, timedOut, total, passRate, uniqueShas: rows.length };
+    return {
+      successes,
+      failures,
+      timedOut,
+      total,
+      passRate,
+      uniqueShas: rows.length,
+    };
   }, [rows, isCrcrTest]);
 
   const passColor =

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -383,16 +383,22 @@ function NightlyHealthCard({ repoFullName }: { repoFullName: string }) {
 }
 
 function NightlySummaryCards({
-  data,
+  rows,
   repoFullName,
 }: {
-  data: CrcrJobRow[];
+  rows: NightlyRow[];
   repoFullName: string;
 }) {
   const isCrcrTest = repoFullName === "pytorch/crcr-test";
 
   const stats = useMemo(() => {
-    const completed = data.filter((j) => j.status === "completed");
+    const jobs: CrcrJobRow[] = [];
+    for (const row of rows) {
+      for (const job of row.jobs.values()) {
+        jobs.push(job);
+      }
+    }
+    const completed = jobs.filter((j) => j.status === "completed");
     const successes = completed.filter(
       (j) => j.conclusion === "success"
     ).length;
@@ -408,9 +414,8 @@ function NightlySummaryCards({
     ).length;
     const total = completed.length;
     const passRate = total > 0 ? successes / total : 0;
-    const uniqueShas = new Set(data.map((j) => j.pytorch_head_sha)).size;
-    return { successes, failures, timedOut, total, passRate, uniqueShas };
-  }, [data, isCrcrTest]);
+    return { successes, failures, timedOut, total, passRate, uniqueShas: rows.length };
+  }, [rows, isCrcrTest]);
 
   const passColor =
     stats.passRate >= 1.0
@@ -1345,7 +1350,7 @@ function CrcrNightlyMatrix({
 
   return (
     <>
-      <NightlySummaryCards data={data} repoFullName={repoFullName} />
+      <NightlySummaryCards rows={matrix.rows} repoFullName={repoFullName} />
       <div style={{ overflowX: "auto", overflowY: "visible" }}>
         <table className={hudStyles.hudTable}>
           <colgroup>


### PR DESCRIPTION
## Summary

Fixes the discrepancy between the nightly summary cards (Total Jobs, Failures) and the table reported in #8691.

**Root cause:** `NightlySummaryCards` computed stats from the raw `data` array (all individual job records), while the table uses `buildNightlyMatrix()` which groups jobs by `pytorch_head_sha` and keeps only the latest `run_attempt` per `(sha, job_name)`. When multiple `run_id`s target the same SHA (e.g., nightly re-triggers), the summary counted all jobs individually but the table collapsed them into one row — so "Total Jobs 42" in the card while only 35 cells were visible.

**Fix:** Change `NightlySummaryCards` to accept the matrix rows (post SHA-grouping and dedup) and iterate over `row.jobs.values()` to compute stats. This ensures the cards count exactly the jobs visible in the table.

**Before:** `NightlySummaryCards({ data: CrcrJobRow[] })` — flat array, counts duplicates
**After:** `NightlySummaryCards({ rows: NightlyRow[] })` — matrix rows, matches table

Companion to #8695 (which fixes partial rows at the time-window boundary).

Ref #8691

## Test plan

- [ ] Verify Total Jobs / Failures cards match the actual cell counts in the nightly table
- [ ] Confirm Pass Rate is consistent with visible data
- [ ] CI passes

Fixes https://github.com/pytorch/test-infra/issues/8691 (partial — companion: #8695)