### PR TITLE
[release/2.14] Validate 3.15 / 3.15t against download.pytorch.org

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -21,10 +21,10 @@ import sys
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 
-# 3.15 / 3.15t are enabled by default on the nightly and test channels for every
-# operating system. They are deliberately absent from "release": 3.15 is still a
-# CPython pre-release, so it must not appear in the release matrix or on the
-# getting-started page until it ships final.
+# 3.15 / 3.15t are enabled on every channel and operating system. 3.15 is still
+# a CPython pre-release, so no wheels for it are published to PyPI -- see
+# PYPI_UNPUBLISHED_PYTHON_ARCHES below, which routes their release-channel
+# install command to download.pytorch.org.
 PYTHON_ARCHES_DICT = {
     "nightly": ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"],
     "test": ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"],
@@ -35,6 +35,13 @@ PYTHON_ARCHES_DICT = {
 # wheels are not published for these versions yet, so the install command must
 # request torch alone.
 TORCH_ONLY_PYTHON_ARCHES = ["3.15", "3.15t"]
+
+# Python versions with no torch wheels on PyPI. The release channel normally
+# validates via a bare `pip3 install torch`, which resolves against PyPI; for
+# these it must use --index-url download.pytorch.org instead. Same members as
+# TORCH_ONLY_PYTHON_ARCHES today but a different fact -- that one is about
+# torchvision not being published, this one about torch.
+PYPI_UNPUBLISHED_PYTHON_ARCHES = ["3.15", "3.15t"]
 
 MACOS_PYTHON_POINT_VERSIONS = {
     "3.10": "3.10.19",
@@ -314,6 +321,7 @@ def get_wheel_install_command(
     if (
         channel == RELEASE
         and (not use_only_dl_pytorch_org)
+        and python_version not in PYPI_UNPUBLISHED_PYTHON_ARCHES
         and (
             (gpu_arch_version == STABLE_CUDA_VERSIONS[channel] and os == LINUX)
             or (gpu_arch_type == CPU and os in [WINDOWS, MACOS_ARM64])


### PR DESCRIPTION
Every 3.15 / 3.15t validation job fails on `release/2.14` — e.g. [win / wheel-py3_15t-cpu](https://github.com/pytorch/test-infra/actions/runs/33638298417/job/100274840469):

```
+ pip3 install --force-reinstall torch
ERROR: Could not find a version that satisfies the requirement torch (from versions: none)
ERROR: No matching distribution found for torch
```

## Cause

3.15 is a CPython pre-release, so no torch wheels are published to PyPI for it. But `get_wheel_install_command()` emits a bare `pip3 install torch` for the release channel on CPU/Windows, CPU/macOS-arm64, stable-CUDA/Linux and linux-aarch64 — deliberately, since that's the canonical PyPI install users follow. With no PyPI wheel, pip has nowhere to look.

Confirmed from the failing job's matrix entry:

```json
"python_version": "3.15t",
"installation": "pip3 install torch",
"channel": "release",
```

## Fix

Route those versions to `--index-url download.pytorch.org`. The wheels are there — `whl/cpu` carries all eight cp315/cp315t artifacts for 2.14.0, including the `win_amd64` one this job needs.

Added `PYPI_UNPUBLISHED_PYTHON_ARCHES` rather than reusing `TORCH_ONLY_PYTHON_ARCHES`. Same members today, but they encode different facts — one is *"torchvision isn't published for this version"*, the other *"torch isn't on PyPI for this version"* — and they can diverge, e.g. once torchvision ships 3.15 wheels while 3.15 is still pre-release.

Also corrected the comment above `PYTHON_ARCHES_DICT`, which claims 3.15 is *"deliberately absent from release"* while the dict directly below lists `3.15` and `3.15t` under `release`. True on main, not here — the stale comment sends readers the wrong way.

## Test plan

Generated the matrix directly for the release channel:

| OS | Python | Install command | |
|---|---|---|---|
| windows | 3.15t | `pip3 install torch --index-url .../whl/cpu` | ← failing job |
| windows | 3.15 | `pip3 install torch --index-url .../whl/cpu` | |
| linux | 3.15 | `pip3 install torch --index-url .../whl/cpu` | |
| macos-arm64 | 3.15 | `pip3 install torch --index-url .../whl/cpu` | |
| linux-aarch64 | 3.15t | `pip3 install torch --index-url .../whl/cpu` | |
| windows | 3.12 | `pip3 install torch torchvision` | PyPI, unchanged |
| macos-arm64 | 3.13 | `pip3 install torch torchvision` | PyPI, unchanged |
| linux-aarch64 | 3.11 | `pip3 install torch torchvision` | PyPI, unchanged |

Nightly and test are unaffected — they already used `--index-url` for every Python version:

```
nightly 3.15t  pip3 install --pre torch --index-url .../whl/nightly/cpu
nightly 3.12   pip3 install --pre torch torchvision --index-url .../whl/nightly/cpu
test    3.15t  pip3 install torch --index-url .../whl/test/cpu
test    3.12   pip3 install torch torchvision --index-url .../whl/test/cpu
```

Confirmed the target wheels exist on https://download.pytorch.org/whl/cpu — 8 cp315/cp315t artifacts for 2.14.0 across manylinux x86_64/aarch64, win_amd64 and macosx_14_0_arm64.

## Note on main

`get_wheel_install_command()` has the same bug on `main`; it just doesn't bite there because main's `PYTHON_ARCHES_DICT["release"]` stops at `3.14t`. It'll need the same fix when 3.15 joins the release matrix. Happy to open that separately — kept this one release-branch-only since it's unblocking 2.14 validation.
