### PR TITLE
Add a shadow column to the state row

### DIFF
--- a/.github/workflows/greenlight-review.yml
+++ b/.github/workflows/greenlight-review.yml
@@ -21,9 +21,15 @@ on:
         default: ""
         type: string
       max:
-        description: "Max dispatches this run (empty = no cap)"
+        # Matches _MAX_DISPATCHES_PER_SCAN in greenlight/src/greenlight/lambda_handler.py. A
+        # dispatch costs 3-8s of serial main-thread work, so an uncapped pass over the whole
+        # evaluation cohort fires an unbounded burst of workflow_dispatch POSTs on one token --
+        # what GitHub's secondary rate limit punishes hardest, and why the scan already throttles
+        # its fingerprint fan-out. Deferring is free: no state row is written for a PR that is
+        # never reached, so the next run re-evaluates it.
+        description: "Max dispatches this run; matches the Lambda's cap (clear the field for no cap)"
         required: false
-        default: ""
+        default: "30"
         type: string
       ref:
         description: "Ref of greenlight-pr-review.yml to dispatch"

--- a/.github/workflows/greenlight-review.yml
+++ b/.github/workflows/greenlight-review.yml
@@ -21,13 +21,15 @@ on:
         default: ""
         type: string
       max:
-        # Matches _MAX_DISPATCHES_PER_SCAN in greenlight/src/greenlight/lambda_handler.py. A
+        # Matches _DEFAULT_MAX_DISPATCHES_PER_SCAN in greenlight/src/greenlight/lambda_handler.py,
+        # which the scheduled Lambda overrides through PYTORCH_GREENLIGHT_MAX_DISPATCHES_PER_SCAN:
+        # this default tracks the Lambda's default, not whatever cap the Lambda is running today. A
         # dispatch costs 3-8s of serial main-thread work, so an uncapped pass over the whole
         # evaluation cohort fires an unbounded burst of workflow_dispatch POSTs on one token --
         # what GitHub's secondary rate limit punishes hardest, and why the scan already throttles
         # its fingerprint fan-out. Deferring is free: no state row is written for a PR that is
         # never reached, so the next run re-evaluates it.
-        description: "Max dispatches this run; matches the Lambda's cap (clear the field for no cap)"
+        description: "Max dispatches this run; matches the Lambda's default (clear the field for no cap)"
         required: false
         default: "30"
         type: string

--- a/.github/workflows/greenlight-tests.yml
+++ b/.github/workflows/greenlight-tests.yml
@@ -8,6 +8,10 @@ on:
       - greenlight/**
       - .claude/hooks/greenlight/**
       - .claude/skills/greenlight-review/**
+      # Holds the other side of the greenlight_pr_state column contract
+      # (test_state_row_schema_sync.py). Its own workflow does not run these tests, so
+      # without this path an adapter-only edit ships green and rows stop arriving.
+      - aws/lambda/clickhouse-replicator-s3/**
   push:
     branches:
       - main
@@ -17,6 +21,7 @@ on:
       - greenlight/**
       - .claude/hooks/greenlight/**
       - .claude/skills/greenlight-review/**
+      - aws/lambda/clickhouse-replicator-s3/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -749,7 +749,8 @@ def greenlight_pr_state_adapter(table, bucket, key):
     `agent_job` String,
     `version` DateTime64(3),
     `run_id` Int64,
-    `emit_id` String
+    `emit_id` String,
+    `shadow` Bool
     """
     general_adapter(table, bucket, key, schema, ["gzip", "none"], "JSONEachRow")
 

--- a/greenlight/CHEATSHEET.md
+++ b/greenlight/CHEATSHEET.md
@@ -239,6 +239,8 @@ automated DDL), so @clee2000 or @huydhn apply them manually:
 - `004_*.sql` — one in-place `ALTER` that adds the `run_id` and `emit_id` columns and
   extends the sort key to `(repo, pr_number, run_id, emit_id)`, keeping the
   `SharedReplacingMergeTree` engine (no new table, backfill, or `EXCHANGE`)
+- `005_alter_greenlight_pr_state_add_shadow.sql` — add the `shadow` Bool (`DEFAULT false`,
+  `AFTER emit_id`, deliberately *not* in the sort key)
 
 The table is append-only-equivalent: the `SharedReplacingMergeTree` never collapses a row
 because the sort key `(repo, pr_number, run_id, emit_id)` ends in a per-emit UUID (`emit_id`),
@@ -248,6 +250,14 @@ race-proof, so a superseded slower dispatch that finishes with a later `version`
 the newer dispatch's higher `run_id`. Applying `004` and deploying the clickhouse-replicator-s3
 Lambda adapter (which gains the matching `run_id` and `emit_id` columns) is a lockstep go-live:
 a schema skew between them drops rows.
+
+`005` is not lockstep — it is strictly ordered, DDL first. Two torchci readers reference `shadow`
+unconditionally and deploy to Vercel on merge: `clickhouse_queries/greenlight_pr_states/query.sql`
+(Dr. CI's render) and `pages/api/greenlight/pr_state.ts` (the route pytorch's land-time merge gate
+reads). Against a table without the column that route returns 500, and since it is the gate's only
+data source, every greenlight-authorized merge waits out the gate's 15-minute transport budget and
+is then denied. Apply the DDL and verify the column via `system.columns` before merging either
+reader.
 
 The `verdict` subcommand does NOT write ClickHouse directly: it emits a gzipped JSON row
 that the record workflow uploads to `s3://gha-artifacts/greenlight_pr_state/`, and the

--- a/greenlight/CHEATSHEET.md
+++ b/greenlight/CHEATSHEET.md
@@ -131,6 +131,7 @@ the scan flags `--pr`, `--max`, `--ref`, and `--timeout-minutes`.
 | `PYTORCH_GREENLIGHT_DRCI_POKE_DELAY_SECONDS` | `10` | `drci-poke` waits this long for state ingestion before the request (`0` = no wait); `review`'s own poke always waits zero |
 | `PYTORCH_GREENLIGHT_DRCI_TOKEN` | unset | Dr. CI endpoint key for `drci-poke` and `review`'s dispatch poke (`DRCI_BOT_KEY`); unset skips the poke |
 | `PYTORCH_GREENLIGHT_DRCI_INTERNAL_TOKEN` | unset | Optional `x-hud-internal-bot` header value for either poke (`HUD_API_TOKEN`); clears HUD's bot challenge, not an endpoint credential |
+| `PYTORCH_GREENLIGHT_MAX_DISPATCHES_PER_SCAN` | `30` | `greenlight-scan` Lambda only: dispatch cap for the scheduled pass, passed through as `review --max` (`0` fingerprints, evaluates, and dispatches nothing; the scan still lists and still revokes on reverted PRs). Non-negative integer, with no upper bound enforced — roughly 30-50 is what fits the 300 s timeout; elsewhere use `--max` |
 
 Raise verbosity with `--log-level DEBUG` (or `PYTORCH_GREENLIGHT_LOG_LEVEL=DEBUG`); DEBUG also
 logs the resolved `Config`.
@@ -168,8 +169,9 @@ The end-to-end flow, per trusted-author PR:
 3. If the PR is new, or its fingerprint changed since that state, and no review is
    in-flight within the `--timeout-minutes` window, it dispatches the reviewer workflow
    (`greenlight-pr-review.yml` on `pytorch/test-infra`) and emits an `AI_REVIEW_DISPATCHED`
-   row, then pokes Dr. CI in-process (no ingestion wait — the row is already in S3) so that
-   first state surfaces immediately instead of on the next sweep.
+   row, then hands Dr. CI a poke to a background pool (no ingestion wait — the row is already
+   in S3) so that first state surfaces immediately instead of on the next sweep. The scan does
+   not wait on the poke; the pool is drained before the scan returns.
 4. The reviewer workflow's `announce_start` job records an `AI_REVIEW_STARTED` marker, so
    the next scan sees the review as in-flight and does not re-dispatch it.
 5. Before the model runs, the workflow sanitizes the untrusted `./pytorch` checkout —

--- a/greenlight/README.md
+++ b/greenlight/README.md
@@ -227,6 +227,13 @@ hang-guard layers off (the SIGALRM soft timeout and the `os._exit` hard watchdog
 under the Lambda runtime); single-instance and hang-bounding come from
 `reserved_concurrent_executions = 1` and the Lambda function timeout instead.
 
+The handler caps each pass at `--max 30` (`_MAX_DISPATCHES_PER_SCAN`), and
+`greenlight-review.yml`'s `max` input defaults to the same 30. A dispatch costs 3-8 s of serial
+main-thread work, so an uncapped pass over the whole evaluation cohort would both run the Lambda
+out of its 300 s clock and fire an unbounded burst of `workflow_dispatch` POSTs on one token —
+what GitHub's secondary rate limit punishes hardest. Deferring is free: no state row is written
+for a PR the cap never reaches, so the next scan re-evaluates and dispatches it.
+
 The scan's Dr. CI poke needs `PYTORCH_GREENLIGHT_DRCI_TOKEN` (and optionally
 `PYTORCH_GREENLIGHT_DRCI_INTERNAL_TOKEN`) wherever the scan runs: the Lambda reads both from its
 function environment, provisioned by the gha-infra terraform, and the manual /

--- a/greenlight/README.md
+++ b/greenlight/README.md
@@ -175,6 +175,21 @@ later step uploading it, whereas the scan has already put the object to S3 befor
 A failed emit is not poked: rebuilding the comment then would only re-render the state the
 marker was meant to replace.
 
+The scan's pokes are fire-and-forget. Each one is handed to a small background pool
+(`drci_poke.POKE_WORKERS`, 8 threads named `greenlight-poke`) and the scan moves straight on to the
+next PR, so a slow or hung Dr. CI costs the scan nothing but the outcome is still logged. Nothing
+reads a poke's result, and a poke that fails — including one the pool refuses to schedule — is
+logged and dropped rather than counted against the scan.
+
+The pool is entered on the scan's `ExitStack`, so `review.run` drains it on the way out. That drain
+runs to completion only where no per-iteration timeout is armed, which is the case that actually
+matters: under Lambda a thread left running is frozen the instant the handler returns and would
+thaw inside a later invocation, and the Lambda disables both hang guards. Under `--loop` or a
+local one-shot the SIGALRM soft timeout can land inside the pool's `shutdown(wait=True)`, interrupt
+the join, and propagate out of the block. The executor is not shut down with `cancel_futures`, so
+the queued pokes are not dropped — they keep running on non-daemon threads and log their outcomes
+into whatever runs next.
+
 The command writes the gzipped row to `/tmp/greenlight-verdict-row.json.gz` and its
 bucket-relative key to `/tmp/greenlight-verdict-key.txt`; the workflow `aws s3 cp`s the
 former to the latter. There is no direct ClickHouse write, so no `CLICKHOUSE_*` credentials
@@ -200,17 +215,26 @@ unprefixed `BOT_LOGIN`:
 | `PYTORCH_GREENLIGHT_DRCI_POKE_DELAY_SECONDS` | `10` | How long `drci-poke` waits for the emitted row to reach ClickHouse before requesting the rebuild (`0` = no wait). Does not apply to `review`'s own dispatch poke, which always waits zero |
 | `PYTORCH_GREENLIGHT_DRCI_TOKEN` | unset | Dr. CI endpoint key used by `drci-poke` and by `review`'s dispatch poke, sent as a raw `Authorization` value (the `DRCI_BOT_KEY` secret); unset skips the poke |
 | `PYTORCH_GREENLIGHT_DRCI_INTERNAL_TOKEN` | unset | Optional `x-hud-internal-bot` header value for either poke (the `HUD_API_TOKEN` secret). Not an endpoint credential — Dr. CI authenticates on `Authorization` alone; this clears HUD's bot challenge, the same pairing `update-drci-comments.yml` already sends |
+| `PYTORCH_GREENLIGHT_MAX_DISPATCHES_PER_SCAN` | `30` | Read only by the `greenlight-scan` Lambda handler, which passes it through as `review --max`; every other path takes the `--max` flag instead. Caps how many PRs one scheduled pass dispatches so the pass fits the 300 s function timeout — the practical ceiling is roughly 30 at the slow end of the dispatch cost and roughly 50 at the fast end (see Deployment). `0` is a pause switch: the scan still lists its candidates, reads their state, and revokes its approval on a reverted PR, but the capped fan-out stops before submitting anything, so nothing is fingerprinted, evaluated, or dispatched. Must be a non-negative integer; blank or unset is the default, and the ceiling is documented rather than enforced |
 
 `review` additionally reads ClickHouse — any scan that finds at least one trusted-author
 PR looks up `misc.greenlight_pr_state` — via the standard `CLICKHOUSE_*` connection
 variables (`CLICKHOUSE_HOST` or its `CLICKHOUSE_ENDPOINT` alias, `CLICKHOUSE_USERNAME`,
 `CLICKHOUSE_PASSWORD`, and `CLICKHOUSE_PORT`, default `8443`).
 
-`PYTORCH_GREENLIGHT_MAX_RUNTIME_SECONDS` (default `600`, `0` = disabled) bounds every
-iteration in both one-shot and `--loop` mode, the scan's in-process Dr. CI pokes included —
-those swallow their own failures but let the timeout through. In `--loop` mode, SIGTERM/SIGINT
-are observed only between iterations, so the per-iteration timeout is what interrupts a
-hung run.
+`PYTORCH_GREENLIGHT_MAX_RUNTIME_SECONDS` (default `600`, `0` = disabled) bounds every iteration in
+both one-shot and `--loop` mode — `runner._bounded_iteration` is shared by `execute_once` and
+`run_forever`, so a plain local `greenlight review` arms both guards too. The scheduled Lambda is
+the only path that runs without them, setting `PYTORCH_GREENLIGHT_MAX_RUNTIME_SECONDS=0`.
+
+Neither guard bounds the scan's Dr. CI pokes. Those run on the background pool, and the soft
+timeout is a SIGALRM delivered to the main thread only. Where the guards are off, the drain simply
+runs to completion, and because `shutdown(wait=True)` waits out the whole queue rather than only
+what is in flight, its worst case is `ceil(queued / workers)` rounds of `drci_poke`'s connect plus
+read timeout (10 s + 30 s per round, and the connect timeout does not bound DNS) — not one poke's
+40 s. Where they are on, a SIGALRM landing in that drain aborts the iteration instead; the queued
+pokes survive it, as above. In `--loop` mode, SIGTERM/SIGINT are observed only between iterations,
+so the per-iteration timeout is what interrupts a hung run.
 
 ## Deployment
 
@@ -227,12 +251,33 @@ hang-guard layers off (the SIGALRM soft timeout and the `os._exit` hard watchdog
 under the Lambda runtime); single-instance and hang-bounding come from
 `reserved_concurrent_executions = 1` and the Lambda function timeout instead.
 
-The handler caps each pass at `--max 30` (`_MAX_DISPATCHES_PER_SCAN`), and
+The handler caps each pass at `--max 30` (`_DEFAULT_MAX_DISPATCHES_PER_SCAN`, changeable on the
+function through `PYTORCH_GREENLIGHT_MAX_DISPATCHES_PER_SCAN` without a redeploy), and
 `greenlight-review.yml`'s `max` input defaults to the same 30. A dispatch costs 3-8 s of serial
 main-thread work, so an uncapped pass over the whole evaluation cohort would both run the Lambda
 out of its 300 s clock and fire an unbounded burst of `workflow_dispatch` POSTs on one token —
 what GitHub's secondary rate limit punishes hardest. Deferring is free: no state row is written
 for a PR the cap never reaches, so the next scan re-evaluates and dispatches it.
+
+The cap also has to cover the poke drain, which is what actually sets the pass's worst case. Taking
+every one of the 30 pokes to `drci_poke`'s full 40 s timeout, across 8 pool workers, against the
+3-8 s dispatch gap `D`:
+
+| `D` | Poke queue | Dispatch phase | Residual drain | Total |
+| --- | --- | --- | --- | --- |
+| 3 s | grows: pokes arrive faster than 8 workers retire them | 87 s | 88 s | 175 s |
+| 5 s | balance point — arrivals match the 8-worker service rate | 145 s | 40 s | 185 s |
+| 8 s | never queues | 232 s | 40 s | 272 s |
+
+At the slow end that leaves about 28 s of the 300 s function timeout for the rest of the pass — the
+PR listing, the ClickHouse state read, the revert guard, and the fingerprint fan-out — so 30 is
+close to the practical ceiling there. At the fast end the same arithmetic puts the ceiling near 50.
+`_max_dispatches_from_env` enforces neither: it validates non-negative and nothing more, so a cap
+set above that range buys extra dispatches at the price of a pass killed mid-flight.
+
+For proportion, the alternative is far worse: taking those same 30 pokes serially in-line, one
+worst-case 40 s each on top of the dispatch gap, puts the pass at roughly 1290-1440 s. The drain is
+a bound worth stating, not a cost the pool introduced.
 
 The scan's Dr. CI poke needs `PYTORCH_GREENLIGHT_DRCI_TOKEN` (and optionally
 `PYTORCH_GREENLIGHT_DRCI_INTERNAL_TOKEN`) wherever the scan runs: the Lambda reads both from its

--- a/greenlight/sql/005_alter_greenlight_pr_state_add_shadow.sql
+++ b/greenlight/sql/005_alter_greenlight_pr_state_add_shadow.sql
@@ -1,0 +1,40 @@
+-- Hand-applied to the live misc.greenlight_pr_state by clee2000/huydhn; automated DDL is
+-- disallowed. Metadata-only ALTER, no data rewrite.
+--
+-- `shadow` marks a row whose evaluation carries no authority: greenlight neither approves the
+-- PR nor lets Dr. CI render the state. It is a stored column rather than a status prefix so the
+-- scan's dedup and next-run-id reads keep matching on `status` unchanged.
+--
+-- Unlike 004, this column is NOT added to the sorting key, which is what makes both modifiers
+-- legal here: ClickHouse rejects a default expression only on a column being appended to the
+-- sort key, and IF NOT EXISTS only forecloses a later MODIFY ORDER BY. DEFAULT false backfills
+-- every existing row as authoritative, which is what they were.
+--
+-- AFTER emit_id, not at the end: `_meta` must stay the last ordinary column, because the
+-- replicator inserts positionally (`SELECT *, (bucket, key) AS _meta` in general_adapter). The
+-- matching `shadow` Bool in greenlight_pr_state_adapter
+-- (aws/lambda/clickhouse-replicator-s3/lambda_function.py) sits in the same position, and that
+-- Lambda auto-deploys on merge to main -- so this DDL must be applied FIRST. Between the two,
+-- inserts fail with NUMBER_OF_COLUMNS_DOESNT_MATCH, which general_adapter swallows into
+-- errors.gen_errors; missed objects are replayable from s3://gha-artifacts/greenlight_pr_state/.
+--
+-- The writer must not run ahead of the adapter either: input_format_skip_unknown_fields = 1
+-- means a `shadow` field the adapter does not declare is dropped without an error.
+--
+-- Two torchci readers reference `shadow` unconditionally in WHERE, and both deploy to Vercel
+-- on merge to main -- so they, too, must not run ahead of this DDL:
+--   * torchci/clickhouse_queries/greenlight_pr_states/query.sql -- Dr. CI's Green Light render;
+--   * torchci/pages/api/greenlight/pr_state.ts -- the /api/greenlight/pr_state route.
+-- Against a table without the column the route's query raises and the handler returns 500.
+-- That route is the ONLY data source for pytorch/pytorch's land-time merge gate
+-- (.github/scripts/greenlight_ledger.py, read by greenlight_guard.py), whose transport budget
+-- is 15 minutes: every merge that greenlight's approval authorizes waits out that quarter hour
+-- and is then DENIED. The gate fails closed, so the blast radius is every greenlight-authorized
+-- merge in the repo, not a degraded render.
+--
+-- Apply this DDL and verify the column is live BEFORE merging either reader. Verify by querying
+-- system.columns for (database = 'misc', table = 'greenlight_pr_state', name = 'shadow') rather
+-- than assuming this file reflects the live table: 002 was never applied to production --
+-- `version` carries no default there.
+ALTER TABLE misc.greenlight_pr_state
+ADD COLUMN IF NOT EXISTS `shadow` Bool DEFAULT false AFTER `emit_id`

--- a/greenlight/src/greenlight/cohort.py
+++ b/greenlight/src/greenlight/cohort.py
@@ -1,0 +1,33 @@
+"""Whose PRs greenlight reviews, and whose word can point it at one.
+
+``TRUSTED_AUTHORS`` answers both today: the listing scan matches on it, and both authz gates --
+the ``--pr`` target author and the ``@greenlight recheck`` requester -- are checked against it.
+It sits in a module of its own rather than inside the scan, so a caller that needs the membership
+answer does not have to import the scan to get it.
+"""
+
+from __future__ import annotations
+
+__all__ = ["TRUSTED_AUTHORS", "is_trusted"]
+
+TRUSTED_AUTHORS: set[str] = {
+    "albanD",  # Alban Desmaison
+    "jathu",  # Jathu Satkunarajah
+    "atalman",  # Andrey Talman
+    "huydhn",  # Huy Do
+    "izaitsevfb",  # Ivan Zaitsev
+    "georgehong",  # George Hong
+    "jeanschmidt",  # Jean Schmidt
+    "ezyang",  # Edward Yang
+    "drisspg",  # Driss Guessous
+    "janeyx99",  # Jane Xu
+    "bobrenjc93",  # Bob Ren
+}
+
+# Case-insensitive membership for the two authz gates (target-PR author and recheck requester);
+# GitHub logins are case-insensitive, so gate on the lowercased login against this derived set.
+_TRUSTED_LOWER: frozenset[str] = frozenset(author.lower() for author in TRUSTED_AUTHORS)
+
+
+def is_trusted(login: str | None) -> bool:
+    return login is not None and login.lower() in _TRUSTED_LOWER

--- a/greenlight/src/greenlight/cohort.py
+++ b/greenlight/src/greenlight/cohort.py
@@ -10,19 +10,21 @@ from __future__ import annotations
 
 __all__ = ["TRUSTED_AUTHORS", "is_trusted"]
 
-TRUSTED_AUTHORS: set[str] = {
-    "albanD",  # Alban Desmaison
-    "jathu",  # Jathu Satkunarajah
-    "atalman",  # Andrey Talman
-    "huydhn",  # Huy Do
-    "izaitsevfb",  # Ivan Zaitsev
-    "georgehong",  # George Hong
-    "jeanschmidt",  # Jean Schmidt
-    "ezyang",  # Edward Yang
-    "drisspg",  # Driss Guessous
-    "janeyx99",  # Jane Xu
-    "bobrenjc93",  # Bob Ren
-}
+TRUSTED_AUTHORS: frozenset[str] = frozenset(
+    {
+        "albanD",  # Alban Desmaison
+        "jathu",  # Jathu Satkunarajah
+        "atalman",  # Andrey Talman
+        "huydhn",  # Huy Do
+        "izaitsevfb",  # Ivan Zaitsev
+        "georgehong",  # George Hong
+        "jeanschmidt",  # Jean Schmidt
+        "ezyang",  # Edward Yang
+        "drisspg",  # Driss Guessous
+        "janeyx99",  # Jane Xu
+        "bobrenjc93",  # Bob Ren
+    }
+)
 
 # Case-insensitive membership for the two authz gates (target-PR author and recheck requester);
 # GitHub logins are case-insensitive, so gate on the lowercased login against this derived set.

--- a/greenlight/src/greenlight/drci_poke.py
+++ b/greenlight/src/greenlight/drci_poke.py
@@ -14,12 +14,21 @@ re-renders the comment from the state the poke was meant to replace.
 The poke swallows every failure. By the time it runs the merge gate has already fired and the state
 row is uploaded, so a failure has nothing left to protect: raising would only turn the job that
 gates auto-landing red over a cosmetic refresh, and the scheduled sweep still backstops a lost poke.
-``IterationTimeout`` is the one exception: it is the caller's per-iteration watchdog signal, not a
-poke failure, and swallowing it would strand the scan past its deadline because SIGALRM is one-shot.
+``IterationTimeout`` is carved out of that anyway, so the swallow stays a policy about poke failures
+rather than about anything a caller might raise through it: it is a per-iteration watchdog signal,
+and only its own caller can decide whether to abort on one. No current caller can deliver it here --
+the scan pokes from a pool worker, which SIGALRM never reaches, and the ``drci-poke`` subcommand
+runs outside the iteration guards entirely -- so the carve-out costs nothing and holds if either
+moves back onto a guarded main thread.
+
+A caller that cannot afford to wait on any of that pokes through ``poke_submitter`` instead: a seam
+that hands each poke to a thread pool and returns immediately. The pool stays the caller's -- so does
+the drain that makes ``POKE_WORKERS`` bound the worst case -- and the submitter only wraps it.
 """
 
 from __future__ import annotations
 
+import functools
 import logging
 import time
 from typing import TYPE_CHECKING
@@ -30,10 +39,11 @@ from greenlight.guards import IterationTimeout
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from concurrent.futures import Future, ThreadPoolExecutor
 
     from greenlight.config import Config
 
-__all__ = ["poke"]
+__all__ = ["POKE_WORKERS", "poke", "poke_submitter"]
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +60,14 @@ _CONNECT_TIMEOUT_SECONDS = 10.0
 _READ_TIMEOUT_SECONDS = 30.0
 
 _SUCCESS_STATUSES: frozenset[int] = frozenset(range(200, 300))
+
+# Width, not a rate limit, and it does not need to be one: the scan submits at most one poke per
+# dispatch and a dispatch costs 3-8s of serial main-thread work, so steady-state concurrency against
+# the shared Dr. CI endpoint is about one. All 8 slots fill only when the endpoint is already
+# answering slower than the scan dispatches -- exactly when width earns its keep, because the pool is
+# drained before the scan returns and its width is what bounds that drain: a hung endpoint holds the
+# scan open for ceil(queued / workers) rounds of the timeouts above.
+POKE_WORKERS = 8
 
 
 def _default_post(url: str, body: bytes, headers: dict[str, str]) -> int:
@@ -72,8 +90,9 @@ def poke(
 ) -> None:
     """Wait out the ingestion delay, then POST one refresh request for ``repo``#``pr_number``.
 
-    Logs and swallows every failure, including a non-2xx response. ``IterationTimeout`` still
-    propagates so the caller's per-iteration watchdog can abort.
+    Logs and swallows every failure, including a non-2xx response. ``IterationTimeout`` is excluded
+    from that: it belongs to the caller's watchdog, not to the poke. Neither current call path can
+    raise one here (see the module docstring).
     """
     org, _, name = repo.partition("/")
     if not org or not name:
@@ -108,3 +127,45 @@ def poke(
         # An auth failure answers 500, not 403 -- the endpoint's auth branch sits outside its
         # try/catch -- so the status code cannot classify the failure. Log it and move on.
         logger.error("Dr. CI poke for %s#%d returned HTTP %d", repo, pr_number, status)
+
+
+def _log_poke_outcome(pr_number: int, future: Future[None]) -> None:
+    # Unlike asyncio, concurrent.futures never reports an unretrieved exception; a poke that fails
+    # somewhere poke does not already log would otherwise leave no trace at all.
+    error = future.exception()
+    if error is not None:
+        logger.error("Dr. CI poke for PR #%d failed: %s", pr_number, error, exc_info=error)
+
+
+def poke_submitter(
+    pool: ThreadPoolExecutor, repo: str, poke_drci: Callable[[str, int, Config], None], config: Config
+) -> Callable[[int], None]:
+    """Build the scan's poke seam: hand each poke to ``pool`` and return without waiting for it.
+
+    Off the main thread a poke is out of ``guards.iteration_timeout``'s reach -- SIGALRM is delivered
+    to the main thread only -- and the pool is drained on the way out, so an unresponsive endpoint
+    overruns the deadline by however long the whole queue takes to clear: ceil(queued / workers)
+    rounds of the connect plus read timeout, not one poke's. Every local path pays that;
+    ``runner._bounded_iteration`` arms both guards for ``execute_once`` as well as ``run_forever``.
+    Only the Lambda escapes it, by setting the max runtime to zero.
+    """
+
+    def submit(pr_number: int) -> None:
+        try:
+            future = pool.submit(poke_drci, repo, pr_number, config)
+        except IterationTimeout:
+            # submit runs on the main thread, so the scan's own deadline can fire inside it, and
+            # IterationTimeout subclasses TimeoutError -> OSError -> Exception. Absorbed below as a
+            # scheduling failure it would leave the iteration running with its one-shot SIGALRM
+            # already spent -- no soft deadline left, and nothing to show the watchdog signal fired.
+            raise
+        except Exception as exc:
+            # Both callers invoke this seam outside their own try blocks, which is safe only because
+            # poke swallows everything. submit does not -- a shut-down pool, or a worker thread that
+            # will not start, raises -- and an escape here would halt the scan mid-loop over a
+            # cosmetic refresh.
+            logger.error("failed to schedule Dr. CI poke for PR #%d: %s", pr_number, exc, exc_info=True)
+            return
+        future.add_done_callback(functools.partial(_log_poke_outcome, pr_number))
+
+    return submit

--- a/greenlight/src/greenlight/lambda_handler.py
+++ b/greenlight/src/greenlight/lambda_handler.py
@@ -38,6 +38,12 @@ _TOKEN_PERMISSIONS = {
 }
 _TOKEN_REPOSITORIES = ["pytorch", "test-infra"]
 
+# A dispatch costs 3-8s of serial main-thread work, and the Lambda function times out at 300s: an
+# uncapped scan against the full evaluation cohort would run out of clock mid-pass. Deferring is
+# free -- no state row is written for a deferred PR, so the next tick re-evaluates and dispatches
+# it -- while overrunning the timeout kills the scan after arbitrary partial work.
+_MAX_DISPATCHES_PER_SCAN = 30
+
 
 def _require_env(name: str) -> str:
     value = os.environ.get(name)
@@ -123,7 +129,7 @@ def handler(event: dict[str, object], context: object) -> dict[str, str]:  # noq
     # No PYTORCH_GREENLIGHT_LOCK_PATH is set: Lambda's reserved_concurrent_executions = 1 already
     # guarantees single-flight, so the in-process fcntl lock is intentionally absent and the
     # EXIT_ALREADY_RUNNING branch below is only defensive/forward-compat.
-    rc = cli.main(["review", "--ref", "main"])
+    rc = cli.main(["review", "--ref", "main", "--max", str(_MAX_DISPATCHES_PER_SCAN)])
     if rc == EXIT_OK:
         return {"status": "ok"}
     if rc == EXIT_ALREADY_RUNNING:

--- a/greenlight/src/greenlight/lambda_handler.py
+++ b/greenlight/src/greenlight/lambda_handler.py
@@ -42,7 +42,8 @@ _TOKEN_REPOSITORIES = ["pytorch", "test-infra"]
 # uncapped scan against the full evaluation cohort would run out of clock mid-pass. Deferring is
 # free -- no state row is written for a deferred PR, so the next tick re-evaluates and dispatches
 # it -- while overrunning the timeout kills the scan after arbitrary partial work.
-_MAX_DISPATCHES_PER_SCAN = 30
+_DEFAULT_MAX_DISPATCHES_PER_SCAN = 30
+_MAX_DISPATCHES_ENV = "PYTORCH_GREENLIGHT_MAX_DISPATCHES_PER_SCAN"
 
 
 def _require_env(name: str) -> str:
@@ -56,6 +57,23 @@ def _require_key(mapping: dict[str, str], key: str, source: str) -> str:
     if key not in mapping:
         raise ValueError(f"{source} is missing required key {key!r}")
     return mapping[key]
+
+
+def _max_dispatches_from_env() -> int:
+    raw = os.environ.get(_MAX_DISPATCHES_ENV, "").strip()
+    if not raw:
+        return _DEFAULT_MAX_DISPATCHES_PER_SCAN
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{_MAX_DISPATCHES_ENV} must be an integer, got {raw!r}") from exc
+    # Zero is a deliberate pause switch: the scan still lists and still revokes its approval on a
+    # reverted PR, it just fingerprints and dispatches nothing. A negative magnitude means the same
+    # thing once the scan clamps it, so it can only be a typo -- and one whose symptom is a silent
+    # stall. "-0" is not that typo and is accepted: it parses to zero because it is zero.
+    if value < 0:
+        raise ValueError(f"{_MAX_DISPATCHES_ENV} must not be negative, got {value}")
+    return value
 
 
 def _require_clickhouse_host() -> None:
@@ -112,6 +130,7 @@ def handler(event: dict[str, object], context: object) -> dict[str, str]:  # noq
     installation_id = int(_require_env("GITHUB_INSTALLATION_ID"))
     _require_env("CLICKHOUSE_USERNAME")
     _require_clickhouse_host()
+    max_dispatches = _max_dispatches_from_env()
 
     secret = _load_secret(secret_store_name)
     secret_source = f"secret {secret_store_name!r}"
@@ -129,7 +148,7 @@ def handler(event: dict[str, object], context: object) -> dict[str, str]:  # noq
     # No PYTORCH_GREENLIGHT_LOCK_PATH is set: Lambda's reserved_concurrent_executions = 1 already
     # guarantees single-flight, so the in-process fcntl lock is intentionally absent and the
     # EXIT_ALREADY_RUNNING branch below is only defensive/forward-compat.
-    rc = cli.main(["review", "--ref", "main", "--max", str(_MAX_DISPATCHES_PER_SCAN)])
+    rc = cli.main(["review", "--ref", "main", "--max", str(max_dispatches)])
     if rc == EXIT_OK:
         return {"status": "ok"}
     if rc == EXIT_ALREADY_RUNNING:

--- a/greenlight/src/greenlight/revert_guard.py
+++ b/greenlight/src/greenlight/revert_guard.py
@@ -126,6 +126,7 @@ def _revoke_and_record(
             pr_number=number,
             head_sha=pr.head.sha,
             run_id=next_run_id(recorded_state),
+            shadow=False,
         )
     except IterationTimeout:
         raise

--- a/greenlight/src/greenlight/review.py
+++ b/greenlight/src/greenlight/review.py
@@ -27,7 +27,7 @@ import threading
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
-from greenlight import candidate_filter, drci_poke, github_client, revert_guard, scan_runner, state, state_emit
+from greenlight import candidate_filter, cohort, drci_poke, github_client, revert_guard, scan_runner, state, state_emit
 from greenlight import dispatch as dispatch_module
 from greenlight.constants import (
     DEFAULT_DISPATCH_REF,
@@ -56,29 +56,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-TRUSTED_AUTHORS: set[str] = {
-    "albanD",  # Alban Desmaison
-    "jathu",  # Jathu Satkunarajah
-    "atalman",  # Andrey Talman
-    "huydhn",  # Huy Do
-    "izaitsevfb",  # Ivan Zaitsev
-    "georgehong",  # George Hong
-    "jeanschmidt",  # Jean Schmidt
-    "ezyang",  # Edward Yang
-    "drisspg",  # Driss Guessous
-    "janeyx99",  # Jane Xu
-    "bobrenjc93",  # Bob Ren
-}
-
-# Case-insensitive membership for the two authz gates (target-PR author and recheck requester);
-# GitHub logins are case-insensitive, so gate on the lowercased login against this derived set.
-_TRUSTED_LOWER: frozenset[str] = frozenset(author.lower() for author in TRUSTED_AUTHORS)
-
-
-def _is_trusted(login: str | None) -> bool:
-    return login is not None and login.lower() in _TRUSTED_LOWER
-
-
 # Aggregate fan-out request rate is workers / seconds-between-requests: more workers or a
 # shorter interval raise it. Cutting workers (8->4) and lengthening the interval (0.25s->0.5s)
 # both lower it, to ~8 req/s, keeping the fan-out under GitHub's secondary (burst-rate) limit
@@ -95,7 +72,7 @@ def _utcnow() -> datetime:
 
 
 def _default_fetch(client: Github) -> list[OpenPR]:
-    return github_client.list_open_prs_by_authors(client, TARGET_REPO, TRUSTED_AUTHORS)
+    return github_client.list_open_prs_by_authors(client, TARGET_REPO, cohort.TRUSTED_AUTHORS)
 
 
 def _default_fetch_author(client: Github, pr_number: int) -> str | None:
@@ -138,9 +115,9 @@ def _candidate_numbers(
         logger.info("targeting single PR #%d in %s", pr, TARGET_REPO)
         return [pr], {}, {}
     open_prs = fetch(client)
-    logger.info("found %d open PR(s) from %d author(s) in %s", len(open_prs), len(TRUSTED_AUTHORS), TARGET_REPO)
+    logger.info("found %d open PR(s) from %d author(s) in %s", len(open_prs), len(cohort.TRUSTED_AUTHORS), TARGET_REPO)
     for open_pr in open_prs:
-        logger.info("open PR #%d by %s: %s (%s)", open_pr.number, open_pr.author, open_pr.title, open_pr.url)
+        logger.debug("open PR #%d by %s: %s (%s)", open_pr.number, open_pr.author, open_pr.title, open_pr.url)
     return (
         [open_pr.number for open_pr in open_prs],
         {open_pr.number: open_pr.updated_at for open_pr in open_prs},
@@ -185,7 +162,7 @@ def run(
     # so a spammed @greenlight recheck from an untrusted login costs nothing. A policy refusal is
     # not a failure -- return cleanly rather than raising (no non-zero exit, no daemon backoff).
     if requester is not None:
-        if not _is_trusted(requester):
+        if not cohort.is_trusted(requester):
             logger.warning("refusing review: requester %r is not a trusted author", requester)
             return
         logger.info("review requested by trusted author %s", requester)
@@ -197,7 +174,7 @@ def run(
         # allow_untrusted_author bypasses ONLY this check (local iteration; never a workflow input).
         if pr is not None and not allow_untrusted_author:
             author = fetch_author(client, pr)
-            if not _is_trusted(author):
+            if not cohort.is_trusted(author):
                 logger.warning("refusing --pr %d: author %r is not a trusted author", pr, author)
                 return
         # Resolved once per scan and never caught here: a cold failure must fail the scan (one-shot
@@ -218,8 +195,8 @@ def run(
         cancel_event = threading.Event()
         # drci_poke's configured delay covers the verdict path's gap between writing the row to /tmp
         # and a later workflow step uploading it. Both emits below have already PUT the object to S3
-        # before returning, and neither loop is capped, so keeping the wait would only multiply one
-        # sleep per PR into the Lambda's function timeout.
+        # before returning, so the wait buys nothing here and one such sleep per PR would multiply
+        # into the Lambda's function timeout.
         poke_config = dataclasses.replace(config, drci_poke_delay_seconds=0.0)
         excluded = revert_guard.exclude_reverted(
             client,

--- a/greenlight/src/greenlight/review.py
+++ b/greenlight/src/greenlight/review.py
@@ -24,6 +24,7 @@ import dataclasses
 import logging
 import queue
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
@@ -198,6 +199,13 @@ def run(
         # before returning, so the wait buys nothing here and one such sleep per PR would multiply
         # into the Lambda's function timeout.
         poke_config = dataclasses.replace(config, drci_poke_delay_seconds=0.0)
+        # Entered on the ExitStack so the drain is __exit__-driven. AWS Lambda freezes the execution
+        # environment the instant the handler returns, so an unjoined poke thread would not finish
+        # here -- it would thaw and log its outcome inside some later invocation instead.
+        poke_pool = clients.enter_context(
+            ThreadPoolExecutor(max_workers=drci_poke.POKE_WORKERS, thread_name_prefix="greenlight-poke")
+        )
+        poke = drci_poke.poke_submitter(poke_pool, TARGET_REPO, poke_drci, poke_config)
         excluded = revert_guard.exclude_reverted(
             client,
             pr_numbers,
@@ -209,7 +217,7 @@ def run(
             get_pr=get_pr,
             dismiss=dismiss_approvals,
             emit=emit_reverted,
-            poke=lambda number: poke_drci(TARGET_REPO, number, poke_config),
+            poke=poke,
             failed=failed,
             cancel_event=cancel_event,
         )
@@ -295,7 +303,7 @@ def run(
                 max_dispatches=max_dispatches,
                 dispatch=dispatch,
                 emit_dispatched=emit_dispatched,
-                poke=lambda number: poke_drci(TARGET_REPO, number, poke_config),
+                poke=poke,
             )
         # Only the --pr recheck path posts refusals; a listing-scan skip is dropped silently
         # (already logged). skips can hold a refusal only when skip_on_approval is False (--pr),

--- a/greenlight/src/greenlight/scan_runner.py
+++ b/greenlight/src/greenlight/scan_runner.py
@@ -279,6 +279,7 @@ def _emit_dispatch_marker(
             head_sha=candidate.head_sha,
             eval_hash=candidate.eval_hash,
             run_id=next_run_id(candidate.state),
+            shadow=False,
         )
     except IterationTimeout:
         raise

--- a/greenlight/src/greenlight/scan_runner.py
+++ b/greenlight/src/greenlight/scan_runner.py
@@ -9,7 +9,7 @@ filter, and client lifecycle, and drives these helpers.
 from __future__ import annotations
 
 import logging
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum, auto
@@ -214,32 +214,42 @@ def _fingerprint_until_dispatchable(
     force: bool,
     cancel_event: threading.Event,
 ) -> list[_Candidate]:
+    """Fingerprint the stalest PRs first, submitting only until ``limit`` candidates are in hand.
+
+    The pool is kept saturated: each completion frees its slot immediately, so no task ever waits
+    on a slower sibling. Submission stops the moment the cap is reached or the fan-out is
+    cancelled, but whatever is already in flight is still evaluated -- its GitHub call is already
+    paid for, and dropping the result would lose a failure or a human-decision skip.
+    """
     ranked = sorted(pr_numbers, key=lambda number: _staleness_key_for_state(states.get(number)))
-    pending: list[_Candidate] = []
+    found: dict[int, _Candidate] = {}
     if worker_count:
+        queued = iter(ranked)
+        in_flight: dict[Future[tuple[str, str] | ReviewSkip | _Cancelled], int] = {}
         with ThreadPoolExecutor(max_workers=worker_count) as pool:
-            for start in range(0, len(ranked), worker_count):
-                if len(pending) >= limit:
-                    break
-                if cancel_event.is_set():
-                    break
-                batch = ranked[start : start + worker_count]
-                futures = {
-                    number: pool.submit(
+            while True:
+                while len(in_flight) < worker_count and len(found) < limit and not cancel_event.is_set():
+                    queued_number = next(queued, None)
+                    if queued_number is None:
+                        break
+                    task = pool.submit(
                         _fingerprint_task,
                         fingerprint,
                         client_pool,
-                        number,
+                        queued_number,
                         authorized_logins,
                         skip_on_approval,
                         cancel_event,
                     )
-                    for number in batch
-                }
-                for number in batch:
+                    in_flight[task] = queued_number
+                if not in_flight:
+                    break
+                done, _unfinished = wait(in_flight, return_when=FIRST_COMPLETED)
+                for future in done:
+                    number = in_flight.pop(future)
                     candidate = _evaluate_pr(
                         number,
-                        futures[number],
+                        future,
                         states,
                         now=now,
                         timeout=timeout,
@@ -249,8 +259,11 @@ def _fingerprint_until_dispatchable(
                         force=force,
                     )
                     if candidate is not None:
-                        pending.append(candidate)
-    return pending
+                        found[number] = candidate
+    # Ranked order, not completion order: the dispatch cap is applied by a stable staleness sort,
+    # so returning these in whichever order the pool happened to finish would hand the last slot
+    # to the fastest task rather than the stalest PR.
+    return [found[number] for number in ranked if number in found]
 
 
 def _emit_dispatch_marker(

--- a/greenlight/src/greenlight/state.py
+++ b/greenlight/src/greenlight/state.py
@@ -18,6 +18,14 @@ with a later ``version`` still loses to the newer dispatch's higher ``run_id``.
 
 ``next_run_id`` is the write-side counterpart of that selection: it is what every scan-written
 row stamps to become the row these reads return.
+
+Both reads here are deliberately shadow-UNfiltered, and that is the one place this reader
+diverges from the two HUD readers (Dr. CI's ``greenlight_pr_states`` query and the
+``/api/greenlight/pr_state`` route), which both filter ``shadow = false`` in ``WHERE``. Those two
+answer "does an authoritative verdict exist"; this one answers "has a review already been
+dispatched, and at what ``run_id``". Filtering here would blind the scan to its own shadow
+markers, so every shadow PR would read as never-dispatched and be re-dispatched on every scan,
+forever.
 """
 
 from __future__ import annotations

--- a/greenlight/src/greenlight/state_emit.py
+++ b/greenlight/src/greenlight/state_emit.py
@@ -1,8 +1,11 @@
 """Build and emit a ``misc.greenlight_pr_state`` row to S3 for replicator ingestion.
 
 Two producers write state rows and MUST agree byte-for-byte on the JSONEachRow field
-order/values and the object-key layout, or the positional S3 -> ClickHouse replicator
-silently drops rows. This module is that single source: ``emit_row`` serializes the row and
+order/values and the object-key layout. A skew against the S3 -> ClickHouse replicator's
+adapter schema does not misalign the insert -- the positional ``SELECT *`` raises
+``NUMBER_OF_COLUMNS_DOESNT_MATCH`` -- but the loss is silent all the same: the replicator's
+``general_adapter`` swallows that error into ``errors.gen_errors``, which nothing alerts on,
+and the row never lands. This module is that single source: ``emit_row`` serializes the row and
 ``object_key`` computes its bucket-relative key. The ``verdict`` command feeds its rows
 through here; the scan emits two marker rows of its own. ``emit_ai_review_dispatched`` fires
 the instant the reviewer workflow is dispatched, so a queued run (which can sit in GitHub's
@@ -62,6 +65,7 @@ def emit_row(
     eval_job: str,
     agent_job: str,
     run_id: int,
+    shadow: bool,
     now: Callable[[], datetime],
     emit: Callable[[bytes, str], None],
     new_emit_id: Callable[[], str],
@@ -70,6 +74,9 @@ def emit_row(
 
     Field order and values are the replicator contract; ``emit`` receives ``(gzip_bytes, key)``
     where ``key`` is the bucket-relative object key. Returns that key for logging.
+
+    ``shadow`` has no default anywhere on this path: an unstamped row would read as authoritative
+    to the merge gate and to Dr. CI, so every writer is forced to state which cohort it is in.
     """
     version = now().replace(tzinfo=None).isoformat(sep=" ", timespec="milliseconds")
     # emit_id is a fresh per-emit UUID that uniquifies both storage keys: the ClickHouse sort key
@@ -90,6 +97,7 @@ def emit_row(
         "version": version,
         "run_id": run_id,
         "emit_id": emit_id,
+        "shadow": shadow,
     }
     line = json.dumps(row, separators=(",", ":"), ensure_ascii=False) + "\n"
     key = object_key(repo, pr_number, version, emit_id)
@@ -120,6 +128,7 @@ def _emit_marker(
     status: str,
     eval_hash: str,
     run_id: int,
+    shadow: bool,
     upload: Callable[[bytes, str], None] | None,
 ) -> None:
     """Emit one scan-written marker row: reason/message and the job URLs are always empty."""
@@ -134,6 +143,7 @@ def _emit_marker(
         eval_job="",
         agent_job="",
         run_id=run_id,
+        shadow=shadow,
         now=_utcnow,
         emit=upload if upload is not None else _default_upload,
         new_emit_id=default_emit_id,
@@ -147,6 +157,7 @@ def emit_ai_review_dispatched(
     head_sha: str,
     eval_hash: str,
     run_id: int,
+    shadow: bool,
     upload: Callable[[bytes, str], None] | None = None,
 ) -> None:
     """Emit an ``AI_REVIEW_DISPATCHED`` row the instant the scan fires the reviewer workflow.
@@ -162,6 +173,7 @@ def emit_ai_review_dispatched(
         status=STATUS_AI_REVIEW_DISPATCHED,
         eval_hash=eval_hash,
         run_id=run_id,
+        shadow=shadow,
         upload=upload,
     )
 
@@ -172,13 +184,14 @@ def emit_reverted(
     pr_number: int,
     head_sha: str,
     run_id: int,
+    shadow: bool,
     upload: Callable[[bytes, str], None] | None = None,
 ) -> None:
     """Emit the ``REVERTED`` row that permanently excludes a PR from review.
 
     ``eval_hash`` is empty: no fingerprint is computed for an excluded PR, and an empty hash can
-    never match one a land-time verifier recomputes. ``run_id`` and ``upload`` behave as for
-    ``emit_ai_review_dispatched``.
+    never match one a land-time verifier recomputes. ``run_id``, ``shadow`` and ``upload`` behave
+    as for ``emit_ai_review_dispatched``.
     """
     _emit_marker(
         repo=repo,
@@ -187,5 +200,6 @@ def emit_reverted(
         status=STATUS_REVERTED,
         eval_hash="",
         run_id=run_id,
+        shadow=shadow,
         upload=upload,
     )

--- a/greenlight/src/greenlight/verdict.py
+++ b/greenlight/src/greenlight/verdict.py
@@ -209,6 +209,7 @@ def _emit_payload(
         eval_job=request.eval_job_url,
         agent_job=request.agent_job_url,
         run_id=request.run_id or 0,
+        shadow=False,
         now=now,
         emit=emit,
         new_emit_id=new_emit_id,

--- a/greenlight/tests/test_cohort.py
+++ b/greenlight/tests/test_cohort.py
@@ -1,0 +1,45 @@
+import pytest
+
+from greenlight import cohort
+
+# The authorization boundary the two authz gates enforce. Pinned here so widening it is a
+# deliberate two-place edit rather than a typo.
+_PINNED_TRUSTED_AUTHORS = {
+    "albanD",
+    "jathu",
+    "atalman",
+    "huydhn",
+    "izaitsevfb",
+    "georgehong",
+    "jeanschmidt",
+    "ezyang",
+    "drisspg",
+    "janeyx99",
+    "bobrenjc93",
+}
+
+
+def test_trusted_authors_membership_is_pinned():
+    assert cohort.TRUSTED_AUTHORS == _PINNED_TRUSTED_AUTHORS
+
+
+def test_trusted_lower_is_lowercase_and_collision_free():
+    # A pair of authors differing only in case would silently shrink the gate by one.
+    assert all(login == login.lower() for login in cohort._TRUSTED_LOWER)
+    assert len(cohort._TRUSTED_LOWER) == len(cohort.TRUSTED_AUTHORS)
+
+
+@pytest.mark.parametrize(
+    ("login", "expected"),
+    [
+        pytest.param("ezyang", True, id="exact-login"),
+        pytest.param("EZYANG", True, id="uppercased"),
+        pytest.param("albanD", True, id="canonical-mixed-case"),
+        pytest.param("aLBAnd", True, id="mixed-case-login-cased-differently"),
+        pytest.param("octocat", False, id="stranger"),
+        pytest.param("", False, id="empty"),
+        pytest.param(None, False, id="absent"),
+    ],
+)
+def test_is_trusted(login: str | None, expected: bool) -> None:
+    assert cohort.is_trusted(login) is expected

--- a/greenlight/tests/test_cohort.py
+++ b/greenlight/tests/test_cohort.py
@@ -23,6 +23,13 @@ def test_trusted_authors_membership_is_pinned():
     assert cohort.TRUSTED_AUTHORS == _PINNED_TRUSTED_AUTHORS
 
 
+def test_trusted_authors_is_immutable():
+    # _TRUSTED_LOWER snapshots this set at import time, so a post-import mutation would never
+    # reach is_trusted: it could widen the gates' source, or revoke from it, without moving the
+    # gates themselves, with nothing anywhere raising.
+    assert isinstance(cohort.TRUSTED_AUTHORS, frozenset)
+
+
 def test_trusted_lower_is_lowercase_and_collision_free():
     # A pair of authors differing only in case would silently shrink the gate by one.
     assert all(login == login.lower() for login in cohort._TRUSTED_LOWER)

--- a/greenlight/tests/test_drci_poke.py
+++ b/greenlight/tests/test_drci_poke.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import logging
-from typing import NoReturn
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING, NoReturn, cast
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -9,6 +10,9 @@ import pytest
 from greenlight import drci_poke
 from greenlight.constants import DRCI_ENDPOINT
 from greenlight.guards import IterationTimeout
+
+if TYPE_CHECKING:
+    from greenlight.config import Config
 
 
 class _Recorder:
@@ -295,3 +299,70 @@ def test_poke_default_seams_are_real_sleep_and_post():
     defaults = inspect.signature(drci_poke.poke).parameters
     assert defaults["sleep"].default is time.sleep
     assert defaults["post"].default is drci_poke._default_post
+
+
+class _RefusingPool:
+    """Stands in for the poke pool when ``submit`` cannot take the work and raises instead."""
+
+    def __init__(self, error: BaseException) -> None:
+        self._error = error
+
+    def submit(self, *_args: object, **_kwargs: object) -> NoReturn:
+        raise self._error
+
+
+def _boom_poke(repo: str, pr_number: int, config: Config) -> NoReturn:
+    raise AssertionError("poke should not be called")
+
+
+def test_poke_submitter_logs_a_refused_submit_and_returns(poke_config, caplog):
+    poked: list[int] = []
+
+    def record_poke(repo: str, pr_number: int, config: Config) -> None:
+        poked.append(pr_number)
+
+    shut_down = RuntimeError("cannot schedule new futures after shutdown")
+    submit = drci_poke.poke_submitter(
+        cast("ThreadPoolExecutor", _RefusingPool(shut_down)), "pytorch/pytorch", record_poke, poke_config()
+    )
+
+    with caplog.at_level(logging.ERROR, logger="greenlight"):
+        submit(1)
+        submit(2)
+
+    # Both callers invoke this seam outside their own try blocks, which only holds because the poke
+    # swallows everything. Handing it to a pool does not: submit raises on a shut-down executor or a
+    # thread that will not start, and letting that escape would halt the scan mid-dispatch-loop.
+    assert poked == []
+    assert "failed to schedule Dr. CI poke for PR #1" in caplog.text
+    assert "failed to schedule Dr. CI poke for PR #2" in caplog.text
+
+
+def test_poke_submitter_lets_the_iteration_timeout_through(poke_config):
+    submit = drci_poke.poke_submitter(
+        cast("ThreadPoolExecutor", _RefusingPool(IterationTimeout("deadline"))),
+        "pytorch/pytorch",
+        _boom_poke,
+        poke_config(),
+    )
+
+    # The soft deadline arrives as SIGALRM raised on whatever the main thread is running, submit
+    # included, and IterationTimeout subclasses TimeoutError -> OSError -> Exception. Logged as a
+    # scheduling failure it would be indistinguishable from a full pool, and the one-shot timer would
+    # already be spent -- the rest of the pass would run with no soft deadline at all.
+    with pytest.raises(IterationTimeout):
+        submit(1)
+
+
+def test_poke_submitter_logs_a_failure_raised_inside_the_pool(poke_config, caplog):
+    def exploding_poke(repo: str, pr_number: int, config: Config) -> NoReturn:
+        raise RuntimeError(f"drci unreachable for #{pr_number}")
+
+    with caplog.at_level(logging.ERROR, logger="greenlight"), ThreadPoolExecutor(max_workers=1) as pool:
+        drci_poke.poke_submitter(pool, "pytorch/pytorch", exploding_poke, poke_config())(1)
+
+    # A future parks an unretrieved exception silently forever, so the outcome is read back in a done
+    # callback -- off-thread, the poke's own logging is the only other thing standing between a
+    # failure and total silence. It stays out of the scan's end-of-pass error aggregation either way:
+    # the poke is cosmetic and must never turn a scan red over a comment refresh.
+    assert "Dr. CI poke for PR #1 failed: drci unreachable for #1" in caplog.text

--- a/greenlight/tests/test_lambda_handler.py
+++ b/greenlight/tests/test_lambda_handler.py
@@ -21,7 +21,9 @@ _SECRET_STORE = "greenlight/prod"
 _APP_ID = "123456"
 _INSTALLATION_ID = 42
 _APP_SLUG = "pytorchgreenlight"
-_EXPECTED_ARGV = ["review", "--ref", "main"]
+# Pinned, not derived from the handler's constant: the cap exists to keep a cold-start scan inside
+# the 300s Lambda timeout, so raising it must be a deliberate two-place edit.
+_EXPECTED_ARGV = ["review", "--ref", "main", "--max", "30"]
 _EXPECTED_PERMISSIONS = {
     "actions": "write",
     "pull_requests": "write",
@@ -99,6 +101,19 @@ def test_handler_happy_path(monkeypatch, fakes):
     fake_github.GithubIntegration.return_value.get_app.assert_called_once_with()
 
     main_mock.assert_called_once_with(_EXPECTED_ARGV)
+
+
+def test_handler_caps_dispatches_per_scan(monkeypatch, fakes):
+    main_mock = Mock(return_value=EXIT_OK)
+    monkeypatch.setattr(cli, "main", main_mock)
+
+    lambda_handler.handler({}, object())
+
+    # The scheduled scan is the one path with a hard wall-clock budget, so it must never run
+    # uncapped: an uncapped pass over the evaluation cohort would spend the whole function timeout
+    # on serial workflow_dispatch POSTs and be killed mid-scan.
+    argv = main_mock.call_args.args[0]
+    assert argv[argv.index("--max") + 1] == str(lambda_handler._MAX_DISPATCHES_PER_SCAN)
 
 
 @pytest.mark.parametrize("slug", [pytest.param("", id="empty"), pytest.param(None, id="absent")])

--- a/greenlight/tests/test_lambda_handler.py
+++ b/greenlight/tests/test_lambda_handler.py
@@ -21,8 +21,11 @@ _SECRET_STORE = "greenlight/prod"
 _APP_ID = "123456"
 _INSTALLATION_ID = 42
 _APP_SLUG = "pytorchgreenlight"
-# Pinned, not derived from the handler's constant: the cap exists to keep a cold-start scan inside
-# the 300s Lambda timeout, so raising it must be a deliberate two-place edit.
+_MAX_ENV = lambda_handler._MAX_DISPATCHES_ENV
+# Pinned, not derived from the handler's constant: the default cap exists to keep a cold-start scan
+# inside the 300s Lambda timeout, so raising it must be a deliberate two-place edit. The env var's
+# name is not pinned the same way -- renaming it is already a deployment-visible break that no
+# assertion here can catch, and a second literal would only drift.
 _EXPECTED_ARGV = ["review", "--ref", "main", "--max", "30"]
 _EXPECTED_PERMISSIONS = {
     "actions": "write",
@@ -50,6 +53,7 @@ def fakes(monkeypatch):
     monkeypatch.setenv("CLICKHOUSE_USERNAME", _CH_USERNAME)
     monkeypatch.setenv("CLICKHOUSE_HOST", _CH_HOST)
     monkeypatch.delenv("CLICKHOUSE_ENDPOINT", raising=False)
+    monkeypatch.delenv(_MAX_ENV, raising=False)
 
     secret_json = json.dumps({"GITHUB_APP_SECRET": _PEM_B64, "CLICKHOUSE_PASSWORD": _CH_PASSWORD})
     fake_boto3 = MagicMock()
@@ -71,6 +75,11 @@ def fakes(monkeypatch):
     importlib.import_module("github")
     monkeypatch.setitem(sys.modules, "github", fake_github)
     return fake_boto3, fake_github
+
+
+def _dispatched_max(main_mock: Mock) -> str:
+    argv: list[str] = main_mock.call_args.args[0]
+    return argv[argv.index("--max") + 1]
 
 
 def test_handler_happy_path(monkeypatch, fakes):
@@ -112,8 +121,73 @@ def test_handler_caps_dispatches_per_scan(monkeypatch, fakes):
     # The scheduled scan is the one path with a hard wall-clock budget, so it must never run
     # uncapped: an uncapped pass over the evaluation cohort would spend the whole function timeout
     # on serial workflow_dispatch POSTs and be killed mid-scan.
-    argv = main_mock.call_args.args[0]
-    assert argv[argv.index("--max") + 1] == str(lambda_handler._MAX_DISPATCHES_PER_SCAN)
+    assert _dispatched_max(main_mock) == str(lambda_handler._DEFAULT_MAX_DISPATCHES_PER_SCAN)
+
+
+@pytest.mark.parametrize("raw", [pytest.param("", id="empty"), pytest.param("   ", id="whitespace")])
+def test_handler_blank_max_dispatches_uses_default(monkeypatch, fakes, raw):
+    monkeypatch.setenv(_MAX_ENV, raw)
+    main_mock = Mock(return_value=EXIT_OK)
+    monkeypatch.setattr(cli, "main", main_mock)
+
+    lambda_handler.handler({}, object())
+
+    assert _dispatched_max(main_mock) == str(lambda_handler._DEFAULT_MAX_DISPATCHES_PER_SCAN)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        pytest.param("5", "5", id="lower"),
+        # One above the default, not a recommended setting: the handler deliberately applies no
+        # upper bound, and the safe range for the 300s timeout is documented in the README instead.
+        pytest.param("31", "31", id="above_default"),
+        pytest.param("  7  ", "7", id="padded"),
+        # Zero is a valid setting, not a blank: it pauses dispatching without pausing the scan.
+        pytest.param("0", "0", id="zero"),
+    ],
+)
+def test_handler_max_dispatches_override(monkeypatch, fakes, raw, expected):
+    monkeypatch.setenv(_MAX_ENV, raw)
+    main_mock = Mock(return_value=EXIT_OK)
+    monkeypatch.setattr(cli, "main", main_mock)
+
+    lambda_handler.handler({}, object())
+
+    assert _dispatched_max(main_mock) == expected
+
+
+@pytest.mark.parametrize(
+    "raw", [pytest.param("thirty", id="word"), pytest.param("30.5", id="float"), pytest.param("3o", id="typo")]
+)
+def test_handler_malformed_max_dispatches_raises(monkeypatch, fakes, raw):
+    _fake_boto3, fake_github = fakes
+    monkeypatch.setenv(_MAX_ENV, raw)
+    main_mock = Mock()
+    monkeypatch.setattr(cli, "main", main_mock)
+
+    with pytest.raises(ValueError, match=_MAX_ENV) as exc_info:
+        lambda_handler.handler({}, object())
+
+    assert repr(raw) in str(exc_info.value)
+    # Rejected before any token is minted, so a bad knob cannot burn an installation token.
+    fake_github.GithubIntegration.assert_not_called()
+    main_mock.assert_not_called()
+
+
+def test_handler_negative_max_dispatches_raises(monkeypatch, fakes):
+    _fake_boto3, fake_github = fakes
+    monkeypatch.setenv(_MAX_ENV, "-1")
+    main_mock = Mock()
+    monkeypatch.setattr(cli, "main", main_mock)
+
+    # A negative clamps to zero inside the scan, so accepting it would silently stall dispatching
+    # on the one path with no human watching the argv.
+    with pytest.raises(ValueError, match="must not be negative"):
+        lambda_handler.handler({}, object())
+
+    fake_github.GithubIntegration.assert_not_called()
+    main_mock.assert_not_called()
 
 
 @pytest.mark.parametrize("slug", [pytest.param("", id="empty"), pytest.param(None, id="absent")])

--- a/greenlight/tests/test_revert_guard.py
+++ b/greenlight/tests/test_revert_guard.py
@@ -99,7 +99,7 @@ def _exclude(
             raise error
         return list(dismissed_ids.get(pr.number, ()))
 
-    def fake_emit(*, repo, pr_number, head_sha, run_id):
+    def fake_emit(*, repo, pr_number, head_sha, run_id, shadow):
         result.events.append(f"emit:{pr_number}")
         error = emit_errors.get(pr_number)
         if error is not None:

--- a/greenlight/tests/test_review.py
+++ b/greenlight/tests/test_review.py
@@ -10,7 +10,16 @@ from unittest.mock import Mock
 
 import pytest
 
-from greenlight import clickhouse_client, drci_poke, github_client, revert_guard, review, scan_runner, state_emit
+from greenlight import (
+    clickhouse_client,
+    cohort,
+    drci_poke,
+    github_client,
+    revert_guard,
+    review,
+    scan_runner,
+    state_emit,
+)
 from greenlight.comment_format import RECHECK_REFUSAL_MARKER
 from greenlight.constants import (
     DEFAULT_DISPATCH_REF,
@@ -1801,7 +1810,7 @@ def test_deferred_dispatch_is_logged(make_config, caplog):
 
 
 def test_listing_path_logs_open_prs_and_decisions(make_config, caplog):
-    with caplog.at_level(logging.INFO, logger="greenlight"):
+    with caplog.at_level(logging.DEBUG, logger="greenlight"):
         _run_scan(
             make_config,
             listed=[_open_pr(1), _open_pr(2)],
@@ -1814,6 +1823,21 @@ def test_listing_path_logs_open_prs_and_decisions(make_config, caplog):
     assert "open PR #1 by albanD" in messages
     assert "PR #1: DISPATCH (never_reviewed)" in messages
     assert "PR #2: SKIP (decided)" in messages
+
+
+def test_per_pr_listing_detail_is_below_info(make_config, caplog):
+    with caplog.at_level(logging.INFO, logger="greenlight"):
+        _run_scan(
+            make_config,
+            listed=[_open_pr(1), _open_pr(2)],
+            fingerprints={1: ("h1", _HASH_A), 2: ("h2", _HASH_A)},
+        )
+
+    # One info line per open PR is affordable for the trusted-author set and not for the whole
+    # merge_rules approver cohort, which is an order of magnitude larger and rescanned every few
+    # minutes. The aggregate count stays at info; the per-PR detail is debug-only.
+    assert "found 2 open PR(s)" in caplog.text
+    assert "open PR #" not in caplog.text
 
 
 def test_run_without_token_raises(make_config):
@@ -1887,7 +1911,7 @@ def test_default_fetch_forwards_to_list_open_prs(monkeypatch):
     assert result is expected
     assert captured["client"] is _CLIENT
     assert captured["repo"] == TARGET_REPO
-    assert captured["authors"] == review.TRUSTED_AUTHORS
+    assert captured["authors"] == cohort.TRUSTED_AUTHORS
 
 
 def test_default_fetch_author_forwards_to_get_pr_author(monkeypatch):

--- a/greenlight/tests/test_review.py
+++ b/greenlight/tests/test_review.py
@@ -230,7 +230,7 @@ def _run_scan(
     def fake_upsert(pr, *, marker, body, author_login, run_id=None):
         refusals.append((pr.number, marker, body, author_login))
 
-    def fake_emit(*, repo, pr_number, head_sha, eval_hash, run_id):
+    def fake_emit(*, repo, pr_number, head_sha, eval_hash, run_id, shadow):
         emitted.append((repo, pr_number, head_sha, eval_hash, run_id))
         events.append(f"emit:{pr_number}")
 
@@ -253,7 +253,7 @@ def _run_scan(
             raise error
         return list(dismissed_ids.get(pr.number, ()))
 
-    def fake_emit_reverted(*, repo, pr_number, head_sha, run_id):
+    def fake_emit_reverted(*, repo, pr_number, head_sha, run_id, shadow):
         reverted_emitted.append((repo, pr_number, head_sha, run_id))
         events.append(f"emit_reverted:{pr_number}")
 

--- a/greenlight/tests/test_review.py
+++ b/greenlight/tests/test_review.py
@@ -5,7 +5,7 @@ import queue
 import threading
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, NoReturn, cast
+from typing import TYPE_CHECKING, cast
 from unittest.mock import Mock
 
 import pytest
@@ -76,10 +76,6 @@ def _open_pr(
     )
 
 
-def _boom_poke(repo: str, pr_number: int, poke_config: Config) -> NoReturn:
-    raise AssertionError(f"poke should not be called for {repo}#{pr_number}")
-
-
 def _no_reverted(_repo: str, _numbers: Sequence[int]) -> set[int]:
     return set()
 
@@ -146,6 +142,7 @@ class _Scan:
     refusals: list[tuple[int, str, str, str]]
     emitted: list[tuple[str, int, str, str, int]]
     poked: list[tuple[str, int, Config]]
+    poke_threads: list[str]
     events: list[str]
     label_fetches: list[int]
     dismissals: list[tuple[int, str, str]]
@@ -190,6 +187,7 @@ def _run_scan(
     refusals: list[tuple[int, str, str, str]] = []
     emitted: list[tuple[str, int, str, str, int]] = []
     poked: list[tuple[str, int, Config]] = []
+    poke_threads: list[str] = []
     events: list[str] = []
     label_fetches: list[int] = []
     dismissals: list[tuple[int, str, str]] = []
@@ -236,6 +234,7 @@ def _run_scan(
 
     def fake_poke(repo, pr_number, poke_config):
         poked.append((repo, pr_number, poke_config))
+        poke_threads.append(threading.current_thread().name)
         events.append(f"poke:{pr_number}")
 
     def fake_read_reverted(_repo, numbers):
@@ -296,6 +295,7 @@ def _run_scan(
         refusals,
         emitted,
         poked,
+        poke_threads,
         events,
         label_fetches,
         dismissals,
@@ -355,10 +355,36 @@ def test_dispatch_pokes_drci_after_the_marker_emit(make_config):
         config_kwargs={"drci_token": "drci-key"},
     )
 
-    # Dr. CI re-reads the state row when poked, so each poke must follow its own marker emit;
-    # without the poke the PR shows no in-flight marker until Dr. CI's next 15-minute sweep.
-    assert scan.events == ["dispatch:1", "emit:1", "poke:1", "dispatch:2", "emit:2", "poke:2"]
-    assert [(repo, number) for repo, number, _ in scan.poked] == [(TARGET_REPO, 1), (TARGET_REPO, 2)]
+    # Dr. CI re-reads the state row when poked, so a PR's poke is only scheduled once its own marker
+    # emit has returned; without the poke the PR shows no in-flight marker until the 15-minute sweep.
+    assert scan.events.index("poke:1") > scan.events.index("emit:1")
+    assert scan.events.index("poke:2") > scan.events.index("emit:2")
+    # Where the two poke events land among the rest is the pool's business, but the main-thread
+    # sequence must run straight through: the dispatch loop never waits on a poke.
+    assert [event for event in scan.events if not event.startswith("poke:")] == [
+        "dispatch:1",
+        "emit:1",
+        "dispatch:2",
+        "emit:2",
+    ]
+    assert sorted((repo, number) for repo, number, _ in scan.poked) == [(TARGET_REPO, 1), (TARGET_REPO, 2)]
+
+
+def test_pokes_run_off_the_main_thread_and_are_drained_before_run_returns(make_config):
+    scan = _run_scan(
+        make_config,
+        listed=[_open_pr(1), _open_pr(2)],
+        fingerprints={1: ("headsha1", _HASH_A), 2: ("headsha2", _HASH_A)},
+        config_kwargs={"drci_token": "drci-key"},
+    )
+
+    # Both pokes ran on the pool and both had finished by the time run returned, because the pool is
+    # entered on run's ExitStack. Draining is not optional: Lambda freezes the execution environment
+    # the instant the handler returns, so a poke left running would resume -- and log its outcome --
+    # inside some later invocation instead of this one.
+    assert len(scan.poke_threads) == 2
+    assert threading.main_thread().name not in scan.poke_threads
+    assert all(name.startswith("greenlight-poke") for name in scan.poke_threads)
 
 
 def test_poke_drops_the_ingestion_delay_but_keeps_the_credentials(make_config):
@@ -679,6 +705,20 @@ def test_reverted_label_drops_pr_before_fingerprinting(make_config, caplog):
     assert scan.reverted_emitted == [(TARGET_REPO, 1, "headsha1", 1)]
     assert 1 in [pr_number for _repo, pr_number, _config in scan.poked]
     assert "excluding 1 reverted PR(s) from review: [1]" in caplog.text
+
+
+def test_reverted_pr_poke_also_goes_through_the_pool(make_config):
+    scan = _run_scan(
+        make_config,
+        listed=[_open_pr(1, updated_at=_NEW, labels=("Reverted",))],
+        fingerprints={},
+        bot_login="greenlight-app[bot]",
+    )
+
+    # revert_guard's poke seam and the dispatch loop's are one callable, so the revert path cannot
+    # regress to a blocking poke while the dispatch path stays fire-and-forget.
+    assert [number for _repo, number, _config in scan.poked] == [1]
+    assert [name.startswith("greenlight-poke") for name in scan.poke_threads] == [True]
 
 
 def test_reverted_row_still_excludes_after_the_label_is_removed(make_config):
@@ -1615,6 +1655,7 @@ def test_rate_limit_defers_completed_candidate_without_dispatching(make_config, 
     monkeypatch.setattr(review, "_FINGERPRINT_WORKERS", 1)
     fingerprinted: list[int] = []
     dispatched: list[int] = []
+    poked: list[int] = []
 
     def fingerprint(_client, number, _authorized, _skip):
         fingerprinted.append(number)
@@ -1625,6 +1666,9 @@ def test_rate_limit_defers_completed_candidate_without_dispatching(make_config, 
     def fake_dispatch(_client, number, _head_sha, _eval_hash, _ref):
         dispatched.append(number)
 
+    def record_poke(_repo, pr_number, _config):
+        poked.append(pr_number)
+
     with caplog.at_level(logging.WARNING, logger="greenlight"), pytest.raises(RuntimeError) as excinfo:
         review.run(
             make_config(github_token="t"),
@@ -1634,7 +1678,7 @@ def test_rate_limit_defers_completed_candidate_without_dispatching(make_config, 
             read_state=lambda _repo, _numbers: {},
             read_reverted=_no_reverted,
             dispatch=fake_dispatch,
-            poke_drci=_boom_poke,
+            poke_drci=record_poke,
             resolve_authorized=lambda: _AUTHORIZED,
             now=lambda: _NOW,
         )
@@ -1646,6 +1690,9 @@ def test_rate_limit_defers_completed_candidate_without_dispatching(make_config, 
     # the event, so PR3 short-circuits without being fingerprinted.
     assert fingerprinted == [1, 2]
     assert dispatched == []
+    # Nothing dispatched, so nothing is poked -- readable here because the end-of-scan RuntimeError is
+    # raised inside the ExitStack, so the poke pool is drained even on the failing path.
+    assert poked == []
     # The deferral is surfaced by the merged rate-limit warning, and the scan still fails closed: PR2
     # (failed) and PR3 (abandoned) are carried distinctly in the end-of-scan RuntimeError.
     assert "skipping dispatch of 1 completed candidate(s) this pass" in caplog.text

--- a/greenlight/tests/test_scan_runner.py
+++ b/greenlight/tests/test_scan_runner.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import queue
 import threading
@@ -500,3 +502,169 @@ def test_dispatch_pending_does_not_poke_deferred_candidates():
     # A candidate deferred by the --max cap was never dispatched or marked, so it must not be poked.
     assert failed == []
     assert poked == [1]
+
+
+_CHANGED_HASH = "b" * 64
+
+
+def _until_dispatchable(
+    pr_numbers: list[int],
+    *,
+    fingerprint: scan_runner.FingerprintFn,
+    limit: int,
+    worker_count: int = 2,
+    states: dict[int, PRState] | None = None,
+    failed: list[int] | None = None,
+    abandoned: list[int] | None = None,
+    skips: list[tuple[int, ReviewSkip]] | None = None,
+    cancel_event: threading.Event | None = None,
+) -> list[scan_runner._Candidate]:
+    client_pool: queue.Queue[Github] = queue.Queue()
+    for _ in range(worker_count):
+        client_pool.put(cast("Github", object()))
+    return scan_runner._fingerprint_until_dispatchable(
+        pr_numbers,
+        states or {},
+        fingerprint=fingerprint,
+        client_pool=client_pool,
+        worker_count=worker_count,
+        authorized_logins=frozenset({"alice"}),
+        skip_on_approval=True,
+        limit=limit,
+        now=datetime(2026, 6, 1),
+        timeout=timedelta(hours=1),
+        failed=failed if failed is not None else [],
+        abandoned=abandoned if abandoned is not None else [],
+        skips=skips if skips is not None else [],
+        force=False,
+        cancel_event=cancel_event if cancel_event is not None else threading.Event(),
+    )
+
+
+def test_fingerprint_until_dispatchable_stops_submitting_once_the_limit_is_reached():
+    fingerprinted: list[int] = []
+    lock = threading.Lock()
+
+    def fingerprint(_client, number, _authorized, _skip):
+        with lock:
+            fingerprinted.append(number)
+        return (f"headsha{number}", _CHANGED_HASH)
+
+    pending = _until_dispatchable(list(range(1, 9)), fingerprint=fingerprint, limit=1, worker_count=2)
+
+    # Eight dispatchable PRs but a cap of one: submission stops after the first evaluation round, so
+    # only the in-flight pair is ever fingerprinted -- the whole point of the capped path.
+    assert sorted(fingerprinted) == [1, 2]
+    # Both are still evaluated and returned: their GitHub calls are already paid for, and the cap
+    # itself is applied later, by _dispatch_pending.
+    assert [candidate.pr_number for candidate in pending] == [1, 2]
+
+
+def test_fingerprint_until_dispatchable_zero_limit_submits_nothing():
+    def boom_fingerprint(*_args):
+        raise AssertionError("no PR may be fingerprinted under a zero cap")
+
+    assert _until_dispatchable([1, 2, 3], fingerprint=boom_fingerprint, limit=0) == []
+
+
+def test_fingerprint_until_dispatchable_refills_the_pool_without_waiting_for_the_slowest_task():
+    later_task_started = threading.Event()
+    failed: list[int] = []
+
+    def fingerprint(_client, number, _authorized, _skip):
+        if number == 1:
+            # PR1 finishes only once a task beyond the first pool-sized group has started. Under a
+            # batch barrier that task is never submitted (it waits on PR1), so this times out.
+            assert later_task_started.wait(timeout=5)
+        elif number == 3:
+            later_task_started.set()
+        return (f"headsha{number}", _CHANGED_HASH)
+
+    pending = _until_dispatchable([1, 2, 3, 4], fingerprint=fingerprint, limit=4, worker_count=2, failed=failed)
+
+    assert failed == []
+    assert sorted(candidate.pr_number for candidate in pending) == [1, 2, 3, 4]
+
+
+def test_fingerprint_until_dispatchable_returns_ranked_order_not_completion_order():
+    stalest_waiting = threading.Event()
+    other_finished = threading.Event()
+    failed: list[int] = []
+
+    def fingerprint(_client, number, _authorized, _skip):
+        # A two-way handshake pins the completion order: PR5 cannot finish until PR9 is parked, and
+        # PR9 cannot finish until PR5 has. The stalest PR therefore always completes last.
+        if number == 9:
+            stalest_waiting.set()
+            assert other_finished.wait(timeout=5)
+        else:
+            assert stalest_waiting.wait(timeout=5)
+            other_finished.set()
+        return (f"headsha{number}", _CHANGED_HASH)
+
+    pending = _until_dispatchable(
+        [9, 5],
+        fingerprint=fingerprint,
+        limit=4,
+        worker_count=2,
+        states={5: _pr_state(5, run_id=3)},
+        failed=failed,
+    )
+
+    assert failed == []
+
+    # PR9 (never reviewed) outranks the recorded PR5 but deliberately finishes last. _dispatch_pending
+    # breaks staleness ties on this order, so completion order here would silently hand the last
+    # dispatch slot to whichever PR happened to answer first.
+    assert [candidate.pr_number for candidate in pending] == [9, 5]
+
+
+def test_fingerprint_until_dispatchable_stops_submitting_once_the_fan_out_is_cancelled():
+    from github import RateLimitExceededException
+
+    cancel_event = threading.Event()
+    reached_fingerprint = threading.Event()
+    fingerprinted: list[int] = []
+    lock = threading.Lock()
+    failed: list[int] = []
+    abandoned: list[int] = []
+    skips: list[tuple[int, ReviewSkip]] = []
+
+    def fingerprint(_client, number, _authorized, _skip_on_approval):
+        with lock:
+            fingerprinted.append(number)
+        if number == 2:
+            # PR2 is past _fingerprint_task's pre-flight cancel check before PR1 can trip the limit,
+            # so it is provably in flight -- not abandoned -- when submission stops. Waiting on the
+            # shared event (which _fingerprint_task sets from PR1's rate limit) is also what pins the
+            # interleaving: no completion is observable until the cancel has landed.
+            reached_fingerprint.set()
+            assert cancel_event.wait(timeout=5)
+            return _skip("changes requested by bob")
+        assert reached_fingerprint.wait(timeout=5)
+        raise RateLimitExceededException(403)
+
+    pending = _until_dispatchable(
+        list(range(1, 9)),
+        fingerprint=fingerprint,
+        limit=8,
+        worker_count=2,
+        failed=failed,
+        abandoned=abandoned,
+        skips=skips,
+        cancel_event=cancel_event,
+    )
+
+    # Eight PRs and a cap of eight, so the cap can never be what stops submission: the cancel event
+    # is the only remaining sub-condition of the `while` guard, and it is the rate-limit safety valve
+    # on the path production takes (the Lambda always passes --max). Coverage cannot see this --
+    # it tracks the branch out of the `while`, not which sub-condition short-circuited.
+    assert sorted(fingerprinted) == [1, 2]
+    # The already-in-flight pair is still drained: PR1's rate limit is recorded as a failure and PR2's
+    # human-decision skip is still collected, rather than both being dropped with the fan-out.
+    assert failed == [1]
+    assert [number for number, _ in skips] == [2]
+    # PRs 3-8 were never submitted, so they are not abandoned tasks either -- abandoned holds only
+    # tasks that reached the pool and found the event already set.
+    assert abandoned == []
+    assert pending == []

--- a/greenlight/tests/test_state_emit.py
+++ b/greenlight/tests/test_state_emit.py
@@ -4,6 +4,8 @@ import re
 from datetime import UTC, datetime
 from typing import Any
 
+import pytest
+
 from greenlight import constants, state_emit
 
 _FIXED = datetime(2026, 7, 30, 12, 0, tzinfo=UTC)
@@ -27,6 +29,7 @@ _ROW_KEYS = [
     "version",
     "run_id",
     "emit_id",
+    "shadow",
 ]
 
 
@@ -76,7 +79,11 @@ def test_utcnow_is_timezone_aware_utc():
     assert state_emit._utcnow().tzinfo is UTC
 
 
-def test_emit_row_is_byte_stable_golden():
+@pytest.mark.parametrize(
+    ("shadow", "shadow_literal"),
+    [pytest.param(False, "false", id="authoritative"), pytest.param(True, "true", id="shadow")],
+)
+def test_emit_row_is_byte_stable_golden(shadow: bool, shadow_literal: str) -> None:
     cap = _Capture()
 
     key = state_emit.emit_row(
@@ -90,6 +97,7 @@ def test_emit_row_is_byte_stable_golden():
         eval_job="ej",
         agent_job="aj",
         run_id=9,
+        shadow=shadow,
         now=lambda: _FIXED,
         emit=cap,
         new_emit_id=lambda: _EMIT_ID,
@@ -100,8 +108,22 @@ def test_emit_row_is_byte_stable_golden():
     assert gzip.decompress(cap.row).decode("utf-8") == (
         f'{{"repo":"o/r","pr_number":5,"head_sha":"h","status":"LAND","reason":"clean",'
         f'"eval_hash":"{_HASH}","message":"LGTM","eval_job":"ej","agent_job":"aj",'
-        f'"version":"{_VERSION}","run_id":9,"emit_id":"{_EMIT_ID}"}}\n'
+        f'"version":"{_VERSION}","run_id":9,"emit_id":"{_EMIT_ID}","shadow":{shadow_literal}}}\n'
     )
+
+
+def test_shadow_is_serialized_immediately_after_emit_id_and_last():
+    # The replicator inserts positionally and appends `_meta` itself, so `shadow` must sit
+    # between `emit_id` and the end of the row -- anywhere else shifts the whole insert.
+    cap = _Capture()
+
+    state_emit.emit_ai_review_dispatched(
+        repo="o/r", pr_number=1, head_sha="h", eval_hash=_HASH, run_id=1, shadow=True, upload=cap
+    )
+
+    keys = list(cap.decoded().keys())
+    assert keys[keys.index("emit_id") + 1] == "shadow"
+    assert keys[-1] == "shadow"
 
 
 def test_emit_ai_review_dispatched_builds_row_and_calls_upload(monkeypatch):
@@ -114,6 +136,7 @@ def test_emit_ai_review_dispatched_builds_row_and_calls_upload(monkeypatch):
         head_sha="deadbeef",
         eval_hash=_HASH,
         run_id=7,
+        shadow=False,
         upload=cap,
     )
 
@@ -135,6 +158,7 @@ def test_emit_ai_review_dispatched_builds_row_and_calls_upload(monkeypatch):
     assert row["agent_job"] == ""
     assert row["version"] == _VERSION
     assert _EMIT_ID_RE.fullmatch(str(row["emit_id"]))
+    assert row["shadow"] is False
 
 
 def test_emit_ai_review_dispatched_key_matches_row_version():
@@ -142,7 +166,7 @@ def test_emit_ai_review_dispatched_key_matches_row_version():
     cap = _Capture()
 
     state_emit.emit_ai_review_dispatched(
-        repo="o/r", pr_number=3, head_sha="h", eval_hash="b" * 64, run_id=1, upload=cap
+        repo="o/r", pr_number=3, head_sha="h", eval_hash="b" * 64, run_id=1, shadow=False, upload=cap
     )
 
     row = cap.decoded()
@@ -159,7 +183,7 @@ def test_two_dispatched_emits_get_distinct_emit_ids():
 
     for _ in range(2):
         state_emit.emit_ai_review_dispatched(
-            repo="o/r", pr_number=1, head_sha="h", eval_hash=_HASH, run_id=1, upload=upload
+            repo="o/r", pr_number=1, head_sha="h", eval_hash=_HASH, run_id=1, shadow=False, upload=upload
         )
 
     assert ids[0] != ids[1]
@@ -170,7 +194,9 @@ def test_emit_reverted_builds_row_with_empty_eval_hash(monkeypatch):
     monkeypatch.setattr(state_emit, "_utcnow", lambda: _FIXED)
     cap = _Capture()
 
-    state_emit.emit_reverted(repo="pytorch/pytorch", pr_number=42, head_sha="deadbeef", run_id=4, upload=cap)
+    state_emit.emit_reverted(
+        repo="pytorch/pytorch", pr_number=42, head_sha="deadbeef", run_id=4, shadow=True, upload=cap
+    )
 
     row = cap.decoded()
     assert cap.key == state_emit.object_key("pytorch/pytorch", 42, _VERSION, str(row["emit_id"]))
@@ -187,13 +213,14 @@ def test_emit_reverted_builds_row_with_empty_eval_hash(monkeypatch):
     assert row["message"] == ""
     assert row["eval_job"] == ""
     assert row["agent_job"] == ""
+    assert row["shadow"] is True
 
 
 def test_emit_reverted_defaults_to_boto3_upload(monkeypatch):
     cap = _Capture()
     monkeypatch.setattr(state_emit, "_default_upload", cap)
 
-    state_emit.emit_reverted(repo="o/r", pr_number=1, head_sha="h", run_id=2)
+    state_emit.emit_reverted(repo="o/r", pr_number=1, head_sha="h", run_id=2, shadow=False)
 
     assert cap.key is not None
     assert cap.key.startswith("greenlight_pr_state/o/r/1/")
@@ -205,7 +232,7 @@ def test_emit_ai_review_dispatched_defaults_to_boto3_upload(monkeypatch):
     cap = _Capture()
     monkeypatch.setattr(state_emit, "_default_upload", cap)
 
-    state_emit.emit_ai_review_dispatched(repo="o/r", pr_number=1, head_sha="h", eval_hash=_HASH, run_id=5)
+    state_emit.emit_ai_review_dispatched(repo="o/r", pr_number=1, head_sha="h", eval_hash=_HASH, run_id=5, shadow=False)
 
     assert cap.key is not None
     assert cap.key.startswith("greenlight_pr_state/o/r/1/")
@@ -271,6 +298,7 @@ def test_two_emits_same_version_get_distinct_object_keys():
             eval_job="",
             agent_job="",
             run_id=1,
+            shadow=False,
             now=lambda: _FIXED,
             emit=upload,
             new_emit_id=state_emit.default_emit_id,

--- a/greenlight/tests/test_state_row_schema_sync.py
+++ b/greenlight/tests/test_state_row_schema_sync.py
@@ -1,0 +1,412 @@
+"""Pins the three artifacts that must agree on ``misc.greenlight_pr_state``'s column order.
+
+The S3 -> ClickHouse replicator inserts positionally -- ``general_adapter`` issues
+``INSERT ... SELECT *, (bucket, key) AS _meta`` -- so the writer's JSONEachRow field order, the
+adapter's schema string, and the table's own DDL are one contract, and order is as load-bearing
+as membership. A skew raises ``NUMBER_OF_COLUMNS_DOESNT_MATCH``, which ``general_adapter``
+swallows into ``errors.gen_errors``; nothing alerts on that table, so the only symptom is that
+rows stop arriving. Nothing at build time links the three, and each lives in a tree the other
+two's CI does not watch.
+
+``greenlight.state_emit.emit_row`` is the source of truth: these tests read the adapter and
+replay the migrations, and fail when either stops matching what the writer emits. The row order
+is probed out of the writer rather than restated here -- a hand-copied list would only pin these
+tests against themselves.
+
+``_meta`` is the one column the writer and the adapter both omit, because the replicator appends
+it. That is also why the DDL must keep it last among the ordinary columns.
+
+The same silence covers the wiring that reaches that schema at all: an object key the replicator
+does not recognize, or a table no longer pointed at this adapter, drops the row just as quietly as
+a column skew. Those two are checked against the imported module -- real values and real function
+identity, not text -- because the replicator's only runtime dependency is one greenlight already
+has.
+"""
+
+from __future__ import annotations
+
+import gzip
+import importlib.util
+import json
+import re
+from datetime import UTC, datetime
+from functools import cache
+from pathlib import Path
+from typing import TYPE_CHECKING, NamedTuple
+
+import pytest
+
+from greenlight import state_emit
+from greenlight.constants import S3_BUCKET, S3_KEY_PREFIX
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+ROOT = Path(__file__).resolve().parents[2]
+
+_ADAPTER = "aws/lambda/clickhouse-replicator-s3/lambda_function.py"
+_SQL_DIR = "greenlight/sql"
+_WRITER = "greenlight/src/greenlight/state_emit.py"
+
+assert (ROOT / _ADAPTER).is_file()
+assert (ROOT / _SQL_DIR).is_dir()
+
+_TABLE = "misc.greenlight_pr_state"
+# Carries the open paren so a suffixed rename (`..._v2`) misses this rather than prefix-matching
+# it and failing later, deep in the parse, with something other than the message written here.
+_ADAPTER_FN = "def greenlight_pr_state_adapter("
+_REPLICATOR_APPENDED = "_meta"
+
+_SQL_COMMENT_RE = re.compile(r"--[^\n]*")
+_IDENT_RE = re.compile(r"`?(\w+)`?")
+_COLUMN_RE = re.compile(r"`?(\w+)`?\s+(.+)", re.DOTALL)
+_SCHEMA_RE = re.compile(r'schema\s*=\s*"""(.*?)"""', re.DOTALL)
+# Everything a column definition may carry AFTER its type. Cut here and what remains is the type.
+_TYPE_MODIFIER_RE = re.compile(
+    r"\b(?:DEFAULT|MATERIALIZED|ALIAS|EPHEMERAL|CODEC|TTL|COMMENT|AFTER|FIRST|NOT\s+NULL|NULL)\b",
+    re.IGNORECASE,
+)
+_WHITESPACE_RE = re.compile(r"\s+")
+_LOW_CARDINALITY_RE = re.compile(r"^lowcardinality\((.*)\)$")
+# MATERIALIZED/ALIAS columns are computed server-side: `SELECT *` never yields them and a
+# positional INSERT never fills them, so they are outside this contract.
+_COMPUTED_RE = re.compile(r"\b(?:MATERIALIZED|ALIAS)\b", re.IGNORECASE)
+_CREATE_RE = re.compile(r"^CREATE\s+TABLE\b", re.IGNORECASE)
+_ALTER_RE = re.compile(r"^ALTER\s+TABLE\b", re.IGNORECASE)
+_ADD_COLUMN_RE = re.compile(r"^ADD\s+COLUMN\s+(?:IF\s+NOT\s+EXISTS\s+)?(.*)$", re.IGNORECASE | re.DOTALL)
+_MODIFY_COLUMN_RE = re.compile(r"^MODIFY\s+COLUMN\s+(?:IF\s+EXISTS\s+)?(`?\w+`?\s+.+)$", re.IGNORECASE | re.DOTALL)
+_DROP_COLUMN_RE = re.compile(r"^DROP\s+COLUMN\s+(?:IF\s+EXISTS\s+)?`?(\w+)`?\b", re.IGNORECASE)
+_MODIFY_ORDER_BY_RE = re.compile(r"^MODIFY\s+ORDER\s+BY\b", re.IGNORECASE)
+_AFTER_RE = re.compile(r"\bAFTER\s+`?(\w+)`?", re.IGNORECASE)
+_FIRST_RE = re.compile(r"\bFIRST\b", re.IGNORECASE)
+
+_FIXED = datetime(2026, 7, 30, 12, 0, tzinfo=UTC)
+_HASH = "a" * 64
+_EMIT_ID = "e" * 32
+
+
+def _drift(artifact: str, detail: str) -> str:
+    return (
+        f"{artifact} drifted from {_WRITER}, which is the source of truth for the state row's "
+        f"column order: change {artifact} to match it, or change all three together ({_WRITER}, "
+        f"{_SQL_DIR}/*.sql, {_ADAPTER}). The replicator's INSERT is positional, so a skew raises "
+        f"NUMBER_OF_COLUMNS_DOESNT_MATCH -- which general_adapter swallows into errors.gen_errors, "
+        f"leaving no signal but rows that stop arriving. {detail}"
+    )
+
+
+def _split_top_level(text: str) -> list[str]:
+    """Split on the commas outside parentheses, keeping ``Tuple(bucket String, key String)`` whole."""
+    parts: list[str] = []
+    depth = 0
+    start = 0
+    for index, char in enumerate(text):
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+        elif char == "," and depth == 0:
+            parts.append(text[start:index])
+            start = index + 1
+    parts.append(text[start:])
+    return [part.strip() for part in parts if part.strip()]
+
+
+def _parenthesized(text: str, search_from: int) -> str:
+    """The contents of the parenthesis group opening at or after ``search_from``."""
+    open_at = text.find("(", search_from)
+    assert open_at != -1, f"no parenthesis group after offset {search_from} in: {text!r}"
+    depth = 0
+    for index in range(open_at, len(text)):
+        if text[index] == "(":
+            depth += 1
+        elif text[index] == ")":
+            depth -= 1
+            if depth == 0:
+                return text[open_at + 1 : index]
+    raise AssertionError(f"unbalanced parentheses from offset {open_at} in: {text!r}")
+
+
+class _Column(NamedTuple):
+    name: str
+    type: str
+
+
+def _column_name(definition: str) -> str:
+    match = _IDENT_RE.match(definition)
+    assert match is not None, f"no column name at the head of {definition!r}"
+    return match.group(1)
+
+
+def _strip_modifiers(rest: str) -> str:
+    """``rest`` up to the first modifier keyword outside parentheses -- i.e. the bare type."""
+    for match in _TYPE_MODIFIER_RE.finditer(rest):
+        # Depth 0 only: a modifier keyword can legitimately be a field name inside a compound type
+        # (``Tuple(comment String)``), where it is part of the type rather than the end of it.
+        if rest.count("(", 0, match.start()) == rest.count(")", 0, match.start()):
+            return rest[: match.start()]
+    return rest
+
+
+def _normalize_type(raw: str) -> str:
+    """Fold the spellings ClickHouse itself treats as one type.
+
+    Case and internal whitespace are both insignificant to ClickHouse, and 002 relies on it:
+    it restates ``version`` as ``DATETIME64 (3)``, the sqlfluff-canonical form inside an
+    ALTER, for the ``DateTime64(3)`` that 001 declares.
+    """
+    return _WHITESPACE_RE.sub("", _strip_modifiers(raw)).lower()
+
+
+def _read_schema_equivalents(table_type: str) -> set[str]:
+    """The adapter spellings that are safe to read a column of ``table_type`` with.
+
+    Exactly one widening is allowed, and only in this direction: a ``LowCardinality(T)`` table
+    column may be read as bare ``T``. LowCardinality is an encoding, not a type -- the s3 reader
+    parses the JSON value as ``T`` either way and ClickHouse applies the dictionary on insert,
+    which is what the adapter already does for ``repo``, ``status`` and ``reason``.
+
+    Nothing else is allowed, including things that would in fact work:
+
+    * ``Nullable(T)`` against ``T`` is rejected outright -- a null parses on the read side and
+      then fails the insert, which is the same swallowed error this file exists to prevent.
+    * A narrower numeric read type (``Int32`` for an ``Int64`` column) is rejected: the read
+      schema is what parses the JSON, so the overflow happens before any widening could help.
+    * ``DateTime64`` precision must match exactly; a different one silently rescales.
+    * Bare ``T`` in the table read as ``LowCardinality(T)`` is harmless but rejected anyway --
+      the pair is ambiguous enough to be worth a human deciding, so this asserts the narrow
+      thing and makes someone come here rather than allowing it in silence.
+    """
+    equivalents = {table_type}
+    unwrapped = _LOW_CARDINALITY_RE.match(table_type)
+    if unwrapped is not None:
+        equivalents.add(unwrapped.group(1))
+    return equivalents
+
+
+def _ordinary_column(definition: str) -> _Column | None:
+    """The declared column, or ``None`` when it is computed server-side rather than stored."""
+    match = _COLUMN_RE.match(definition)
+    assert match is not None, f"no `<name> <type>` at the head of {definition!r}"
+    name, rest = match.group(1), match.group(2)
+    if _COMPUTED_RE.search(rest):
+        return None
+    declared = _normalize_type(rest)
+    assert declared, f"no type on column `{name}` in {definition!r}"
+    return _Column(name, declared)
+
+
+def _index_of(columns: list[_Column], name: str) -> int | None:
+    return next((index for index, column in enumerate(columns) if column.name == name), None)
+
+
+def _apply_add_column(definition: str, columns: list[_Column]) -> None:
+    column = _ordinary_column(definition)
+    if column is None:
+        return
+    after = _AFTER_RE.search(definition)
+    if after is not None:
+        anchor = _index_of(columns, after.group(1))
+        assert anchor is not None, (
+            f"{_SQL_DIR} places `{column.name}` AFTER `{after.group(1)}`, which no earlier migration adds"
+        )
+        columns.insert(anchor + 1, column)
+    elif _FIRST_RE.search(definition):
+        columns.insert(0, column)
+    else:
+        columns.append(column)
+
+
+def _apply_alter_clause(clause: str, columns: list[_Column]) -> None:
+    add = _ADD_COLUMN_RE.match(clause)
+    if add is not None:
+        _apply_add_column(add.group(1), columns)
+        return
+    modify = _MODIFY_COLUMN_RE.match(clause)
+    if modify is not None:
+        # A MODIFY COLUMN restates a type or default in place: it never moves the column, but the
+        # type it restates IS the column's type from here on, so the replay has to take it.
+        modified = _ordinary_column(modify.group(1))
+        assert modified is not None, f"{_SQL_DIR} modifies a column into a computed one: {clause!r}"
+        index = _index_of(columns, modified.name)
+        assert index is not None, f"{_SQL_DIR} modifies `{modified.name}`, which no earlier migration adds"
+        columns[index] = modified
+        return
+    drop = _DROP_COLUMN_RE.match(clause)
+    if drop is not None:
+        index = _index_of(columns, drop.group(1))
+        assert index is not None, f"{_SQL_DIR} drops `{drop.group(1)}`, which no earlier migration adds"
+        del columns[index]
+        return
+    assert _MODIFY_ORDER_BY_RE.match(clause) is not None, (
+        f"{_SQL_DIR} has a DDL clause this replay cannot model: {clause!r}. Teach it that clause -- "
+        f"a migration it reads as a no-op is a column order it silently stops checking."
+    )
+
+
+def _apply_statement(statement: str, columns: list[_Column]) -> None:
+    assert _TABLE in statement, f"{_SQL_DIR} holds a statement that is not about {_TABLE}: {statement!r}"
+    if _CREATE_RE.match(statement):
+        for definition in _split_top_level(_parenthesized(statement, statement.index(_TABLE))):
+            column = _ordinary_column(definition)
+            if column is not None:
+                columns.append(column)
+        return
+    assert _ALTER_RE.match(statement) is not None, f"{_SQL_DIR} holds an unrecognized statement: {statement!r}"
+    for clause in _split_top_level(statement[statement.index(_TABLE) + len(_TABLE) :]):
+        _apply_alter_clause(clause, columns)
+
+
+def _table_columns() -> list[_Column]:
+    """The table's ordinary columns, in order, by replaying every migration in filename order."""
+    paths = sorted((ROOT / _SQL_DIR).glob("*.sql"))
+    assert paths, f"no migrations under {_SQL_DIR}"
+    columns: list[_Column] = []
+    for path in paths:
+        for raw in _SQL_COMMENT_RE.sub("", path.read_text()).split(";"):
+            statement = raw.strip()
+            if statement:
+                _apply_statement(statement, columns)
+    assert columns
+    return columns
+
+
+def _sql_columns() -> list[_Column]:
+    return [column for column in _table_columns() if column.name != _REPLICATOR_APPENDED]
+
+
+def _adapter_columns() -> list[_Column]:
+    text = (ROOT / _ADAPTER).read_text()
+    start = text.find(_ADAPTER_FN)
+    assert start != -1, f"no `{_ADAPTER_FN}` in {_ADAPTER}; re-target this test at its new name"
+    end = text.find("\ndef ", start)
+    match = _SCHEMA_RE.search(text[start:] if end == -1 else text[start:end])
+    assert match is not None, f'no `schema = """..."""` inside {_ADAPTER_FN} in {_ADAPTER}'
+    columns: list[_Column] = []
+    for definition in _split_top_level(match.group(1)):
+        column = _ordinary_column(definition)
+        assert column is not None, f"{_ADAPTER} declares a computed column in its read schema: {definition!r}"
+        columns.append(column)
+    assert columns, f"{_ADAPTER_FN} declares an empty schema in {_ADAPTER}"
+    return columns
+
+
+def _writer_columns() -> list[str]:
+    captured: list[str] = []
+
+    def emit(row_gzip: bytes, _key: str) -> None:
+        captured.extend(json.loads(gzip.decompress(row_gzip).decode("utf-8")))
+
+    state_emit.emit_row(
+        repo="o/r",
+        pr_number=1,
+        head_sha="h",
+        status="LAND",
+        reason="clean",
+        eval_hash=_HASH,
+        message="LGTM",
+        eval_job="ej",
+        agent_job="aj",
+        run_id=9,
+        shadow=False,
+        now=lambda: _FIXED,
+        emit=emit,
+        new_emit_id=lambda: _EMIT_ID,
+    )
+
+    assert captured
+    return captured
+
+
+_SOURCES = {
+    _ADAPTER: _adapter_columns,
+    _SQL_DIR: _sql_columns,
+}
+
+
+@pytest.mark.parametrize("artifact", list(_SOURCES))
+def test_state_row_columns_match_the_writer(artifact: str) -> None:
+    extracted = [column.name for column in _SOURCES[artifact]()]
+    canonical = _writer_columns()
+    assert extracted == canonical, _drift(artifact, f"it declares {extracted}, the writer emits {canonical}.")
+
+
+def test_adapter_column_types_match_the_table() -> None:
+    # Order and membership are only half the contract. A type skew is not a positional error, so it
+    # raises a parse/convert failure rather than NUMBER_OF_COLUMNS_DOESNT_MATCH -- but general_adapter
+    # swallows both into errors.gen_errors identically, so the symptom is the same silent stop. The
+    # writer emits JSON and carries no types, which is why this pair is adapter against table.
+    table = {column.name: column.type for column in _sql_columns()}
+    mismatched = {
+        column.name: (column.type, table[column.name])
+        # A name absent from the table is drift the name test above reports; skip it rather than
+        # raise a KeyError that buries that clearer message.
+        for column in _adapter_columns()
+        if column.name in table and column.type not in _read_schema_equivalents(table[column.name])
+    }
+    assert not mismatched, _drift(
+        _ADAPTER,
+        f"these columns are read with a type the table does not hold, as (adapter, table): {mismatched}. "
+        f"Only a LowCardinality(T) column read as bare T is allowed; see _read_schema_equivalents for "
+        f"why the rest -- Nullable, narrower numerics, a different DateTime64 precision -- are not.",
+    )
+
+
+@cache
+def _replicator() -> ModuleType:
+    """The replicator imported for real, so its wiring is checked as values rather than as text."""
+    spec = importlib.util.spec_from_file_location("_clickhouse_replicator_s3", ROOT / _ADAPTER)
+    assert spec is not None, f"cannot load {_ADAPTER} as a module"
+    assert spec.loader is not None, f"{_ADAPTER} has no module loader"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_the_writers_key_prefix_is_a_registered_path() -> None:
+    # Read out of the replicator's own SUPPORTED_PATHS and keyed by the writer's own S3_KEY_PREFIX,
+    # so neither side of this is a literal restated here. An unregistered prefix is not an error in
+    # the replicator -- extract_clickhouse_table_name simply returns None and the object is ignored,
+    # so the rows never even reach the adapter to fail.
+    registered = _replicator().SUPPORTED_PATHS.get(S3_KEY_PREFIX)
+    assert registered == _TABLE, _drift(
+        _ADAPTER,
+        f"SUPPORTED_PATHS maps {S3_KEY_PREFIX!r} to {registered!r} rather than to {_TABLE}. The writer "
+        f"keys every object under that prefix, so the entry must exist and must name this table.",
+    )
+
+
+def test_an_emitted_object_key_routes_to_the_state_table() -> None:
+    # The registration above stated as the replicator resolves it: a key the writer really produces,
+    # through the function the replicator really dispatches on. SUPPORTED_PATHS is matched by
+    # `startswith(f"{path}/")`, not by equality, so the entry can be present and correct and a key
+    # still fail to route -- this is the assertion that covers the prefix boundary itself.
+    key = state_emit.object_key("pytorch/pytorch", 1, "2026-07-30 12:00:00.000", _EMIT_ID)
+    routed = _replicator().extract_clickhouse_table_name(S3_BUCKET, key)
+    assert routed == _TABLE, _drift(
+        _ADAPTER,
+        f"it routes {key!r} to {routed!r} rather than {_TABLE}.",
+    )
+
+
+def test_the_state_table_is_wired_to_the_state_adapter() -> None:
+    # Routing to the table is only half of it: OBJECT_CONVERTER is what turns that table into the
+    # schema the two tests above pin. Left unwired, every column here can be correct and no row lands.
+    module = _replicator()
+    wired = module.OBJECT_CONVERTER.get(_TABLE)
+    assert wired is module.greenlight_pr_state_adapter, _drift(
+        _ADAPTER,
+        f"OBJECT_CONVERTER maps {_TABLE} to {getattr(wired, '__name__', wired)!r} rather than to "
+        f"greenlight_pr_state_adapter, so the column list this file pins is not the one it inserts with.",
+    )
+
+
+def test_meta_stays_the_last_ordinary_column() -> None:
+    columns = [column.name for column in _table_columns()]
+    assert columns[-1] == _REPLICATOR_APPENDED, _drift(
+        _SQL_DIR,
+        f"`{_REPLICATOR_APPENDED}` is not the last ordinary column: {columns}. general_adapter "
+        f"appends it as the final expression of its `SELECT *, (bucket, key)`, so every column "
+        f"added after it lands in the wrong slot -- or, when the counts still match, silently "
+        f"stores the bucket/key tuple's value.",
+    )

--- a/greenlight/tests/test_verdict.py
+++ b/greenlight/tests/test_verdict.py
@@ -189,6 +189,7 @@ def test_full_land_emits_payload_then_approves(make_config, tmp_path):
         "version": _VERSION,
         "run_id": 0,
         "emit_id": _EMIT_ID,
+        "shadow": False,
     }
     assert emit.key == f"greenlight_pr_state/pytorch/pytorch/7/{_VERSION_COMPACT}-{_EMIT_ID}.json.gz"
     event, body = pr.created_reviews[0]
@@ -312,6 +313,7 @@ def test_emit_payload_is_single_gzipped_jsoneachrow_line(make_config, tmp_path):
         "version",
         "run_id",
         "emit_id",
+        "shadow",
     ]
     assert isinstance(obj["pr_number"], int)
     assert isinstance(obj["version"], str)
@@ -340,7 +342,7 @@ def test_verdict_emitted_row_is_byte_stable(make_config):
     assert raw == (
         '{"repo":"pytorch/pytorch","pr_number":9,"head_sha":"h","status":"CANCELLED",'
         '"reason":"","eval_hash":"","message":"","eval_job":"","agent_job":"",'
-        f'"version":"{_VERSION}","run_id":0,"emit_id":"{_EMIT_ID}"}}\n'
+        f'"version":"{_VERSION}","run_id":0,"emit_id":"{_EMIT_ID}","shadow":false}}\n'
     )
 
 
@@ -561,6 +563,7 @@ def test_marker_cancelled_emits_payload_only(make_config):
         "version": _VERSION,
         "run_id": 0,
         "emit_id": _EMIT_ID,
+        "shadow": False,
     }
     assert emit.key == f"greenlight_pr_state/pytorch/pytorch/9/{_VERSION_COMPACT}-{_EMIT_ID}.json.gz"
 
@@ -607,6 +610,7 @@ def test_marker_ai_review_started_emits_payload_only(make_config):
         "version": _VERSION,
         "run_id": 0,
         "emit_id": _EMIT_ID,
+        "shadow": False,
     }
     assert emit.key == f"greenlight_pr_state/pytorch/pytorch/11/{_VERSION_COMPACT}-{_EMIT_ID}.json.gz"
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #8729
* #8728
* #8727
* #8726
* #8725
* __->__ #8724
* #8723
* #8722

**Impact:** the `misc.greenlight_pr_state` write path; no reader behaviour change yet
**Risk:** high — the DDL is hand-applied and the replicator auto-deploys, so ordering matters

## What
`misc.greenlight_pr_state` gains a `shadow` Bool. Migration `005` adds it to the live table,
the clickhouse-replicator-s3 adapter declares it, and every writer now has to state a value:
`shadow` is a required keyword on `emit_row` and on both marker writers, with no default
anywhere on the path. Every caller passes `false` — nothing derives or reads the column yet.
A new schema-sync test pins the three artifacts that have to agree on the column order, and
the greenlight test workflow starts watching the replicator's tree so an adapter-only edit
cannot ship without them.

## Why
The column is the storage half of shadow mode: a marker on rows whose evaluation carries no
authority. It lands on its own, ahead of anything that writes a `true`, so the schema change
can be applied and verified against production before any behaviour depends on it.

`shadow` has no default because an unstamped row reads as authoritative — Dr. CI renders it
and the merge gate honours it. A forgotten argument must be a `TypeError` at the call site,
not a silent downgrade.

The schema-sync test exists because this contract has no build-time link and fails silently.
The replicator's insert is positional (`SELECT *, (bucket, key) AS _meta`), so the writer's
JSONEachRow field order, the adapter's schema string, and the table DDL are one contract in
which order matters as much as membership. A skew raises `NUMBER_OF_COLUMNS_DOESNT_MATCH`,
which `general_adapter` swallows into `errors.gen_errors` — a table nothing alerts on. The
only symptom is rows quietly ceasing to arrive.

# Notes
**Apply the DDL before merging this.** The replicator Lambda auto-deploys on merge to main,
and its adapter gains the matching column here. Between a deployed adapter and an unmigrated
table, every insert fails with `NUMBER_OF_COLUMNS_DOESNT_MATCH` and is swallowed into
`errors.gen_errors`; state rows simply stop landing, with no alert. The writer must not run
ahead of the adapter either — `input_format_skip_unknown_fields = 1` means a `shadow` field
the adapter does not declare is dropped without an error.

Verify with a `system.columns` query for `(database = 'misc', table = 'greenlight_pr_state',
name = 'shadow')` rather than assuming any file under `greenlight/sql/` reflects the live
table. Missed objects are replayable from `s3://gha-artifacts/greenlight_pr_state/`.