### PR TITLE
[RFC][torchci] Add OSDC migration tracking page

### DIFF
--- a/torchci/.env.example
+++ b/torchci/.env.example
@@ -6,6 +6,11 @@ PRIVATE_KEY=
 APP_ID=
 WEBHOOK_SECRET=
 
+# "OSDC Migration Tracker" GitHub App: read-only, separate from PyTorchBot so
+# it has its own rate limit. Only needed for /osdc_migration
+OSDC_MIGRATION_TRACKER_APP_ID=
+OSDC_MIGRATION_TRACKER_PRIVATE_KEY=
+
 # AWS Access key for Dynamo/S3. Only needed if testing lambda stuff locally.
 OUR_AWS_ACCESS_KEY_ID=
 OUR_AWS_SECRET_ACCESS_KEY=

--- a/torchci/clickhouse_queries/osdc_migration_by_file/params.json
+++ b/torchci/clickhouse_queries/osdc_migration_by_file/params.json
@@ -1,0 +1,14 @@
+{
+  "params": {
+    "repo": "String",
+    "startTime": "DateTime64(3)",
+    "stopTime": "DateTime64(3)"
+  },
+  "tests": [
+    {
+      "repo": "pytorch/vision",
+      "startTime": "2026-08-24 00:00:00.000",
+      "stopTime": "2026-08-31 00:00:00.000"
+    }
+  ]
+}

--- a/torchci/clickhouse_queries/osdc_migration_by_file/query.sql
+++ b/torchci/clickhouse_queries/osdc_migration_by_file/query.sql
@@ -1,0 +1,102 @@
+-- OSDC migration status for every workflow file in a repo that ran CI in the window.
+--
+-- A job's fleet is decided by the runner that actually executed it:
+--   legacy EC2     -> runner_name is an EC2 instance id (i-0abc...)
+--   OSDC ARC       -> runner_group_name is an OSDC cluster (see osdc/clusters.yaml)
+--   other          -> GitHub-hosted or partner hardware (ROCm / XPU / TPU), out of scope
+-- runner_name, not the label or the runner group: GitHub's larger runners share the
+-- `default` group with legacy EC2, and some carry linux.* labels (linux.24_04.4x), so
+-- both of those signals would misclassify them as legacy.
+--
+-- Only Linux legacy jobs count as unmigrated: Windows and macOS have no ARC runners yet.
+-- (macOS runners are mac*.metal EC2 instances, so they match the i- pattern too.)
+--
+-- File granularity comes from workflow_run.path, which is the *calling* workflow file --
+-- the one a repo owner edits, even when the runner is picked by a reusable workflow.
+--
+-- Mainline = any run whose workflow definition comes from the repo's merged history:
+-- default-branch pushes, nightly, release tags, schedules. PR-scoped runs (pull_request,
+-- and pytorch's ciflow/* tags) instead execute the definition from the PR branch, so a
+-- long-lived branch keeps replaying pre-migration YAML long after main is clean --
+-- pytorch/pytorch has ~155 legacy jobs from branches predating map_ec2_to_arc.py.
+--
+-- Deliberately NOT "pushes to main only": that would also drop nightly and v*-rc tags,
+-- which run current YAML and hold pytorch/pytorch's remaining ~190 real legacy jobs
+-- (docker-release.yml -> test-infra/validate-docker-images.yml -> linux_job_v2.yml).
+-- Splitting the counters lets the page answer "is the merged state migrated?" separately
+-- from "is anything still hitting EC2?".
+--
+-- Caveat: this only sees files that ran in the window. A file with no CI activity is
+-- absent entirely, so the page pairs this with the repo's real workflow file list.
+SELECT
+    workflowFile,
+    legacyJobs,
+    osdcJobs,
+    otherJobs,
+    legacyMainline,
+    osdcMainline,
+    legacyLabels,
+    -- one bucket per day, index 0 = most recent day in the window
+    arrayMap(
+        d -> toUInt32(countEqual(legacyDayOffsets, toUInt16(d))),
+        range(toUInt32(dateDiff('day', {startTime: DateTime64(3) }, {stopTime: DateTime64(3) })))
+    ) AS legacyByDay,
+    arrayMap(
+        d -> toUInt32(countEqual(legacyMainlineDayOffsets, toUInt16(d))),
+        range(toUInt32(dateDiff('day', {startTime: DateTime64(3) }, {stopTime: DateTime64(3) })))
+    ) AS legacyMainlineByDay,
+    lastLegacyRun,
+    lastLegacyMainlineRun,
+    lastRun,
+    if(legacyJobs + osdcJobs = 0, 0, legacyJobs / (legacyJobs + osdcJobs)) AS legacyShare,
+    multiIf(
+        legacyJobs = 0 AND osdcJobs = 0, 'out_of_scope',
+        legacyJobs = 0, 'migrated',
+        osdcJobs = 0, 'unmigrated',
+        'partial'
+    ) AS status
+FROM
+(
+    SELECT
+        workflowFile,
+        countIf(isLegacy) AS legacyJobs,
+        countIf(isOsdc) AS osdcJobs,
+        count() - legacyJobs - osdcJobs AS otherJobs,
+        countIf(isLegacy AND isMainline) AS legacyMainline,
+        countIf(isOsdc AND isMainline) AS osdcMainline,
+        arraySort(groupUniqArrayIf(label, isLegacy)) AS legacyLabels,
+        groupArrayIf(dayOffset, isLegacy) AS legacyDayOffsets,
+        groupArrayIf(dayOffset, isLegacy AND isMainline) AS legacyMainlineDayOffsets,
+        maxIf(createdAt, isLegacy) AS lastLegacyRun,
+        maxIf(createdAt, isLegacy AND isMainline) AS lastLegacyMainlineRun,
+        max(createdAt) AS lastRun
+    FROM
+    (
+        SELECT
+            run.path AS workflowFile,
+            job.labels[1] AS label,
+            job.created_at AS createdAt,
+            toUInt16(dateDiff('day', toDate(job.created_at), toDate({stopTime: DateTime64(3) }))) AS dayOffset,
+            match(job.runner_name, '^i-[0-9a-f]{8,}$')
+                AND startsWith(job.labels[1], 'linux') AS isLegacy,
+            match(job.runner_group_name, '^(meta|lf)-(prod|staging)-aws-') AS isOsdc,
+            NOT (
+                run.event = 'pull_request'
+                OR (run.event = 'push' AND startsWith(run.head_branch, 'ciflow/'))
+            ) AS isMainline
+        FROM default.workflow_job AS job
+        INNER JOIN default.workflow_run AS run ON job.run_id = run.id
+        WHERE
+            job.created_at >= {startTime: DateTime64(3) }
+            AND job.created_at < {stopTime: DateTime64(3) }
+            -- widen the run side by a day so runs created just before the window still join
+            AND run.created_at >= {startTime: DateTime64(3) } - INTERVAL 1 DAY
+            AND run.created_at < {stopTime: DateTime64(3) }
+            AND job.repository_full_name = {repo: String }
+            AND run.repository.'full_name' = {repo: String }
+            -- drop jobs that never got a runner (queued / cancelled / skipped)
+            AND job.runner_name != ''
+    )
+    GROUP BY workflowFile
+)
+ORDER BY legacyJobs DESC, osdcJobs DESC, workflowFile ASC

--- a/torchci/clickhouse_queries/osdc_migration_by_file/query.sql
+++ b/torchci/clickhouse_queries/osdc_migration_by_file/query.sql
@@ -73,12 +73,15 @@ FROM
     FROM
     (
         SELECT
+            job.id AS jobId,
             run.path AS workflowFile,
-            job.labels[1] AS label,
+            -- scan every label, not just labels[1]: a job can be tagged
+            -- ['self-hosted', 'linux.4xlarge'] and the Linux label is not first
+            arrayFirst(l -> startsWith(l, 'linux'), job.labels) AS label,
             job.created_at AS createdAt,
             toUInt16(dateDiff('day', toDate(job.created_at), toDate({stopTime: DateTime64(3) }))) AS dayOffset,
             match(job.runner_name, '^i-[0-9a-f]{8,}$')
-                AND startsWith(job.labels[1], 'linux') AS isLegacy,
+                AND arrayExists(l -> startsWith(l, 'linux'), job.labels) AS isLegacy,
             match(job.runner_group_name, '^(meta|lf)-(prod|staging)-aws-') AS isOsdc,
             NOT (
                 run.event = 'pull_request'
@@ -96,6 +99,12 @@ FROM
             AND run.repository.'full_name' = {repo: String }
             -- drop jobs that never got a runner (queued / cancelled / skipped)
             AND job.runner_name != ''
+        -- Both tables are ReplacingMergeTree, so unmerged parts hold several rows
+        -- per job (one per webhook: in_progress, completed) and per run. Left as
+        -- is, every count and day-bucket is inflated ~4%. Dedupe to one row per
+        -- job id -- the versions carry the same runner, so any row is equivalent.
+        -- Cheaper than FINAL, which costs ~12x here for the same result.
+        LIMIT 1 BY jobId
     )
     GROUP BY workflowFile
 )

--- a/torchci/clickhouse_queries/osdc_migration_by_file/query.sql
+++ b/torchci/clickhouse_queries/osdc_migration_by_file/query.sql
@@ -33,7 +33,6 @@ SELECT
     workflowFile,
     legacyJobs,
     osdcJobs,
-    otherJobs,
     legacyMainline,
     osdcMainline,
     legacyLabels,
@@ -56,7 +55,6 @@ SELECT
     ) AS legacyMainlineByDay,
     lastLegacyRun,
     lastLegacyMainlineRun,
-    lastRun,
     if(legacyJobs + osdcJobs = 0, 0, legacyJobs / (legacyJobs + osdcJobs)) AS legacyShare,
     multiIf(
         legacyJobs = 0 AND osdcJobs = 0, 'out_of_scope',
@@ -70,15 +68,13 @@ FROM
         workflowFile,
         countIf(isLegacy) AS legacyJobs,
         countIf(isOsdc) AS osdcJobs,
-        count() - legacyJobs - osdcJobs AS otherJobs,
         countIf(isLegacy AND isMainline) AS legacyMainline,
         countIf(isOsdc AND isMainline) AS osdcMainline,
         arraySort(groupUniqArrayIf(label, isLegacy)) AS legacyLabels,
         groupArrayIf(dayOffset, isLegacy) AS legacyDayOffsets,
         groupArrayIf(dayOffset, isLegacy AND isMainline) AS legacyMainlineDayOffsets,
         maxIf(createdAt, isLegacy) AS lastLegacyRun,
-        maxIf(createdAt, isLegacy AND isMainline) AS lastLegacyMainlineRun,
-        max(createdAt) AS lastRun
+        maxIf(createdAt, isLegacy AND isMainline) AS lastLegacyMainlineRun
     FROM
     (
         SELECT

--- a/torchci/clickhouse_queries/osdc_migration_by_file/query.sql
+++ b/torchci/clickhouse_queries/osdc_migration_by_file/query.sql
@@ -2,7 +2,8 @@
 --
 -- A job's fleet is decided by the runner that actually executed it:
 --   legacy EC2     -> runner_name is an EC2 instance id (i-0abc...)
---   OSDC ARC       -> runner_group_name is an OSDC cluster (see osdc/clusters.yaml)
+--   OSDC ARC       -> runner_group_name is an OSDC cluster
+--                     (https://github.com/pytorch/ci-infra/blob/main/osdc/clusters.yaml)
 --   other          -> GitHub-hosted or partner hardware (ROCm / XPU / TPU), out of scope
 -- runner_name, not the label or the runner group: GitHub's larger runners share the
 -- `default` group with legacy EC2, and some carry linux.* labels (linux.24_04.4x), so
@@ -36,14 +37,22 @@ SELECT
     legacyMainline,
     osdcMainline,
     legacyLabels,
-    -- one bucket per day, index 0 = most recent day in the window
+    -- one bucket per calendar date touched, index 0 = most recent
     arrayMap(
         d -> toUInt32(countEqual(legacyDayOffsets, toUInt16(d))),
-        range(toUInt32(dateDiff('day', {startTime: DateTime64(3) }, {stopTime: DateTime64(3) })))
+        range(
+            toUInt32(
+                dateDiff('day', {startTime: DateTime64(3) }, {stopTime: DateTime64(3) })
+            ) + 1
+        )
     ) AS legacyByDay,
     arrayMap(
         d -> toUInt32(countEqual(legacyMainlineDayOffsets, toUInt16(d))),
-        range(toUInt32(dateDiff('day', {startTime: DateTime64(3) }, {stopTime: DateTime64(3) })))
+        range(
+            toUInt32(
+                dateDiff('day', {startTime: DateTime64(3) }, {stopTime: DateTime64(3) })
+            ) + 1
+        )
     ) AS legacyMainlineByDay,
     lastLegacyRun,
     lastLegacyMainlineRun,
@@ -77,11 +86,17 @@ FROM
             run.path AS workflowFile,
             -- scan every label, not just labels[1]: a job can be tagged
             -- ['self-hosted', 'linux.4xlarge'] and the Linux label is not first
-            arrayFirst(l -> startsWith(l, 'linux'), job.labels) AS label,
+            arrayFirst(
+                l -> match(l, '^(lf\\.)?(c\\.)?linux(\\.|$)'),
+                job.labels
+            ) AS label,
             job.created_at AS createdAt,
             toUInt16(dateDiff('day', toDate(job.created_at), toDate({stopTime: DateTime64(3) }))) AS dayOffset,
             match(job.runner_name, '^i-[0-9a-f]{8,}$')
-                AND arrayExists(l -> startsWith(l, 'linux'), job.labels) AS isLegacy,
+                AND arrayExists(
+                    l -> match(l, '^(lf\\.)?(c\\.)?linux(\\.|$)'),
+                    job.labels
+                ) AS isLegacy,
             match(job.runner_group_name, '^(meta|lf)-(prod|staging)-aws-') AS isOsdc,
             NOT (
                 run.event = 'pull_request'
@@ -92,8 +107,9 @@ FROM
         WHERE
             job.created_at >= {startTime: DateTime64(3) }
             AND job.created_at < {stopTime: DateTime64(3) }
-            -- widen the run side by a day so runs created just before the window still join
-            AND run.created_at >= {startTime: DateTime64(3) } - INTERVAL 1 DAY
+            -- A rerun keeps the original created_at but advances updated_at.
+            -- job.created_at remains the authoritative reporting window.
+            AND run.updated_at >= {startTime: DateTime64(3) } - INTERVAL 1 DAY
             AND run.created_at < {stopTime: DateTime64(3) }
             AND job.repository_full_name = {repo: String }
             AND run.repository.'full_name' = {repo: String }

--- a/torchci/components/layout/NavBar.tsx
+++ b/torchci/components/layout/NavBar.tsx
@@ -35,6 +35,10 @@ function NavBar() {
       href: "/reliability",
     },
     {
+      name: "OSDC Migration",
+      href: "/osdc_migration",
+    },
+    {
       name: "Flaky Trunk",
       href: "/flaky_trunk",
     },

--- a/torchci/lib/github.ts
+++ b/torchci/lib/github.ts
@@ -8,13 +8,38 @@ export async function getOctokit(
   owner: string,
   repo: string
 ): Promise<Octokit> {
-  let privateKey = process.env.PRIVATE_KEY as string;
-  privateKey = Buffer.from(privateKey, "base64").toString();
+  return getAppOctokit(
+    owner,
+    repo,
+    process.env.APP_ID!,
+    process.env.PRIVATE_KEY!
+  );
+}
 
-  const app = new App({
-    appId: process.env.APP_ID!,
-    privateKey,
-  });
+// Authenticated as the OSDC Migration Tracker app: read-only, and installed
+// only on the repos that page tracks. No PyTorchBot fallback - that key is
+// write-scoped and shares Dr. CI's rate limit.
+export async function getOsdcMigrationOctokit(
+  owner: string,
+  repo: string
+): Promise<Octokit> {
+  const appId = process.env.OSDC_MIGRATION_TRACKER_APP_ID;
+  const privateKey = process.env.OSDC_MIGRATION_TRACKER_PRIVATE_KEY;
+  if (!appId || !privateKey) {
+    throw new Error("OSDC Migration Tracker credentials are not configured");
+  }
+  return getAppOctokit(owner, repo, appId, privateKey);
+}
+
+async function getAppOctokit(
+  owner: string,
+  repo: string,
+  appId: string,
+  base64PrivateKey: string
+): Promise<Octokit> {
+  const privateKey = Buffer.from(base64PrivateKey, "base64").toString();
+
+  const app = new App({ appId, privateKey });
 
   let installation;
   try {
@@ -25,14 +50,14 @@ export async function getOctokit(
   } catch (e) {
     console.error(e);
     throw new Error(
-      `Failed to get installation for repo ${owner}/${repo}. Is the app installed on this repo?`
+      `Failed to get installation for repo ${owner}/${repo}. Is app ${appId} installed on this repo?`
     );
   }
 
   return new Octokit({
     authStrategy: createAppAuth,
     auth: {
-      appId: process.env.APP_ID,
+      appId,
       privateKey,
       installationId: installation.data.id,
     },

--- a/torchci/lib/osdcMigrationRepos.ts
+++ b/torchci/lib/osdcMigrationRepos.ts
@@ -1,0 +1,25 @@
+export const PYTORCH_MIGRATION_REPOS: readonly string[] = [
+  "pytorch/executorch",
+  "pytorch/helion",
+  "pytorch/FBGEMM",
+  "pytorch/vision",
+  "pytorch/torchtitan",
+  "pytorch/ao",
+];
+
+export const META_PYTORCH_MIGRATION_REPOS: readonly string[] = [
+  "meta-pytorch/monarch",
+  "meta-pytorch/torchcodec",
+  "meta-pytorch/torchcomms",
+];
+
+// Reference only: reaches OSDC through runtime label translation (.github/arc.yaml
+// + map_ec2_to_arc.py) rather than runs-on edits, and is not finished --
+// docker-release.yml still puts legacy jobs on nightly/release tags.
+export const OSDC_REFERENCE_REPOS: readonly string[] = ["pytorch/pytorch"];
+
+export const OSDC_TRACKED_REPOS: readonly string[] = [
+  ...PYTORCH_MIGRATION_REPOS,
+  ...META_PYTORCH_MIGRATION_REPOS,
+  ...OSDC_REFERENCE_REPOS,
+];

--- a/torchci/pages/api/osdc_migration/workflow_files.ts
+++ b/torchci/pages/api/osdc_migration/workflow_files.ts
@@ -2,8 +2,8 @@
 //
 // The ClickHouse side of the OSDC migration page can only see files that ran CI
 // in the query window, so it undercounts: a workflow that has not fired recently
-// is absent entirely. This gives the page a real denominator, cheaply -- one tree
-// read per repo, no YAML parsing.
+// is absent entirely. This gives the page a current-file inventory, cheaply --
+// one tree read per repo, no YAML parsing.
 import { getOctokit } from "lib/github";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -44,9 +44,10 @@ export default async function handler(
     // are attributed to the caller's path -- so counting them in the denominator
     // would park permanently-unmigratable rows in every repo's percentage.
     //
-    // Safe because the page only uses this list to ADD files it did not observe:
-    // a `_` workflow that does run standalone (pytorch's
-    // _binary-build-flash-attention-wheel-*.yml) still arrives from ClickHouse.
+    // The API also returns `allFiles`, which the page uses to recognize current
+    // observed paths. A `_` workflow that does run standalone (pytorch's
+    // _binary-build-flash-attention-wheel-*.yml) therefore still arrives from
+    // ClickHouse and remains in the table.
     //
     // Convention-based, so it is not exhaustive -- callees without the prefix
     // (torchtitan's set-matrix.yaml, helion's compute-benchmark-matrix.yml) are
@@ -66,6 +67,7 @@ export default async function handler(
       defaultBranch: repoInfo.data.default_branch,
       truncated: tree.data.truncated,
       reusableExcluded,
+      allFiles: all,
       files,
     });
   } catch (e: any) {

--- a/torchci/pages/api/osdc_migration/workflow_files.ts
+++ b/torchci/pages/api/osdc_migration/workflow_files.ts
@@ -1,0 +1,74 @@
+// Lists the workflow files that actually exist in a repo's default branch.
+//
+// The ClickHouse side of the OSDC migration page can only see files that ran CI
+// in the query window, so it undercounts: a workflow that has not fired recently
+// is absent entirely. This gives the page a real denominator, cheaply -- one tree
+// read per repo, no YAML parsing.
+import { getOctokit } from "lib/github";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const repo = req.query.repo as string;
+  const [owner, name] = (repo ?? "").split("/");
+  if (!owner || !name) {
+    return res.status(400).json({ error: "repo must be <owner>/<name>" });
+  }
+
+  try {
+    const octokit = await getOctokit(owner, name);
+    const repoInfo = await octokit.rest.repos.get({ owner, repo: name });
+    const tree = await octokit.rest.git.getTree({
+      owner,
+      repo: name,
+      tree_sha: repoInfo.data.default_branch,
+      recursive: "1",
+    });
+
+    const all = tree.data.tree
+      .filter(
+        (t) =>
+          t.type === "blob" &&
+          t.path !== undefined &&
+          t.path.startsWith(".github/workflows/") &&
+          (t.path.endsWith(".yml") || t.path.endsWith(".yaml"))
+      )
+      .map((t) => t.path as string)
+      .sort();
+
+    // Drop `_`-prefixed files. By convention across these repos those are
+    // workflow_call-only helpers (_linux-build.yml, _fbgemm_gpu_cuda_test.yml,
+    // _unittest.yml). They never emit a workflow_run of their own -- their jobs
+    // are attributed to the caller's path -- so counting them in the denominator
+    // would park permanently-unmigratable rows in every repo's percentage.
+    //
+    // Safe because the page only uses this list to ADD files it did not observe:
+    // a `_` workflow that does run standalone (pytorch's
+    // _binary-build-flash-attention-wheel-*.yml) still arrives from ClickHouse.
+    //
+    // Convention-based, so it is not exhaustive -- callees without the prefix
+    // (torchtitan's set-matrix.yaml, helion's compute-benchmark-matrix.yml) are
+    // still counted. Catching those needs an `on:` parse of each file.
+    const files = all.filter((p) => !p.split("/").pop()!.startsWith("_"));
+
+    const reusableExcluded = all.length - files.length;
+
+    // Cache aggressively: the workflow file list changes on the order of days,
+    // and this is only a denominator.
+    res.setHeader(
+      "Cache-Control",
+      "s-maxage=3600, stale-while-revalidate=86400"
+    );
+    res.status(200).json({
+      repo,
+      defaultBranch: repoInfo.data.default_branch,
+      truncated: tree.data.truncated,
+      reusableExcluded,
+      files,
+    });
+  } catch (e: any) {
+    res.status(500).json({ error: e?.message ?? "failed to list workflows" });
+  }
+}

--- a/torchci/pages/api/osdc_migration/workflow_files.ts
+++ b/torchci/pages/api/osdc_migration/workflow_files.ts
@@ -4,7 +4,7 @@
 // in the query window, so it undercounts: a workflow that has not fired recently
 // is absent entirely. This gives the page a current-file inventory, cheaply --
 // one directory read per repo, no YAML parsing.
-import { getOctokit } from "lib/github";
+import { getOsdcMigrationOctokit } from "lib/github";
 import { OSDC_TRACKED_REPOS } from "lib/osdcMigrationRepos";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -33,7 +33,7 @@ export default async function handler(
   const [owner, name] = repo.split("/");
 
   try {
-    const octokit = await getOctokit(owner, name);
+    const octokit = await getOsdcMigrationOctokit(owner, name);
     const contents = await octokit.rest.repos.getContent({
       owner,
       repo: name,

--- a/torchci/pages/api/osdc_migration/workflow_files.ts
+++ b/torchci/pages/api/osdc_migration/workflow_files.ts
@@ -3,39 +3,53 @@
 // The ClickHouse side of the OSDC migration page can only see files that ran CI
 // in the query window, so it undercounts: a workflow that has not fired recently
 // is absent entirely. This gives the page a current-file inventory, cheaply --
-// one tree read per repo, no YAML parsing.
+// one directory read per repo, no YAML parsing.
 import { getOctokit } from "lib/github";
+import { OSDC_TRACKED_REPOS } from "lib/osdcMigrationRepos";
 import type { NextApiRequest, NextApiResponse } from "next";
+
+const ALLOWED_REPOS = new Set(OSDC_TRACKED_REPOS);
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  const repo = req.query.repo as string;
-  const [owner, name] = (repo ?? "").split("/");
-  if (!owner || !name) {
-    return res.status(400).json({ error: "repo must be <owner>/<name>" });
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({ error: "Method not allowed" });
   }
+
+  if (Object.keys(req.query).some((key) => key !== "repo")) {
+    return res.status(400).json({ error: "Unexpected query parameter" });
+  }
+
+  const { repo } = req.query;
+  if (typeof repo !== "string") {
+    return res.status(400).json({ error: "repo must be a single string" });
+  }
+  if (!ALLOWED_REPOS.has(repo)) {
+    return res.status(403).json({ error: "Repository not allowed" });
+  }
+  const [owner, name] = repo.split("/");
 
   try {
     const octokit = await getOctokit(owner, name);
-    const repoInfo = await octokit.rest.repos.get({ owner, repo: name });
-    const tree = await octokit.rest.git.getTree({
+    const contents = await octokit.rest.repos.getContent({
       owner,
       repo: name,
-      tree_sha: repoInfo.data.default_branch,
-      recursive: "1",
+      path: ".github/workflows",
     });
+    if (!Array.isArray(contents.data)) {
+      throw new Error("Workflow path is not a directory");
+    }
 
-    const all = tree.data.tree
+    const all = contents.data
       .filter(
-        (t) =>
-          t.type === "blob" &&
-          t.path !== undefined &&
-          t.path.startsWith(".github/workflows/") &&
-          (t.path.endsWith(".yml") || t.path.endsWith(".yaml"))
+        (entry) =>
+          entry.type === "file" &&
+          (entry.path.endsWith(".yml") || entry.path.endsWith(".yaml"))
       )
-      .map((t) => t.path as string)
+      .map((entry) => entry.path)
       .sort();
 
     // Drop `_`-prefixed files. By convention across these repos those are
@@ -64,13 +78,14 @@ export default async function handler(
     );
     res.status(200).json({
       repo,
-      defaultBranch: repoInfo.data.default_branch,
-      truncated: tree.data.truncated,
+      // getContent lists at most 1000 directory entries
+      truncated: contents.data.length >= 1000,
       reusableExcluded,
       allFiles: all,
       files,
     });
-  } catch (e: any) {
-    res.status(500).json({ error: e?.message ?? "failed to list workflows" });
+  } catch (error) {
+    console.error(`Failed to list workflows for ${repo}:`, error);
+    res.status(500).json({ error: "Failed to list workflow files" });
   }
 }

--- a/torchci/pages/api/osdc_migration/workflow_files.ts
+++ b/torchci/pages/api/osdc_migration/workflow_files.ts
@@ -55,8 +55,8 @@ export default async function handler(
     // Drop `_`-prefixed files. By convention across these repos those are
     // workflow_call-only helpers (_linux-build.yml, _fbgemm_gpu_cuda_test.yml,
     // _unittest.yml). They never emit a workflow_run of their own -- their jobs
-    // are attributed to the caller's path -- so counting them in the denominator
-    // would park permanently-unmigratable rows in every repo's percentage.
+    // are attributed to the caller's path -- so listing them would park
+    // permanently-unmigratable rows in every repo's table.
     //
     // The API also returns `allFiles`, which the page uses to recognize current
     // observed paths. A `_` workflow that does run standalone (pytorch's
@@ -70,8 +70,7 @@ export default async function handler(
 
     const reusableExcluded = all.length - files.length;
 
-    // Cache aggressively: the workflow file list changes on the order of days,
-    // and this is only a denominator.
+    // Cache aggressively: the workflow file list changes on the order of days.
     res.setHeader(
       "Cache-Control",
       "s-maxage=3600, stale-while-revalidate=86400"

--- a/torchci/pages/osdc_migration.tsx
+++ b/torchci/pages/osdc_migration.tsx
@@ -49,10 +49,11 @@ const REPOS = [
   "pytorch/ao",
 ];
 
-// pytorch/pytorch is the reference: it finished this migration, so it shows what
-// "done" looks like. It is not comparable to the repos above -- it reaches OSDC
-// through runtime label translation (.github/arc.yaml + map_ec2_to_arc.py) rather
-// than by editing runs-on, so its source YAML still reads as EC2.
+// pytorch/pytorch is the reference: furthest along, so it shows roughly what
+// "done" looks like -- though docker-release.yml still puts legacy jobs on
+// nightly/release tags. It is not comparable to the repos above either: it reaches
+// OSDC through runtime label translation (.github/arc.yaml + map_ec2_to_arc.py)
+// rather than by editing runs-on, so its source YAML still reads as EC2.
 const REFERENCE_REPOS = ["pytorch/pytorch"];
 
 const ROW_HEIGHT = 240;
@@ -238,21 +239,36 @@ export default function Page() {
     refreshInterval: 5 * 60 * 1000,
   });
 
-  // Real file list from the repo tree -- the denominator ClickHouse cannot supply.
-  // If this fails (app not installed on the repo, GitHub down) the page still
-  // works off observed files alone, but it is then undercounting, so say so.
-  const { data: tree, error: treeError } = useSWR<{ files: string[] }>(
+  // Current default-branch file inventory, which ClickHouse cannot supply. If
+  // this fails (app not installed on the repo, GitHub down), the page still works
+  // off observed files alone, but its current-file coverage is unknown.
+  const { data: tree, error: treeError } = useSWR<{
+    files: string[];
+    allFiles: string[];
+    truncated: boolean;
+  }>(
     `/api/osdc_migration/workflow_files?repo=${encodeURIComponent(repo)}`,
     fetcher
   );
-  const treeUnavailable = treeError !== undefined || tree?.files === undefined;
+  const treeLoading = tree === undefined && treeError === undefined;
+  const treeUnavailable =
+    treeError !== undefined ||
+    tree?.files === undefined ||
+    tree?.allFiles === undefined ||
+    tree?.truncated === true;
 
-  const loading = observed === undefined;
+  const loading = observed === undefined || treeLoading;
 
-  // Union the observed rows with the files that exist but did not run.
+  // Use the default-branch tree to keep deleted, branch-only, and GitHub-generated
+  // workflow paths out of the current-state summary. If the tree is unavailable,
+  // fall back to observed paths so the page remains useful (with a warning below).
   const observedByFile = new Map(
     (observed ?? []).map((r) => [r.workflowFile, r])
   );
+  const currentFileSet = new Set(tree?.allFiles ?? []);
+  const currentObserved = treeUnavailable
+    ? observed ?? []
+    : (observed ?? []).filter((r) => currentFileSet.has(r.workflowFile));
   const notRun: FileRow[] = (tree?.files ?? [])
     .filter((f) => !observedByFile.has(f))
     .map((f) => ({
@@ -274,7 +290,7 @@ export default function Page() {
 
   // Fold the active view's counters into the fields the table renders, so the
   // column definitions stay view-agnostic.
-  const rows: FileRow[] = [...(observed ?? []), ...notRun].map((r) => {
+  const rows: FileRow[] = [...currentObserved, ...notRun].map((r) => {
     if (!excludePrScoped || r.status === "not_run") {
       return r;
     }
@@ -499,7 +515,7 @@ export default function Page() {
       >
         <Box sx={{ flex: 1 }}>
           <ScalarPanelWithValue
-            title={"% of files migrated"}
+            title={"% of observed files migrated"}
             value={loading ? undefined : pct}
             valueRenderer={(v) =>
               v === undefined ? "n/a" : (v * 100).toFixed(0) + "%"
@@ -509,9 +525,17 @@ export default function Page() {
         </Box>
         <Box sx={{ flex: 1 }}>
           <ScalarPanelWithValue
-            title={"Files migrated / in scope"}
+            title={"Observed files migrated / in scope"}
             value={loading ? undefined : `${migrated.length}/${scoped}`}
             valueRenderer={(v) => String(v)}
+            badThreshold={() => false}
+          />
+        </Box>
+        <Box sx={{ flex: 1 }}>
+          <ScalarPanelWithValue
+            title={"Current tracked files not run"}
+            value={loading ? undefined : notRun.length}
+            valueRenderer={(v) => Number(v).toLocaleString()}
             badThreshold={() => false}
           />
         </Box>
@@ -570,17 +594,20 @@ export default function Page() {
           variant="caption"
           sx={{ display: "block", mb: 1, color: "#c77700", fontWeight: 600 }}
         >
-          Could not read this repo&apos;s workflow file list from GitHub, so
-          only files that ran CI in the window are shown — files with no recent
-          CI are missing from the table.
+          Could not read this repo&apos;s complete workflow file list from
+          GitHub, so only files that ran CI in the window are shown — files with
+          no recent CI may be missing from the table and summary.
         </Typography>
       )}
       {REFERENCE_REPOS.includes(repo) && (
         <Typography variant="caption" sx={{ display: "block", mb: 1 }}>
-          <b>Reference repo.</b> pytorch/pytorch has already completed this
-          migration, so it shows what &ldquo;done&rdquo; looks like. It is not
-          directly comparable to the repos above: it reaches OSDC via runtime
-          label translation (<code>.github/arc.yaml</code> +{" "}
+          <b>Reference repo.</b> pytorch/pytorch is furthest along, so it shows
+          roughly what &ldquo;done&rdquo; looks like — but it is not finished:{" "}
+          <code>docker-release.yml</code> still runs legacy jobs on{" "}
+          <code>nightly</code> and release tags, via test-infra&apos;s{" "}
+          <code>validate-docker-images.yml</code>. It is also not directly
+          comparable to the repos above: it reaches OSDC via runtime label
+          translation (<code>.github/arc.yaml</code> +{" "}
           <code>map_ec2_to_arc.py</code>), so its workflow YAML still reads as
           EC2 even where the jobs run on ARC.
         </Typography>
@@ -594,7 +621,10 @@ export default function Page() {
         equivalent yet — is excluded from the percentage as{" "}
         <b>Nothing to migrate</b>. Files with no CI activity in the window are
         listed as <b>Not run in window</b> and are also excluded — they are
-        unknown, not migrated. The file percentage counts a Partial file as not
+        unknown, not migrated. Deleted, branch-only, and GitHub-generated
+        workflow paths are excluded using the repo&apos;s current default-branch
+        file list. Underscore-prefixed reusable helpers are not tracked unless
+        they run standalone. The file percentage counts a Partial file as not
         yet migrated; the job percentage does not, which is why the two diverge
         as a repo nears the end.
       </Typography>

--- a/torchci/pages/osdc_migration.tsx
+++ b/torchci/pages/osdc_migration.tsx
@@ -1,0 +1,603 @@
+/**
+ * OSDC migration tracker.
+ *
+ * Shows, per repo, how much of its CI still runs on the legacy Lambda-autoscaled
+ * EC2 fleet versus OSDC (ARC on EKS), broken down by workflow file so a repo
+ * owner has a concrete checklist rather than a percentage.
+ *
+ * How a file is judged: every job it ran in the window is bucketed by the runner
+ * that actually executed it -- an EC2 instance id means legacy, an OSDC cluster
+ * runner group means migrated. See clickhouse_queries/osdc_migration_by_file.
+ *
+ * Two deliberate scoping choices, both surfaced in the UI rather than hidden:
+ *  - Only Linux counts. Windows and macOS have no ARC runners yet, so including
+ *    them would cap every repo below 100% forever.
+ *  - ClickHouse only sees files that ran. The real file list comes from the repo
+ *    tree, so files with no recent CI show up as "not run" instead of vanishing.
+ */
+import {
+  Box,
+  Checkbox,
+  Chip,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  ListSubheader,
+  MenuItem,
+  Paper,
+  Select,
+  SelectChangeEvent,
+  Stack,
+  Tooltip,
+  Typography,
+  useTheme,
+} from "@mui/material";
+import { GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
+import { ScalarPanelWithValue } from "components/metrics/panels/ScalarPanel";
+import { TablePanelWithData } from "components/metrics/panels/TablePanel";
+import dayjs from "dayjs";
+import { fetcher } from "lib/GeneralUtils";
+import { useEffect, useState } from "react";
+import useSWR from "swr";
+
+const REPOS = [
+  "pytorch/executorch",
+  "pytorch/helion",
+  "pytorch/FBGEMM",
+  "pytorch/vision",
+  "pytorch/torchtitan",
+  "pytorch/ao",
+];
+
+// pytorch/pytorch is the reference: it finished this migration, so it shows what
+// "done" looks like. It is not comparable to the repos above -- it reaches OSDC
+// through runtime label translation (.github/arc.yaml + map_ec2_to_arc.py) rather
+// than by editing runs-on, so its source YAML still reads as EC2.
+const REFERENCE_REPOS = ["pytorch/pytorch"];
+
+const ROW_HEIGHT = 240;
+
+// The Daily hits column draws one bar per day, so a longer window turns it into
+// an unreadable smear. Cap the picker rather than making the column adaptive:
+// migration state is a "what is true right now" question, not a trend, and the
+// shared TimeRangePicker can't be capped without changing it for /metrics too.
+const TIME_RANGES = [1, 3, 7, 14];
+
+type Status =
+  | "unmigrated"
+  | "partial"
+  | "migrated"
+  | "out_of_scope"
+  | "not_run";
+
+type FileRow = {
+  workflowFile: string;
+  legacyJobs: number;
+  osdcJobs: number;
+  otherJobs: number;
+  legacyMainline: number;
+  osdcMainline: number;
+  legacyLabels: string[];
+  legacyByDay: number[];
+  legacyMainlineByDay: number[];
+  lastLegacyRun: string;
+  lastLegacyMainlineRun: string;
+  lastRun: string;
+  legacyShare: number;
+  status: Status;
+};
+
+/**
+ * Single source of truth for the verdict. The page derives it rather than using
+ * the query's `status` column, because the exclude-PR-scoped toggle has to be
+ * able to recompute it from a different pair of counters.
+ */
+function deriveStatus(legacy: number, osdc: number): Status {
+  if (legacy === 0 && osdc === 0) return "out_of_scope";
+  if (legacy === 0) return "migrated";
+  if (osdc === 0) return "unmigrated";
+  return "partial";
+}
+
+const STATUS_LABEL: { [k: string]: string } = {
+  unmigrated: "Unmigrated",
+  partial: "Partial",
+  migrated: "Migrated",
+  out_of_scope: "Nothing to migrate",
+  not_run: "Not run in window",
+};
+
+/** Compact chip geometry that fits a dense table row. */
+const CHIP_SX = {
+  height: 20,
+  fontSize: "0.7rem",
+  "& .MuiChip-label": { px: 1 },
+};
+
+function StatusChip({ status }: { status: string }) {
+  const theme = useTheme();
+  const dark = theme.palette.mode === "dark";
+  // [background, foreground] per mode. Only the three states a repo owner can act
+  // on get a fill; "Nothing to migrate" and "Not run" are outlined so the eye
+  // skips them -- in a migrated repo they are most of the rows.
+  const filled: { [k: string]: [string, string] } = {
+    unmigrated: dark ? ["#5c2b2b", "#ffb4b4"] : ["#fdecea", "#a12622"],
+    partial: dark ? ["#5a4520", "#ffcc80"] : ["#fff3e0", "#a15c00"],
+    migrated: dark ? ["#22432c", "#a5d6a7"] : ["#e8f5e9", "#1b5e20"],
+  };
+  const label = STATUS_LABEL[status] ?? status;
+  const fill = filled[status];
+  if (fill === undefined) {
+    return (
+      <Chip
+        size="small"
+        variant="outlined"
+        label={label}
+        sx={{
+          ...CHIP_SX,
+          opacity: 0.6,
+          borderColor: dark ? "#4a4a4a" : "#d5d5d5",
+        }}
+      />
+    );
+  }
+  return (
+    <Chip
+      size="small"
+      label={label}
+      sx={{
+        ...CHIP_SX,
+        backgroundColor: fill[0],
+        color: fill[1],
+        fontWeight: 600,
+      }}
+    />
+  );
+}
+
+/**
+ * "2h ago" / "6d ago" -- short enough for a table cell.
+ *
+ * Returns null when there is no legacy job to date: the query's maxIf yields the
+ * epoch for files that never touched EC2, which must not render as "20000d ago".
+ */
+function relativeAge(iso: string, now: dayjs.Dayjs): string | null {
+  if (!iso) return null;
+  const t = dayjs(iso);
+  if (!t.isValid() || t.year() < 2000) return null;
+  const mins = now.diff(t, "minute");
+  if (mins < 60) return `${Math.max(mins, 1)}m ago`;
+  const hours = now.diff(t, "hour");
+  if (hours < 48) return `${hours}h ago`;
+  return `${now.diff(t, "day")}d ago`;
+}
+
+/** Tiny inline bar chart of legacy jobs per day, oldest on the left. */
+function DailyHits({ counts }: { counts: number[] }) {
+  const theme = useTheme();
+  if (!counts || counts.length === 0) {
+    return <span style={{ opacity: 0.4 }}>—</span>;
+  }
+  // query returns index 0 = most recent day; render chronologically
+  const series = [...counts].reverse();
+  const max = Math.max(...series, 1);
+  const total = series.reduce((a, b) => a + b, 0);
+  return (
+    <Tooltip
+      title={`${total.toLocaleString()} legacy jobs: ${series.join(", ")}`}
+    >
+      <Box
+        sx={{ display: "flex", alignItems: "flex-end", gap: "2px", height: 22 }}
+      >
+        {series.map((c, i) => (
+          <Box
+            key={i}
+            sx={{
+              width: 6,
+              height: Math.max(2, Math.round((c / max) * 20)),
+              backgroundColor:
+                c === 0
+                  ? theme.palette.mode === "dark"
+                    ? "#3a3a3a"
+                    : "#e0e0e0"
+                  : "#ee6666",
+              borderRadius: "1px",
+            }}
+          />
+        ))}
+      </Box>
+    </Tooltip>
+  );
+}
+
+export default function Page() {
+  const [repo, setRepo] = useState<string>(REPOS[0]);
+  const [days, setDays] = useState<number>(7);
+  const [excludePrScoped, setExcludePrScoped] = useState(false);
+
+  // Slide the window forward every 5 minutes so a left-open tab keeps showing
+  // "the last N days" rather than freezing at page load.
+  const [now, setNow] = useState(() => dayjs());
+  useEffect(() => {
+    const id = setInterval(() => setNow(dayjs()), 5 * 60 * 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const timeParams = {
+    startTime: now
+      .subtract(days, "day")
+      .utc()
+      .format("YYYY-MM-DDTHH:mm:ss.SSS"),
+    stopTime: now.utc().format("YYYY-MM-DDTHH:mm:ss.SSS"),
+  };
+
+  const observedUrl = `/api/clickhouse/osdc_migration_by_file?parameters=${encodeURIComponent(
+    JSON.stringify({ ...timeParams, repo })
+  )}`;
+  const { data: observed } = useSWR<FileRow[]>(observedUrl, fetcher, {
+    refreshInterval: 5 * 60 * 1000,
+  });
+
+  // Real file list from the repo tree -- the denominator ClickHouse cannot supply.
+  // If this fails (app not installed on the repo, GitHub down) the page still
+  // works off observed files alone, but it is then undercounting, so say so.
+  const { data: tree, error: treeError } = useSWR<{ files: string[] }>(
+    `/api/osdc_migration/workflow_files?repo=${encodeURIComponent(repo)}`,
+    fetcher
+  );
+  const treeUnavailable = treeError !== undefined || tree?.files === undefined;
+
+  const loading = observed === undefined;
+
+  // Union the observed rows with the files that exist but did not run.
+  const observedByFile = new Map(
+    (observed ?? []).map((r) => [r.workflowFile, r])
+  );
+  const notRun: FileRow[] = (tree?.files ?? [])
+    .filter((f) => !observedByFile.has(f))
+    .map((f) => ({
+      workflowFile: f,
+      legacyJobs: 0,
+      osdcJobs: 0,
+      otherJobs: 0,
+      legacyMainline: 0,
+      osdcMainline: 0,
+      legacyLabels: [],
+      legacyByDay: [],
+      legacyMainlineByDay: [],
+      lastLegacyRun: "",
+      lastLegacyMainlineRun: "",
+      lastRun: "",
+      legacyShare: 0,
+      status: "not_run" as const,
+    }));
+
+  // Fold the active view's counters into the fields the table renders, so the
+  // column definitions stay view-agnostic.
+  const rows: FileRow[] = [...(observed ?? []), ...notRun].map((r) => {
+    if (!excludePrScoped || r.status === "not_run") {
+      return r;
+    }
+    const legacy = r.legacyMainline;
+    const osdc = r.osdcMainline;
+    return {
+      ...r,
+      legacyJobs: legacy,
+      osdcJobs: osdc,
+      legacyByDay: r.legacyMainlineByDay,
+      lastLegacyRun: r.lastLegacyMainlineRun,
+      legacyShare: legacy + osdc === 0 ? 0 : legacy / (legacy + osdc),
+      status: deriveStatus(legacy, osdc),
+    };
+  });
+
+  const unmigrated = rows.filter((r) => r.status === "unmigrated");
+  const partial = rows.filter((r) => r.status === "partial");
+  const migrated = rows.filter((r) => r.status === "migrated");
+  // Denominator is files that ran something OSDC could take. "Nothing to migrate"
+  // and "Not run" are excluded -- counting them would make the number unmovable.
+  const scoped = unmigrated.length + partial.length + migrated.length;
+  const pct = scoped === 0 ? undefined : migrated.length / scoped;
+  const legacyJobTotal = rows.reduce((a, r) => a + r.legacyJobs, 0);
+  const osdcJobTotal = rows.reduce((a, r) => a + r.osdcJobs, 0);
+  // Job share moves long before file share does: a repo can be 79% of files but
+  // 99.97% of jobs, which means only stragglers are left. Showing both makes that
+  // visible instead of hiding it behind one number.
+  const jobPct =
+    legacyJobTotal + osdcJobTotal === 0
+      ? undefined
+      : osdcJobTotal / (legacyJobTotal + osdcJobTotal);
+
+  const columns: GridColDef[] = [
+    {
+      field: "workflowFile",
+      headerName: "Workflow file",
+      flex: 1,
+      minWidth: 320,
+      renderCell: (params: GridRenderCellParams) => (
+        <a
+          href={`https://github.com/${repo}/blob/HEAD/${params.value}`}
+          target="_blank"
+          rel="noreferrer"
+          style={{ fontFamily: "monospace", fontSize: "0.8rem" }}
+        >
+          {String(params.value).replace(".github/workflows/", "")}
+        </a>
+      ),
+    },
+    {
+      field: "status",
+      headerName: "Migration status",
+      width: 180,
+      renderCell: (params: GridRenderCellParams) => (
+        <Stack
+          direction="row"
+          spacing={0.5}
+          alignItems="center"
+          sx={{ height: "100%" }}
+        >
+          <StatusChip status={params.value} />
+        </Stack>
+      ),
+    },
+    // Keep the two absolute counts adjacent and right after the status: the
+    // legacy-vs-OSDC comparison is the whole point, and the derived % reads as a
+    // summary of the pair immediately to its left.
+    {
+      field: "legacyJobs",
+      headerName: "Legacy jobs",
+      width: 110,
+      type: "number",
+      valueFormatter: (value: number) =>
+        value === 0 ? "—" : value.toLocaleString(),
+    },
+    {
+      field: "osdcJobs",
+      headerName: "OSDC jobs",
+      width: 105,
+      type: "number",
+      valueFormatter: (value: number) =>
+        value === 0 ? "—" : value.toLocaleString(),
+    },
+    {
+      field: "legacyShare",
+      headerName: "% legacy",
+      width: 95,
+      type: "number",
+      valueFormatter: (value: number, row: FileRow) =>
+        row.status === "migrated" || row.status === "not_run"
+          ? "—"
+          : // don't round a real straggler down to a clean 0%
+            (value * 100).toFixed(value > 0 && value < 0.001 ? 3 : 1) + "%",
+    },
+    // Recency of the last legacy job, shown rather than folded into the status.
+    // A short-window rule that auto-promoted quiet files to "Migrated" flapped
+    // badly on intermittent stragglers, so surface the evidence and let the
+    // reader judge: "6d ago" is finished, "2h ago" is still leaking.
+    {
+      field: "lastLegacyRun",
+      headerName: "Last legacy job",
+      width: 130,
+      renderCell: (params: GridRenderCellParams) => {
+        const age = relativeAge(params.value, now);
+        if (age === null) return <span style={{ opacity: 0.4 }}>—</span>;
+        return (
+          <Tooltip title={dayjs(params.value).format("YYYY-MM-DD HH:mm:ss")}>
+            <span>{age}</span>
+          </Tooltip>
+        );
+      },
+    },
+    {
+      field: "legacyByDay",
+      headerName: "Daily hits",
+      width: 110,
+      sortable: false,
+      renderCell: (params: GridRenderCellParams) => (
+        <Stack justifyContent="center" sx={{ height: "100%" }}>
+          <DailyHits counts={params.value} />
+        </Stack>
+      ),
+    },
+    {
+      field: "legacyLabels",
+      headerName: "Legacy runner labels",
+      flex: 1,
+      minWidth: 260,
+      sortable: false,
+      renderCell: (params: GridRenderCellParams) => {
+        const labels: string[] = params.value ?? [];
+        if (labels.length === 0) return <span style={{ opacity: 0.4 }}>—</span>;
+        return (
+          <Tooltip title={labels.join(", ")}>
+            <span style={{ fontFamily: "monospace", fontSize: "0.75rem" }}>
+              {labels.join(", ")}
+            </span>
+          </Tooltip>
+        );
+      },
+    },
+  ];
+
+  return (
+    <div>
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }} alignItems="center">
+        <Typography fontSize={"2rem"} fontWeight={"bold"}>
+          OSDC Migration
+        </Typography>
+        <FormControl>
+          <InputLabel id="osdc-repo-label">Repo</InputLabel>
+          <Select
+            defaultValue={REPOS[0]}
+            label="Repo"
+            labelId="osdc-repo-label"
+            onChange={(e: SelectChangeEvent<string>) =>
+              setRepo(e.target.value as string)
+            }
+            id="osdc-repo-picker"
+            value={repo}
+            size="small"
+          >
+            {REPOS.map((r) => (
+              <MenuItem key={r} value={r}>
+                {r}
+              </MenuItem>
+            ))}
+            <ListSubheader>Reference (already migrated)</ListSubheader>
+            {REFERENCE_REPOS.map((r) => (
+              <MenuItem key={r} value={r}>
+                {r}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <FormControl>
+          <InputLabel id="osdc-range-label">Time Range</InputLabel>
+          <Select
+            label="Time Range"
+            labelId="osdc-range-label"
+            id="osdc-range-picker"
+            value={days}
+            onChange={(e: SelectChangeEvent<number>) =>
+              setDays(Number(e.target.value))
+            }
+            size="small"
+          >
+            {TIME_RANGES.map((d) => (
+              <MenuItem key={d} value={d}>
+                Last {d} {d === 1 ? "Day" : "Days"}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Tooltip
+          title={
+            "Drop pull_request runs and ciflow/* tag pushes. Those execute the workflow " +
+            "definition from the PR branch, so a long-lived branch keeps replaying " +
+            "pre-migration YAML after main is already clean. Default-branch pushes, nightly, " +
+            "release tags and schedules are kept — they run the current definition."
+          }
+        >
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={excludePrScoped}
+                onChange={(e) => setExcludePrScoped(e.target.checked)}
+                size="small"
+              />
+            }
+            label="Exclude PR-scoped runs"
+          />
+        </Tooltip>
+      </Stack>
+
+      <Stack
+        direction="row"
+        spacing={2}
+        sx={{ mb: 2 }}
+        height={ROW_HEIGHT / 1.6}
+      >
+        <Box sx={{ flex: 1 }}>
+          <ScalarPanelWithValue
+            title={"% of files migrated"}
+            value={loading ? undefined : pct}
+            valueRenderer={(v) =>
+              v === undefined ? "n/a" : (v * 100).toFixed(0) + "%"
+            }
+            badThreshold={(v) => v !== undefined && v < 0.5}
+          />
+        </Box>
+        <Box sx={{ flex: 1 }}>
+          <ScalarPanelWithValue
+            title={"Files migrated / in scope"}
+            value={loading ? undefined : `${migrated.length}/${scoped}`}
+            valueRenderer={(v) => String(v)}
+            badThreshold={() => false}
+          />
+        </Box>
+        <Box sx={{ flex: 1 }}>
+          <ScalarPanelWithValue
+            title={"% of jobs on OSDC"}
+            value={loading ? undefined : jobPct}
+            valueRenderer={(v) =>
+              v === undefined ? "n/a" : (v * 100).toFixed(1) + "%"
+            }
+            badThreshold={(v) => v !== undefined && v < 0.5}
+          />
+        </Box>
+        <Box sx={{ flex: 1 }}>
+          <ScalarPanelWithValue
+            title={"Jobs still on legacy EC2"}
+            value={loading ? undefined : legacyJobTotal}
+            valueRenderer={(v) => Number(v).toLocaleString()}
+            badThreshold={(v) => v > 0}
+          />
+        </Box>
+      </Stack>
+
+      {partial.length > 0 && (
+        <Typography variant="caption" sx={{ display: "block", mb: 1 }}>
+          <b>{partial.length}</b>{" "}
+          {partial.length === 1 ? "file has" : "files have"} jobs on both
+          fleets. Sort by <b>% legacy</b> to separate real work from stragglers
+          — a file at 0.03% is one leaked job, not an unmigrated workflow.
+        </Typography>
+      )}
+
+      <Paper sx={{ p: 1, mb: 2 }} elevation={3}>
+        <Box sx={{ height: 620 }}>
+          <TablePanelWithData
+            title={`${repo} — workflow files`}
+            data={rows.map((r) => ({ ...r, id: r.workflowFile }))}
+            columns={columns}
+            dataGridProps={{
+              getRowId: (r: any) => r.workflowFile,
+              initialState: {
+                sorting: {
+                  sortModel: [{ field: "legacyJobs", sort: "desc" }],
+                },
+              },
+            }}
+            showFooter={true}
+            disableAutoPageSize={true}
+            pageSize={25}
+          />
+        </Box>
+      </Paper>
+
+      {treeUnavailable && (
+        <Typography
+          variant="caption"
+          sx={{ display: "block", mb: 1, color: "#c77700", fontWeight: 600 }}
+        >
+          Could not read this repo&apos;s workflow file list from GitHub, so
+          only files that ran CI in the window are shown — files with no recent
+          CI are missing from the table.
+        </Typography>
+      )}
+      {REFERENCE_REPOS.includes(repo) && (
+        <Typography variant="caption" sx={{ display: "block", mb: 1 }}>
+          <b>Reference repo.</b> pytorch/pytorch has already completed this
+          migration, so it shows what &ldquo;done&rdquo; looks like. It is not
+          directly comparable to the repos above: it reaches OSDC via runtime
+          label translation (<code>.github/arc.yaml</code> +{" "}
+          <code>map_ec2_to_arc.py</code>), so its workflow YAML still reads as
+          EC2 even where the jobs run on ARC.
+        </Typography>
+      )}
+      <Typography variant="caption" sx={{ opacity: 0.7 }}>
+        Each file is judged by the fleet its Linux jobs actually ran on:{" "}
+        <b>Migrated</b> = only OSDC, <b>Unmigrated</b> = only legacy EC2,{" "}
+        <b>Partial</b> = both (see % legacy). A file whose jobs all ran
+        somewhere OSDC does not replace — GitHub-hosted runners, partner
+        hardware (ROCm / XPU / TPU), or Windows and macOS, which have no ARC
+        equivalent yet — is excluded from the percentage as{" "}
+        <b>Nothing to migrate</b>. Files with no CI activity in the window are
+        listed as <b>Not run in window</b> and are also excluded — they are
+        unknown, not migrated. The file percentage counts a Partial file as not
+        yet migrated; the job percentage does not, which is why the two diverge
+        as a repo nears the end.
+      </Typography>
+    </div>
+  );
+}

--- a/torchci/pages/osdc_migration.tsx
+++ b/torchci/pages/osdc_migration.tsx
@@ -12,8 +12,8 @@
  * Two deliberate scoping choices, both surfaced in the UI rather than hidden:
  *  - Only Linux counts. Windows and macOS have no ARC runners yet, so including
  *    them would cap every repo below 100% forever.
- *  - ClickHouse only sees files that ran. The real file list comes from the repo
- *    tree, so files with no recent CI show up as "not run" instead of vanishing.
+ *  - ClickHouse only sees files that ran. The real file list comes from the repo's
+ *    workflow directory, so files with no recent CI show up as "not run".
  */
 import {
   Box,
@@ -37,24 +37,13 @@ import { ScalarPanelWithValue } from "components/metrics/panels/ScalarPanel";
 import { TablePanelWithData } from "components/metrics/panels/TablePanel";
 import dayjs from "dayjs";
 import { fetcher } from "lib/GeneralUtils";
+import {
+  META_PYTORCH_MIGRATION_REPOS,
+  OSDC_REFERENCE_REPOS,
+  PYTORCH_MIGRATION_REPOS,
+} from "lib/osdcMigrationRepos";
 import { useEffect, useState } from "react";
 import useSWR from "swr";
-
-const REPOS = [
-  "pytorch/executorch",
-  "pytorch/helion",
-  "pytorch/FBGEMM",
-  "pytorch/vision",
-  "pytorch/torchtitan",
-  "pytorch/ao",
-];
-
-// pytorch/pytorch is the reference: furthest along, so it shows roughly what
-// "done" looks like -- though docker-release.yml still puts legacy jobs on
-// nightly/release tags. It is not comparable to the repos above either: it reaches
-// OSDC through runtime label translation (.github/arc.yaml + map_ec2_to_arc.py)
-// rather than by editing runs-on, so its source YAML still reads as EC2.
-const REFERENCE_REPOS = ["pytorch/pytorch"];
 
 const ROW_HEIGHT = 240;
 
@@ -212,7 +201,7 @@ function DailyHits({ counts }: { counts: number[] }) {
 }
 
 export default function Page() {
-  const [repo, setRepo] = useState<string>(REPOS[0]);
+  const [repo, setRepo] = useState<string>(PYTORCH_MIGRATION_REPOS[0]);
   const [days, setDays] = useState<number>(7);
   const [excludePrScoped, setExcludePrScoped] = useState(false);
 
@@ -259,9 +248,9 @@ export default function Page() {
 
   const loading = observed === undefined || treeLoading;
 
-  // Use the default-branch tree to keep deleted, branch-only, and GitHub-generated
-  // workflow paths out of the current-state summary. If the tree is unavailable,
-  // fall back to observed paths so the page remains useful (with a warning below).
+  // Use the default-branch file list to keep deleted, branch-only, and
+  // GitHub-generated workflow paths out of the current-state summary. If it is
+  // unavailable, fall back to observed paths (with a warning below).
   const observedByFile = new Map(
     (observed ?? []).map((r) => [r.workflowFile, r])
   );
@@ -444,7 +433,7 @@ export default function Page() {
         <FormControl>
           <InputLabel id="osdc-repo-label">Repo</InputLabel>
           <Select
-            defaultValue={REPOS[0]}
+            defaultValue={PYTORCH_MIGRATION_REPOS[0]}
             label="Repo"
             labelId="osdc-repo-label"
             onChange={(e: SelectChangeEvent<string>) =>
@@ -454,13 +443,20 @@ export default function Page() {
             value={repo}
             size="small"
           >
-            {REPOS.map((r) => (
+            <ListSubheader>pytorch</ListSubheader>
+            {PYTORCH_MIGRATION_REPOS.map((r) => (
+              <MenuItem key={r} value={r}>
+                {r}
+              </MenuItem>
+            ))}
+            <ListSubheader>meta-pytorch</ListSubheader>
+            {META_PYTORCH_MIGRATION_REPOS.map((r) => (
               <MenuItem key={r} value={r}>
                 {r}
               </MenuItem>
             ))}
             <ListSubheader>Reference (already migrated)</ListSubheader>
-            {REFERENCE_REPOS.map((r) => (
+            {OSDC_REFERENCE_REPOS.map((r) => (
               <MenuItem key={r} value={r}>
                 {r}
               </MenuItem>
@@ -599,7 +595,7 @@ export default function Page() {
           no recent CI may be missing from the table and summary.
         </Typography>
       )}
-      {REFERENCE_REPOS.includes(repo) && (
+      {OSDC_REFERENCE_REPOS.includes(repo) && (
         <Typography variant="caption" sx={{ display: "block", mb: 1 }}>
           <b>Reference repo.</b> pytorch/pytorch is furthest along, so it shows
           roughly what &ldquo;done&rdquo; looks like — but it is not finished:{" "}

--- a/torchci/pages/osdc_migration.tsx
+++ b/torchci/pages/osdc_migration.tsx
@@ -231,7 +231,7 @@ export default function Page() {
   // Current default-branch file inventory, which ClickHouse cannot supply. If
   // this fails (app not installed on the repo, GitHub down), the page still works
   // off observed files alone, but its current-file coverage is unknown.
-  const { data: tree, error: treeError } = useSWR<{
+  const { data: workflowInventory, error: workflowInventoryError } = useSWR<{
     files: string[];
     allFiles: string[];
     truncated: boolean;
@@ -239,14 +239,15 @@ export default function Page() {
     `/api/osdc_migration/workflow_files?repo=${encodeURIComponent(repo)}`,
     fetcher
   );
-  const treeLoading = tree === undefined && treeError === undefined;
-  const treeUnavailable =
-    treeError !== undefined ||
-    tree?.files === undefined ||
-    tree?.allFiles === undefined ||
-    tree?.truncated === true;
+  const workflowInventoryLoading =
+    workflowInventory === undefined && workflowInventoryError === undefined;
+  const workflowInventoryUnavailable =
+    workflowInventoryError !== undefined ||
+    workflowInventory?.files === undefined ||
+    workflowInventory?.allFiles === undefined ||
+    workflowInventory?.truncated === true;
 
-  const loading = observed === undefined || treeLoading;
+  const loading = observed === undefined || workflowInventoryLoading;
 
   // Use the default-branch file list to keep deleted, branch-only, and
   // GitHub-generated workflow paths out of the current-state summary. If it is
@@ -254,11 +255,11 @@ export default function Page() {
   const observedByFile = new Map(
     (observed ?? []).map((r) => [r.workflowFile, r])
   );
-  const currentFileSet = new Set(tree?.allFiles ?? []);
-  const currentObserved = treeUnavailable
+  const currentFileSet = new Set(workflowInventory?.allFiles ?? []);
+  const currentObserved = workflowInventoryUnavailable
     ? observed ?? []
     : (observed ?? []).filter((r) => currentFileSet.has(r.workflowFile));
-  const notRun: FileRow[] = (tree?.files ?? [])
+  const notRun: FileRow[] = (workflowInventory?.files ?? [])
     .filter((f) => !observedByFile.has(f))
     .map((f) => ({
       workflowFile: f,
@@ -280,17 +281,19 @@ export default function Page() {
   // Fold the active view's counters into the fields the table renders, so the
   // column definitions stay view-agnostic.
   const rows: FileRow[] = [...currentObserved, ...notRun].map((r) => {
-    if (!excludePrScoped || r.status === "not_run") {
+    if (r.status === "not_run") {
       return r;
     }
-    const legacy = r.legacyMainline;
-    const osdc = r.osdcMainline;
+    const legacy = excludePrScoped ? r.legacyMainline : r.legacyJobs;
+    const osdc = excludePrScoped ? r.osdcMainline : r.osdcJobs;
     return {
       ...r,
       legacyJobs: legacy,
       osdcJobs: osdc,
-      legacyByDay: r.legacyMainlineByDay,
-      lastLegacyRun: r.lastLegacyMainlineRun,
+      legacyByDay: excludePrScoped ? r.legacyMainlineByDay : r.legacyByDay,
+      lastLegacyRun: excludePrScoped
+        ? r.lastLegacyMainlineRun
+        : r.lastLegacyRun,
       legacyShare: legacy + osdc === 0 ? 0 : legacy / (legacy + osdc),
       status: deriveStatus(legacy, osdc),
     };
@@ -370,7 +373,9 @@ export default function Page() {
       width: 95,
       type: "number",
       valueFormatter: (value: number, row: FileRow) =>
-        row.status === "migrated" || row.status === "not_run"
+        row.status === "migrated" ||
+        row.status === "out_of_scope" ||
+        row.status === "not_run"
           ? "—"
           : // don't round a real straggler down to a clean 0%
             (value * 100).toFixed(value > 0 && value < 0.001 ? 3 : 1) + "%",
@@ -396,7 +401,8 @@ export default function Page() {
     {
       field: "legacyByDay",
       headerName: "Daily hits",
-      width: 110,
+      // fits the 14-day window's 15 bars without clipping the most recent day
+      width: 135,
       sortable: false,
       renderCell: (params: GridRenderCellParams) => (
         <Stack justifyContent="center" sx={{ height: "100%" }}>
@@ -585,7 +591,7 @@ export default function Page() {
         </Box>
       </Paper>
 
-      {treeUnavailable && (
+      {!workflowInventoryLoading && workflowInventoryUnavailable && (
         <Typography
           variant="caption"
           sx={{ display: "block", mb: 1, color: "#c77700", fontWeight: 600 }}

--- a/torchci/pages/osdc_migration.tsx
+++ b/torchci/pages/osdc_migration.tsx
@@ -45,7 +45,7 @@ import {
 import { useEffect, useState } from "react";
 import useSWR from "swr";
 
-const ROW_HEIGHT = 240;
+const SUMMARY_PANEL_HEIGHT = 150;
 
 // The Daily hits column draws one bar per day, so a longer window turns it into
 // an unreadable smear. Cap the picker rather than making the column adaptive:
@@ -64,7 +64,6 @@ type FileRow = {
   workflowFile: string;
   legacyJobs: number;
   osdcJobs: number;
-  otherJobs: number;
   legacyMainline: number;
   osdcMainline: number;
   legacyLabels: string[];
@@ -72,7 +71,6 @@ type FileRow = {
   legacyMainlineByDay: number[];
   lastLegacyRun: string;
   lastLegacyMainlineRun: string;
-  lastRun: string;
   legacyShare: number;
   status: Status;
 };
@@ -190,7 +188,7 @@ function DailyHits({ counts }: { counts: number[] }) {
                   ? theme.palette.mode === "dark"
                     ? "#3a3a3a"
                     : "#e0e0e0"
-                  : "#ee6666",
+                  : theme.palette.error.main,
               borderRadius: "1px",
             }}
           />
@@ -265,7 +263,6 @@ export default function Page() {
       workflowFile: f,
       legacyJobs: 0,
       osdcJobs: 0,
-      otherJobs: 0,
       legacyMainline: 0,
       osdcMainline: 0,
       legacyLabels: [],
@@ -273,7 +270,6 @@ export default function Page() {
       legacyMainlineByDay: [],
       lastLegacyRun: "",
       lastLegacyMainlineRun: "",
-      lastRun: "",
       legacyShare: 0,
       status: "not_run" as const,
     }));
@@ -439,7 +435,6 @@ export default function Page() {
         <FormControl>
           <InputLabel id="osdc-repo-label">Repo</InputLabel>
           <Select
-            defaultValue={PYTORCH_MIGRATION_REPOS[0]}
             label="Repo"
             labelId="osdc-repo-label"
             onChange={(e: SelectChangeEvent<string>) =>
@@ -513,7 +508,7 @@ export default function Page() {
         direction="row"
         spacing={2}
         sx={{ mb: 2 }}
-        height={ROW_HEIGHT / 1.6}
+        height={SUMMARY_PANEL_HEIGHT}
       >
         <Box sx={{ flex: 1 }}>
           <ScalarPanelWithValue
@@ -594,7 +589,12 @@ export default function Page() {
       {!workflowInventoryLoading && workflowInventoryUnavailable && (
         <Typography
           variant="caption"
-          sx={{ display: "block", mb: 1, color: "#c77700", fontWeight: 600 }}
+          sx={{
+            display: "block",
+            mb: 1,
+            color: "warning.main",
+            fontWeight: 600,
+          }}
         >
           Could not read this repo&apos;s complete workflow file list from
           GitHub, so only files that ran CI in the window are shown — files with

--- a/torchci/test/osdcMigrationWorkflowFiles.test.ts
+++ b/torchci/test/osdcMigrationWorkflowFiles.test.ts
@@ -1,0 +1,133 @@
+import { getOctokit } from "lib/github";
+import type { NextApiRequest, NextApiResponse } from "next";
+import handler from "pages/api/osdc_migration/workflow_files";
+
+jest.mock("lib/github", () => ({
+  getOctokit: jest.fn(),
+}));
+
+const mockedGetOctokit = jest.mocked(getOctokit);
+
+function mockResponse(): NextApiResponse {
+  const res = {
+    status: jest.fn(),
+    json: jest.fn(),
+    setHeader: jest.fn(),
+  };
+  res.status.mockReturnValue(res);
+  res.json.mockReturnValue(res);
+  res.setHeader.mockReturnValue(res);
+  return res as unknown as NextApiResponse;
+}
+
+function mockRequest(
+  query: NextApiRequest["query"],
+  method = "GET"
+): NextApiRequest {
+  return { method, query } as NextApiRequest;
+}
+
+describe("OSDC migration workflow file endpoint", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("rejects requests for repositories outside the tracker", async () => {
+    const res = mockResponse();
+
+    await handler(mockRequest({ repo: "pytorch/test-infra" }), res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(mockedGetOctokit).not.toHaveBeenCalled();
+  });
+
+  test("rejects repeated and unexpected query parameters", async () => {
+    const repeatedRes = mockResponse();
+    await handler(
+      mockRequest({ repo: ["pytorch/pytorch", "pytorch/vision"] }),
+      repeatedRes
+    );
+
+    expect(repeatedRes.status).toHaveBeenCalledWith(400);
+    expect(mockedGetOctokit).not.toHaveBeenCalled();
+
+    const unexpectedRes = mockResponse();
+    await handler(
+      mockRequest({ repo: "pytorch/pytorch", nonce: "cache-buster" }),
+      unexpectedRes
+    );
+
+    expect(unexpectedRes.status).toHaveBeenCalledWith(400);
+    expect(mockedGetOctokit).not.toHaveBeenCalled();
+  });
+
+  test("rejects methods other than GET", async () => {
+    const res = mockResponse();
+
+    await handler(mockRequest({ repo: "pytorch/pytorch" }, "POST"), res);
+
+    expect(res.status).toHaveBeenCalledWith(405);
+    expect(res.setHeader).toHaveBeenCalledWith("Allow", "GET");
+    expect(mockedGetOctokit).not.toHaveBeenCalled();
+  });
+
+  test("lists workflow files for allowlisted meta-pytorch repositories", async () => {
+    const getContent = jest.fn().mockResolvedValue({
+      data: [
+        {
+          type: "file",
+          path: ".github/workflows/test.yml",
+        },
+        {
+          type: "file",
+          path: ".github/workflows/_reusable.yaml",
+        },
+        {
+          type: "file",
+          path: ".github/workflows/README.md",
+        },
+      ],
+    });
+    mockedGetOctokit.mockResolvedValue({
+      rest: { repos: { getContent } },
+    } as any);
+    const res = mockResponse();
+
+    await handler(mockRequest({ repo: "meta-pytorch/monarch" }), res);
+
+    expect(mockedGetOctokit).toHaveBeenCalledWith("meta-pytorch", "monarch");
+    expect(getContent).toHaveBeenCalledWith({
+      owner: "meta-pytorch",
+      repo: "monarch",
+      path: ".github/workflows",
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      repo: "meta-pytorch/monarch",
+      truncated: false,
+      reusableExcluded: 1,
+      allFiles: [
+        ".github/workflows/_reusable.yaml",
+        ".github/workflows/test.yml",
+      ],
+      files: [".github/workflows/test.yml"],
+    });
+  });
+
+  test("does not return internal GitHub errors", async () => {
+    mockedGetOctokit.mockRejectedValue(new Error("sensitive GitHub failure"));
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const res = mockResponse();
+
+    await handler(mockRequest({ repo: "meta-pytorch/torchcodec" }), res);
+
+    expect(consoleError).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Failed to list workflow files",
+    });
+    consoleError.mockRestore();
+  });
+});

--- a/torchci/test/osdcMigrationWorkflowFiles.test.ts
+++ b/torchci/test/osdcMigrationWorkflowFiles.test.ts
@@ -1,12 +1,12 @@
-import { getOctokit } from "lib/github";
+import { getOsdcMigrationOctokit } from "lib/github";
 import type { NextApiRequest, NextApiResponse } from "next";
 import handler from "pages/api/osdc_migration/workflow_files";
 
 jest.mock("lib/github", () => ({
-  getOctokit: jest.fn(),
+  getOsdcMigrationOctokit: jest.fn(),
 }));
 
-const mockedGetOctokit = jest.mocked(getOctokit);
+const mockedGetOsdcMigrationOctokit = jest.mocked(getOsdcMigrationOctokit);
 
 function mockResponse(): NextApiResponse {
   const res = {
@@ -38,7 +38,7 @@ describe("OSDC migration workflow file endpoint", () => {
     await handler(mockRequest({ repo: "pytorch/test-infra" }), res);
 
     expect(res.status).toHaveBeenCalledWith(403);
-    expect(mockedGetOctokit).not.toHaveBeenCalled();
+    expect(mockedGetOsdcMigrationOctokit).not.toHaveBeenCalled();
   });
 
   test("rejects repeated and unexpected query parameters", async () => {
@@ -49,7 +49,7 @@ describe("OSDC migration workflow file endpoint", () => {
     );
 
     expect(repeatedRes.status).toHaveBeenCalledWith(400);
-    expect(mockedGetOctokit).not.toHaveBeenCalled();
+    expect(mockedGetOsdcMigrationOctokit).not.toHaveBeenCalled();
 
     const unexpectedRes = mockResponse();
     await handler(
@@ -58,7 +58,7 @@ describe("OSDC migration workflow file endpoint", () => {
     );
 
     expect(unexpectedRes.status).toHaveBeenCalledWith(400);
-    expect(mockedGetOctokit).not.toHaveBeenCalled();
+    expect(mockedGetOsdcMigrationOctokit).not.toHaveBeenCalled();
   });
 
   test("rejects methods other than GET", async () => {
@@ -68,7 +68,7 @@ describe("OSDC migration workflow file endpoint", () => {
 
     expect(res.status).toHaveBeenCalledWith(405);
     expect(res.setHeader).toHaveBeenCalledWith("Allow", "GET");
-    expect(mockedGetOctokit).not.toHaveBeenCalled();
+    expect(mockedGetOsdcMigrationOctokit).not.toHaveBeenCalled();
   });
 
   test("lists workflow files for allowlisted meta-pytorch repositories", async () => {
@@ -88,14 +88,17 @@ describe("OSDC migration workflow file endpoint", () => {
         },
       ],
     });
-    mockedGetOctokit.mockResolvedValue({
+    mockedGetOsdcMigrationOctokit.mockResolvedValue({
       rest: { repos: { getContent } },
     } as any);
     const res = mockResponse();
 
     await handler(mockRequest({ repo: "meta-pytorch/monarch" }), res);
 
-    expect(mockedGetOctokit).toHaveBeenCalledWith("meta-pytorch", "monarch");
+    expect(mockedGetOsdcMigrationOctokit).toHaveBeenCalledWith(
+      "meta-pytorch",
+      "monarch"
+    );
     expect(getContent).toHaveBeenCalledWith({
       owner: "meta-pytorch",
       repo: "monarch",
@@ -115,7 +118,9 @@ describe("OSDC migration workflow file endpoint", () => {
   });
 
   test("does not return internal GitHub errors", async () => {
-    mockedGetOctokit.mockRejectedValue(new Error("sensitive GitHub failure"));
+    mockedGetOsdcMigrationOctokit.mockRejectedValue(
+      new Error("sensitive GitHub failure")
+    );
     const consoleError = jest
       .spyOn(console, "error")
       .mockImplementation(() => {});
@@ -129,5 +134,19 @@ describe("OSDC migration workflow file endpoint", () => {
       error: "Failed to list workflow files",
     });
     consoleError.mockRestore();
+  });
+
+  test("does not fall back to PyTorchBot when unconfigured", async () => {
+    const real = jest.requireActual("lib/github");
+    const saved = process.env;
+    process.env = { ...saved, APP_ID: "40112", PRIVATE_KEY: "unused" };
+    delete process.env.OSDC_MIGRATION_TRACKER_APP_ID;
+    delete process.env.OSDC_MIGRATION_TRACKER_PRIVATE_KEY;
+
+    await expect(
+      real.getOsdcMigrationOctokit("pytorch", "vision")
+    ).rejects.toThrow("not configured");
+
+    process.env = saved;
   });
 });


### PR DESCRIPTION
Per-repo view of which workflow files still run CI on the legacy EC2 fleet vs OSDC, at file granularity so repo owners get a checklist.

A job's fleet comes from the runner that actually executed it: runner_name is an EC2 instance id (legacy) or the runner group is an OSDC cluster. Not the label or group alone -- GitHub's larger runners share the `default` group with legacy EC2 and some carry linux.* labels. This also handles pytorch/pytorch, where arc.yaml rewrites labels at dispatch so the source YAML still reads as EC2. Scoped to Linux (no ARC runners for Windows/macOS yet).

ClickHouse only sees files that ran, so the repo's workflow directory is read separately: it drops observed paths that no longer exist on the default branch and surfaces files with no recent CI as "Not run in window". Percentages are over files that ran at least one in-scope job -- "Not run" and "Nothing to migrate" are excluded.

"Exclude PR-scoped runs" drops pull_request and ciflow/* tags, which execute the definition from the PR branch and replay pre-migration YAML from long-lived branches.

Repo access is allowlisted to the ten tracked repos (six pytorch, three meta-pytorch, plus pytorch/pytorch as a migrated reference); the endpoint is GET-only and rejects unexpected query params so the CDN cache can't be bust. Counts are deduped per job id -- workflow_job is a ReplacingMergeTree and unmerged parts inflate raw counts ~4%. Note the three meta-pytorch repos need the GitHub App installed on that org; without it those rows fall back to the "workflow file list unavailable" path.
