### PR TITLE
[CRCR] Hide crcr-test from nightly CI summary table

### DIFF
--- a/torchci/pages/crcr/index.tsx
+++ b/torchci/pages/crcr/index.tsx
@@ -700,9 +700,11 @@ export default function CrcrSummaryPage() {
     refreshInterval: 60_000,
   });
 
-  const nightlyRepoCount = nightlyData
-    ? nightlyData.filter((r) => r.repo !== CRCR_HEALTH_REPO).length
-    : 0;
+  const visibleNightlyData = useMemo(
+    () => nightlyData?.filter((r) => r.repo !== CRCR_HEALTH_REPO) ?? [],
+    [nightlyData],
+  );
+  const nightlyRepoCount = visibleNightlyData.length;
 
   const metricsMap = useMemo(() => {
     const map = new Map<string, CiMetricsRow>();
@@ -999,15 +1001,13 @@ export default function CrcrSummaryPage() {
               </Typography>
             </Paper>
 
-            {nightlyData && nightlyData.length > 0 ? (
+            {visibleNightlyData.length > 0 ? (
               <>
                 <Typography variant="h6" sx={{ mt: 2 }}>
                   Nightly CI Runs — Last {days} Days
                 </Typography>
                 <NightlyTable
-                  nightlyData={nightlyData.filter(
-                    (r) => r.repo !== CRCR_HEALTH_REPO
-                  )}
+                  nightlyData={visibleNightlyData}
                   days={days}
                 />
               </>

--- a/torchci/pages/crcr/index.tsx
+++ b/torchci/pages/crcr/index.tsx
@@ -700,7 +700,9 @@ export default function CrcrSummaryPage() {
     refreshInterval: 60_000,
   });
 
-  const nightlyRepoCount = nightlyData?.length ?? 0;
+  const nightlyRepoCount = nightlyData
+    ? nightlyData.filter((r) => r.repo !== CRCR_HEALTH_REPO).length
+    : 0;
 
   const metricsMap = useMemo(() => {
     const map = new Map<string, CiMetricsRow>();
@@ -1002,7 +1004,12 @@ export default function CrcrSummaryPage() {
                 <Typography variant="h6" sx={{ mt: 2 }}>
                   Nightly CI Runs — Last {days} Days
                 </Typography>
-                <NightlyTable nightlyData={nightlyData} days={days} />
+                <NightlyTable
+                  nightlyData={nightlyData.filter(
+                    (r) => r.repo !== CRCR_HEALTH_REPO
+                  )}
+                  days={days}
+                />
               </>
             ) : (
               <Paper


### PR DESCRIPTION
## Summary

Hides `pytorch/crcr-test` from the nightly tab on the CRCR summary page, matching the existing behavior on the PR-level tab.

`crcr-test` is a health probe repo — its nightly results are already surfaced via the "CRCR Relay Health - Nightly" card at the top. Showing it again in the nightly repos table is redundant and creates a discrepancy between the health card (which accounts for expected failures like xfail/xtimeout) and the raw pass rate in the table (which doesn't).

**Changes:**
- Filter `CRCR_HEALTH_REPO` from the `nightlyData` passed to `NightlyTable`
- Filter it from `nightlyRepoCount` (the tab badge number)

Fixes #8622

## Test plan

- [ ] Nightly tab no longer shows `pytorch/crcr-test` in the table
- [ ] Nightly tab badge count decreases by 1
- [ ] CRCR Relay Health - Nightly card still works (unaffected)
- [ ] CI passes