### PR TITLE
Record the default.merges ClickHouse schema and the column #195503 needs

### DIFF
--- a/clickhouse_db_schema/default.merges/001_alter_add_ai_not_related_checks.sql
+++ b/clickhouse_db_schema/default.merges/001_alter_add_ai_not_related_checks.sql
@@ -1,0 +1,22 @@
+-- Records the failing checks that the AI CI Advisor cleared, so the one
+-- classification no human made is not the only one leaving no audit trail.
+-- Written by save_merge_record in pytorch/pytorch#195503.
+--
+-- SEQUENCING. aws/lambda/clickhouse-replicator-s3 inserts positionally
+-- (`select *, (bucket, key)`), so it supplies exactly as many values as the
+-- table has columns. Running this ALTER on its own therefore breaks EVERY
+-- merge insert on column count -- wherever the column is placed -- until that
+-- lambda also declares it. The break is silent: the exception goes to
+-- errors.gen_errors and the S3 objects are not reprocessed. So either
+--   * land pytorch/test-infra#8716 first (it names the columns, after which
+--     the table's column count stops mattering), or
+--   * apply this ALTER and the matching merges_adapter schema change together.
+--
+-- `AFTER unstable_checks` in both cases: `_meta` stays the last column, which
+-- is what the positional insert requires and what the rest of this directory
+-- assumes.
+--
+-- Applied to the live table by hand -- see clickhouse_db_schema/README.md.
+ALTER TABLE default.merges
+ADD COLUMN IF NOT EXISTS `ai_not_related_checks` Array(Array(String))
+AFTER `unstable_checks`

--- a/clickhouse_db_schema/default.merges/schema.sql
+++ b/clickhouse_db_schema/default.merges/schema.sql
@@ -1,0 +1,35 @@
+-- Written by trymerge.py (pytorch/pytorch) as a JSON object per merge attempt,
+-- uploaded to S3 and ingested by aws/lambda/clickhouse-replicator-s3.
+--
+-- `ai_not_related_checks` is added by 001_alter_add_ai_not_related_checks.sql
+-- in this directory; the rest of this file is the table as it stands today.
+CREATE TABLE default.merges
+(
+    `_id` String,
+    `author` String,
+    `broken_trunk_checks` Array(Array(String)),
+    `comment_id` Int64,
+    `dry_run` Bool,
+    `error` String,
+    `failed_checks` Array(Array(String)),
+    `flaky_checks` Array(Array(String)),
+    `ignore_current` Bool,
+    `ignore_current_checks` Array(Array(String)),
+    `is_failed` Bool,
+    `last_commit_sha` String,
+    `merge_base_sha` String,
+    `merge_commit_sha` String,
+    `owner` String,
+    `pending_checks` Array(Array(String)),
+    `pr_num` Int64,
+    `project` String,
+    `skip_mandatory_checks` Bool,
+    `unstable_checks` Array(Array(String)),
+    `ai_not_related_checks` Array(Array(String)),
+    `_meta` Tuple(
+        bucket String,
+        key String)
+)
+ENGINE = SharedReplacingMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}')
+ORDER BY (pr_num, _id)
+SETTINGS index_granularity = 8192


### PR DESCRIPTION
✴️ iz2: opened on behalf of @izaitsevfb

`default.merges` has no entry under `clickhouse_db_schema/`, so the only written description of its shape is the positional column list inside `aws/lambda/clickhouse-replicator-s3/lambda_function.py`. This adds one.

## `schema.sql`

`SHOW CREATE TABLE default.merges` verbatim — diffed against the live cluster, byte-identical apart from the one column below — plus `ai_not_related_checks`, which `save_merge_record` writes in pytorch/pytorch#195503.

## `001_alter_add_ai_not_related_checks.sql`

A separate file rather than a comment, because it carries a constraint worth reading before anyone runs it.

The replicator lambda inserts positionally (`insert into default.merges select *, (bucket, key)`), so it supplies exactly as many values as the table has columns. **Running this ALTER on its own breaks every merge insert on column count — wherever the column is placed — until the lambda declares it too.** It breaks silently: `general_adapter` routes the exception to `errors.gen_errors` and the S3 objects are not reprocessed, so those merge records are lost.

Two orders work:

- land pytorch/test-infra#8716 (it names the columns, after which the table's column count stops mattering), then apply the ALTER; or
- apply the ALTER and the matching `merges_adapter` schema change together.

`AFTER unstable_checks` either way, so `_meta` stays last — what the positional insert needs and what the rest of this directory assumes.

## Note on the snapshot being slightly ahead of reality

Per `clickhouse_db_schema/README.md` these files are applied to ClickHouse by hand and there is no automation, so `schema.sql` here describes the table *after* the sibling ALTER is applied. If you would rather it record only today's shape and be updated afterwards, say so and I will split it.
