### PR TITLE
Add bobrenjc93 to greenlight trusted authors

### DIFF
--- a/greenlight/src/greenlight/review.py
+++ b/greenlight/src/greenlight/review.py
@@ -67,6 +67,7 @@ TRUSTED_AUTHORS: set[str] = {
     "ezyang",  # Edward Yang
     "drisspg",  # Driss Guessous
     "janeyx99",  # Jane Xu
+    "bobrenjc93",  # Bob Ren
 }
 
 # Case-insensitive membership for the two authz gates (target-PR author and recheck requester);


### PR DESCRIPTION
**Impact:** greenlight review scan — one more pytorch/pytorch author whose PRs get auto-reviewed **Risk:** low

## What

Adds `bobrenjc93` (Bob Ren) to `TRUSTED_AUTHORS` in the greenlight review scan.

## Why

`TRUSTED_AUTHORS` is the match rule for the scan: only PRs from these authors are fingerprinted and dispatched to the reviewer workflow, and it also gates `@greenlight recheck` requests. Bob is onboarding to the pilot, so his PRs need to be in scope.