### PR TITLE
[hud] Add merge attempt analysis page with Sankey chart

### DIFF
--- a/torchci/clickhouse_queries/merge_attempt_flow/params.json
+++ b/torchci/clickhouse_queries/merge_attempt_flow/params.json
@@ -1,0 +1,12 @@
+{
+  "params": {
+    "startTime": "DateTime64(3)",
+    "stopTime": "DateTime64(3)"
+  },
+  "tests": [
+    {
+      "startTime": { "from_now": -30 },
+      "stopTime": { "from_now": 0 }
+    }
+  ]
+}

--- a/torchci/clickhouse_queries/merge_attempt_flow/query.sql
+++ b/torchci/clickhouse_queries/merge_attempt_flow/query.sql
@@ -1,0 +1,207 @@
+-- Sankey links for user-initiated pytorch/pytorch merge attempts.
+--
+-- Cohort: non-updatebot PRs *created* in the selected range that have at least
+-- one trymerge record. All their attempts are kept, including paths that never
+-- landed. Runs sharing a comment_id collapse into one attempt, preferring a
+-- successful outcome.
+--
+-- The range filters PR creation date, not attempt date, so trailing windows are
+-- right-censored: PRs created late in the range may not have attempted a merge
+-- yet, and retries still to come have not happened. Short windows therefore
+-- skew toward first-attempt successes, and a window's shape keeps shifting
+-- until it settles.
+--
+-- '-f' and '-i' are the raw trymerge fields skip_mandatory_checks and
+-- ignore_current, not the HUD force-merge definition in
+-- clickhouse_queries/weekly_force_merge_stats, which also requires that
+-- something was actually skipped or ignored.
+--
+-- Links are emitted in a single pass over `cohort`. Five UNION ALL branches
+-- each reading `cohort` re-ran the whole pipeline five times, since ClickHouse
+-- inlines CTEs rather than materialising them.
+WITH created_prs AS (
+    SELECT number AS pr_num
+    FROM default.pull_request FINAL
+    WHERE
+        dynamoKey LIKE 'pytorch/pytorch/%'
+        AND parseDateTimeBestEffort(created_at) >= {startTime: DateTime64(3)}
+        AND parseDateTimeBestEffort(created_at) < {stopTime: DateTime64(3)}
+        AND user.login != 'pytorchupdatebot'
+),
+
+merge_attempts AS (
+    SELECT
+        pr_num,
+        comment_id,
+        max(skip_mandatory_checks) AS used_force,
+        max(ignore_current) AS used_ignore_current,
+        max(merge_commit_sha != '') AS passed,
+        max(is_failed) AS failed
+    FROM default.merges FINAL
+    WHERE
+        owner = 'pytorch'
+        AND project = 'pytorch'
+        AND dry_run = false
+    GROUP BY
+        pr_num,
+        comment_id
+),
+
+-- `merges` carries no timestamp, so attempt order comes from the triggering
+-- comment. FINAL is load-bearing here: duplicate comment rows would otherwise
+-- inject phantom attempts into the path.
+--
+-- trymerge normally writes a record only after the attempt is over. Keep an
+-- explicit unknown outcome anyway so unexpected or partially ingested records
+-- remain visible instead of silently disappearing from the cohort.
+merge_events AS (
+    SELECT
+        m.pr_num,
+        m.comment_id,
+        c.created_at,
+        multiIf(
+            m.used_force = 1, '-f',
+            m.used_ignore_current = 1, '-i',
+            'default'
+        ) AS action,
+        multiIf(
+            m.passed = 1, 'passed',
+            m.failed = 1, 'failed',
+            'unknown'
+        ) AS outcome
+    FROM merge_attempts m
+    INNER JOIN (
+        SELECT
+            id,
+            created_at
+        FROM default.issue_comment FINAL
+        WHERE dynamoKey LIKE 'pytorch/pytorch/%'
+    ) c ON m.comment_id = c.id
+),
+
+pr_paths AS (
+    SELECT
+        pr_num,
+        arraySort(groupArray((created_at, comment_id, action, outcome)))
+            AS attempts
+    FROM merge_events
+    GROUP BY pr_num
+),
+
+cohort AS (
+    SELECT p.attempts
+    FROM pr_paths p
+    INNER JOIN created_prs c ON p.pr_num = c.pr_num
+),
+
+-- Each PR contributes one link per stage it reaches: entry, the initial
+-- command's outcome, then one per retry it took. Paths stop after a successful
+-- merge; attempts beyond retry 3 collapse into a single overflow node.
+--
+-- "No further attempt" is not the same as "gave up": it also covers PRs still
+-- in flight and PRs that landed by another route (internal diff import, or as
+-- a member of a stack merged from its top PR).
+link_rows AS (
+    SELECT
+        arrayJoin(arrayConcat(
+            -- Entry to the first command.
+            [(
+                'Merging PRs',
+                concat('Initial: ', attempts[1] .3),
+                toUInt8(0), toUInt8(1)
+            )],
+
+            -- Initial command outcome or first retry choice.
+            [(
+                concat('Initial: ', attempts[1] .3),
+                multiIf(
+                    attempts[1] .4 = 'passed', 'Landed on initial attempt',
+                    attempts[1] .4 = 'failed' AND length(attempts) > 1,
+                    concat('Retry 1: ', attempts[2] .3),
+                    attempts[1] .4 = 'failed',
+                    'No further attempt after initial',
+                    'Unknown outcome after initial'
+                ),
+                toUInt8(1), toUInt8(2)
+            )],
+
+            -- First retry outcome or second retry choice.
+            if(
+                length(attempts) >= 2
+                AND attempts[1] .4 = 'failed',
+                [(
+                    concat('Retry 1: ', attempts[2] .3),
+                    multiIf(
+                        attempts[2] .4 = 'passed', 'Landed on retry 1',
+                        attempts[2] .4 = 'failed' AND length(attempts) > 2,
+                        concat('Retry 2: ', attempts[3] .3),
+                        attempts[2] .4 = 'failed',
+                        'No further attempt after retry 1',
+                        'Unknown outcome after retry 1'
+                    ),
+                    toUInt8(2), toUInt8(3)
+                )],
+                CAST([], 'Array(Tuple(String, String, UInt8, UInt8))')
+            ),
+
+            -- Second retry outcome or third retry choice.
+            if(
+                length(attempts) >= 3
+                AND attempts[1] .4 = 'failed'
+                AND attempts[2] .4 = 'failed',
+                [(
+                    concat('Retry 2: ', attempts[3] .3),
+                    multiIf(
+                        attempts[3] .4 = 'passed', 'Landed on retry 2',
+                        attempts[3] .4 = 'failed' AND length(attempts) > 3,
+                        concat('Retry 3: ', attempts[4] .3),
+                        attempts[3] .4 = 'failed',
+                        'No further attempt after retry 2',
+                        'Unknown outcome after retry 2'
+                    ),
+                    toUInt8(3), toUInt8(4)
+                )],
+                CAST([], 'Array(Tuple(String, String, UInt8, UInt8))')
+            ),
+
+            -- Third retry outcome. Longer paths are grouped into one overflow node.
+            if(
+                length(attempts) >= 4
+                AND attempts[1] .4 = 'failed'
+                AND attempts[2] .4 = 'failed'
+                AND attempts[3] .4 = 'failed',
+                [(
+                    concat('Retry 3: ', attempts[4] .3),
+                    multiIf(
+                        attempts[4] .4 = 'passed', 'Landed on retry 3',
+                        attempts[4] .4 = 'failed' AND length(attempts) > 4,
+                        'More than 3 retries',
+                        attempts[4] .4 = 'failed',
+                        'No further attempt after retry 3',
+                        'Unknown outcome after retry 3'
+                    ),
+                    toUInt8(4), toUInt8(5)
+                )],
+                CAST([], 'Array(Tuple(String, String, UInt8, UInt8))')
+            )
+        )) AS link
+    FROM cohort
+)
+
+SELECT
+    link .1 AS source,
+    link .2 AS target,
+    count() AS value,
+    link .3 AS source_depth,
+    link .4 AS target_depth
+FROM link_rows
+GROUP BY
+    source,
+    target,
+    source_depth,
+    target_depth
+ORDER BY
+    source_depth,
+    source,
+    value DESC,
+    target

--- a/torchci/components/layout/NavBar.tsx
+++ b/torchci/components/layout/NavBar.tsx
@@ -103,6 +103,10 @@ function NavBar() {
       href: "/metrics/autorevert",
     },
     {
+      name: "Merge Analysis",
+      href: "/metrics/merge_analysis",
+    },
+    {
       name: "Claude Billing",
       href: "/claude_billing",
     },

--- a/torchci/components/metrics/MergeAttemptFlow.tsx
+++ b/torchci/components/metrics/MergeAttemptFlow.tsx
@@ -1,0 +1,186 @@
+import { Box, Paper, Skeleton, Typography } from "@mui/material";
+import { EChartsOption } from "echarts";
+import ReactECharts from "echarts-for-react";
+import { useDarkMode } from "lib/DarkModeContext";
+import { useClickHouseAPIImmutable } from "lib/GeneralUtils";
+import { useMemo } from "react";
+
+interface MergeFlowLinkRow {
+  source: string;
+  target: string;
+  value: number;
+  source_depth: number;
+  target_depth: number;
+}
+
+interface SankeyNode {
+  name: string;
+  depth: number;
+  itemStyle: { color: string };
+}
+
+function nodeColor(name: string): string {
+  if (name === "Merging PRs") return "#5470c6";
+  if (name.startsWith("Landed")) return "#3ba272";
+  if (
+    name.startsWith("No further attempt") ||
+    name.startsWith("Unknown outcome")
+  ) {
+    return "#8c8c8c";
+  }
+  if (name.startsWith("More than")) return "#9a60b4";
+  if (name.endsWith(": -f")) return "#ee6666";
+  if (name.endsWith(": -i")) return "#fac858";
+  return "#73c0de";
+}
+
+// Fixed locale: the server and the browser must agree or hydration mismatches.
+function formatCount(value: number): string {
+  return value.toLocaleString("en-US");
+}
+
+export default function MergeAttemptFlow({
+  startTime,
+  stopTime,
+}: {
+  startTime: string;
+  stopTime: string;
+}) {
+  const { darkMode } = useDarkMode();
+  // Immutable: TimeRangePicker already advances startTime/stopTime every 5
+  // minutes, which re-keys the request. A refreshInterval on top of that just
+  // doubles the uncached round trips (/api/clickhouse sets use_query_cache=0).
+  const { data, error } = useClickHouseAPIImmutable<MergeFlowLinkRow>(
+    "merge_attempt_flow",
+    { startTime, stopTime }
+  );
+
+  const { links, nodes, totalPrs } = useMemo(() => {
+    const rows = data ?? [];
+    const nodeDepths = new Map<string, number>();
+
+    for (const row of rows) {
+      nodeDepths.set(row.source, Number(row.source_depth));
+      nodeDepths.set(row.target, Number(row.target_depth));
+    }
+
+    const nodes: SankeyNode[] = Array.from(nodeDepths, ([name, depth]) => ({
+      name,
+      depth,
+      itemStyle: { color: nodeColor(name) },
+    }));
+    const links = rows.map((row) => ({
+      source: row.source,
+      target: row.target,
+      value: Number(row.value),
+    }));
+    const totalPrs = links
+      .filter((link) => link.source === "Merging PRs")
+      .reduce((total, link) => total + link.value, 0);
+
+    return { links, nodes, totalPrs };
+  }, [data]);
+
+  const options = useMemo<EChartsOption>(
+    () => ({
+      animationDuration: 400,
+      tooltip: {
+        trigger: "item",
+        formatter: (params: any) => {
+          const value = Number(params.value ?? 0);
+          const percentage = totalPrs > 0 ? (100 * value) / totalPrs : 0;
+
+          if (params.dataType === "edge") {
+            return `${params.data.source} → ${
+              params.data.target
+            }<br/><strong>${formatCount(
+              value
+            )} PRs</strong> (${percentage.toFixed(1)}% of cohort)`;
+          }
+
+          return `${params.name}<br/><strong>${formatCount(
+            value
+          )} PRs</strong> (${percentage.toFixed(1)}% of cohort)`;
+        },
+      },
+      series: [
+        {
+          type: "sankey",
+          data: nodes,
+          links,
+          left: 20,
+          right: 190,
+          top: 20,
+          bottom: 20,
+          nodeAlign: "justify",
+          nodeGap: 16,
+          nodeWidth: 18,
+          draggable: false,
+          layoutIterations: 32,
+          emphasis: { focus: "adjacency" },
+          lineStyle: {
+            color: "source",
+            curveness: 0.5,
+            opacity: 0.35,
+          },
+          label: {
+            color: darkMode ? "#e0e0e0" : "#333333",
+            fontSize: 12,
+            formatter: (params: any) => {
+              const value = Number(params.value ?? 0);
+              const percentage = totalPrs > 0 ? (100 * value) / totalPrs : 0;
+              return `${params.name}\n${formatCount(
+                value
+              )} (${percentage.toFixed(1)}%)`;
+            },
+          },
+        },
+      ],
+    }),
+    [darkMode, links, nodes, totalPrs]
+  );
+
+  if (error) {
+    return (
+      <Paper sx={{ p: 2 }} elevation={3}>
+        <Typography color="error">
+          Unable to load merge-attempt data.
+        </Typography>
+      </Paper>
+    );
+  }
+
+  if (data === undefined) {
+    return <Skeleton variant="rectangular" height={620} />;
+  }
+
+  if (data.length === 0) {
+    return (
+      <Paper sx={{ p: 2 }} elevation={3}>
+        <Typography>No completed merge attempts in this time range.</Typography>
+      </Paper>
+    );
+  }
+
+  return (
+    <Paper sx={{ p: 2 }} elevation={3}>
+      <Typography variant="h6" fontWeight="bold">
+        Merge attempt flow
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+        {formatCount(totalPrs)} PRs <strong>created</strong> in the selected
+        range with at least one recorded merge attempt. Paths stop after a
+        successful merge; attempts beyond retry 3 are grouped together. Recent
+        ranges are incomplete and skew toward first-attempt successes.
+      </Typography>
+      <Box sx={{ minWidth: 1100, height: 600 }}>
+        <ReactECharts
+          theme={darkMode ? "dark-hud" : undefined}
+          option={options}
+          style={{ height: "100%", width: "100%" }}
+          notMerge
+        />
+      </Box>
+    </Paper>
+  );
+}

--- a/torchci/components/metrics/panels/ScalarPanel.tsx
+++ b/torchci/components/metrics/panels/ScalarPanel.tsx
@@ -4,6 +4,7 @@
 
 import { Box, Paper, Skeleton, Typography } from "@mui/material";
 import { fetcher } from "lib/GeneralUtils";
+import Link from "next/link";
 import useSWR from "swr";
 
 export function ScalarPanelWithValue({
@@ -15,11 +16,14 @@ export function ScalarPanelWithValue({
   valueRenderer,
   // Callback to decide whether the scalar value is "bad" and should be displayed red.
   badThreshold,
+  // Optional detail page for the metric.
+  href,
 }: {
   title: string;
   value: any;
   valueRenderer: (_value: any) => string;
   badThreshold: (_value: any) => boolean;
+  href?: string;
 }) {
   if (value === undefined) {
     return <Skeleton variant={"rectangular"} height={"100%"} />;
@@ -27,8 +31,17 @@ export function ScalarPanelWithValue({
 
   let fontColor = badThreshold(value) ? "#ee6666" : "inherit";
 
-  return (
-    <Paper sx={{ p: 2 }} elevation={3}>
+  const panel = (
+    <Paper
+      sx={{
+        p: 2,
+        ...(href && {
+          cursor: "pointer",
+          "&:hover": { boxShadow: 6 },
+        }),
+      }}
+      elevation={3}
+    >
       <Box
         sx={{
           display: "flex",
@@ -51,6 +64,16 @@ export function ScalarPanelWithValue({
       </Box>
     </Paper>
   );
+
+  if (href === undefined) {
+    return panel;
+  }
+
+  return (
+    <Link href={href} style={{ color: "inherit", textDecoration: "none" }}>
+      {panel}
+    </Link>
+  );
 }
 
 export default function ScalarPanel({
@@ -66,6 +89,8 @@ export default function ScalarPanel({
   metricName,
   // Callback to decide whether the scalar value is "bad" and should be displayed red.
   badThreshold,
+  // Optional detail page for the metric.
+  href,
   // Custom function to retrieve the value from the query
   getValue = (_data: any) => _data?.[0]?.[metricName],
 }: {
@@ -75,6 +100,7 @@ export default function ScalarPanel({
   valueRenderer: (_value: any) => string;
   metricName: string;
   badThreshold: (_value: any) => boolean;
+  href?: string;
   getValue?: (_data: any) => any;
 }) {
   const url = `/api/clickhouse/${queryName}?parameters=${encodeURIComponent(
@@ -96,6 +122,7 @@ export default function ScalarPanel({
       value={value}
       valueRenderer={valueRenderer}
       badThreshold={badThreshold}
+      href={href}
     />
   );
 }

--- a/torchci/pages/metrics.tsx
+++ b/torchci/pages/metrics.tsx
@@ -820,6 +820,7 @@ export default function Page() {
               }
               queryParams={timeParams}
               badThreshold={(value) => value > 2.0} // 2.0 average retries
+              href="/metrics/merge_analysis"
             />
             <ScalarPanel
               title={"PR landing time (avg)"}

--- a/torchci/pages/metrics/merge_analysis.tsx
+++ b/torchci/pages/metrics/merge_analysis.tsx
@@ -1,0 +1,75 @@
+import { Box, Stack, Typography } from "@mui/material";
+import MergeAttemptFlow from "components/metrics/MergeAttemptFlow";
+import dayjs from "dayjs";
+import { TimeRangePicker } from "pages/metrics";
+import { useState } from "react";
+
+export default function MergeAnalysisPage() {
+  const [startTime, setStartTime] = useState(dayjs().subtract(7, "day"));
+  const [stopTime, setStopTime] = useState(dayjs());
+  const [timeRange, setTimeRange] = useState<number>(7);
+
+  const queryTimes = {
+    startTime: startTime.utc().format("YYYY-MM-DDTHH:mm:ss.SSS"),
+    stopTime: stopTime.utc().format("YYYY-MM-DDTHH:mm:ss.SSS"),
+  };
+
+  return (
+    <Stack spacing={3} sx={{ p: 3 }}>
+      <Box
+        sx={{ display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap" }}
+      >
+        <Typography variant="h4" fontWeight="bold">
+          Merge Analysis
+        </Typography>
+      </Box>
+
+      <Typography variant="body2" color="text.secondary">
+        Shows how PRs created in the selected range move from their initial
+        merge command through successful landing or up to three retries.
+        Default, <code>-i</code>, and <code>-f</code> attempts come directly
+        from structured trymerge records; comment text is not parsed.
+      </Typography>
+
+      <Typography variant="body2" color="text.secondary">
+        <strong>The range filters PR creation date, not attempt date.</strong>{" "}
+        Counts are PRs, not attempts. A PR is in the cohort if it was created in
+        the range and has at least one trymerge record; all of its attempts then
+        count, including any made after the range ends. PRs created in the range
+        with no attempt yet are absent.
+      </Typography>
+
+      <Typography variant="body2" color="text.secondary">
+        <strong>
+          <code>-f</code> and <code>-i</code> are raw flag usage
+        </strong>{" "}
+        (trymerge&apos;s <code>skip_mandatory_checks</code> and{" "}
+        <code>ignore_current</code>), not the HUD force-merge KPI, which also
+        requires the flag to have actually skipped or ignored something, so
+        these lanes run wider.
+      </Typography>
+
+      <Typography variant="body2" color="text.secondary">
+        <strong>&ldquo;No further attempt&rdquo;</strong> means no later
+        trymerge record exists, not that the PR was abandoned. The bucket also
+        holds PRs still in flight and PRs that landed by another route, such as
+        an internal diff import or a stack member merged from its top PR.
+      </Typography>
+
+      <Box>
+        <TimeRangePicker
+          startTime={startTime}
+          setStartTime={setStartTime}
+          stopTime={stopTime}
+          setStopTime={setStopTime}
+          timeRange={timeRange}
+          setTimeRange={setTimeRange}
+        />
+      </Box>
+
+      <Box sx={{ width: "100%", overflowX: "auto" }}>
+        <MergeAttemptFlow {...queryTimes} />
+      </Box>
+    </Stack>
+  );
+}


### PR DESCRIPTION
Add Sankey chart to demonstrate the overall flow of merge commits and distribution between default, -i, and -f flags. 
- Accessible via dropdown from "Metrics" or panel on retries
- Retries that skew heavily with -i and -f may indicate test selection/health needs further action
- Differs from HUD page by also including PRs that have not yet been merged, and should be sensitive to outages and other events.

