### PR TITLE
[docker] Do not validate a docker image type pytorch/pytorch does not build

### DIFF
--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -58,6 +58,16 @@ ROCM_ARCHES_DICT = {
     "release": ["7.2", "7.14"],
 }
 
+# CUDA versions that can only produce the runtime docker image. The devel image
+# apt-installs cuda-toolkit-<major>-<minor> from NVIDIA's repo, which carries
+# 13-0 through 13-3 only: 13.4 is still a release candidate (13.4.0rc1). The
+# runtime image just pip-installs the published cu134 nightly, so it builds.
+# Keep in sync with pytorch/pytorch .github/scripts/generate_binary_build_matrix.py,
+# which drives the build side of this same matrix -- validating an image type
+# that repo does not build fails the nightly with `manifest unknown`.
+# Drop an entry once its toolkit ships in the apt repo.
+CUDA_ARCHES_RUNTIME_IMAGE_ONLY = ["13.4"]
+
 CUDA_CUDNN_VERSIONS = {
     "12.6": {"cuda": "12.6.3", "cudnn": "9"},
     "12.8": {"cuda": "12.8.0", "cudnn": "9"},

--- a/tools/scripts/generate_docker_release_matrix.py
+++ b/tools/scripts/generate_docker_release_matrix.py
@@ -47,6 +47,11 @@ def generate_docker_matrix(
     for cuda in generate_binary_build_matrix.CUDA_ARCHES_DICT[channel]:
         version = generate_binary_build_matrix.CUDA_CUDNN_VERSIONS[cuda]
         for image in DOCKER_IMAGE_TYPES:
+            if (
+                image == "devel"
+                and cuda in generate_binary_build_matrix.CUDA_ARCHES_RUNTIME_IMAGE_ONLY
+            ):
+                continue
             ret.append(
                 {
                     "cuda": cuda,

--- a/tools/tests/test_generate_docker_release_matrix.py
+++ b/tools/tests/test_generate_docker_release_matrix.py
@@ -1,0 +1,67 @@
+"""Tests for the docker release matrix.
+
+The build side of this matrix lives in pytorch/pytorch
+(.github/scripts/generate_docker_release_matrix.py) and the validate side here.
+They are independent copies, so they drift: a CUDA version this repo emits a
+`devel` entry for, but pytorch/pytorch does not build, fails the nightly
+"Build Official Docker Images" workflow with `manifest unknown`. These tests pin
+the part of the contract that drifted.
+"""
+
+import unittest
+
+import generate_binary_build_matrix
+from generate_docker_release_matrix import generate_docker_matrix
+
+
+class TestDockerReleaseMatrix(unittest.TestCase):
+    def _entries(self, channel="nightly"):
+        return generate_docker_matrix(channel, "false")["include"]
+
+    def test_runtime_image_only_arches_get_no_devel_entry(self):
+        for channel in ("nightly", "test", "release"):
+            entries = self._entries(channel)
+            for cuda in generate_binary_build_matrix.CUDA_ARCHES_RUNTIME_IMAGE_ONLY:
+                devel = [
+                    e
+                    for e in entries
+                    if e["cuda"] == cuda and e["image_type"] == "devel"
+                ]
+                self.assertEqual(
+                    devel,
+                    [],
+                    f"{channel}: CUDA {cuda} is runtime-image-only, so no devel "
+                    "entry may be emitted -- pytorch/pytorch does not build it",
+                )
+
+    def test_runtime_image_only_arches_still_get_runtime(self):
+        # The point of runtime-image-only is that the runtime image still ships.
+        entries = self._entries("nightly")
+        for cuda in generate_binary_build_matrix.CUDA_ARCHES_RUNTIME_IMAGE_ONLY:
+            if cuda not in generate_binary_build_matrix.CUDA_ARCHES_DICT["nightly"]:
+                continue
+            runtime = [
+                e for e in entries if e["cuda"] == cuda and e["image_type"] == "runtime"
+            ]
+            self.assertEqual(len(runtime), 1, f"CUDA {cuda} lost its runtime entry")
+
+    def test_other_arches_get_both_image_types(self):
+        entries = self._entries("nightly")
+        for cuda in generate_binary_build_matrix.CUDA_ARCHES_DICT["nightly"]:
+            if cuda in generate_binary_build_matrix.CUDA_ARCHES_RUNTIME_IMAGE_ONLY:
+                continue
+            types = sorted(e["image_type"] for e in entries if e["cuda"] == cuda)
+            self.assertEqual(
+                types, ["devel", "runtime"], f"CUDA {cuda} should emit both"
+            )
+
+    def test_cpu_arm64_runtime_entry_is_unchanged(self):
+        entries = self._entries("nightly")
+        cpu = [e for e in entries if e["cuda"] == "cpu"]
+        self.assertEqual(len(cpu), 1)
+        self.assertEqual(cpu[0]["image_type"], "runtime")
+        self.assertEqual(cpu[0]["platform"], "linux/arm64")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

`Build Official Docker Images` has failed on **every nightly since 2026-08-25** — 12 consecutive runs (08-25, 08-26, 08-27, 08-28, 08-29 x2, 08-30 x2, 08-31, 09-01, 09-02) — at `validate / cuda13.4-cudnn9-devel`:

```
docker manifest inspect ghcr.io/pytorch/pytorch-nightly:2.15.0.dev20260829-cuda13.4-cudnn9-devel
manifest unknown
+ docker pull ... (x3 retries)
Error: Process completed with exit code 1
```

The validate job is pulling an image that is **deliberately never built**.

## Root cause: two copies of the generator, drifted

| side | file | 13.4 behavior |
|---|---|---|
| build | pytorch/pytorch `.github/scripts/generate_binary_build_matrix.py` | `CUDA_ARCHES_RUNTIME_IMAGE_ONLY = ["13.4"]` -> devel entry skipped |
| validate | this repo `tools/scripts/generate_docker_release_matrix.py` | no such notion -> still emits `cuda13.4-cudnn9-devel` |

13.4 is runtime-image-only because the devel stage does `apt-get install cuda-toolkit-13-4`, and NVIDIA's `ubuntu2204` repo carries **13-0 through 13-3 only** (13.4 is still `13.4.0rc1`). I re-checked today: still absent. The runtime image builds fine because it only pip-installs the published `cu134` nightly.

A retry cannot recover this, and it has been masking any other failure in that workflow for nine days.

## Changes

Mirror the constant and the guard from pytorch/pytorch. Both generators now emit identical matrices:

```
nightly: 12.6 x {devel,runtime}, 13.0 x {devel,runtime}, 13.2 x {devel,runtime}, 13.4 runtime, cpu runtime
test:    same
release: 12.6/13.0/13.2 x {devel,runtime}, cpu runtime
```

Verified by running both repos' generators and diffing the `(cuda, image_type)` sets -- they match row for row.

**The 13.4 runtime image keeps shipping**, which is the point of carrying 13.4 in nightlies before GA. When `cuda-toolkit-13-4` reaches the apt repo, delete `"13.4"` from `CUDA_ARCHES_RUNTIME_IMAGE_ONLY` in both repos and 13.4 gets both image types -- the end state is reached by removing code, and the constant's comment says so.

## Tests

Adds `tools/tests/test_generate_docker_release_matrix.py` (there was none), pinning the part of the contract that drifted:

- runtime-image-only arches emit **no** devel entry, on all three channels
- ...but still emit their runtime entry
- every other arch emits both image types
- the cpu/arm64 runtime entry is unchanged

4 tests, all passing.

## Follow-up worth doing separately

These two generators will drift again -- that is what produced this outage. A scheduled job diffing their outputs and filing an issue on mismatch would catch the next one at commit time rather than after nine red nightlies.
