### PR TITLE
[vllm-triage] Update vllm nightly triage issue filing filter

### DIFF
--- a/.claude/skills/vllm-pytorch-ci-triage/CONFIDENCE.md
+++ b/.claude/skills/vllm-pytorch-ci-triage/CONFIDENCE.md
@@ -5,7 +5,7 @@
 | Level | Meaning |
 |---|---|
 | high |  Evidence directly identifies one route and rules out the alternatives, exact match to a cheat-sheet entry, or strong pattern match (same exception class + framework frames) |
-| med | Reasonable inference from the exception pattern |
+| medium | Reasonable inference from the exception pattern |
 | low | Weak or generic signal — routing based on context, or guessing with no clear pattern match |
 
 ## new_failure_confidence (per group)
@@ -13,7 +13,7 @@
 | Level | Meaning |
 |---|---|
 | high | Clearly a regression signature with no known variant; distinctive |
-| med | Plausible but could be a flake or a known-issue variant |
+| medium | Plausible but could be a flake or a known-issue variant |
 | low | Weak, generic exception, or likely a variant of an existing known issue |
 
 ## shared_root_cause_confidence (per failure)
@@ -21,5 +21,5 @@
 | Level | Meaning |
 |---|---|
 | high | Identical exception signature to the group, or same exception class + closely related message |
-| med | Same exception class, different message but likely related |
+| medium | Same exception class, different message but likely related |
 | low | Different exception but plausibly the same bug, or grouped only by job proximity |

--- a/.claude/skills/vllm-pytorch-ci-triage/CONFIDENCE.md
+++ b/.claude/skills/vllm-pytorch-ci-triage/CONFIDENCE.md
@@ -4,7 +4,7 @@
 
 | Level | Meaning |
 |---|---|
-| high | Exact match to a cheat-sheet entry, or strong pattern match (same exception class + framework frames) |
+| high |  Evidence directly identifies one route and rules out the alternatives, exact match to a cheat-sheet entry, or strong pattern match (same exception class + framework frames) |
 | med | Reasonable inference from the exception pattern |
 | low | Weak or generic signal — routing based on context, or guessing with no clear pattern match |
 

--- a/.claude/skills/vllm-pytorch-ci-triage/SKILL.md
+++ b/.claude/skills/vllm-pytorch-ci-triage/SKILL.md
@@ -24,9 +24,15 @@ fetch anything. Your tools are `Read`, `Glob`, `Grep`, `Write`; there is no Pyth
 execution and no Buildkite / ClickHouse access. Read what is on disk in the triage input
 dir:
 
-- `report.md` — the A/B summary and the regressed clusters (see Step 2).
-- `report.json` — the same, structured: `torch_nightly_build`, `baseline_build`,
-  `commit`, and the `regressed` / `both` job lists.
+- `report.md` — a concise, human-readable A/B summary and regressed clusters. Its
+  **Test-set regressions** list deliberately renders each new failed test only as
+  ``<test_id> — <pytest_exception_class>``; it does not include tracebacks.
+- `report.json` — the structured companion: `torch_nightly_build`,
+  `baseline_build`, `commit`, the `regressed` / `both` job lists, and
+  `regressed_tests`. Each `regressed_tests.new_failures` entry is a complete
+  `FailedTest` signature (`test_id`, `pytest_exception_class`,
+  `exception_chain`, `inline_message`, `test_is_infra`). Each shared failure has
+  complete `torch_nightly` and `baseline` `FailedTest` entries.
 - `cluster-logs/*.log` — one representative log per regressed cluster, ANSI-stripped.
    This is your primary root-cause material.
 
@@ -46,7 +52,7 @@ Every file opens with a header:
 
 ```
 ## tests/kernels/test_deepgemm.py::test_gemm
-exception_class: RuntimeError
+pytest_exception_class: RuntimeError
 test_is_infra: false
 
 def test_gemm():
@@ -56,12 +62,16 @@ test_deepgemm.py:42: RuntimeError
 ```
 
 - `## <test_id>` — pytest node ID.
-- `exception_class` — exception type from the FAILURES section.
+- `pytest_exception_class` — exception type pytest named on its inline
+  `FAILED`/`ERROR` summary line. This is the `FailedTest.pytest_exception_class`
+  field in `report.json`; it can be empty when pytest did not provide a class.
 - `test_is_infra` — per-test transient-infra tag (CUDA-init, `exit status 137`,
-  `Free memory … less than desired`, …).
+  `Free memory … less than desired`, …). This is the `FailedTest.test_is_infra`
+  field in `report.json`.
 - Everything after the blank line is the **raw section body** (the traceback): source
   lines, `E` error lines, file refs, chained-exception connectors. This is the
-  `exception_chain` Step 3 refers to — your primary content for root cause.
+  `FailedTest.exception_chain` that Step 3 refers to — your primary content for
+  root cause.
 
 **Fallback form** — no pytest failures were parsed (a build/crash before pytest ran,
 an empty parse, or the parser raising). The header is followed by:

--- a/tools/torchci/tests/test_vllm_torch_nightly_triage.py
+++ b/tools/torchci/tests/test_vllm_torch_nightly_triage.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from unittest import mock
 
 import torchci.vllm_torch_nightly_triage as triage
-from torchci.vllm_log_parser import parse_log
+from torchci.vllm_log_parser import FailedTest, parse_log
 from torchci.vllm_torch_nightly_triage import diff_failing_tests
 
 
@@ -230,6 +230,19 @@ class TestDiffBothClusters(unittest.TestCase):
         self.assertEqual(entry["baseline_url"], "base#job")
         new_ids = [nf["test_id"] for nf in entry["new_failures"]]
         self.assertEqual(new_ids, ["tests/test_b.py::test_bar"])
+        self.assertEqual(
+            entry["new_failures"][0],
+            {
+                "test_id": "tests/test_b.py::test_bar",
+                "pytest_exception_class": "ValueError",
+                "exception_chain": "ValueError: new failure",
+                "inline_message": "new failure",
+                "test_is_infra": False,
+            },
+        )
+        self.assertEqual(
+            entry["shared_failures"][0]["torch_nightly"]["test_is_infra"], False
+        )
 
     def test_no_new_failures_dropped(self) -> None:
         rep = _both_job("Job A", "tn#job", "base#job")
@@ -237,6 +250,32 @@ class TestDiffBothClusters(unittest.TestCase):
             [("tests/test_a.py::test_foo", "AssertionError", "shared boom")]
         )
         self.assertEqual(triage.diff_both_clusters([("Job A", rep, body, body)]), [])
+
+    def test_entry_preserves_an_infrastructure_failure_signature(self) -> None:
+        failure = FailedTest(
+            test_id="tests/test_infra.py::test_cuda",
+            pytest_exception_class="RuntimeError",
+            exception_chain="RuntimeError: CUDA driver initialization failed",
+            inline_message="CUDA driver initialization failed",
+            test_is_infra=True,
+        )
+        entry = triage._build_regressed_entry(
+            "Job A",
+            _both_job("Job A", "tn#job", "base#job"),
+            triage.DiffResult(new_failures=[failure]),
+        )
+        self.assertEqual(
+            entry["new_failures"],
+            [
+                {
+                    "test_id": "tests/test_infra.py::test_cuda",
+                    "pytest_exception_class": "RuntimeError",
+                    "exception_chain": "RuntimeError: CUDA driver initialization failed",
+                    "inline_message": "CUDA driver initialization failed",
+                    "test_is_infra": True,
+                }
+            ],
+        )
 
 
 class TestWriteBothArtifacts(unittest.TestCase):
@@ -289,16 +328,29 @@ def _regressed_entry():
         "new_failures": [
             {
                 "test_id": "tests/test_b.py::test_bar",
-                "exception_class": "ValueError",
-                "torch_nightly_exception_chain": "ValueError: new-failure-marker",
+                "pytest_exception_class": "ValueError",
+                "exception_chain": "ValueError: new-failure-marker",
+                "inline_message": "new-failure-marker",
+                "test_is_infra": False,
             }
         ],
         "shared_failures": [
             {
                 "test_id": "tests/test_a.py::test_foo",
-                "exception_class": "AssertionError",
-                "torch_nightly_exception_chain": "AssertionError: shared",
-                "baseline_exception_chain": "AssertionError: shared",
+                "torch_nightly": {
+                    "test_id": "tests/test_a.py::test_foo",
+                    "pytest_exception_class": "AssertionError",
+                    "exception_chain": "AssertionError: shared",
+                    "inline_message": "shared",
+                    "test_is_infra": False,
+                },
+                "baseline": {
+                    "test_id": "tests/test_a.py::test_foo",
+                    "pytest_exception_class": "AssertionError",
+                    "exception_chain": "AssertionError: shared",
+                    "inline_message": "shared",
+                    "test_is_infra": False,
+                },
             }
         ],
     }
@@ -334,6 +386,8 @@ class TestRenderRegressedTests(unittest.TestCase):
         self.assertIn("Test-set regressions", out)
         self.assertIn("tests/test_b.py::test_bar", out)
         self.assertIn("ValueError", out)
+        self.assertNotIn("new-failure-marker", out)
+        self.assertNotIn("exception_chain", out)
         # The shared count rides along as context.
         self.assertIn("1 shared", out)
 

--- a/tools/torchci/tests/test_vllm_triage_file_issues.py
+++ b/tools/torchci/tests/test_vllm_triage_file_issues.py
@@ -47,7 +47,6 @@ class TestEligible(unittest.TestCase):
         self.assertTrue(eligible(cause(routing=" PyTorch/PyTorch ")))
 
     def test_low_classification_confidence_is_skipped(self):
-        self.assertFalse(eligible(cause(classification_confidence="medium")))
         self.assertFalse(eligible(cause(classification_confidence="low")))
 
     def test_known_variant_is_skipped_but_medium_is_filed(self):
@@ -64,8 +63,6 @@ class TestEligible(unittest.TestCase):
         self.assertEqual(
             classification_confidence({"classification_confidence": "MED"}), "medium"
         )
-        # "med" classification is below the bar in either spelling.
-        self.assertFalse(eligible(cause(classification_confidence="med")))
 
     def test_legacy_confidence_field_still_gates(self):
         # Pre-rename findings.json: one `confidence`, no new_failure_confidence.

--- a/tools/torchci/vllm_torch_nightly_triage.py
+++ b/tools/torchci/vllm_torch_nightly_triage.py
@@ -33,7 +33,7 @@ import sys
 import urllib.error
 import urllib.request
 from collections import Counter, defaultdict
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
 from torchci.clickhouse import get_clickhouse_client
@@ -395,7 +395,9 @@ def render_regressed_tests_section(regressed_tests: List[Dict]) -> List[str]:
         )
         out.append(f"- [{entry['name']}]({entry['url']}) — `{entry['state']}`")
         for failure in new_failures:
-            out.append(f"  - `{failure['test_id']}` — `{failure['exception_class']}`")
+            out.append(
+                f"  - `{failure['test_id']}` — `{failure['pytest_exception_class']}`"
+            )
         out.append("\n</details>")
     return out
 
@@ -514,6 +516,10 @@ def _render_shared_section(shared_failures: List[Tuple[FailedTest, FailedTest]])
         sections.append(
             f"pytest_exception_class: {torch_nightly_side.pytest_exception_class}"
         )
+        sections.append(
+            f"torch_nightly_test_is_infra: {torch_nightly_side.test_is_infra}"
+        )
+        sections.append(f"baseline_test_is_infra: {baseline_side.test_is_infra}")
         sections.append("")
         sections.append("### torch_nightly_exception_chain")
         sections.append(torch_nightly_side.exception_chain)
@@ -628,14 +634,6 @@ def _http_error_hint(exc: urllib.error.HTTPError) -> str:
     return ""
 
 
-def _failure_dict(failure: FailedTest) -> Dict[str, str]:
-    return {
-        "test_id": failure.test_id,
-        "exception_class": failure.pytest_exception_class,
-        "torch_nightly_exception_chain": failure.exception_chain,
-    }
-
-
 def _build_regressed_entry(cluster: str, rep: Dict, diff: DiffResult) -> Dict:
     """Build the regressed_tests entry for one `both`-cluster with new failures.
 
@@ -654,13 +652,12 @@ def _build_regressed_entry(cluster: str, rep: Dict, diff: DiffResult) -> Dict:
         "baseline_url": rep.get("baseline_url"),
         "state": rep["state"],
         "baseline_state": rep["baseline_state"],
-        "new_failures": [_failure_dict(failure) for failure in diff.new_failures],
+        "new_failures": [asdict(failure) for failure in diff.new_failures],
         "shared_failures": [
             {
                 "test_id": torch_nightly_side.test_id,
-                "exception_class": torch_nightly_side.pytest_exception_class,
-                "torch_nightly_exception_chain": torch_nightly_side.exception_chain,
-                "baseline_exception_chain": baseline_side.exception_chain,
+                "torch_nightly": asdict(torch_nightly_side),
+                "baseline": asdict(baseline_side),
             }
             for torch_nightly_side, baseline_side in diff.shared_failures
         ],

--- a/tools/torchci/vllm_triage_file_issues.py
+++ b/tools/torchci/vllm_triage_file_issues.py
@@ -197,7 +197,7 @@ def new_failure_confidence(cause: Dict[str, Any]) -> str:
 
 
 def eligible(cause: Dict[str, Any]) -> bool:
-    """High-confidence torch/triton causes only.
+    """Medium-confidence torch/triton causes only.
 
     Infra-looking clusters and anything the agent could not root-cause stay out of
     the tracker: at three runs a week, filing uncertain causes would bury the real
@@ -208,11 +208,11 @@ def eligible(cause: Dict[str, Any]) -> bool:
     """
     return (
         bool(cause.get("determined"))
-        and classification_confidence(cause) == "high"
+        and classification_confidence(cause) != "low"
+        and classification_confidence(cause)
         and new_failure_confidence(cause) != "low"
         and str(cause.get("routing", "")).strip().lower() == "pytorch/pytorch"
     )
-
 
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)

--- a/tools/torchci/vllm_triage_file_issues.py
+++ b/tools/torchci/vllm_triage_file_issues.py
@@ -207,12 +207,13 @@ def eligible(cause: Dict[str, Any]) -> bool:
     issue", so filing it would duplicate a child issue that already exists.
     """
     return (
-        bool(cause.get("determined"))
+        bool(cause.get("determined"))  # type: ignore[return-value]
         and classification_confidence(cause) != "low"
         and classification_confidence(cause)
         and new_failure_confidence(cause) != "low"
         and str(cause.get("routing", "")).strip().lower() == "pytorch/pytorch"
     )
+
 
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)


### PR DESCRIPTION
The primary behavior change is for 

```python
eligible(cause: Dict[str, Any]) -> bool: 
```
function where I changed to accept medium or high classification confidence instead of only high. 

I tweaked the skill a bit. The proper long term solution IMO is to accumulate failures that have been annotated and use for our dataset to iterate on a more rigorous definition of classification confidence.

In addition, I updated  a couple areas where it looked like we may be losing some information due to merging code bases / code drift. 
