### PR TITLE
Add python-abi3 option to the binary build matrix

### DIFF
--- a/.github/workflows/generate_binary_build_matrix.yml
+++ b/.github/workflows/generate_binary_build_matrix.yml
@@ -52,6 +52,10 @@ on:
         description: "A JSON-encoded list of python versions to build. An empty list means building all supported versions"
         default: "[]"
         type: string
+      python-abi3:
+        description: "Build a single abi3 wheel instead of one wheel per python version. Free-threaded versions still get one wheel each"
+        default: "disable"
+        type: string
       getting-started:
         description: "Release matrix for getting started page"
         required: false
@@ -97,6 +101,7 @@ jobs:
           BUILD_PYTHON_ONLY: ${{ inputs.build-python-only }}
           GETTING_STARTED: ${{ inputs.getting-started }}
           PYTHON_VERSIONS: ${{ inputs.python-versions }}
+          PYTHON_ABI3: ${{ inputs.python-abi3 }}
         run: |
           set -eou pipefail
           MATRIX_BLOB="$(python3 tools/scripts/generate_binary_build_matrix.py)"

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -366,6 +366,7 @@ def generate_libtorch_matrix(
     abi_versions: Optional[List[str]] = None,
     arches: Optional[List[str]] = None,
     libtorch_variants: Optional[List[str]] = None,
+    python_abi3: bool = False,
 ) -> List[Dict[str, str]]:
     ret: List[Dict[str, str]] = []
 
@@ -462,6 +463,7 @@ def generate_wheels_matrix(
     getting_started: bool = False,
     python_versions: Optional[List[str]] = None,
     arches: Optional[List[str]] = None,
+    python_abi3: bool = False,
 ) -> List[Dict[str, str]]:
     package_type = "wheel"
 
@@ -500,6 +502,15 @@ def generate_wheels_matrix(
 
         if with_xpu == ENABLE and os in (LINUX, WINDOWS):
             arches += [XPU]
+
+    if python_abi3:
+        # An abi3 wheel built against the oldest supported interpreter is installable
+        # on every later CPython, so only that one needs to be built. Free-threaded
+        # interpreters reject abi3 wheels (see packaging.tags._abi3_applies), so they
+        # still need a wheel each.
+        free_threaded = [v for v in python_versions if v.endswith("t")]
+        stable = [v for v in python_versions if not v.endswith("t")]
+        python_versions = stable[:1] + free_threaded
 
     if limit_pr_builds:
         python_versions = [python_versions[0]]
@@ -572,6 +583,7 @@ def generate_build_matrix(
     build_python_only: str,
     getting_started: str = "false",
     python_versions: Optional[List[str]] = None,
+    python_abi3: str = DISABLE,
 ) -> Dict[str, List[Dict[str, str]]]:
     includes = []
 
@@ -601,6 +613,7 @@ def generate_build_matrix(
                     use_only_dl_pytorch_org == "true",
                     getting_started == "true",
                     python_versions,
+                    python_abi3=python_abi3 == ENABLE,
                 )
             )
 
@@ -702,6 +715,17 @@ def main(args: List[str]) -> None:
         default=os.getenv("PYTHON_VERSIONS", "[]"),
     )
 
+    # For packages that build a Py_LIMITED_API extension and can therefore ship a
+    # single wheel (e.g. torchaudio-2.11.0-cp310-abi3-manylinux_2_28_x86_64.whl)
+    # instead of one per python version.
+    parser.add_argument(
+        "--python-abi3",
+        help="Build a single abi3 wheel instead of one wheel per python version",
+        type=str,
+        choices=[ENABLE, DISABLE],
+        default=os.getenv("PYTHON_ABI3", DISABLE),
+    )
+
     options = parser.parse_args(args)
     try:
         python_versions = json.loads(options.python_versions)
@@ -725,6 +749,7 @@ def main(args: List[str]) -> None:
         options.build_python_only,
         options.getting_started,
         python_versions,
+        options.python_abi3,
     )
 
     print(json.dumps(build_matrix))

--- a/tools/tests/test_generate_binary_build_matrix.py
+++ b/tools/tests/test_generate_binary_build_matrix.py
@@ -134,6 +134,7 @@ class GenerateBuildMatrixTest(TestCase):
         self,
         operating_system: str,
         channel: str = "test",
+        python_abi3: bool = False,
     ) -> set:
         out = generate_build_matrix(
             "wheel",
@@ -148,6 +149,7 @@ class GenerateBuildMatrixTest(TestCase):
             "disable",
             "false",
             None,
+            "enable" if python_abi3 else "disable",
         )
         return {entry["python_version"] for entry in out["include"]}
 
@@ -182,6 +184,37 @@ class GenerateBuildMatrixTest(TestCase):
         versions = self._test_channel_python_versions("windows-arm64")
         self.assertNotIn("3.15", versions)
         self.assertNotIn("3.15t", versions)
+
+    def test_python_abi3_keeps_oldest_and_free_threaded(self):
+        # A single abi3 wheel covers every later CPython, but free-threaded
+        # interpreters reject abi3 wheels and still need one wheel each.
+        for operating_system in ("linux", "linux-aarch64", "windows"):
+            self.assertEqual(
+                self._test_channel_python_versions(
+                    operating_system, channel="nightly", python_abi3=True
+                ),
+                {"3.10", "3.14t", "3.15t"},
+            )
+            self.assertEqual(
+                self._test_channel_python_versions(
+                    operating_system, channel="release", python_abi3=True
+                ),
+                {"3.10", "3.14t"},
+            )
+
+        # macOS pins .0 point versions, see MACOS_PYTHON_POINT_VERSIONS.
+        self.assertEqual(
+            self._test_channel_python_versions(
+                "macos-arm64", channel="nightly", python_abi3=True
+            ),
+            {"3.10.19", "3.14t", "3.15t"},
+        )
+
+    def test_python_abi3_disabled_by_default(self):
+        self.assertEqual(
+            self._test_channel_python_versions("linux", channel="nightly"),
+            {"3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"},
+        )
 
     def test_torch_only_install_command_for_torch_only_arches(self):
         out = generate_build_matrix(


### PR DESCRIPTION
Packages like `torchaudio` whose extensions are built against `Py_LIMITED_API` can ship a single abi3 wheel per platform instead of one per Python version.

Adding `python-abi3: enable` flag to `generate_binary_build_matrix.yml` keeps only the oldest supported Python, plus every free-threaded version (free-threaded interpreters reject abi3 wheels):

```
nightly: ['3.10', '3.14t', '3.15t']   # was 8 versions
release: ['3.10', '3.14t']            # was 6 versions
```

The flag is off by default; the libtorch matrix and all reference assets are unchanged. First user will be pytorch/audio.

First step of P2486386010, the corresponding PR in torchaudio is https://github.com/pytorch/audio/pull/4224.