### PR TITLE
Name the columns every replicated insert writes into

### DIFF
--- a/.github/workflows/clickhouse-replicator-s3-lambda.yml
+++ b/.github/workflows/clickhouse-replicator-s3-lambda.yml
@@ -24,6 +24,10 @@ jobs:
         with:
           python-version: '3.12'
           cache: pip
+      # The job is named "Test and deploy" and had no test. These checks need
+      # no credentials and no network, so they run before the role is assumed —
+      # a bad column list fails the deploy instead of shipping and going quiet.
+      - run: python test_lambda_function.py
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
         with:

--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -1,6 +1,9 @@
 import json
 import os
-import urllib
+
+# `import urllib` alone does not bind the `parse` submodule; encode_url_component
+# works today only because a dependency imports urllib.parse first.
+import urllib.parse
 from collections import defaultdict
 from enum import Enum
 from functools import lru_cache
@@ -390,13 +393,125 @@ def log_failure_to_clickhouse(table, bucket, key, error) -> None:
     )
 
 
+# The tuple recording which S3 object a row came from. Three tables predate the
+# `_meta` spelling and call it `meta`. A positional insert never had to know —
+# it matched by position — so naming the columns is what surfaces this.
+META_COLUMN = {
+    "default.merge_bases": "meta",
+    "default.queue_times_historical": "meta",
+    "default.rerun_disabled_tests": "meta",
+}
+
+
+def meta_column(table) -> str:
+    return META_COLUMN.get(table, "_meta")
+
+
+def quote_identifier(name) -> str:
+    return "`" + name.replace("`", "``") + "`"
+
+
+def _split_top_level(schema) -> List[str]:
+    """Split a structure string on commas at paren depth zero.
+
+    Quote-aware, because depth counting is only meaningful outside quotes: a
+    paren inside an Enum value — `Enum8('a)' = 1, 'b' = 2)` — would otherwise
+    unbalance the depth and split the rest of the schema in the wrong places.
+    """
+    parts, depth, buf = [], 0, []
+    in_identifier = in_string = False
+    i = 0
+    while i < len(schema):
+        char = schema[i]
+        if in_identifier:
+            if char == "`" and schema[i + 1 : i + 2] == "`":
+                buf.append("``")
+                i += 2
+                continue
+            if char == "`":
+                in_identifier = False
+        elif in_string:
+            if char == "\\" and i + 1 < len(schema):
+                buf.append(schema[i : i + 2])
+                i += 2
+                continue
+            if char == "'" and schema[i + 1 : i + 2] == "'":
+                buf.append("''")
+                i += 2
+                continue
+            if char == "'":
+                in_string = False
+        elif char == "`":
+            in_identifier = True
+        elif char == "'":
+            in_string = True
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+        elif char == "," and depth == 0:
+            parts.append("".join(buf))
+            buf = []
+            i += 1
+            continue
+        buf.append(char)
+        i += 1
+    parts.append("".join(buf))
+    return parts
+
+
+def schema_columns(schema) -> List[str]:
+    """Top-level column names from a ClickHouse structure string.
+
+    Splitting per LINE instead looks equivalent and is not: the inner fields of
+    a nested `Tuple(...)` sit at the same indentation as real columns, so a
+    line-wise parse invents columns for oss_ci_benchmark_v3 (59 lines, 17
+    columns, `repo` appearing twice), oss_ci_utilization_metadata and
+    cloudwatch_metrics.
+    """
+    names = []
+    for part in _split_top_level(schema):
+        part = part.strip()
+        if not part:
+            continue
+        if not part.startswith("`"):
+            # Every schema here backtick-quotes its column names. Refuse rather
+            # than guess: a wrong name writes into the wrong column, and the
+            # deploy workflow runs test_lambda_function.py, so a schema this
+            # parser cannot read fails the deploy instead of reaching prod.
+            raise ValueError(f"column name is not backtick-quoted: {part!r}")
+        i, chars = 1, []
+        while i < len(part):
+            if part[i] == "`":
+                if part[i + 1 : i + 2] == "`":
+                    chars.append("`")
+                    i += 2
+                    continue
+                break
+            chars.append(part[i])
+            i += 1
+        else:
+            raise ValueError(f"unterminated column name: {part!r}")
+        names.append("".join(chars))
+    return names
+
+
 def general_adapter(table, bucket, key, schema, compressions, format) -> None:
     url = f"https://{bucket}.s3.amazonaws.com/{encode_url_component(key)}"
 
     def get_insert_query(compression):
+        # Named, not positional. `insert into <table> select *` matches the
+        # destination by ORDER, so the table has to carry exactly these columns
+        # in exactly this sequence: adding one anywhere breaks every insert
+        # until this schema is edited to match, and the break is silent because
+        # the exception below goes to errors.gen_errors and nowhere else.
+        columns = ", ".join(
+            quote_identifier(name)
+            for name in [*schema_columns(schema), meta_column(table)]
+        )
         return f"""
-        insert into {table}
-        select *, ('{bucket}', '{key}') as _meta
+        insert into {table} ({columns})
+        select *, ('{bucket}', '{key}')
         from s3('{url}', '{format}', '{schema}', '{compression}',
             extra_credentials(
                 role_arn = 'arn:aws:iam::308535385114:role/clickhouse_role'

--- a/aws/lambda/clickhouse-replicator-s3/test_lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/test_lambda_function.py
@@ -1,0 +1,189 @@
+"""Checks on the column list this lambda writes into.
+
+Every adapter that goes through `general_adapter` now NAMES its destination
+columns, derived from the same schema string handed to `s3()`. Two ways that
+goes wrong, both silent in production — `general_adapter` routes its exception
+to `errors.gen_errors` and nothing else reads that table:
+
+  * a derived name that is not a column on the table: every insert for that
+    table fails, and the S3 objects are never reprocessed.
+  * a parse that walks INTO a nested `Tuple(...)`: inner field names sit at the
+    same indentation as real columns, so a line-wise parse silently invents
+    columns for oss_ci_benchmark_v3, oss_ci_utilization_metadata and
+    cloudwatch_metrics.
+
+Run with `python test_lambda_function.py` (also wired into the deploy
+workflow). Importing lambda_function pulls in clickhouse_connect, which is not
+needed here, so it is stubbed before import.
+"""
+
+import sys
+import types
+from unittest import mock
+
+
+sys.modules.setdefault(
+    "clickhouse_connect", types.SimpleNamespace(get_client=lambda **kwargs: None)
+)
+
+from lambda_function import (  # noqa: E402
+    merges_adapter,
+    META_COLUMN,
+    OBJECT_CONVERTER,
+    quote_identifier,
+    schema_columns,
+)
+
+
+def test_flat_schema():
+    schema = """
+    `sha` String,
+    `repository` String,
+    `timestamp` DateTime64(9)
+    """
+    assert schema_columns(schema) == ["sha", "repository", "timestamp"]
+
+
+def test_nested_tuple_fields_are_not_mistaken_for_columns():
+    # `metric` is ONE column. Its inner fields are indented exactly like the
+    # top-level ones, and `name` collides with a real column name.
+    schema = """
+    `timestamp` UInt64,
+    `name` String,
+    `metric` Tuple(
+        name String,
+        benchmark_values Array(Float32),
+        target_value Float32
+    ),
+    `repo` String
+    """
+    assert schema_columns(schema) == ["timestamp", "name", "metric", "repo"]
+
+
+def test_array_of_tuples_is_one_column():
+    schema = """
+    `job_id` Int64,
+    `segments` Array(Tuple(level String, name String, start_at DateTime64(0))),
+    `tags` Array(String)
+    """
+    assert schema_columns(schema) == ["job_id", "segments", "tags"]
+
+
+def test_unquoted_column_name_is_refused_not_guessed():
+    try:
+        schema_columns("`ok` String, notquoted String")
+    except ValueError:
+        return
+    raise AssertionError("an unquoted column name must raise, not be guessed")
+
+
+def test_insert_names_its_columns_including_meta():
+    queries = []
+
+    class FakeClient:
+        def query(self, q):
+            queries.append(q)
+
+    with mock.patch("lambda_function.get_clickhouse_client", lambda: FakeClient()):
+        merges_adapter("default.merges", "bkt", "merges/abc.json")
+
+    assert len(queries) == 1, queries
+    head = queries[0].strip().splitlines()[0]
+    assert head.startswith("insert into default.merges (`_id`, `author`, "), head
+    assert head.endswith("`unstable_checks`, `_meta`)"), head
+
+
+def test_legacy_tables_get_meta_not_underscore_meta():
+    # These three predate the `_meta` spelling. A positional insert matched by
+    # position and never had to know; a named one does. Asserted as an exact
+    # dict and by driving all three adapters — a set-of-values check passes with
+    # a key missing or misspelled, which is the whole failure mode.
+    assert META_COLUMN == {
+        "default.merge_bases": "meta",
+        "default.queue_times_historical": "meta",
+        "default.rerun_disabled_tests": "meta",
+    }, META_COLUMN
+
+    class FakeClient:
+        def __init__(self, sink):
+            self.sink = sink
+
+        def query(self, q):
+            self.sink.append(q)
+
+    for table in META_COLUMN:
+        queries = []
+        client = FakeClient(queries)
+        with mock.patch(
+            "lambda_function.get_clickhouse_client", lambda client=client: client
+        ):
+            OBJECT_CONVERTER[table](table, "bkt", "prefix/abc.json")
+
+        head = queries[0].strip().splitlines()[0]
+        assert head.endswith(", `meta`)"), f"{table}: {head}"
+        assert "`_meta`" not in head, f"{table}: {head}"
+
+
+def test_quoting_survives_commas_parens_and_backticks():
+    # None of today's schemas need this, but the parser is the thing standing
+    # between a schema edit and a silently wrong column list.
+    assert schema_columns("`a,b` String, `c` Int64") == ["a,b", "c"]
+    assert schema_columns("`x` Enum8('a)' = 1, 'b' = 2), `y` Int64") == ["x", "y"]
+    assert schema_columns("`we``ird` String, `z` Int64") == ["we`ird", "z"]
+    assert quote_identifier("we`ird") == "`we``ird`"
+
+
+def test_every_general_adapter_table_names_its_columns():
+    """No adapter silently keeps the positional form.
+
+    A `select *` insert still parses and still runs; the only thing that
+    notices is the next column added to that table.
+    """
+    seen = {}
+
+    class FakeClient:
+        def __init__(self, table):
+            self.table = table
+
+        def query(self, q):
+            seen.setdefault(self.table, q)
+
+    positional = []
+    for table, adapter in OBJECT_CONVERTER.items():
+        client = FakeClient(table)
+        with mock.patch(
+            "lambda_function.get_clickhouse_client", lambda client=client: client
+        ):
+            try:
+                adapter(table, "bkt", "prefix/abc.json")
+            except Exception as e:  # noqa: BLE001 - reported, not swallowed
+                raise AssertionError(f"{table} adapter raised: {e}") from e
+        query = seen.get(table, "")
+        if f"insert into {table} (" not in query:
+            positional.append(table)
+
+    # The four bespoke handlers spell their SELECT out column by column instead
+    # of going through general_adapter; they are not part of this contract.
+    bespoke = {
+        "default.test_run_s3",
+        "default.failed_test_runs",
+        "default.test_run_summary",
+        "tests.all_test_runs",
+    }
+    assert set(positional) == bespoke, (
+        f"expected only {sorted(bespoke)} to be positional, got {sorted(positional)}"
+    )
+
+
+if __name__ == "__main__":
+    # Discovered, not listed: a hand-maintained list silently stops running the
+    # test you add to the file and forget to append here.
+    tests = sorted(
+        (name, fn)
+        for name, fn in list(globals().items())
+        if name.startswith("test_") and callable(fn)
+    )
+    for name, fn in tests:
+        fn()
+        print(f"ok  {name}")
+    print(f"OK ({len(tests)} tests)")


### PR DESCRIPTION
✴️ iz2: opened on behalf of @izaitsevfb

> **On hold — please don't merge yet.** @izaitsevfb is weighing this against a version scoped to `default.merges` alone. The change is verified (below), but it moves the insert statement for every table this lambda serves, and that is a bigger blast radius than the problem that prompted it strictly requires.

`general_adapter` builds a positional insert:

```sql
insert into <table>
select *, ('<bucket>', '<key>') as _meta
from s3(<url>, 'JSONEachRow', '<schema>', ...)
```

`select *` yields exactly the columns the `schema` argument declares, in that order. So every one of the 21 tables this serves has to carry precisely those columns, in precisely that sequence, with the meta tuple last. Add a column anywhere and every insert for that table fails on column count — **silently**, because `general_adapter` catches the exception and writes it to `errors.gen_errors`, which nothing reads. The S3 objects are not reprocessed, so those rows are gone.

That is what blocks adding `ai_not_related_checks` to `default.merges` for pytorch/pytorch#195503: the ALTER cannot go first.

## What changed

The insert names its columns, derived from the same schema string that is already handed to `s3()`. Column order and count on the table stop mattering, so a column can be ALTERed in before the code that populates it.

The derivation splits on commas at paren depth zero, outside quotes. A line-wise split looks equivalent and is not — the inner fields of a nested `Tuple(...)` sit at the same indentation as real columns, so it invents columns for `oss_ci_benchmark_v3` (59 schema lines, 17 actual columns, `repo` appearing twice), `oss_ci_utilization_metadata` and `cloudwatch_metrics`. Quote-awareness matters for the same reason paren depth does: a paren inside an Enum value would unbalance everything after it. A column name that is not backtick-quoted raises rather than being guessed at — a wrong name here writes into the wrong column.

## Two things this surfaced

- **`default.merge_bases`, `default.queue_times_historical` and `default.rerun_disabled_tests` call the tuple `meta`, not `_meta`.** A positional insert matched by position and never had to know. Hence `META_COLUMN`.
- **`fortesting.oss_ci_utilization_metadata` has an `extra_info` column at position 18, *after* `_meta` at 17**, so the positional insert supplied 17 values for 18 insertable columns. Naming them fixes it. (It is the `fortesting` copy and shows no traffic in `errors.gen_errors`, so this is a latent mismatch rather than an observed outage.)

Also `import urllib` → `import urllib.parse`. The bare form does not bind the submodule; `encode_url_component` works today only because a dependency imports `urllib.parse` first.

## Test plan

Adds `test_lambda_function.py` and runs it from the deploy workflow, which was already named "Test and deploy" and had no test. It needs no credentials and no network, so it runs before the AWS role is assumed — a bad column list fails the deploy instead of shipping and going quiet.

- **All 21 `general_adapter` tables checked against the live cluster**: the column list was extracted from the actually-generated SQL and every name looked up in `system.columns`. 21/21 resolve; none is `MATERIALIZED`/`ALIAS`/`EPHEMERAL` (naming such a column would be rejected — the three `_inserted_at` columns are correctly not in any list).
- The four bespoke handlers (`test_run_s3`, `failed_test_runs`, `test_run_summary`, `all_test_runs`) spell their SELECT out by hand and do not go through `general_adapter`; a test asserts they are the *only* ones left positional.
- Mutation-tested: reverting to a positional insert, hardcoding `_meta`, disabling backtick-awareness and disabling string-awareness each turn the suite red; unmutated is green.
- `lintrunner` clean.

## Residual risk, stated plainly

The checks above are static plus a live column-name lookup; nothing here has actually run an insert against ClickHouse. If a derived list were wrong for some table, that table's ingestion would stop silently and its S3 objects would not be reprocessed. Rollback is a revert, which redeploys on merge.

## Related

- pytorch/test-infra#8719 records the `default.merges` schema and the ALTER.
- Pre-existing and out of scope: `('{bucket}', '{key}')` and the schema are interpolated into SQL without escaping. Bucket and key come from S3 event notifications for buckets we own, but an object key containing a quote would break or inject.
