### PR TITLE
Run the GreenLight PR reviewer with the Concise output style

### DIFF
--- a/.github/workflows/greenlight-pr-review.yml
+++ b/.github/workflows/greenlight-pr-review.yml
@@ -476,6 +476,10 @@ jobs:
           # claude-code-action blocks unless allowlisted. Scope to our bot only:
           # "*" would let any external App trigger reviews on this public repo.
           allowed_bots: "pytorchgreenlight[bot]"
+          # claude-code-action merges this into $HOME/.claude/settings.json, a
+          # separate and lower-precedence layer than the .claude/settings.local.json
+          # written above, so it cannot disturb the hook registrations there.
+          settings: '{"outputStyle": "Concise"}'
           claude_args: >-
             --model global.anthropic.claude-opus-5
             --effort high


### PR DESCRIPTION
**Impact:** CI only — the GreenLight PR review workflow
**Risk:** low

## What
Passes `settings: '{"outputStyle": "Concise"}'` to `claude-code-action` in the GreenLight review job, so the reviewer runs under the Concise output style.

## Why
The reviewer's job is to produce a verdict JSON plus a short message, not narration. Concise cuts the preamble and step-by-step commentary, making the responses easier to understand.

The action merges this into `$HOME/.claude/settings.json`, a different (and lower-precedence) layer than the repo-level `.claude/settings.local.json` the workflow writes earlier, so the write-sandbox / read-restrict / verdict-gate hook registrations are untouched.