### PR TITLE
Read the sccache bucket anonymously when there are no credentials

### DIFF
--- a/.github/workflows/linux_job_v3.yml
+++ b/.github/workflows/linux_job_v3.yml
@@ -279,6 +279,15 @@ jobs:
         working-directory: ${{ inputs.repository || github.repository }}
         env:
           ALL_SECRETS: ${{ toJSON(secrets) }}
+          # A pull request from a fork gets no OIDC token, so the role assume
+          # above fails and there are no credentials to sign an S3 request with.
+          # CI images put sccache stubs ahead of the real compilers, and sccache
+          # fails its startup read rather than compiling uncached, which surfaces
+          # as `the C compiler is not able to compile a simple test program`.
+          # Reading the cache anonymously keeps those builds working, as
+          # pytorch's _linux-build.yml does for the same bucket. `outcome` rather
+          # than `conclusion`: continue-on-error rewrites the latter to success.
+          SCCACHE_S3_NO_CREDENTIALS: ${{ steps.aws-creds.outcome != 'success' && 'true' || 'false' }}
         run: |
           set -ex
           {

--- a/.github/workflows/test_linux_job_v3.yml
+++ b/.github/workflows/test_linux_job_v3.yml
@@ -266,3 +266,28 @@ jobs:
           [[ "${HF_HOME:-}" != "${RUNNER_TEMP}/hf_cache" ]] || { echo "HF_HOME unexpectedly repointed"; exit 1; }
           echo "default-mode env OK"
         fi
+
+  test-sccache-credentials:
+    uses: ./.github/workflows/linux_job_v3.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      job-name: "linux-sccache-credentials"
+      runner: mt-l-x86iavx512-8-64
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      gpu-arch-type: cpu
+      gpu-arch-version: ""
+      script: |
+        set -x
+        # The value has to reach the script, since that is where the compilers
+        # and so the sccache server start. A run in this repository has an OIDC
+        # token, so the role assume succeeds and anonymous access stays off; the
+        # fork case cannot be exercised here, only the plumbing.
+        case "${SCCACHE_S3_NO_CREDENTIALS:-<unset>}" in
+          true|false) echo "SCCACHE_S3_NO_CREDENTIALS=${SCCACHE_S3_NO_CREDENTIALS}" ;;
+          *) echo "SCCACHE_S3_NO_CREDENTIALS not plumbed through: ${SCCACHE_S3_NO_CREDENTIALS:-<unset>}"; exit 1 ;;
+        esac
+        [[ -n "${AWS_ACCESS_KEY_ID:-}" ]] || { echo "expected credentials in this repository"; exit 1; }
+        [[ "${SCCACHE_S3_NO_CREDENTIALS}" == "false" ]] || { echo "credentials loaded, so anonymous access should be off"; exit 1; }


### PR DESCRIPTION
A pull request from a fork gets no OIDC token, so linux_job_v3's role assume fails. That step is `continue-on-error`, so the job carries on into the script, where the CI image's sccache stubs sit ahead of the real compilers on `PATH`. sccache fails its startup read rather than compiling uncached, and the first cmake probe reports

```
The C compiler "/opt/cache/bin/cc" is not able to compile a simple test program.
```

which reads as a code problem to the contributor who hit it. Live today in executorch: on fork head `214f83c2`, [run 33749324463](https://github.com/pytorch/executorch/actions/runs/33749324463) fails exactly the three Linux jobs already on v3 while the same commit pushed inside the main repository passes all 120.

Set `SCCACHE_S3_NO_CREDENTIALS` from the outcome of the assume, as pytorch's `_linux-build.yml` does against the same bucket.

Anonymous reads work: on pytorch fork run 33806115960, job 100817557572 logged `Credentials could not be loaded` and `SCCACHE_S3_NO_CREDENTIALS=true`, then built with **3207 cache hits at 99.94%**. Writes fail harmlessly. A local disk cache would have been the other option, but it caches nothing in an ephemeral pod.

`outcome`, not `conclusion` — `continue-on-error` rewrites the latter to `success`.

The test only covers the plumbing, asserting the value reaches the script and is `false` when credentials did load. The fork path needs a fork, so it can't be exercised here.

Authored with Claude Code.
