### PR TITLE
Fix R2 promotion: throttling, throughput, and R2_ONLY scope

### DIFF
--- a/release/promote/common_utils.sh
+++ b/release/promote/common_utils.sh
@@ -181,9 +181,15 @@ CFG
     # List matching files from S3 first (using current OIDC credentials)
     echo "+ Listing matching files from S3..."
     local file_list="${tmp_dir}/file_list.txt"
+    # Largest first. The biggest artifacts (rocm wheels, multi-GB) are the ones
+    # that exhaust disk or trip R2's per-object throttle, so promoting them up
+    # front surfaces those failures in the first few files instead of after 240.
+    # It also front-loads peak disk, so a temp volume that is too small fails
+    # immediately rather than most of the way through.
     ${AWS} s3 ls "${s3_from_path}/" --recursive \
         | grep -E "${match_pattern}" \
         | grep -Ev "${sub_channel_exclude}" \
+        | sort -k3 -nr \
         | awk '{print $NF}' > "${file_list}" || true
 
     local total_files
@@ -208,7 +214,11 @@ CFG
     # workers cannot race each other's S3/R2 swap.
     _promote_one_file() {
         local s3_key="$1"
-        local filename local_file rel_path r2_target sha256
+        local filename local_file rel_path r2_target sha256 marker err_log
+        # Keyed on the object, not $$ -- $$ is the script's pid and is identical
+        # in every background job, so a shared marker collapsed N failures to 1.
+        marker="${fail_dir}/${s3_key//\//_}"
+        err_log="${marker}.err"
         filename=$(basename "${s3_key}")
         local_file="${tmp_dir}/${filename}"
         rel_path="${s3_key#"${s3_from_prefix}"/}"
@@ -226,9 +236,11 @@ CFG
                 export AWS_DEFAULT_REGION="${saved_aws_default_region}"
             fi
             ${AWS} s3 cp --quiet "${PYTORCH_S3_BUCKET}/${s3_key}" "${local_file}"
-        ) || {
+        ) 2>"${err_log}" || {
             echo "- FAILED download: ${PYTORCH_S3_BUCKET}/${s3_key}" >&2
-            touch "${fail_dir}/$$"
+            sed 's/^/    /' "${err_log}" >&2
+            rm -f "${local_file}" "${err_log}"
+            touch "${marker}"
             return 1
         }
 
@@ -245,14 +257,15 @@ CFG
             ${AWS} s3 cp --quiet "${local_file}" "${r2_target}" \
                 --metadata "checksum-sha256=${sha256}" \
                 --endpoint-url "${R2_ENDPOINT_URL}"
-        ) || {
+        ) 2>"${err_log}" || {
             echo "- FAILED upload: ${r2_target}" >&2
-            rm -f "${local_file}"
-            touch "${fail_dir}/$$"
+            sed 's/^/    /' "${err_log}" >&2
+            rm -f "${local_file}" "${err_log}"
+            touch "${marker}"
             return 1
         }
 
-        rm -f "${local_file}"
+        rm -f "${local_file}" "${err_log}"
         echo "+ ${PYTORCH_S3_BUCKET}/${s3_key} -> ${r2_target}"
     }
 
@@ -269,7 +282,7 @@ CFG
     wait
 
     local failures
-    failures=$(find "${fail_dir}" -type f | wc -l)
+    failures=$(find "${fail_dir}" -type f ! -name '*.err' | wc -l)
     if [[ ${failures} -gt 0 ]]; then
         echo "- ERROR: ${failures} file(s) failed to promote to R2"
         return 1

--- a/release/promote/common_utils.sh
+++ b/release/promote/common_utils.sh
@@ -226,7 +226,11 @@ CFG
                 export AWS_DEFAULT_REGION="${saved_aws_default_region}"
             fi
             ${AWS} s3 cp --quiet "${PYTORCH_S3_BUCKET}/${s3_key}" "${local_file}"
-        ) || { touch "${fail_dir}/$$"; return 1; }
+        ) || {
+            echo "- FAILED download: ${PYTORCH_S3_BUCKET}/${s3_key}" >&2
+            touch "${fail_dir}/$$"
+            return 1
+        }
 
         sha256=$(sha256sum "${local_file}" | awk '{print $1}')
 
@@ -241,10 +245,15 @@ CFG
             ${AWS} s3 cp --quiet "${local_file}" "${r2_target}" \
                 --metadata "checksum-sha256=${sha256}" \
                 --endpoint-url "${R2_ENDPOINT_URL}"
-        ) || { rm -f "${local_file}"; touch "${fail_dir}/$$"; return 1; }
+        ) || {
+            echo "- FAILED upload: ${r2_target}" >&2
+            rm -f "${local_file}"
+            touch "${fail_dir}/$$"
+            return 1
+        }
 
         rm -f "${local_file}"
-        echo "+ ${rel_path}"
+        echo "+ ${PYTORCH_S3_BUCKET}/${s3_key} -> ${r2_target}"
     }
 
     echo "+ Promoting ${total_files} files to R2, ${parallel} at a time..."

--- a/release/promote/common_utils.sh
+++ b/release/promote/common_utils.sh
@@ -132,13 +132,27 @@ r2_promote() {
     local pkg_regex="${package_name//\*/.*}"
     local include_glob="${PACKAGE_INCLUDE_SUFFIX:-*}"
     local include_regex="${include_glob//\*/.*}"
-    local match_pattern="${pkg_regex}-${pytorch_version}${include_regex}"
+    # Escape the dots, or promoting 2.1 also matches 2.14.
+    local version_regex="${pytorch_version//./\\.}"
+    local match_pattern="${pkg_regex}-${version_regex}${include_regex}"
+
+    local s3_from_path="${PYTORCH_S3_FROM%/}"
+    # Bucket-relative source prefix (e.g. "libtorch/test"), used to preserve the
+    # per-arch subfolder layout (cpu/, cu126/, ...) when mapping keys onto R2.
+    local s3_from_prefix="${s3_from_path#"${PYTORCH_S3_BUCKET}"/}"
+    # A channel directory holds the other channels: whl/ (stable, TO empty) is
+    # the parent of whl/nightly/ and whl/test/, so a recursive listing sweeps
+    # them in. Harmless with the default FROM=test, but R2_ONLY=true points the
+    # source at the destination channel, which turned a 282-file promotion into
+    # 15764 -- nearly all of them nightlies already mirrored on R2.
+    local sub_channel_exclude="(^|[[:space:]])${s3_from_prefix}/(nightly|test)/"
 
     if [[ $DRY_RUN = "enabled" ]]; then
         echo "+ DRY RUN: Would copy matching files from ${PYTORCH_S3_FROM} to R2 ${r2_dest}"
         # List what would be copied
-        ${AWS} s3 ls "${PYTORCH_S3_FROM/\/$//}/" --recursive \
-            | grep -E "${match_pattern}" || true
+        ${AWS} s3 ls "${s3_from_path}/" --recursive \
+            | grep -E "${match_pattern}" \
+            | grep -Ev "${sub_channel_exclude}" || true
         return 0
     fi
 
@@ -153,15 +167,23 @@ r2_promote() {
     tmp_dir=$(mktemp -d)
     trap "rm -rf ${tmp_dir}" RETURN
 
+    # R2 rate-limits concurrent writes to a single key, and the CLI's default of
+    # 10 in-flight multipart parts trips it on the larger wheels. These are s3
+    # transfer settings, which the CLI reads only from a config file.
+    local r2_aws_config="${tmp_dir}/r2-aws-config"
+    cat > "${r2_aws_config}" <<CFG
+[default]
+s3 =
+    max_concurrent_requests = ${R2_MAX_CONCURRENT_REQUESTS:-1}
+    multipart_chunksize = ${R2_MULTIPART_CHUNKSIZE:-64MB}
+CFG
+
     # List matching files from S3 first (using current OIDC credentials)
     echo "+ Listing matching files from S3..."
-    local s3_from_path="${PYTORCH_S3_FROM%/}"
-    # Bucket-relative source prefix (e.g. "libtorch/test"), used to preserve the
-    # per-arch subfolder layout (cpu/, cu126/, ...) when mapping keys onto R2.
-    local s3_from_prefix="${s3_from_path#"${PYTORCH_S3_BUCKET}"/}"
     local file_list="${tmp_dir}/file_list.txt"
     ${AWS} s3 ls "${s3_from_path}/" --recursive \
         | grep -E "${match_pattern}" \
+        | grep -Ev "${sub_channel_exclude}" \
         | awk '{print $NF}' > "${file_list}" || true
 
     local total_files
@@ -173,73 +195,76 @@ r2_promote() {
         return 0
     fi
 
-    # Helper to restore S3 credentials
-    _restore_s3_creds() {
-        export AWS_ACCESS_KEY_ID="${saved_aws_access_key_id}"
-        export AWS_SECRET_ACCESS_KEY="${saved_aws_secret_access_key}"
-        if [[ -n "${saved_aws_session_token}" ]]; then
-            export AWS_SESSION_TOKEN="${saved_aws_session_token}"
-        else
-            unset AWS_SESSION_TOKEN 2>/dev/null || true
-        fi
-        if [[ -n "${saved_aws_default_region}" ]]; then
-            export AWS_DEFAULT_REGION="${saved_aws_default_region}"
-        else
-            unset AWS_DEFAULT_REGION 2>/dev/null || true
-        fi
-    }
+    # Promote files concurrently. R2's throttle is per-object -- "reduce your
+    # concurrent request rate for the same object" -- so parallelising across
+    # distinct keys is safe and recovers the throughput the serialised multipart
+    # above gives up. Disk stays bounded: each worker deletes its file as soon as
+    # it is uploaded, so peak usage is ~R2_PARALLEL_FILES x the largest wheel.
+    local parallel="${R2_PARALLEL_FILES:-4}"
+    local fail_dir="${tmp_dir}/failures"
+    mkdir -p "${fail_dir}"
 
-    # Helper to switch to R2 credentials
-    _set_r2_creds() {
-        export AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}"
-        export AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}"
-        unset AWS_SESSION_TOKEN 2>/dev/null || true
-        export AWS_DEFAULT_REGION="auto"
-    }
-
-    # Download and upload files one at a time to avoid running out of disk space
-    echo "+ Downloading and uploading files to R2 one by one..."
-    local file_count=0
-    while IFS= read -r s3_key; do
-        local filename
+    # Credentials are applied per subshell rather than exported, so concurrent
+    # workers cannot race each other's S3/R2 swap.
+    _promote_one_file() {
+        local s3_key="$1"
+        local filename local_file rel_path r2_target sha256
         filename=$(basename "${s3_key}")
-        local local_file="${tmp_dir}/${filename}"
+        local_file="${tmp_dir}/${filename}"
+        rel_path="${s3_key#"${s3_from_prefix}"/}"
+        r2_target="${r2_dest%/}/${rel_path}"
 
-        # Preserve the source subfolder layout relative to the promotion
-        # channel so per-arch directories (cpu/, cu126/, ...) are kept on R2
-        # instead of being flattened to the destination root.
-        local rel_path="${s3_key#"${s3_from_prefix}"/}"
-        local r2_target="${r2_dest%/}/${rel_path}"
-
-        # Download single file from S3 (using S3 credentials)
-        _restore_s3_creds
         (
-            set -x
-            ${AWS} s3 cp "${PYTORCH_S3_BUCKET}/${s3_key}" "${local_file}"
-        )
+            export AWS_ACCESS_KEY_ID="${saved_aws_access_key_id}"
+            export AWS_SECRET_ACCESS_KEY="${saved_aws_secret_access_key}"
+            if [[ -n "${saved_aws_session_token}" ]]; then
+                export AWS_SESSION_TOKEN="${saved_aws_session_token}"
+            else
+                unset AWS_SESSION_TOKEN
+            fi
+            if [[ -n "${saved_aws_default_region}" ]]; then
+                export AWS_DEFAULT_REGION="${saved_aws_default_region}"
+            fi
+            ${AWS} s3 cp --quiet "${PYTORCH_S3_BUCKET}/${s3_key}" "${local_file}"
+        ) || { touch "${fail_dir}/$$"; return 1; }
 
-        # Compute sha256 checksum
-        local sha256
         sha256=$(sha256sum "${local_file}" | awk '{print $1}')
 
-        # Upload to R2
-        _set_r2_creds
         (
-            set -x
-            ${AWS} s3 cp "${local_file}" "${r2_target}" \
+            export AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}"
+            export AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}"
+            unset AWS_SESSION_TOKEN
+            export AWS_DEFAULT_REGION="auto"
+            export AWS_CONFIG_FILE="${r2_aws_config}"
+            export AWS_RETRY_MODE=adaptive
+            export AWS_MAX_ATTEMPTS="${R2_MAX_ATTEMPTS:-10}"
+            ${AWS} s3 cp --quiet "${local_file}" "${r2_target}" \
                 --metadata "checksum-sha256=${sha256}" \
                 --endpoint-url "${R2_ENDPOINT_URL}"
-        )
+        ) || { rm -f "${local_file}"; touch "${fail_dir}/$$"; return 1; }
 
-        # Remove local file to free disk space
         rm -f "${local_file}"
+        echo "+ ${rel_path}"
+    }
 
+    echo "+ Promoting ${total_files} files to R2, ${parallel} at a time..."
+    local file_count=0
+    while IFS= read -r s3_key; do
+        _promote_one_file "${s3_key}" &
         file_count=$((file_count + 1))
-        echo "+ Progress: ${file_count}/${total_files} files uploaded"
+        if (( file_count % parallel == 0 )); then
+            wait
+            echo "+ Progress: ${file_count}/${total_files}"
+        fi
     done < "${file_list}"
+    wait
+
+    local failures
+    failures=$(find "${fail_dir}" -type f | wc -l)
+    if [[ ${failures} -gt 0 ]]; then
+        echo "- ERROR: ${failures} file(s) failed to promote to R2"
+        return 1
+    fi
 
     echo "+ Uploaded ${file_count} files to R2"
-
-    # Restore original AWS credentials
-    _restore_s3_creds
 }

--- a/release/promote/s3_to_s3.sh
+++ b/release/promote/s3_to_s3.sh
@@ -17,9 +17,12 @@ TO=${TO:-}
 PYTORCH_S3_TO=${PYTORCH_S3_TO:-${PYTORCH_S3_BUCKET}/${PACKAGE_TYPE}/${TO}}
 
 # R2_ONLY: set to "true" to skip the S3-to-S3 copy and only promote to R2.
-# In that mode the S3 prod promotion has already happened, so mirror from the
-# prod (destination) location instead of the test channel, keeping R2 in sync
-# with what is actually live on S3.
+# The source stays the FROM channel. Mirroring from the prod destination instead
+# would keep R2 in sync with what is literally live on S3, but aws_promote
+# copies test -> prod server-side, so the two hold the same objects, and for a
+# stable release the prod prefix is whl/ -- the parent of whl/nightly/. Listing
+# that enumerates months of nightlies to find 282 files.
+# Set PYTORCH_S3_FROM explicitly if you do need to mirror from prod.
 R2_ONLY=${R2_ONLY:-false}
 
 # SKIP_CHECKSUMS: set to "true" to skip the SHA256 recomputation pass. Kept
@@ -31,8 +34,7 @@ SKIP_CHECKSUMS=${SKIP_CHECKSUMS:-false}
 if [[ "${R2_ONLY}" != "true" ]]; then
     aws_promote "${PACKAGE_NAME}"
 else
-    echo "+ R2_ONLY=true, skipping S3-to-S3 promotion; mirroring ${PYTORCH_S3_TO} to R2"
-    PYTORCH_S3_FROM="${PYTORCH_S3_TO}"
+    echo "+ R2_ONLY=true, skipping S3-to-S3 promotion; mirroring ${PYTORCH_S3_FROM} to R2"
 fi
 
 # Promote to R2 (Cloudflare) before the slow SHA256 recomputation step so R2

--- a/release/promote/s3_to_s3.sh
+++ b/release/promote/s3_to_s3.sh
@@ -12,9 +12,28 @@ PACKAGE_TYPE=${PACKAGE_TYPE:-whl}
 
 PYTORCH_S3_BUCKET=${PYTORCH_S3_BUCKET:-s3://pytorch}
 FROM=${FROM:-test}
-PYTORCH_S3_FROM=${PYTORCH_S3_FROM:-${PYTORCH_S3_BUCKET}/${PACKAGE_TYPE}/${FROM}}
 TO=${TO:-}
-PYTORCH_S3_TO=${PYTORCH_S3_TO:-${PYTORCH_S3_BUCKET}/${PACKAGE_TYPE}/${TO}}
+DEFAULT_S3_FROM="${PYTORCH_S3_BUCKET}/${PACKAGE_TYPE}/${FROM}"
+DEFAULT_S3_TO="${PYTORCH_S3_BUCKET}/${PACKAGE_TYPE}/${TO}"
+PYTORCH_S3_FROM=${PYTORCH_S3_FROM:-${DEFAULT_S3_FROM}}
+PYTORCH_S3_TO=${PYTORCH_S3_TO:-${DEFAULT_S3_TO}}
+
+# An inherited PYTORCH_S3_FROM/TO silently wins over PACKAGE_TYPE. promote.sh
+# invokes this script once per package with a different PACKAGE_TYPE each time,
+# so a leftover export from an earlier shell command sends every later package to
+# the wrong channel -- libtorch copying whl/test -> whl/, matching nothing and
+# promoting nothing, while still exiting 0.
+if [[ "${PYTORCH_S3_FROM}" != "${DEFAULT_S3_FROM}" || "${PYTORCH_S3_TO}" != "${DEFAULT_S3_TO}" ]]; then
+    echo "- PYTORCH_S3_FROM/TO do not match PACKAGE_TYPE=${PACKAGE_TYPE}:"
+    echo "-   from: ${PYTORCH_S3_FROM}   (expected ${DEFAULT_S3_FROM})"
+    echo "-   to  : ${PYTORCH_S3_TO}   (expected ${DEFAULT_S3_TO})"
+    if [[ "${ALLOW_S3_PATH_OVERRIDE:-false}" != "true" ]]; then
+        echo "- ERROR: refusing to promote. Run 'unset PYTORCH_S3_FROM PYTORCH_S3_TO',"
+        echo "-        or set ALLOW_S3_PATH_OVERRIDE=true if the override is deliberate."
+        exit 1
+    fi
+    echo "- ALLOW_S3_PATH_OVERRIDE=true, continuing"
+fi
 
 # R2_ONLY: set to "true" to skip the S3-to-S3 copy and only promote to R2.
 # The source stays the FROM channel. Mirroring from the prod destination instead

--- a/release/promote/s3_to_s3.sh
+++ b/release/promote/s3_to_s3.sh
@@ -22,6 +22,12 @@ PYTORCH_S3_TO=${PYTORCH_S3_TO:-${PYTORCH_S3_BUCKET}/${PACKAGE_TYPE}/${TO}}
 # with what is actually live on S3.
 R2_ONLY=${R2_ONLY:-false}
 
+# SKIP_CHECKSUMS: set to "true" to skip the SHA256 recomputation pass. Kept
+# separate from R2_ONLY: re-running the R2 mirror after a failure is common, and
+# that says nothing about whether the checksum pass has run. It has not, if an
+# earlier attempt died in r2_promote -- the checksum pass is the step after it.
+SKIP_CHECKSUMS=${SKIP_CHECKSUMS:-false}
+
 if [[ "${R2_ONLY}" != "true" ]]; then
     aws_promote "${PACKAGE_NAME}"
 else
@@ -36,6 +42,6 @@ r2_promote "${PACKAGE_NAME}"
 # Finally, recompute SHA256 checksum metadata on the S3 destination wheels.
 # This is the slowest step (downloads every wheel from S3) and runs last so
 # it does not delay the R2 upload above.
-if [[ "${R2_ONLY}" != "true" ]]; then
+if [[ "${SKIP_CHECKSUMS}" != "true" ]]; then
     aws_set_checksums "${PACKAGE_NAME}"
 fi


### PR DESCRIPTION
Three fixes to `r2_promote`, all surfaced by the 2.14.0 promotion.

## 1. R2 throttles concurrent writes to the same key

```
An error occurred (ServiceUnavailable) when calling the UploadPart operation:
Reduce your concurrent request rate for the same object.
```

The loop was already sequential across files, so the concurrency R2 objected to was *within* one object: the CLI defaults to 10 in-flight multipart parts and an 8MB chunk, making an ~800MB wheel ~100 parts against one key. Set `max_concurrent_requests = 1` and `multipart_chunksize = 64MB` — that wheel drops to ~13 parts, so the larger chunk recovers most of what serialising costs.

These are s3 **transfer** settings, readable by the CLI only from a config file. It's written under the existing `tmp_dir` (removed by the `RETURN` trap) rather than via `aws configure set`, so the runner's `~/.aws/config` is untouched.

## 2. The S3 → temp → R2 round trip ran strictly one file at a time

That's the bulk of the wall time, and serialising multipart above makes it worse. R2's limit is *per-object*, so promoting distinct keys concurrently is safe. Files are now promoted `R2_PARALLEL_FILES` (default 4) at a time.

Disk stays bounded — the original reason for going one at a time — because each worker deletes its file immediately after upload, so peak usage is ~parallelism × the largest wheel rather than the whole channel.

Credentials move from exported globals to per-subshell, so concurrent workers can't race each other's S3/R2 swap. `_set_r2_creds` / `_restore_s3_creds` are gone; nothing outside the subshells is mutated, so the caller's credentials are left alone rather than saved and restored.

A worker failure marks `tmp_dir/failures` and the function returns non-zero at the end. Previously a failing `aws s3 cp` aborted under `set -e`; with background workers that no longer propagates, so it has to be collected explicitly.

## 3. `R2_ONLY` promoted the wrong channel

`R2_ONLY=true` sets `PYTORCH_S3_FROM="${PYTORCH_S3_TO}"`, and for a stable release `TO` is empty — so the source becomes `s3://pytorch/whl/`, the parent of `whl/nightly/` and `whl/test/`. The recursive listing swept both in, turning a 282-file promotion into **15764**, nearly all of them nightlies already mirrored on R2. Sub-channel directories are now excluded from the listing.

Also escaped the dots in the version regex: `torch-2.1.*` matched `torch-2.14.0+cu130-…`, so promoting a 2.1.x release would have picked up 2.14 artifacts.

`R2_MAX_CONCURRENT_REQUESTS`, `R2_MULTIPART_CHUNKSIZE`, `R2_MAX_ATTEMPTS` and `R2_PARALLEL_FILES` all override their defaults.

## Test plan

- `bash -n` passes; `shellcheck -S warning` reports only the pre-existing SC2064 on the `trap` at line 168.
- Exercised end to end against a stub `aws` faking `s3 ls` / `s3 cp`:
  - **Selection** — from a listing containing `whl/cu130/`, `whl/cpu/`, `whl/nightly/`, `whl/test/` and a `torch-2.1.0` artifact, promoting 2.14.0 selects exactly the three `whl/cu130` + `whl/cpu` 2.14.0 keys.
  - **Parallelism** — 6 files at 0.3s/op: `1.884s` at `R2_PARALLEL_FILES=1`, `0.640s` at 3.
  - **Isolation** — uploads carry the R2 key and the temp `AWS_CONFIG_FILE`, downloads carry the S3 key, and `AWS_ACCESS_KEY_ID` in the caller's shell is unchanged afterwards.
  - **Failure** — a stub failing every `--endpoint-url` call makes `r2_promote` return 1 rather than reporting success.
- Not exercised against real S3/R2; the next promotion is the real test. `DRY_RUN` returns before any of this.

## Follow-up (not in this PR)

Still no resume, so a failure costs a full re-run. Skipping keys already present on R2 with a matching size would make retries cheap.
