### PR TITLE
Move the trusted-author set into its own module

### DIFF
--- a/greenlight/src/greenlight/cohort.py
+++ b/greenlight/src/greenlight/cohort.py
@@ -1,0 +1,33 @@
+"""Whose PRs greenlight reviews, and whose word can point it at one.
+
+``TRUSTED_AUTHORS`` answers both today: the listing scan matches on it, and both authz gates --
+the ``--pr`` target author and the ``@greenlight recheck`` requester -- are checked against it.
+It sits in a module of its own rather than inside the scan, so a caller that needs the membership
+answer does not have to import the scan to get it.
+"""
+
+from __future__ import annotations
+
+__all__ = ["TRUSTED_AUTHORS", "is_trusted"]
+
+TRUSTED_AUTHORS: set[str] = {
+    "albanD",  # Alban Desmaison
+    "jathu",  # Jathu Satkunarajah
+    "atalman",  # Andrey Talman
+    "huydhn",  # Huy Do
+    "izaitsevfb",  # Ivan Zaitsev
+    "georgehong",  # George Hong
+    "jeanschmidt",  # Jean Schmidt
+    "ezyang",  # Edward Yang
+    "drisspg",  # Driss Guessous
+    "janeyx99",  # Jane Xu
+    "bobrenjc93",  # Bob Ren
+}
+
+# Case-insensitive membership for the two authz gates (target-PR author and recheck requester);
+# GitHub logins are case-insensitive, so gate on the lowercased login against this derived set.
+_TRUSTED_LOWER: frozenset[str] = frozenset(author.lower() for author in TRUSTED_AUTHORS)
+
+
+def is_trusted(login: str | None) -> bool:
+    return login is not None and login.lower() in _TRUSTED_LOWER

--- a/greenlight/src/greenlight/cohort.py
+++ b/greenlight/src/greenlight/cohort.py
@@ -10,19 +10,21 @@ from __future__ import annotations
 
 __all__ = ["TRUSTED_AUTHORS", "is_trusted"]
 
-TRUSTED_AUTHORS: set[str] = {
-    "albanD",  # Alban Desmaison
-    "jathu",  # Jathu Satkunarajah
-    "atalman",  # Andrey Talman
-    "huydhn",  # Huy Do
-    "izaitsevfb",  # Ivan Zaitsev
-    "georgehong",  # George Hong
-    "jeanschmidt",  # Jean Schmidt
-    "ezyang",  # Edward Yang
-    "drisspg",  # Driss Guessous
-    "janeyx99",  # Jane Xu
-    "bobrenjc93",  # Bob Ren
-}
+TRUSTED_AUTHORS: frozenset[str] = frozenset(
+    {
+        "albanD",  # Alban Desmaison
+        "jathu",  # Jathu Satkunarajah
+        "atalman",  # Andrey Talman
+        "huydhn",  # Huy Do
+        "izaitsevfb",  # Ivan Zaitsev
+        "georgehong",  # George Hong
+        "jeanschmidt",  # Jean Schmidt
+        "ezyang",  # Edward Yang
+        "drisspg",  # Driss Guessous
+        "janeyx99",  # Jane Xu
+        "bobrenjc93",  # Bob Ren
+    }
+)
 
 # Case-insensitive membership for the two authz gates (target-PR author and recheck requester);
 # GitHub logins are case-insensitive, so gate on the lowercased login against this derived set.

--- a/greenlight/src/greenlight/review.py
+++ b/greenlight/src/greenlight/review.py
@@ -27,7 +27,7 @@ import threading
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
-from greenlight import candidate_filter, drci_poke, github_client, revert_guard, scan_runner, state, state_emit
+from greenlight import candidate_filter, cohort, drci_poke, github_client, revert_guard, scan_runner, state, state_emit
 from greenlight import dispatch as dispatch_module
 from greenlight.constants import (
     DEFAULT_DISPATCH_REF,
@@ -56,29 +56,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-TRUSTED_AUTHORS: set[str] = {
-    "albanD",  # Alban Desmaison
-    "jathu",  # Jathu Satkunarajah
-    "atalman",  # Andrey Talman
-    "huydhn",  # Huy Do
-    "izaitsevfb",  # Ivan Zaitsev
-    "georgehong",  # George Hong
-    "jeanschmidt",  # Jean Schmidt
-    "ezyang",  # Edward Yang
-    "drisspg",  # Driss Guessous
-    "janeyx99",  # Jane Xu
-    "bobrenjc93",  # Bob Ren
-}
-
-# Case-insensitive membership for the two authz gates (target-PR author and recheck requester);
-# GitHub logins are case-insensitive, so gate on the lowercased login against this derived set.
-_TRUSTED_LOWER: frozenset[str] = frozenset(author.lower() for author in TRUSTED_AUTHORS)
-
-
-def _is_trusted(login: str | None) -> bool:
-    return login is not None and login.lower() in _TRUSTED_LOWER
-
-
 # Aggregate fan-out request rate is workers / seconds-between-requests: more workers or a
 # shorter interval raise it. Cutting workers (8->4) and lengthening the interval (0.25s->0.5s)
 # both lower it, to ~8 req/s, keeping the fan-out under GitHub's secondary (burst-rate) limit
@@ -95,7 +72,7 @@ def _utcnow() -> datetime:
 
 
 def _default_fetch(client: Github) -> list[OpenPR]:
-    return github_client.list_open_prs_by_authors(client, TARGET_REPO, TRUSTED_AUTHORS)
+    return github_client.list_open_prs_by_authors(client, TARGET_REPO, cohort.TRUSTED_AUTHORS)
 
 
 def _default_fetch_author(client: Github, pr_number: int) -> str | None:
@@ -138,7 +115,7 @@ def _candidate_numbers(
         logger.info("targeting single PR #%d in %s", pr, TARGET_REPO)
         return [pr], {}, {}
     open_prs = fetch(client)
-    logger.info("found %d open PR(s) from %d author(s) in %s", len(open_prs), len(TRUSTED_AUTHORS), TARGET_REPO)
+    logger.info("found %d open PR(s) from %d author(s) in %s", len(open_prs), len(cohort.TRUSTED_AUTHORS), TARGET_REPO)
     for open_pr in open_prs:
         logger.info("open PR #%d by %s: %s (%s)", open_pr.number, open_pr.author, open_pr.title, open_pr.url)
     return (
@@ -185,7 +162,7 @@ def run(
     # so a spammed @greenlight recheck from an untrusted login costs nothing. A policy refusal is
     # not a failure -- return cleanly rather than raising (no non-zero exit, no daemon backoff).
     if requester is not None:
-        if not _is_trusted(requester):
+        if not cohort.is_trusted(requester):
             logger.warning("refusing review: requester %r is not a trusted author", requester)
             return
         logger.info("review requested by trusted author %s", requester)
@@ -197,7 +174,7 @@ def run(
         # allow_untrusted_author bypasses ONLY this check (local iteration; never a workflow input).
         if pr is not None and not allow_untrusted_author:
             author = fetch_author(client, pr)
-            if not _is_trusted(author):
+            if not cohort.is_trusted(author):
                 logger.warning("refusing --pr %d: author %r is not a trusted author", pr, author)
                 return
         # Resolved once per scan and never caught here: a cold failure must fail the scan (one-shot

--- a/greenlight/tests/test_cohort.py
+++ b/greenlight/tests/test_cohort.py
@@ -1,0 +1,45 @@
+import pytest
+
+from greenlight import cohort
+
+# The authorization boundary the two authz gates enforce. Pinned here so widening it is a
+# deliberate two-place edit rather than a typo.
+_PINNED_TRUSTED_AUTHORS = {
+    "albanD",
+    "jathu",
+    "atalman",
+    "huydhn",
+    "izaitsevfb",
+    "georgehong",
+    "jeanschmidt",
+    "ezyang",
+    "drisspg",
+    "janeyx99",
+    "bobrenjc93",
+}
+
+
+def test_trusted_authors_membership_is_pinned():
+    assert cohort.TRUSTED_AUTHORS == _PINNED_TRUSTED_AUTHORS
+
+
+def test_trusted_lower_is_lowercase_and_collision_free():
+    # A pair of authors differing only in case would silently shrink the gate by one.
+    assert all(login == login.lower() for login in cohort._TRUSTED_LOWER)
+    assert len(cohort._TRUSTED_LOWER) == len(cohort.TRUSTED_AUTHORS)
+
+
+@pytest.mark.parametrize(
+    ("login", "expected"),
+    [
+        pytest.param("ezyang", True, id="exact-login"),
+        pytest.param("EZYANG", True, id="uppercased"),
+        pytest.param("albanD", True, id="canonical-mixed-case"),
+        pytest.param("aLBAnd", True, id="mixed-case-login-cased-differently"),
+        pytest.param("octocat", False, id="stranger"),
+        pytest.param("", False, id="empty"),
+        pytest.param(None, False, id="absent"),
+    ],
+)
+def test_is_trusted(login: str | None, expected: bool) -> None:
+    assert cohort.is_trusted(login) is expected

--- a/greenlight/tests/test_cohort.py
+++ b/greenlight/tests/test_cohort.py
@@ -23,6 +23,13 @@ def test_trusted_authors_membership_is_pinned():
     assert cohort.TRUSTED_AUTHORS == _PINNED_TRUSTED_AUTHORS
 
 
+def test_trusted_authors_is_immutable():
+    # _TRUSTED_LOWER snapshots this set at import time, so a post-import mutation would never
+    # reach is_trusted: it could widen the gates' source, or revoke from it, without moving the
+    # gates themselves, with nothing anywhere raising.
+    assert isinstance(cohort.TRUSTED_AUTHORS, frozenset)
+
+
 def test_trusted_lower_is_lowercase_and_collision_free():
     # A pair of authors differing only in case would silently shrink the gate by one.
     assert all(login == login.lower() for login in cohort._TRUSTED_LOWER)

--- a/greenlight/tests/test_review.py
+++ b/greenlight/tests/test_review.py
@@ -10,7 +10,16 @@ from unittest.mock import Mock
 
 import pytest
 
-from greenlight import clickhouse_client, drci_poke, github_client, revert_guard, review, scan_runner, state_emit
+from greenlight import (
+    clickhouse_client,
+    cohort,
+    drci_poke,
+    github_client,
+    revert_guard,
+    review,
+    scan_runner,
+    state_emit,
+)
 from greenlight.comment_format import RECHECK_REFUSAL_MARKER
 from greenlight.constants import (
     DEFAULT_DISPATCH_REF,
@@ -1887,7 +1896,7 @@ def test_default_fetch_forwards_to_list_open_prs(monkeypatch):
     assert result is expected
     assert captured["client"] is _CLIENT
     assert captured["repo"] == TARGET_REPO
-    assert captured["authors"] == review.TRUSTED_AUTHORS
+    assert captured["authors"] == cohort.TRUSTED_AUTHORS
 
 
 def test_default_fetch_author_forwards_to_get_pr_author(monkeypatch):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #8729
* #8728
* #8727
* #8726
* #8725
* #8724
* #8723
* __->__ #8722

**Impact:** greenlight scan only; no behaviour change
**Risk:** low

## What
`TRUSTED_AUTHORS`, its lowercased derivative, and the membership check move out of
`review.py` into a new `cohort.py`. The scan imports them instead of defining them.
Who is trusted, and what the two authz gates do with that answer, is unchanged.

## Why
The set answers a question the scan is merely the first caller of rather than the owner
of: whose PRs greenlight is allowed to act on. Other callers need the same answer, and
importing the scanner to ask it drags the whole review loop and its GitHub/ClickHouse
seams along. A module of its own lets them ask without a circular import, and keeps the
boundary defined exactly once.