### PR TITLE
[GreenLight] Mark GreenLight-approved PRs on the trunk HUD

### DIFF
--- a/torchci/components/greenlight/GreenLightIcon.tsx
+++ b/torchci/components/greenlight/GreenLightIcon.tsx
@@ -1,0 +1,125 @@
+// The traffic-light glyph that marks a PR's GreenLight state on the HUD's own
+// surfaces. One component owns the status -> colour/label mapping so the trunk
+// HUD, the commit page and the PR page cannot drift into saying different
+// things about the same row.
+//
+// Renders nothing for a status it does not know. That is deliberate: the ledger
+// grows statuses on the Python side (greenlight/src/greenlight/constants.py) and
+// an unrecognised one must read as "no claim", never fall back to a colour that
+// implies a verdict.
+
+import { Tooltip, useTheme } from "@mui/material";
+import {
+  GREENLIGHT_INCOMPLETE_HEADLINE,
+  GREENLIGHT_LAND_HEADLINE,
+  GREENLIGHT_NO_LAND_HEADLINE,
+  GREENLIGHT_REVERTED_HEADLINE,
+  GREENLIGHT_REVIEWING_HEADLINE,
+  GREENLIGHT_STATUS_AI_REVIEW_DISPATCHED,
+  GREENLIGHT_STATUS_AI_REVIEW_STARTED,
+  GREENLIGHT_STATUS_CANCELLED,
+  GREENLIGHT_STATUS_FAILED,
+  GREENLIGHT_STATUS_LAND,
+  GREENLIGHT_STATUS_NO_LAND,
+  GREENLIGHT_STATUS_REVERTED,
+} from "lib/greenlight/greenlightRender";
+
+type Tone = "approved" | "declined" | "running" | "inconclusive";
+
+// Two shades per tone because the HUD renders on both palettes and a single
+// value legible on one is washed out or glaring on the other (torchci/CLAUDE.md).
+const TONE_COLORS: Record<Tone, { light: string; dark: string }> = {
+  approved: { light: "#2e7d32", dark: "#66bb6a" },
+  declined: { light: "#c62828", dark: "#ef5350" },
+  running: { light: "#ed6c02", dark: "#ffa726" },
+  inconclusive: { light: "#757575", dark: "#9e9e9e" },
+};
+
+const STATUS_TONES: Record<string, { tone: Tone; label: string }> = {
+  [GREENLIGHT_STATUS_LAND]: {
+    tone: "approved",
+    label: GREENLIGHT_LAND_HEADLINE,
+  },
+  [GREENLIGHT_STATUS_NO_LAND]: {
+    tone: "declined",
+    label: GREENLIGHT_NO_LAND_HEADLINE,
+  },
+  [GREENLIGHT_STATUS_AI_REVIEW_STARTED]: {
+    tone: "running",
+    label: GREENLIGHT_REVIEWING_HEADLINE,
+  },
+  [GREENLIGHT_STATUS_AI_REVIEW_DISPATCHED]: {
+    tone: "running",
+    label: GREENLIGHT_REVIEWING_HEADLINE,
+  },
+  [GREENLIGHT_STATUS_CANCELLED]: {
+    tone: "inconclusive",
+    label: GREENLIGHT_INCOMPLETE_HEADLINE,
+  },
+  [GREENLIGHT_STATUS_FAILED]: {
+    tone: "inconclusive",
+    label: GREENLIGHT_INCOMPLETE_HEADLINE,
+  },
+  [GREENLIGHT_STATUS_REVERTED]: {
+    tone: "inconclusive",
+    label: GREENLIGHT_REVERTED_HEADLINE,
+  },
+};
+
+/** The tooltip/aria text for a status, or "" if the status is unrecognised. */
+export function greenlightStatusLabel(
+  status: string | undefined | null
+): string {
+  const entry = STATUS_TONES[(status ?? "").trim()];
+  return entry === undefined ? "" : `Green Light: ${entry.label}`;
+}
+
+export default function GreenLightIcon({
+  status,
+  size = 12,
+  titleSuffix,
+}: {
+  status: string | undefined | null;
+  size?: number;
+  // Appended to the tooltip, for callers that can say more than the status does
+  // on its own (e.g. which commit the verdict was reached on).
+  titleSuffix?: string;
+}) {
+  const theme = useTheme();
+  const entry = STATUS_TONES[(status ?? "").trim()];
+  if (entry === undefined) {
+    return null;
+  }
+
+  const colors = TONE_COLORS[entry.tone];
+  const fill = theme.palette.mode === "dark" ? colors.dark : colors.light;
+  const label = `Green Light: ${entry.label}${
+    titleSuffix ? ` (${titleSuffix})` : ""
+  }`;
+
+  return (
+    <Tooltip title={label}>
+      <svg
+        role="img"
+        aria-label={label}
+        width={size}
+        height={size}
+        viewBox="0 0 16 16"
+        // Nudged onto the text baseline; an svg is inline and would otherwise
+        // sit on the line box bottom and push the row taller.
+        style={{ verticalAlign: "text-bottom", flexShrink: 0 }}
+      >
+        <circle
+          cx="8"
+          cy="8"
+          r="6.5"
+          fill="none"
+          stroke={fill}
+          strokeOpacity="0.45"
+          strokeWidth="1.5"
+        />
+        <circle cx="8" cy="8" r="4" fill={fill} />
+      </svg>
+    </Tooltip>
+  );
+}

--- a/torchci/components/hud.module.css
+++ b/torchci/components/hud.module.css
@@ -124,6 +124,15 @@
   padding: 3px;
 }
 
+/* Keeps the GreenLight glyph on the same line as the #PR link. The link's own
+   child is a <div>, so without a flex row here the glyph would wrap below it
+   and make every approved row a line taller than its neighbours. */
+.prCell {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+
 .forcedMerge {
   background-color: var(--forced-merge-bg);
 }

--- a/torchci/lib/greenlight/greenlightComment.ts
+++ b/torchci/lib/greenlight/greenlightComment.ts
@@ -7,26 +7,13 @@ import {
   greenlightRepoKey,
   isGreenlightRepo,
 } from "lib/greenlight/greenlightConfig";
+import { GreenlightPrStateRow } from "lib/greenlight/greenlightHudState";
 import {
   GreenlightState,
   renderGreenlightSection,
 } from "lib/greenlight/greenlightRender";
 
-// The columns of a misc.greenlight_pr_state row that the render consumes, as the
-// greenlight_pr_states saved query returns them. Saved queries are untyped
-// (any[]), so this is the cast target. run_id is selected there too, but only to
-// order the rows; nothing downstream reads it.
-interface GreenlightStateRow {
-  pr_number: number;
-  status: string;
-  reason: string;
-  message: string;
-  head_sha: string;
-  eval_job: string;
-  version: string;
-}
-
-function toGreenlightState(row: GreenlightStateRow): GreenlightState {
+function toGreenlightState(row: GreenlightPrStateRow): GreenlightState {
   return {
     prNumber: row.pr_number,
     status: row.status,
@@ -64,7 +51,7 @@ export async function buildGreenlightSections(
   const rows = (await queryClickhouseSaved("greenlight_pr_states", {
     repo: greenlightRepoKey(owner, repo),
     prNumbers,
-  })) as GreenlightStateRow[];
+  })) as GreenlightPrStateRow[];
 
   // One instant for the whole sweep, so age-derived rendering is consistent across PRs.
   const now = new Date();

--- a/torchci/lib/greenlight/greenlightHudState.ts
+++ b/torchci/lib/greenlight/greenlightHudState.ts
@@ -1,0 +1,93 @@
+// Client-side view of a misc.greenlight_pr_state row, for the HUD's own
+// surfaces (the trunk HUD's PR column, the commit page, the PR page) -- as
+// distinct from greenlightRender.ts, which turns the same row into markdown for
+// the Dr.CI comment. The status vocabulary is imported from there rather than
+// re-declared: greenlight/tests/test_render_sync.py pins those declarations to
+// the Python source, so that file has to stay the one place they are spelled.
+//
+// The model-authored `message` needs none of greenlightRender's defanging here.
+// That defanging exists because the Dr.CI comment is markdown GitHub renders:
+// a fence stops the text becoming markup and a zero-width space stops an
+// @-mention pinging. React escapes text nodes instead, so the containment is
+// structural as long as no consumer routes the message through
+// dangerouslySetInnerHTML or a markdown renderer -- none does.
+//
+// No ClickHouse / Octokit / server-only imports, so this is unit-testable and
+// importable from any component.
+
+import { GREENLIGHT_STATUS_LAND } from "lib/greenlight/greenlightRender";
+
+/**
+ * One `misc.greenlight_pr_state` row as the `greenlight_pr_states` saved query
+ * returns it. Saved queries are untyped (`any[]`), so this is the cast target.
+ */
+export interface GreenlightPrStateRow {
+  pr_number: number;
+  status: string;
+  reason: string;
+  message: string;
+  head_sha: string;
+  eval_job: string;
+  run_id: number;
+  version: string;
+}
+
+/**
+ * Whether this status means GreenLight approved the PR to land without a human
+ * review. Only LAND does: every other status -- NO_LAND, the in-flight markers,
+ * the retry outcomes, REVERTED -- is either a refusal or an absence of one, and
+ * an icon on any of them would read as an endorsement the ledger never made.
+ */
+export function isGreenlightApproved(
+  status: string | undefined | null
+): boolean {
+  return (status ?? "").trim() === GREENLIGHT_STATUS_LAND;
+}
+
+/**
+ * Whether `candidate` supersedes `incumbent` under the ledger's read-time
+ * selection: highest `run_id`, then latest `version`.
+ *
+ * Mirrors `state.read_latest_states` (greenlight/src/greenlight/state.py) and
+ * the `greenlight_pr_states` saved query. Ordering `run_id` ahead of `version`
+ * is what makes it race-proof -- a superseded slower dispatch that finishes with
+ * a later `version` still loses to the newer dispatch's higher `run_id`.
+ *
+ * The saved queries already collapse to one row per key, so this only bites if
+ * that ever stops being true. Keeping it explicit is cheap insurance: picking
+ * arbitrarily among rows for one key would sooner or later surface an approval
+ * that a later review revoked.
+ */
+export function supersedes(
+  candidate: Pick<GreenlightPrStateRow, "run_id" | "version">,
+  incumbent: Pick<GreenlightPrStateRow, "run_id" | "version">
+): boolean {
+  if (candidate.run_id !== incumbent.run_id) {
+    return candidate.run_id > incumbent.run_id;
+  }
+  return candidate.version > incumbent.version;
+}
+
+/**
+ * Collapse rows to `pr_number -> status`, keeping the authoritative row per PR.
+ * Rows with a non-positive PR number are dropped: nothing on the HUD can key off
+ * one, and the ledger's own reader never emits one.
+ */
+export function buildStatusByPr(
+  rows: GreenlightPrStateRow[] | undefined
+): Map<number, string> {
+  const authoritative = new Map<number, GreenlightPrStateRow>();
+  for (const row of rows ?? []) {
+    const prNumber = Number(row.pr_number);
+    if (!Number.isFinite(prNumber) || prNumber <= 0) {
+      continue;
+    }
+    const incumbent = authoritative.get(prNumber);
+    if (incumbent === undefined || supersedes(row, incumbent)) {
+      authoritative.set(prNumber, row);
+    }
+  }
+  return new Map(
+    Array.from(authoritative, ([prNumber, row]) => [prNumber, row.status])
+  );
+}

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -8,6 +8,7 @@ import LoadingPage from "components/common/LoadingPage";
 import PageSelector from "components/common/PageSelector";
 import { LocalTimeHuman } from "components/common/TimeUtils";
 import TooltipTarget from "components/common/tooltipTarget/TooltipTarget";
+import GreenLightIcon from "components/greenlight/GreenLightIcon";
 import styles from "components/hud.module.css";
 import {
   GroupHudTableColumns,
@@ -28,6 +29,16 @@ import {
 } from "lib/advisorVerdictUtils";
 import { isJobAutorevertSignal } from "lib/autorevertUtils";
 import { fetcher, useClickHouseAPIImmutable } from "lib/GeneralUtils";
+import {
+  greenlightRepoKey,
+  isGreenlightRepo,
+} from "lib/greenlight/greenlightConfig";
+import {
+  buildStatusByPr,
+  GreenlightPrStateRow,
+  isGreenlightApproved,
+} from "lib/greenlight/greenlightHudState";
+import { GREENLIGHT_STATUS_LAND } from "lib/greenlight/greenlightRender";
 import {
   getGroupingData,
   groups,
@@ -195,6 +206,7 @@ function HudRow({
   const sha = rowData.sha;
 
   const [pinnedId, setPinnedId] = useContext(PinnedTooltipContext);
+  const greenlightStatuses = useContext(GreenlightStatusesContext);
 
   let rowStyle = "";
   if (pinnedId.sha == sha) {
@@ -230,30 +242,38 @@ function HudRow({
       </td>
       <td className={styles.jobMetadata}>
         {rowData.prNum !== null && (
-          <a
-            href={`https://github.com/${params.repoOwner}/${params.repoName}/pull/${rowData.prNum}`}
-            title={
-              rowData.isForcedMerge
-                ? rowData.isForcedMergeWithFailures
-                  ? "Forced merge with failures that were merge-blocking"
-                  : "Forced merge. Had no merge-blocking failures"
-                : undefined
-            }
-          >
-            {rowData.isForcedMerge ? (
-              <mark
-                className={
-                  rowData.isForcedMergeWithFailures
-                    ? styles.forcedMergeWithFailure
-                    : styles.forcedMerge
-                }
-              >
-                #{rowData.prNum}
-              </mark>
-            ) : (
-              <div>#{rowData.prNum}</div>
+          <div className={styles.prCell}>
+            <a
+              href={`https://github.com/${params.repoOwner}/${params.repoName}/pull/${rowData.prNum}`}
+              title={
+                rowData.isForcedMerge
+                  ? rowData.isForcedMergeWithFailures
+                    ? "Forced merge with failures that were merge-blocking"
+                    : "Forced merge. Had no merge-blocking failures"
+                  : undefined
+              }
+            >
+              {rowData.isForcedMerge ? (
+                <mark
+                  className={
+                    rowData.isForcedMergeWithFailures
+                      ? styles.forcedMergeWithFailure
+                      : styles.forcedMerge
+                  }
+                >
+                  #{rowData.prNum}
+                </mark>
+              ) : (
+                <div>#{rowData.prNum}</div>
+              )}
+            </a>
+            {/* LAND only. Every other status is a refusal or the absence of
+            one, and a glyph on the trunk HUD -- where the PR has already landed
+            -- would read as an endorsement the ledger never made. */}
+            {isGreenlightApproved(greenlightStatuses.get(rowData.prNum)) && (
+              <GreenLightIcon status={GREENLIGHT_STATUS_LAND} size={11} />
             )}
-          </a>
+          </div>
         )}
       </td>
       <td className={styles.jobMetadata}>
@@ -526,6 +546,13 @@ export const MonsterFailuresContext = createContext<
 export const AdvisorVerdictsContext = createContext<
   Map<string, AdvisorVerdict[]>
 >(new Map());
+
+// GreenLight verdicts for the PRs on screen: prNum -> misc.greenlight_pr_state
+// status. A context rather than a prop because the only consumer is the PR cell
+// four levels down, and the rows in between have nothing to say about it.
+export const GreenlightStatusesContext = createContext<Map<number, string>>(
+  new Map()
+);
 
 export const GroupingContext = createContext<{
   groupNameMapping: Map<string, Array<string>>;
@@ -866,6 +893,27 @@ function GroupedHudTable({ params }: { params: HudParams }) {
     isPyTorch && prNums.length > 0
   );
 
+  // Lazy-load GreenLight verdicts for the same PRs. Gated on GREENLIGHT_REPOS
+  // rather than on isPyTorch: that allowlist is what the Dr.CI render already
+  // keys off, so both surfaces light up and go dark for the same repos.
+  const isGreenlight = isGreenlightRepo(params.repoOwner, params.repoName);
+  const { data: greenlightRows } =
+    useClickHouseAPIImmutable<GreenlightPrStateRow>(
+      "greenlight_pr_states",
+      {
+        repo: greenlightRepoKey(params.repoOwner, params.repoName),
+        prNumbers: prNums,
+      },
+      isGreenlight && prNums.length > 0
+    );
+  // Immutable, like the advisor and CRCR fetches beside it: every PR on a trunk
+  // HUD page has already landed, so its verdict is final and re-polling it
+  // would only add load.
+  const greenlightStatusByPr = useMemo(
+    () => buildStatusByPr(greenlightRows),
+    [greenlightRows]
+  );
+
   // Merge CRCR results into each row's nameToJobs so they appear as
   // regular grid columns (with grouping, filtering, monsterization).
   const dataWithCrcr = useMemo(() => {
@@ -1045,21 +1093,23 @@ function GroupedHudTable({ params }: { params: HudParams }) {
 
   return (
     <AdvisorVerdictsContext.Provider value={advisorVerdictsBySha}>
-      <GroupingContext.Provider
-        value={{ groupNameMapping, expandedGroups, setExpandedGroups }}
-      >
-        <table className={styles.hudTable} style={{ overflow: "auto" }}>
-          <GroupHudTableColumns names={names} />
-          <GroupHudTableHeader names={names} />
-          <HudTableBody
-            shaGrid={shaGrid}
-            names={names}
-            unstableIssues={unstableIssuesData ?? []}
-            repoOwner={params.repoOwner}
-            repoName={params.repoName}
-          />
-        </table>
-      </GroupingContext.Provider>
+      <GreenlightStatusesContext.Provider value={greenlightStatusByPr}>
+        <GroupingContext.Provider
+          value={{ groupNameMapping, expandedGroups, setExpandedGroups }}
+        >
+          <table className={styles.hudTable} style={{ overflow: "auto" }}>
+            <GroupHudTableColumns names={names} />
+            <GroupHudTableHeader names={names} />
+            <HudTableBody
+              shaGrid={shaGrid}
+              names={names}
+              unstableIssues={unstableIssuesData ?? []}
+              repoOwner={params.repoOwner}
+              repoName={params.repoName}
+            />
+          </table>
+        </GroupingContext.Provider>
+      </GreenlightStatusesContext.Provider>
     </AdvisorVerdictsContext.Provider>
   );
 }

--- a/torchci/test/greenlightHudState.test.ts
+++ b/torchci/test/greenlightHudState.test.ts
@@ -1,0 +1,116 @@
+import {
+  buildStatusByPr,
+  GreenlightPrStateRow,
+  isGreenlightApproved,
+  supersedes,
+} from "lib/greenlight/greenlightHudState";
+import {
+  GREENLIGHT_STATUS_AI_REVIEW_STARTED,
+  GREENLIGHT_STATUS_CANCELLED,
+  GREENLIGHT_STATUS_LAND,
+  GREENLIGHT_STATUS_NO_LAND,
+  GREENLIGHT_STATUS_REVERTED,
+} from "lib/greenlight/greenlightRender";
+
+function row(overrides: Partial<GreenlightPrStateRow>): GreenlightPrStateRow {
+  return {
+    pr_number: 1,
+    status: GREENLIGHT_STATUS_LAND,
+    reason: "clean",
+    message: "looks fine",
+    head_sha: "a".repeat(40),
+    eval_job: "",
+    run_id: 1,
+    version: "2026-09-01 00:00:00.000",
+    ...overrides,
+  };
+}
+
+describe("isGreenlightApproved", () => {
+  test("only LAND counts as approved", () => {
+    expect(isGreenlightApproved(GREENLIGHT_STATUS_LAND)).toBe(true);
+    for (const status of [
+      GREENLIGHT_STATUS_NO_LAND,
+      GREENLIGHT_STATUS_AI_REVIEW_STARTED,
+      GREENLIGHT_STATUS_CANCELLED,
+      GREENLIGHT_STATUS_REVERTED,
+    ]) {
+      expect(isGreenlightApproved(status)).toBe(false);
+    }
+  });
+
+  test("absent, empty and unknown statuses are not approved", () => {
+    expect(isGreenlightApproved(undefined)).toBe(false);
+    expect(isGreenlightApproved(null)).toBe(false);
+    expect(isGreenlightApproved("")).toBe(false);
+    expect(isGreenlightApproved("SOMETHING_NEW")).toBe(false);
+  });
+
+  test("tolerates the surrounding whitespace a ClickHouse String can carry", () => {
+    expect(isGreenlightApproved(` ${GREENLIGHT_STATUS_LAND} `)).toBe(true);
+  });
+});
+
+describe("supersedes", () => {
+  test("a higher run_id wins even with an older version", () => {
+    const newer = { run_id: 9, version: "2026-01-01 00:00:00.000" };
+    const older = { run_id: 8, version: "2026-09-01 00:00:00.000" };
+    expect(supersedes(newer, older)).toBe(true);
+    expect(supersedes(older, newer)).toBe(false);
+  });
+
+  test("version breaks a run_id tie", () => {
+    const later = { run_id: 9, version: "2026-09-02 00:00:00.000" };
+    const earlier = { run_id: 9, version: "2026-09-01 00:00:00.000" };
+    expect(supersedes(later, earlier)).toBe(true);
+    expect(supersedes(earlier, later)).toBe(false);
+  });
+
+  test("a row does not supersede itself", () => {
+    const only = { run_id: 9, version: "2026-09-01 00:00:00.000" };
+    expect(supersedes(only, only)).toBe(false);
+  });
+});
+
+describe("buildStatusByPr", () => {
+  test("keys each PR's status by pr_number", () => {
+    const byPr = buildStatusByPr([
+      row({ pr_number: 10, status: GREENLIGHT_STATUS_LAND }),
+      row({ pr_number: 11, status: GREENLIGHT_STATUS_NO_LAND }),
+    ]);
+    expect(byPr.get(10)).toBe(GREENLIGHT_STATUS_LAND);
+    expect(byPr.get(11)).toBe(GREENLIGHT_STATUS_NO_LAND);
+  });
+
+  test("keeps the authoritative row when a PR somehow has several", () => {
+    // The saved query already collapses these; the guard matters because
+    // picking the wrong one shows an approval a later review revoked.
+    const byPr = buildStatusByPr([
+      row({ pr_number: 10, status: GREENLIGHT_STATUS_LAND, run_id: 5 }),
+      row({ pr_number: 10, status: GREENLIGHT_STATUS_NO_LAND, run_id: 6 }),
+    ]);
+    expect(byPr.get(10)).toBe(GREENLIGHT_STATUS_NO_LAND);
+  });
+
+  test("order of arrival does not decide the winner", () => {
+    const byPr = buildStatusByPr([
+      row({ pr_number: 10, status: GREENLIGHT_STATUS_NO_LAND, run_id: 6 }),
+      row({ pr_number: 10, status: GREENLIGHT_STATUS_LAND, run_id: 5 }),
+    ]);
+    expect(byPr.get(10)).toBe(GREENLIGHT_STATUS_NO_LAND);
+  });
+
+  test("drops rows with no usable PR number", () => {
+    const byPr = buildStatusByPr([
+      row({ pr_number: 0 }),
+      row({ pr_number: -1 }),
+      row({ pr_number: NaN }),
+    ]);
+    expect(byPr.size).toBe(0);
+  });
+
+  test("undefined and empty input give an empty map", () => {
+    expect(buildStatusByPr(undefined).size).toBe(0);
+    expect(buildStatusByPr([]).size).toBe(0);
+  });
+});


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #8749
* #8748
* __->__ #8747

Adds a traffic-light glyph next to the #PR link on the HUD's PR column
when GreenLight approved that PR to land without a human review, reusing
the existing column rather than adding a new one.

Only LAND draws a glyph. Every other misc.greenlight_pr_state status is
a refusal or the absence of one, and on a trunk HUD -- where the PR has
already landed -- a mark on those would read as an endorsement the
ledger never made.

Three pieces, the first two shared with the commit/PR pages that follow
in this stack:

- lib/greenlight/greenlightHudState.ts: the client-side row type plus
  isGreenlightApproved / supersedes / buildStatusByPr. The status
  vocabulary is imported from greenlightRender.ts rather than
  re-declared, because greenlight/tests/test_render_sync.py pins those
  declarations to the Python source and needs them spelled in exactly
  one file. buildStatusByPr mirrors the ledger's read-time selection
  (highest run_id, then latest version) so a superseded verdict can
  never win.

- components/greenlight/GreenLightIcon.tsx: the glyph, with a light and
  a dark shade per tone per torchci/CLAUDE.md. Renders nothing for an
  unrecognised status, so a status added on the Python side reads as
  "no claim" instead of falling back to a colour that implies a verdict.

- The HUD page batches one greenlight_pr_states read over the PRs on
  screen (the existing saved query, gated on GREENLIGHT_REPOS so this
  surface and the Dr.CI render light up for the same repos) and hands
  the result down through a context, matching the advisor and CRCR
  fetches beside it.

greenlightComment.ts drops its private copy of the row interface and
imports the shared one; no behaviour change there.

Test plan: yarn test test/greenlightHudState.test.ts
test/greenlightComment.test.ts test/greenlightRender.test.ts