### PR TITLE
[setup-python] Make macOS venv cleanup resilient to EACCES

### DIFF
--- a/.github/actions/setup-python/cleanup.js
+++ b/.github/actions/setup-python/cleanup.js
@@ -12,13 +12,9 @@ if (venvPath) {
       return false;
     }
   };
-  // Best-effort cleanup on pet runners: a plain `rm -rf` fails with EACCES when
-  // the venv contains read-only or root-owned leftovers (regularly seen on the
-  // torch/distributed subtree). Try a privileged remove first since it clears
-  // both cases; `-n` keeps sudo non-interactive so it never blocks on a
-  // password prompt, and we fall back to a plain `rm -rf` if passwordless sudo
-  // is unavailable. Never fail the job on cleanup; the next job re-cleans
-  // leftover site-packages.
+  // Try sudo if permitted (`-n` never prompts): guaranteed to clean this
+  // user-only folder even with read-only/root-owned leftovers. Fall back to a
+  // plain `rm -rf`. Best-effort: never fail the job.
   if (!tryRun(`sudo -n rm -rf "${venvPath}"`)) {
     tryRun(`rm -rf "${venvPath}"`);
   }

--- a/.github/actions/setup-python/cleanup.js
+++ b/.github/actions/setup-python/cleanup.js
@@ -3,7 +3,26 @@ const {execSync} = require('child_process');
 const venvPath = process.env['STATE_venvPath'];
 if (venvPath) {
   console.log(`Removing virtual environment at ${venvPath}`);
-  execSync(`rm -rf "${venvPath}"`, {stdio: 'inherit'});
+  const tryRun = (cmd) => {
+    try {
+      execSync(cmd, {stdio: 'inherit'});
+      return true;
+    } catch (e) {
+      console.log(`Warning: \`${cmd}\` failed: ${e.message}`);
+      return false;
+    }
+  };
+  // Best-effort cleanup on pet runners: a plain `rm -rf` can fail with EACCES
+  // when an installed package (e.g. torch) leaves read-only directories, or
+  // when a prior job seeded root-owned files under the venv. Clear the
+  // read-only bits and retry, then fall back to a privileged remove. Never
+  // fail the job on cleanup; the next job re-cleans leftover site-packages.
+  if (!tryRun(`rm -rf "${venvPath}"`)) {
+    tryRun(`chmod -R u+w "${venvPath}"`);
+    if (!tryRun(`rm -rf "${venvPath}"`)) {
+      tryRun(`sudo rm -rf "${venvPath}"`);
+    }
+  }
 } else {
   console.log('No virtual environment to remove.');
 }

--- a/.github/actions/setup-python/cleanup.js
+++ b/.github/actions/setup-python/cleanup.js
@@ -13,10 +13,11 @@ if (venvPath) {
     }
   };
   // Try sudo if permitted (`-n` never prompts): guaranteed to clean this
-  // user-only folder even with read-only/root-owned leftovers. Fall back to a
-  // plain `rm -rf`. Best-effort: never fail the job.
+  // user-only folder even with read-only/root-owned leftovers. Otherwise fall
+  // back to a plain `rm -rf` and let it throw, so a genuinely poisoned runner
+  // still surfaces an error.
   if (!tryRun(`sudo -n rm -rf "${venvPath}"`)) {
-    tryRun(`rm -rf "${venvPath}"`);
+    execSync(`rm -rf "${venvPath}"`, {stdio: 'inherit'});
   }
 } else {
   console.log('No virtual environment to remove.');

--- a/.github/actions/setup-python/cleanup.js
+++ b/.github/actions/setup-python/cleanup.js
@@ -12,16 +12,15 @@ if (venvPath) {
       return false;
     }
   };
-  // Best-effort cleanup on pet runners: a plain `rm -rf` can fail with EACCES
-  // when an installed package (e.g. torch) leaves read-only directories, or
-  // when a prior job seeded root-owned files under the venv. Clear the
-  // read-only bits and retry, then fall back to a privileged remove. Never
-  // fail the job on cleanup; the next job re-cleans leftover site-packages.
-  if (!tryRun(`rm -rf "${venvPath}"`)) {
-    tryRun(`chmod -R u+w "${venvPath}"`);
-    if (!tryRun(`rm -rf "${venvPath}"`)) {
-      tryRun(`sudo rm -rf "${venvPath}"`);
-    }
+  // Best-effort cleanup on pet runners: a plain `rm -rf` fails with EACCES when
+  // the venv contains read-only or root-owned leftovers (regularly seen on the
+  // torch/distributed subtree). Try a privileged remove first since it clears
+  // both cases; `-n` keeps sudo non-interactive so it never blocks on a
+  // password prompt, and we fall back to a plain `rm -rf` if passwordless sudo
+  // is unavailable. Never fail the job on cleanup; the next job re-cleans
+  // leftover site-packages.
+  if (!tryRun(`sudo -n rm -rf "${venvPath}"`)) {
+    tryRun(`rm -rf "${venvPath}"`);
   }
 } else {
   console.log('No virtual environment to remove.');


### PR DESCRIPTION
## Problem

The macOS `setup-python` post-job cleanup does a bare `rm -rf` on the temp
venv and **throws on any failure**, so a single undeletable path fails the
whole job:

```js
// cleanup.js
execSync(`rm -rf "${venvPath}"`, {stdio: 'inherit'});  // throws -> job red
```

On the pytorch/pytorch macOS runners this surfaces regularly as `EACCES`
removing the venv's `torch/distributed` subtree:

```
Removing virtual environment at .../venv-3.12-XX
rm: .../site-packages/torch/distributed: Permission denied
...
Error: Command failed: rm -rf ".../venv-3.12-XX"
    at .../setup-python/cleanup.js:6:3
```

### Impact (pytorch/pytorch, ClickHouse `default.workflow_job`, last 2 weeks)

- **621** jobs hit a `Post Setup Python` step failure.
- **507 (82%)** of those had **passing** tests -- the cleanup post-step alone
  turned an otherwise-green job red.
- Spread across **130+ distinct runners**; **200-311/week and rising**.
- Concentrated on `macos-py3-arm64 / test (default, *, 3, macos-m1-stable)`.

Example jobs where the tests passed but the cleanup step failed with the
`EACCES` error above:

- https://github.com/pytorch/pytorch/actions/runs/34143755918/job/101814847721 (default, 1, 3, macos-m1-stable)
- https://github.com/pytorch/pytorch/actions/runs/34143060403/job/101813179606 (default, 2, 3, macos-m1-stable)
- https://github.com/pytorch/pytorch/actions/runs/34143060403/job/101813179576 (default, 3, 3, macos-m1-stable)
- https://github.com/pytorch/pytorch/actions/runs/34143755918/job/101814847679 (mps, 1, 1, macos-m2-15)

So this is not test-outcome-driven and not a single bad host -- it's a
systemic cleanup failure reddening green macOS jobs.

## Fix

Make cleanup prefer a privileged remove and stop failing green jobs:

```js
if (!tryRun(`sudo -n rm -rf "${venvPath}"`)) {
  execSync(`rm -rf "${venvPath}"`, {stdio: 'inherit'});
}
```

- `sudo` first: guaranteed to clean this user-only folder even with
  read-only/root-owned leftovers.
- `-n` (non-interactive): sudo never blocks on a password prompt; if
  passwordless sudo is unavailable it fails fast and we fall back.
- fallback to a plain `rm -rf` that still throws, so a genuinely poisoned
  runner surfaces an error instead of being silently ignored.

The exact root cause of why the venv becomes unwritable is still unknown; this
is the mitigation.

---
_Authored with assistance from an AI agent (Claude Code)._