### PR TITLE
Brings transferable parts of pr-review skill from PyTorch to GreenLight

### DIFF
--- a/.claude/skills/greenlight-review/SKILL.md
+++ b/.claude/skills/greenlight-review/SKILL.md
@@ -66,6 +66,23 @@ Judge the change, not the author. Work from the diff outward into `./pytorch`.
    migration, or deprecation path.
 7. **Build/CI integrity** — Obvious build breakage, or removal of a CI safety gate.
 
+**Mechanical formatting is already gated.** Before raising a concern, check whether it
+is on this list: formatting, line length, trailing whitespace, style. A lint gate that
+blocks the merge enforces those, and it runs whatever you or the author conclude, so a
+concern of that kind is not yours to raise — leaving it out absorbs no risk. Membership
+means the mechanical property itself is the defect — misformatted code, an over-long
+line — not that a concern's subject matter happens to be mechanical: what a large
+mechanical diff might be hiding is a scope-and-clarity question and stays in force. The
+list is exhaustive, and it is stated here because you cannot work it out yourself: you
+have no check results, and nothing in your inputs settles which jobs run on this PR,
+which of them block the merge, or which paths they cover. Do not extend it, and do not
+clear anything else on the belief that some check would catch it. Key the clearance on
+the concern being on that list, never on the diff merely looking cosmetic — a
+reformatting that changes behavior is a correctness question, and no linter fails on it.
+Criteria 5 and 7 stand outside the list entirely: judge every item either one names on
+its own. A committed secret, a build break, and a diff that edits, disables, or removes
+a security check or a CI gate are illustrations of that, not the whole of it.
+
 ## Decision
 
 - **LAND** — The change is well-scoped and, as far as you can determine, correct;
@@ -80,6 +97,21 @@ Judge the change, not the author. Work from the diff outward into `./pytorch`.
 the context to be confident, choose NO_LAND. A false NO_LAND costs a human glance; a
 false LAND ships an unreviewed regression. See **Time budget** for what "confident"
 means once your review time is spent.
+
+**Ground every claim.** When you are about to state something as fact — that a change
+breaks a caller, that a test covers a path, that nothing else uses a symbol — you must
+have read the lines that show it. If you have not and the claim bears on the verdict, go
+read them; a targeted lookup is cheap. If you still cannot point at the lines, the claim
+is not a finding: leave it out. This binds clearing claims exactly as hard as damning
+ones — an unread test file supports neither "covered" nor "uncovered". It binds the
+verdict message above all, the only artifact that ships: a claim you hedged in your
+reasoning but state flatly there has not been dropped.
+
+**Dropping a claim never clears a criterion.** A **What to inspect** criterion you never
+examined stays unexamined, and fail safe governs it: that is still NO_LAND. Dropping an
+ungrounded assertion removes it from your message; it does not answer the question that
+prompted it. If that question is critical to the verdict and still unanswered, that is a
+NO_LAND too.
 
 ## Output Contract
 


### PR DESCRIPTION
**Impact:** greenlight auto-land reviewer on pytorch/pytorch PRs
**Risk:** medium

## What
Two additions to the `greenlight-review` skill, both adapted from [pytorch's own](https://github.com/pytorch/pytorch/tree/main/.claude/skills/pr-review) `.claude/skills/pr-review/`: a short list of mechanical concerns (formatting, line length, trailing whitespace, style) the reviewer should not raise because a blocking lint gate already covers them, and a rule that every claim in the verdict must be backed by lines the reviewer actually read.

## Why
The reviewer's two failure modes are noise and confident invention. Pr-review skill has already been through several noise-reduction rounds on the human side, and its fact-check step is the most transferable part of it — a claim you can't point at lines for isn't a finding, and that binds "this is covered by tests" exactly as hard as "this breaks a caller". The lint clearance covers the other side: concerns that cost a NO_LAND but that a gate enforces regardless of what the reviewer concludes.


# Notes
The clearance list is deliberately closed and deliberately short:

- **No import ordering.** `# usort: skip` exists precisely to tell the gate to have no opinion, so "lint enforces import order" is false at exactly the sites where the order is load-bearing.
- **Keyed on the class of concern, not on "some check would catch this."** The reviewer has no check results, and pytorch's lint coverage is very non-uniform — `.lintrunner.toml` excludes large chunks of `torch/csrc/**` from clang-tidy, `pyrefly.toml` excludes more. Letting it reason about coverage would be letting it guess.
- Criteria 5 (security) and 7 (build/CI) are explicitly exempt so a "cosmetic-looking" diff can't buy a pass on either.

Content is inlined rather than referenced by path on purpose. `./pytorch/.claude/skills/pr-review/` is live and readable in the reviewer's sandbox; pointing at it would invite the reviewer to open the ~160-item checklist and inherit all of it.