### PR TITLE
[CRCR] Update max execution time calculation to exclude timed-out jobs

### DIFF
--- a/torchci/clickhouse_queries/crcr_backend_summary/query.sql
+++ b/torchci/clickhouse_queries/crcr_backend_summary/query.sql
@@ -72,7 +72,9 @@ SELECT
     uniqExact(pr_number) AS total_prs,
     avg(queue_time) AS avg_queue_time_s,
     avg(execution_time) AS avg_exec_time_s,
-    max(execution_time) AS max_exec_time_s,
+    -- Excludes timed-out jobs: their execution_time reflects the timeout
+    -- ceiling, not genuine run time, and would inflate this otherwise.
+    maxIf(execution_time, conclusion != 'timed_out') AS max_exec_time_s,
     quantileExact(0.95)(execution_time) AS p95_exec_time_s,
     -- E2E time is per-run (RFC-0050); run_rn = 1 keeps one sample per run.
     -- Exact (not sampled) quantiles since this gates L3 promotion decisions.


### PR DESCRIPTION
## Summary

`max_exec_time_s` in `crcr_backend_summary` used `max(execution_time)` over all completed jobs, including ones that timed out. A timed-out job's `execution_time` reflects the timeout ceiling rather than genuine run time, so it could inflate the "Max Execution Time" stat card on `/crcr/[org]/[repo]`.

Changed to `maxIf(execution_time, conclusion != 'timed_out')` so only jobs that actually finished on their own contribute to this metric. `total_jobs`, `timeout_rate`, and the end-to-end time calculation are unaffected — they still need to account for timed-out jobs.