### PR TITLE
[release/2.14] Backport remote BuildKit action

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -12,5 +12,7 @@ self-hosted-runner:
     # Below are OSDC ARC runner
     - mt-l-x86iamx-8-16
     - mt-l-arm64g2-6-32
+    - mt-l-x86iavx512-8-64
+    - mt-l-arm64g4-16-62
     - mt-rel-l-x86iavx512-8-64
     - mt-rel-l-arm64g4-16-62

--- a/.github/actions/docker-build-remote-buildkit/README.md
+++ b/.github/actions/docker-build-remote-buildkit/README.md
@@ -1,0 +1,62 @@
+# docker-build-remote-buildkit
+
+Build and push a Docker image from an OSDC/ARC runner.
+
+OSDC runners are ephemeral Kubernetes pods with **no host docker daemon**, so `docker build` and
+`docker/build-push-action`'s default driver do not work. OSDC instead runs a per-arch `buildkitd`
+service in every cluster. This action registers it as a remote `buildx` builder and runs the build
+against it.
+
+```yaml
+- uses: pytorch/test-infra/.github/actions/docker-build-remote-buildkit@main
+  with:
+    context: ./docker
+    file: ./docker/Dockerfile
+    tags: ghcr.io/pytorch/my-image:${{ github.sha }}
+    build-args: |
+      BASE_IMAGE=quay.io/pypa/manylinux_2_28_x86_64
+```
+
+The step blocks until the image has been pushed, so a job that builds an image and a job that
+consumes it can be ordered with a plain `needs:` — no polling for the tag to appear.
+
+## Wrapping your own build script
+
+Builds driven by a script or make target — as pytorch/pytorch's image builds are — pass the whole
+command instead of the buildx inputs:
+
+```yaml
+- uses: pytorch/test-infra/.github/actions/docker-build-remote-buildkit@main
+  env:
+    REMOTE_BUILDKIT: 1        # if your script keys off it, as .ci/docker/build.sh does
+  with:
+    command: .ci/docker/manywheel/build.sh manylinux2_28-builder:cpu -t my-tag
+```
+
+The command owns its tags and its `--push`; the action only registers the builder and applies the
+retry. `--load` still cannot work, since there is no local daemon.
+
+## Why not `docker/setup-buildx-action`
+
+Both `docker/setup-buildx-action` and `docker buildx create --bootstrap` run
+`buildx inspect --bootstrap`, whose ~20s gRPC connect timeout expires on a cold or bursting builder
+pool before the autoscaler can add a builder. This action uses a bare `docker buildx create` and
+retries only *connection-phase* failures (`waiting for connection`, `failed to dial/list workers`,
+`context deadline exceeded`, `server preface`, …). Once BuildKit has started the build, a failure is
+a real build error and is never retried.
+
+Each builder pod serves one build at a time (HAProxy `maxconn 1`), so during a burst your build
+queues behind the pool scaling up. The retry loop defaults to `connect-attempts: 480` at
+`connect-delay: 15`, i.e. it will wait roughly two hours for a builder. Bound how long a job is
+actually willing to wait with its own `timeout-minutes` rather than by lowering the attempts.
+
+## Notes
+
+- **Push, don't load.** There is no local daemon, so `--load` has nothing to load into. `push: false`
+  builds and discards the image.
+- **Remote BuildKit is per-arch**, so the build always targets the runner's own architecture. To
+  build for another platform, run the job on a runner of that architecture.
+- BuildKit allows roughly 120 minutes per build — keep the job's `timeout-minutes` above that for
+  large images.
+
+Adapted from `pytorch/pytorch:.github/scripts/build_with_remote_buildkit.sh`.

--- a/.github/actions/docker-build-remote-buildkit/action.yml
+++ b/.github/actions/docker-build-remote-buildkit/action.yml
@@ -1,0 +1,149 @@
+name: Build a Docker image on remote BuildKit
+
+description: >
+  Build (and push) a Docker image from an OSDC/ARC runner, which has no host docker daemon.
+  Registers the in-cluster remote BuildKit builder for the runner's architecture and retries
+  connection-phase failures while the autoscaled builder pool is cold, so callers get a build
+  that either succeeds or fails for a real reason. The step blocks until the image is pushed,
+  so downstream jobs can depend on it with `needs:`.
+
+inputs:
+  command:
+    description: >
+      A build command to run on the remote builder instead of assembling a `docker buildx build`
+      invocation — a repo build script or make target, for example. When set, the buildx inputs
+      below (tags, context, file, build-args, labels, target, push, cache-from, cache-to) are
+      ignored and the `image` output is not set. The command is responsible for its own tags and
+      for `--push`; note there is no local daemon, so `--load` cannot work.
+    default: ''
+  tags:
+    description: >
+      Newline- or comma-separated list of image tags, e.g. ghcr.io/pytorch/my-image:abc123.
+      Required unless `command` is set.
+    default: ''
+  context:
+    description: Build context path.
+    default: .
+  file:
+    description: Path to the Dockerfile. Defaults to <context>/Dockerfile.
+    default: ''
+  build-args:
+    description: Newline-separated KEY=VALUE build arguments.
+    default: ''
+  labels:
+    description: Newline-separated KEY=VALUE image labels, e.g. the output of docker/metadata-action.
+    default: ''
+  target:
+    description: Dockerfile stage to build.
+    default: ''
+  push:
+    description: >
+      Push the image to the registry. There is no local docker daemon on an OSDC runner, so
+      `--load` has nothing to load into; a build with push=false is only useful as a syntax check.
+    default: 'true'
+  cache-from:
+    description: Newline-separated buildx --cache-from entries.
+    default: ''
+  cache-to:
+    description: Newline-separated buildx --cache-to entries.
+    default: ''
+  connect-attempts:
+    description: >
+      How many times to retry a connection-phase failure before giving up. The default of 480 at
+      the default 15s delay waits roughly two hours for a builder, which covers a fully cold or
+      saturated pool (one build per builder pod, so a burst queues). Bound the real ceiling with
+      the job's `timeout-minutes`, not by lowering this.
+    default: '480'
+  connect-delay:
+    description: Seconds to wait between connection-phase retries.
+    default: '15'
+
+outputs:
+  image:
+    description: >
+      The first tag passed in, for convenience when wiring up downstream jobs. Empty in command
+      mode.
+    value: ${{ steps.build.outputs.image }}
+
+runs:
+  using: composite
+  steps:
+    - name: Build and push with remote BuildKit
+      id: build
+      shell: bash
+      env:
+        COMMAND: ${{ inputs.command }}
+        TAGS: ${{ inputs.tags }}
+        CONTEXT: ${{ inputs.context }}
+        FILE: ${{ inputs.file }}
+        BUILD_ARGS: ${{ inputs.build-args }}
+        LABELS: ${{ inputs.labels }}
+        TARGET: ${{ inputs.target }}
+        PUSH: ${{ inputs.push }}
+        CACHE_FROM: ${{ inputs.cache-from }}
+        CACHE_TO: ${{ inputs.cache-to }}
+        REMOTE_BUILDKIT_CONNECT_ATTEMPTS: ${{ inputs.connect-attempts }}
+        REMOTE_BUILDKIT_CONNECT_DELAY: ${{ inputs.connect-delay }}
+      run: |
+        set -euo pipefail
+
+        # Command mode: hand the whole thing to the helper, which registers the
+        # builder and retries only connection-phase failures.
+        if [[ -n "${COMMAND}" ]]; then
+          exec bash "${GITHUB_ACTION_PATH}/build_with_remote_buildkit.sh" bash -c "${COMMAND}"
+        fi
+
+        args=()
+
+        # Tags may be newline- or comma-separated.
+        first_tag=""
+        while IFS= read -r tag; do
+          tag="$(echo "${tag}" | tr -d '[:space:]')"
+          [[ -z "${tag}" ]] && continue
+          [[ -z "${first_tag}" ]] && first_tag="${tag}"
+          args+=(--tag "${tag}")
+        done < <(echo "${TAGS}" | tr ',' '\n')
+        if [[ -z "${first_tag}" ]]; then
+          echo "::error::no image tag was provided" >&2
+          exit 1
+        fi
+        echo "image=${first_tag}" >> "${GITHUB_OUTPUT}"
+
+        # Remote BuildKit is per-arch, so the only buildable platform is the
+        # runner's own.
+        case "$(uname -m)" in
+          aarch64|arm64) args+=(--platform linux/arm64) ;;
+          *)             args+=(--platform linux/amd64) ;;
+        esac
+
+        [[ -n "${FILE}" ]] && args+=(--file "${FILE}")
+        [[ -n "${TARGET}" ]] && args+=(--target "${TARGET}")
+
+        while IFS= read -r build_arg; do
+          [[ -z "${build_arg}" ]] && continue
+          args+=(--build-arg "${build_arg}")
+        done <<< "${BUILD_ARGS}"
+
+        while IFS= read -r label; do
+          [[ -z "${label}" ]] && continue
+          args+=(--label "${label}")
+        done <<< "${LABELS}"
+
+        while IFS= read -r cache; do
+          [[ -z "${cache}" ]] && continue
+          args+=(--cache-from "${cache}")
+        done <<< "${CACHE_FROM}"
+
+        while IFS= read -r cache; do
+          [[ -z "${cache}" ]] && continue
+          args+=(--cache-to "${cache}")
+        done <<< "${CACHE_TO}"
+
+        if [[ "${PUSH}" == "true" ]]; then
+          args+=(--push)
+        else
+          echo "::warning::push=false — the image is built but discarded (no local docker daemon to --load into)"
+        fi
+
+        bash "${GITHUB_ACTION_PATH}/build_with_remote_buildkit.sh" \
+          docker buildx build "${args[@]}" "${CONTEXT}"

--- a/.github/actions/docker-build-remote-buildkit/build_with_remote_buildkit.sh
+++ b/.github/actions/docker-build-remote-buildkit/build_with_remote_buildkit.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Build a docker image on the remote BuildKit pool used by OSDC/ARC runners,
+# which have no host docker daemon. Registers a remote buildx builder, then runs
+# the passed command ("$@", e.g. a build.sh or `make ... -image`) and retries
+# only connection-phase failures while the autoscaled pool is cold/at capacity.
+# Genuine build errors (once BuildKit has started the build) are never retried.
+#
+# Adapted from pytorch/pytorch .github/scripts/build_with_remote_buildkit.sh.
+set -euo pipefail
+
+case "$(uname -m)" in
+  aarch64|arm64) buildkit_addr="tcp://buildkitd-arm64.buildkit:1234" ;;
+  *)             buildkit_addr="tcp://buildkitd-amd64.buildkit:1234" ;;
+esac
+
+# Bare `create` on purpose: `docker buildx create --bootstrap` and
+# docker/setup-buildx-action both run `buildx inspect --bootstrap`, whose ~20s
+# gRPC connect timeout fails on a cold or bursting pool before the autoscaler
+# can add a builder.
+docker buildx create --name remote-buildkit --driver remote --use "${buildkit_addr}" >/dev/null 2>&1 \
+  || docker buildx use remote-buildkit
+
+log="$(mktemp)"
+trap 'rm -f "${log}"' EXIT
+
+# 480 x 15s ~= 2h of waiting for a builder, which covers a fully cold or
+# saturated pool. Bound the real ceiling with the job's timeout-minutes.
+attempts="${REMOTE_BUILDKIT_CONNECT_ATTEMPTS:-480}"
+delay="${REMOTE_BUILDKIT_CONNECT_DELAY:-15}"
+for attempt in $(seq 1 "${attempts}"); do
+  set +e
+  "$@" 2>&1 | tee "${log}"
+  rc="${PIPESTATUS[0]}"
+  set -e
+  if [[ "${rc}" -eq 0 ]]; then
+    exit 0
+  fi
+  # Retry only while buildx never reached a worker (cold pool). Once BuildKit has
+  # started the build it emits progress ("load build definition", context
+  # transfer, "[n/m]" steps); a failure after that is a real build error.
+  if [[ "${attempt}" -lt "${attempts}" ]] \
+     && ! grep -qE "load build definition|transferring context|\[[0-9 ]+/[0-9 ]+\]" "${log}" \
+     && grep -qiE "waiting for connection|failed to (dial|list workers)|connection (refused|reset)|no such host|context deadline exceeded|server preface" "${log}"; then
+    echo "Remote BuildKit not ready yet (attempt ${attempt}/${attempts}); retrying in ${delay}s..." >&2
+    sleep "${delay}"
+    continue
+  fi
+  exit "${rc}"
+done

--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -21,33 +21,25 @@ jobs:
         include:
           # --- CPU ---
           - runner: mt-rel-l-x86iavx512-8-64
-            platform: linux/amd64
             base_image: quay.io/pypa/manylinux_2_28_x86_64
             install_cuda: ""
             variant_tag: cpu-x86_64
-            buildkit_addr: tcp://buildkitd-amd64.buildkit:1234
             dockerfile: Dockerfile
           - runner: mt-rel-l-arm64g4-16-62
-            platform: linux/arm64
             base_image: quay.io/pypa/manylinux_2_28_aarch64
             install_cuda: ""
             variant_tag: cpu-aarch64
-            buildkit_addr: tcp://buildkitd-arm64.buildkit:1234
             dockerfile: Dockerfile.aarch64
           # --- CUDA (all versions in one image, self-hosted DinD runners) ---
           - runner: mt-rel-l-x86iavx512-8-64
-            platform: linux/amd64
             base_image: quay.io/pypa/manylinux_2_28_x86_64
             install_cuda: "1"
             variant_tag: cuda-x86_64
-            buildkit_addr: tcp://buildkitd-amd64.buildkit:1234
             dockerfile: Dockerfile
           - runner: mt-rel-l-arm64g4-16-62
-            platform: linux/arm64
             base_image: quay.io/pypa/manylinux_2_28_aarch64
             install_cuda: "1"
             variant_tag: cuda-aarch64
-            buildkit_addr: tcp://buildkitd-arm64.buildkit:1234
             dockerfile: Dockerfile.aarch64
     container:
       image: "ghcr.io/actions/actions-runner:latest"
@@ -63,14 +55,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-        with:
-          driver: remote
-          endpoint: ${{ matrix.buildkit_addr }}
-
       - name: Docker meta
-        if: inputs.push
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
@@ -81,15 +66,18 @@ jobs:
             type=sha,prefix=${{ matrix.variant_tag }}-,format=short
             type=raw,value=${{ matrix.variant_tag }}-latest,enable=${{ github.ref == 'refs/heads/main' }}
 
+      # Builds on the in-cluster remote BuildKit service: OSDC runners have no
+      # host docker daemon. The action registers the builder for this runner's
+      # architecture without bootstrapping it, and retries while the builder
+      # pool scales up.
       - name: Build and push
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        uses: pytorch/test-infra/.github/actions/docker-build-remote-buildkit@osdc-remote-buildkit-action
         with:
           context: ./docker
           file: ./docker/${{ matrix.dockerfile }}
-          platforms: ${{ matrix.platform }}
           push: ${{ inputs.push }}
-          tags: ${{ steps.meta.outputs.tags || '' }}
-          labels: ${{ steps.meta.outputs.labels || '' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             BASE_IMAGE=${{ matrix.base_image }}
             INSTALL_CUDA=${{ matrix.install_cuda }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     paths:
       - "docker/**"
+      # Validate changes to the build workflows themselves (push: false on PRs)
+      - ".github/workflows/docker-build.yml"
+      - ".github/workflows/_docker-build.yml"
   workflow_dispatch: {}
 
 concurrency:

--- a/.github/workflows/test-docker-build-remote-buildkit.yml
+++ b/.github/workflows/test-docker-build-remote-buildkit.yml
@@ -1,0 +1,136 @@
+name: Test docker-build-remote-buildkit
+
+on:
+  pull_request:
+    paths:
+      - .github/actions/docker-build-remote-buildkit/**
+      - .github/workflows/test-docker-build-remote-buildkit.yml
+  push:
+    branches:
+      - main
+    paths:
+      - .github/actions/docker-build-remote-buildkit/**
+      - .github/workflows/test-docker-build-remote-buildkit.yml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  smoke:
+    # Fork PRs get no writable token, so the ghcr push can't work there.
+    if: ${{ github.event.pull_request.head.repo.fork != true }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: mt-l-x86iavx512-8-64
+          - arch: arm64
+            runner: mt-l-arm64g4-16-62
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: ghcr.io/actions/actions-runner:latest
+    # The actions-runner container defaults `run:` to sh; the action and these
+    # steps need bash.
+    defaults:
+      run:
+        shell: bash
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Write a trivial build context
+        id: ctx
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/ctx"
+          # Emit the container-side path: the runner.temp expression resolves to
+          # the *host* path, which does not exist inside this container.
+          echo "dir=${RUNNER_TEMP}/ctx" >> "${GITHUB_OUTPUT}"
+          cat > "${RUNNER_TEMP}/ctx/Dockerfile" <<'EOF'
+          FROM alpine:3.20
+          ARG GREETING=hello
+          RUN echo "${GREETING} from remote buildkit" > /greeting
+          EOF
+          # Used by the negative test below: fails *after* BuildKit has started
+          # the build and emitted progress, which is the case the retry
+          # discriminator must not treat as a cold pool.
+          cat > "${RUNNER_TEMP}/ctx/Dockerfile.broken" <<'EOF'
+          FROM alpine:3.20
+          RUN echo "this build is meant to fail" && exit 1
+          EOF
+
+      # Happy path: builds on the in-cluster builder and pushes. Exercises the
+      # cold-pool retry, the per-arch endpoint, and --push.
+      # Relative `uses: ./…` does NOT work here: the ARC k8s hook copies the
+      # workspace into the job container, so the runner process never sees the
+      # checkout and can't resolve a local action. Reference it by full path.
+      # TODO: flip the ref to @main when this PR lands.
+      - name: Build and push
+        id: build
+        uses: pytorch/test-infra/.github/actions/docker-build-remote-buildkit@osdc-remote-buildkit-action
+        with:
+          context: ${{ steps.ctx.outputs.dir }}
+          tags: ghcr.io/pytorch/test-infra/buildkit-smoke:${{ matrix.arch }}
+          build-args: |
+            GREETING=ci
+          push: true
+
+      - name: Assert the image is really in the registry
+        env:
+          IMAGE: ${{ steps.build.outputs.image }}
+        run: |
+          set -euo pipefail
+          echo "action reported image=${IMAGE}"
+          [[ "${IMAGE}" == "ghcr.io/pytorch/test-infra/buildkit-smoke:${{ matrix.arch }}" ]]
+          # Registry-side inspect: no local daemon needed.
+          docker buildx imagetools inspect "${IMAGE}"
+
+      # Command mode: the action should hand an arbitrary build command to the
+      # helper, which is how repo build scripts drive it.
+      - name: Build via command mode
+        uses: pytorch/test-infra/.github/actions/docker-build-remote-buildkit@osdc-remote-buildkit-action
+        with:
+          command: >-
+            docker buildx build
+            --build-arg GREETING=command-mode
+            -f ${{ steps.ctx.outputs.dir }}/Dockerfile
+            ${{ steps.ctx.outputs.dir }}
+
+      # Negative path: a genuine build error must fail fast, not burn 40
+      # connection retries. If the retry discriminator ever regresses to
+      # "retry anything", this step blows the job timeout instead of failing.
+      - name: Build a deliberately broken image
+        id: broken
+        continue-on-error: true
+        uses: pytorch/test-infra/.github/actions/docker-build-remote-buildkit@osdc-remote-buildkit-action
+        with:
+          context: ${{ steps.ctx.outputs.dir }}
+          file: ${{ steps.ctx.outputs.dir }}/Dockerfile.broken
+          tags: ghcr.io/pytorch/test-infra/buildkit-smoke:${{ matrix.arch }}-broken
+          push: false
+          connect-attempts: '3'
+          connect-delay: '5'
+
+      - name: Assert the broken build failed
+        run: |
+          set -euo pipefail
+          if [[ "${{ steps.broken.outcome }}" != "failure" ]]; then
+            echo "::error::a Dockerfile with a failing RUN should have failed the build, got '${{ steps.broken.outcome }}'"
+            exit 1
+          fi
+          echo "broken build failed as expected (and was not retried)"


### PR DESCRIPTION
## Summary

Backport the remote BuildKit composite action from #8487 to `release/2.14`.

ExecuTorch's 1.5 release branch uses this action in its Docker workflow. The standard release pin changes that reference from `pytorch/test-infra@main` to `@release/2.14`, but the release branch was cut before the action was added.

This is a clean `-x` cherry-pick of `d6074793e090422e1e43854050119087bbbafea2`.

## Test plan

- `git diff --check origin/release/2.14...HEAD`
- `bash -n .github/actions/docker-build-remote-buildkit/build_with_remote_buildkit.sh`
- parsed the changed action and workflow YAML files

Needed by the ExecuTorch 1.5 release-only CI pin.
