### PR TITLE
Fix 3.15 release validation and show one ROCm per channel on getting-started

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -204,7 +204,9 @@ def initialize_globals(
             arch for arch in CUDA_ARCHES if arch not in CUDA_ARCHES_NO_GETTING_STARTED
         ]
     ROCM_ARCHES = ROCM_ARCHES_DICT[channel]
-    if getting_started and channel == NIGHTLY:
+    if getting_started:
+        # The getting-started page offers a single ROCm option per channel, and
+        # it should be the newest one the channel ships.
         ROCM_ARCHES = [max(ROCM_ARCHES, key=parse_version)]
     if build_python_only:
         # Only select the oldest version of python if building a python only package

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -36,6 +36,13 @@ PYTHON_ARCHES_DICT = {
 # request torch alone.
 TORCH_ONLY_PYTHON_ARCHES = ["3.15", "3.15t"]
 
+# Python versions with no torch wheels on PyPI. The release channel normally
+# validates via a bare `pip3 install torch`, which resolves against PyPI; for
+# these it must use --index-url download.pytorch.org instead. Same members as
+# TORCH_ONLY_PYTHON_ARCHES today but a different fact -- that one is about
+# torchvision not being published, this one about torch.
+PYPI_UNPUBLISHED_PYTHON_ARCHES = ["3.15", "3.15t"]
+
 MACOS_PYTHON_POINT_VERSIONS = {
     "3.10": "3.10.19",
     "3.11": "3.11.14",
@@ -332,6 +339,7 @@ def get_wheel_install_command(
     if (
         channel == RELEASE
         and (not use_only_dl_pytorch_org)
+        and python_version not in PYPI_UNPUBLISHED_PYTHON_ARCHES
         and (
             (gpu_arch_version == STABLE_CUDA_VERSIONS[channel] and os == LINUX)
             or (gpu_arch_type == CPU and os in [WINDOWS, MACOS_ARM64])

--- a/tools/tests/test_generate_binary_build_matrix.py
+++ b/tools/tests/test_generate_binary_build_matrix.py
@@ -232,17 +232,20 @@ class GenerateBuildMatrixTest(TestCase):
             "7.14",
         )
 
-    def test_getting_started_nightly_ships_one_rocm(self):
-        versions = self._rocm_versions("nightly", "true")
-        self.assertEqual(len(versions), 1)
-        self.assertEqual(
-            versions, {max(ROCM_ARCHES_DICT["nightly"], key=parse_version)}
-        )
+    def test_getting_started_ships_newest_rocm_per_channel(self):
+        for channel in ("nightly", "test", "release"):
+            versions = self._rocm_versions(channel, "true")
+            self.assertEqual(
+                versions,
+                {max(ROCM_ARCHES_DICT[channel], key=parse_version)},
+                channel,
+            )
 
-    def test_nightly_builds_keep_every_rocm(self):
-        versions = self._rocm_versions("nightly", "false")
-        self.assertEqual(versions, set(ROCM_ARCHES_DICT["nightly"]))
-        self.assertGreater(len(versions), 1)
+    def test_builds_keep_every_rocm(self):
+        for channel in ("nightly", "test", "release"):
+            versions = self._rocm_versions(channel, "false")
+            self.assertEqual(versions, set(ROCM_ARCHES_DICT[channel]), channel)
+            self.assertGreater(len(versions), 1, channel)
 
 
 def parse_args():


### PR DESCRIPTION
Two release-channel matrix fixes.

## 1. Validate 3.15 / 3.15t against download.pytorch.org

Same fix as #8710, which unblocks `release/2.14` validation. Applied here so the bug doesn't reappear when 3.15 joins main's release matrix.

3.15 is a CPython pre-release, so no torch wheels are published to PyPI for it. `get_wheel_install_command()` emits a bare `pip3 install torch` for the release channel on CPU/Windows, CPU/macOS-arm64, stable-CUDA/Linux and linux-aarch64 -- deliberately, since that's the canonical PyPI install users follow. With no PyPI wheel, pip has nowhere to look:

```
ERROR: Could not find a version that satisfies the requirement torch (from versions: none)
```

`PYPI_UNPUBLISHED_PYTHON_ARCHES` routes those versions to `--index-url download.pytorch.org` instead. It is new rather than a reuse of `TORCH_ONLY_PYTHON_ARCHES`: same members today, different facts -- one is *"torchvision isn't published for this version"*, the other *"torch isn't on PyPI for this version"* -- and they can diverge once torchvision ships 3.15 wheels while 3.15 is still pre-release.

This is latent on main and live on `release/2.14`: `PYTHON_ARCHES_DICT["release"]` stops at `3.14t` here, so no 3.15 release job is generated. `release/2.14` does list them, which is where it fires -- see [the failing job](https://github.com/pytorch/test-infra/actions/runs/33638298417/job/100274840469).

## 2. One ROCm per channel on the getting-started page

The single-ROCm reduction in `initialize_globals` was gated on the nightly channel, so test and release emitted every ROCm they build and the page offered more than one option. Apply it to every channel, keeping the newest:

```python
-    if getting_started and channel == NIGHTLY:
+    if getting_started:
         ROCM_ARCHES = [max(ROCM_ARCHES, key=parse_version)]
```

Resulting getting-started selection:

| channel | before | after |
| --- | --- | --- |
| nightly | 10.0 | 10.0 (unchanged) |
| test | 7.2, 7.14 | 7.14 |
| release | 7.1, 7.2 | 7.2 -> **7.14 once #8712 lands** |

Release resolves to 7.14 only after #8712 syncs `ROCM_ARCHES_DICT["release"]` to `["7.2", "7.14"]`, which is what 2.14 actually shipped. That change is deliberately not duplicated here -- both PRs touch the same few lines, and #8712 also inserts a line directly above this one, so whichever lands second may need a one-line rebase.

## Test plan

`release` currently generates `['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']`, so the live Python matrix is unchanged. Called `get_wheel_install_command()` directly for the versions that will matter:

```
3.15t  pip3 install torch --index-url https://download.pytorch.org/whl/cpu
3.15   pip3 install torch --index-url https://download.pytorch.org/whl/cpu
3.12   pip3 install torch torchvision                       <- PyPI, unchanged
```

Nightly and test are unaffected by (1) -- they already used `--index-url` for every Python version.

For (2), generalized the two nightly-only ROCm tests to loop over all three channels. 14 tests pass. Also simulated `#8712` on top of this branch to confirm release then resolves to `['7.14']`.