### PR TITLE
[GreenLight] Show the GreenLight verdict on the commit page

### DIFF
--- a/torchci/clickhouse_queries/greenlight_pr_state_history/params.json
+++ b/torchci/clickhouse_queries/greenlight_pr_state_history/params.json
@@ -1,0 +1,12 @@
+{
+  "params": {
+    "repo": "String",
+    "prNumber": "Int64"
+  },
+  "tests": [
+    {
+      "repo": "pytorch/pytorch",
+      "prNumber": 185648
+    }
+  ]
+}

--- a/torchci/clickhouse_queries/greenlight_pr_state_history/query.sql
+++ b/torchci/clickhouse_queries/greenlight_pr_state_history/query.sql
@@ -1,0 +1,29 @@
+-- Latest greenlight state per reviewed commit, for a single PR.
+--
+-- Sibling of greenlight_pr_states, which collapses to one row per PR for a whole
+-- Dr.CI sweep. This one takes one PR and collapses per head_sha instead, because
+-- the HUD's commit and PR pages are commit-scoped: they ask what GreenLight said
+-- about the commit on screen, not only what it last said about the PR. The
+-- caller recovers the PR-level answer from the same result by re-applying the
+-- (run_id DESC, version DESC) order across shas.
+--
+-- misc.greenlight_pr_state is append-only: emit_id ends the sort key, so every
+-- row's key is unique. FINAL therefore collapses nothing, and argMax(...,
+-- version) would pick by version alone. Ordering run_id ahead of version is what
+-- makes this read race-proof -- a superseded slower dispatch that finishes with
+-- a later version still loses to the newer dispatch's higher run_id.
+SELECT
+    pr_number,
+    head_sha,
+    status,
+    reason,
+    message,
+    eval_job,
+    run_id,
+    version
+FROM misc.greenlight_pr_state
+WHERE
+    repo = {repo: String}
+    AND pr_number = {prNumber: Int64}
+ORDER BY head_sha, run_id DESC, version DESC
+LIMIT 1 BY head_sha

--- a/torchci/components/commit/CommitInfo.tsx
+++ b/torchci/components/commit/CommitInfo.tsx
@@ -1,4 +1,6 @@
 import CommitStatus from "components/commit/CommitStatus";
+import GreenLightCommitBadge from "components/greenlight/GreenLightCommitBadge";
+import GreenLightSection from "components/greenlight/GreenLightSection";
 import { fetcher } from "lib/GeneralUtils";
 import { CommitApiResponse } from "pages/api/[repoOwner]/[repoName]/commit/[sha]";
 import { IssueLabelApiResponse } from "pages/api/issue/[label]";
@@ -47,7 +49,27 @@ export function CommitInfo({
 
   return (
     <div>
-      {isCommitPage && <h2>{commit.commitTitle}</h2>}
+      {isCommitPage && (
+        <h2>
+          <GreenLightCommitBadge
+            repoOwner={repoOwner}
+            repoName={repoName}
+            prNumber={commit.prNum}
+            sha={sha}
+          />{" "}
+          {commit.commitTitle}
+        </h2>
+      )}
+      {/* Above the job grid, not below it: the verdict is a statement about the
+      whole change, and a reader who has scrolled past every workflow box has
+      already stopped looking for one. Shared with the PR page, which renders
+      CommitInfo for whichever commit its picker has selected. */}
+      <GreenLightSection
+        repoOwner={repoOwner}
+        repoName={repoName}
+        prNumber={commit.prNum}
+        sha={sha}
+      />
       <CommitStatus
         repoOwner={repoOwner}
         repoName={repoName}

--- a/torchci/components/greenlight/GreenLightCommitBadge.tsx
+++ b/torchci/components/greenlight/GreenLightCommitBadge.tsx
@@ -1,0 +1,49 @@
+// The GreenLight glyph shown beside a commit or PR title. Same row and same
+// fetch as GreenLightSection below it -- SWR dedupes the identical key, so the
+// two mount one request between them -- and it exists as its own component only
+// because a page title is not somewhere a whole panel can go.
+
+import GreenLightIcon from "components/greenlight/GreenLightIcon";
+import { selectStateForSha } from "lib/greenlight/greenlightHudState";
+import { useGreenlightPrHistory } from "lib/greenlight/useGreenlightPrHistory";
+
+const SHORT_SHA_LENGTH = 7;
+
+export default function GreenLightCommitBadge({
+  repoOwner,
+  repoName,
+  prNumber,
+  sha,
+  size = 16,
+}: {
+  repoOwner: string;
+  repoName: string;
+  prNumber: number | null | undefined;
+  sha: string;
+  size?: number;
+}) {
+  const { data: rows } = useGreenlightPrHistory(repoOwner, repoName, prNumber);
+  const selected = selectStateForSha(rows, sha);
+  if (selected === undefined) {
+    return null;
+  }
+
+  const { state, isForThisSha } = selected;
+  return (
+    <GreenLightIcon
+      status={state.status}
+      size={size}
+      // Named on a landed commit because it is always a different sha there:
+      // pytorch rebases on merge, so the trunk commit is never the PR head
+      // GreenLight reviewed. An unqualified glyph would claim otherwise.
+      titleSuffix={
+        isForThisSha
+          ? undefined
+          : `reviewed on ${state.head_sha
+              .trim()
+              .toLowerCase()
+              .slice(0, SHORT_SHA_LENGTH)}`
+      }
+    />
+  );
+}

--- a/torchci/components/greenlight/GreenLightSection.tsx
+++ b/torchci/components/greenlight/GreenLightSection.tsx
@@ -1,0 +1,245 @@
+// The GREEN LIGHT panel on the HUD's commit and PR pages: what GreenLight
+// decided about a commit, and the model's stated reason for it.
+//
+// The same misc.greenlight_pr_state row Dr.CI renders into the PR comment, shown
+// on the HUD instead. The wording is shared with that renderer
+// (greenlightRender.ts headline constants) so the two surfaces cannot disagree
+// about what a status means; the layout is not, because a comment section folded
+// into Dr.CI's own <details> is a different job from a panel on a page.
+//
+// The model's `message` is rendered as a text node inside a monospace block.
+// That is the containment: React escapes it, so unlike the markdown comment path
+// it needs no fence and no @-mention defanging -- but nothing here may route it
+// through dangerouslySetInnerHTML or a markdown renderer.
+
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Link,
+  Stack,
+  Typography,
+} from "@mui/material";
+import GreenLightIcon from "components/greenlight/GreenLightIcon";
+import {
+  isGreenlightApproved,
+  normalizeSha,
+  selectStateForSha,
+} from "lib/greenlight/greenlightHudState";
+import {
+  GREENLIGHT_INCOMPLETE_HEADLINE,
+  GREENLIGHT_LAND_HEADLINE,
+  GREENLIGHT_MESSAGE_CAP,
+  GREENLIGHT_NO_LAND_HEADLINE,
+  GREENLIGHT_REVERTED_BODY,
+  GREENLIGHT_REVERTED_HEADLINE,
+  GREENLIGHT_REVIEWING_BODY,
+  GREENLIGHT_REVIEWING_HEADLINE,
+  GREENLIGHT_STALLED_REASON,
+  GREENLIGHT_STATUS_AI_REVIEW_DISPATCHED,
+  GREENLIGHT_STATUS_AI_REVIEW_STARTED,
+  GREENLIGHT_STATUS_CANCELLED,
+  GREENLIGHT_STATUS_FAILED,
+  GREENLIGHT_STATUS_LAND,
+  GREENLIGHT_STATUS_NO_LAND,
+  GREENLIGHT_STATUS_REVERTED,
+} from "lib/greenlight/greenlightRender";
+import { isInProgressStale } from "lib/greenlight/greenlightStaleness";
+import { useGreenlightPrHistory } from "lib/greenlight/useGreenlightPrHistory";
+
+const SHORT_SHA_LENGTH = 7;
+
+// Same host anchoring as greenlightRender's SAFE_JOB_URL_RE: a userinfo prefix
+// (https://u:p@github.com/) and a lookalike host (https://github.com.evil/) both
+// satisfy a mere "contains github.com", and eval_job is a database column.
+const SAFE_JOB_URL_RE = /^https:\/\/github\.com\/[^\s()<>"'\\]+$/;
+
+function shortSha(sha: string): string {
+  return normalizeSha(sha).slice(0, SHORT_SHA_LENGTH);
+}
+
+interface Described {
+  headline: string;
+  /** Fixed prose for states the row carries no model message for. */
+  body: string;
+  /**
+   * The reason to display, which is the row's own `reason` only for a verdict.
+   * The marker statuses carry an empty one and name themselves instead, exactly
+   * as comment_format.marker_body does.
+   */
+  reason: string;
+}
+
+/**
+ * How to present one row. Mirrors renderGreenlightSection's branches, headline
+ * for headline: a status with no case here has no panel to show, just as it has
+ * no Dr.CI section.
+ */
+function describeStatus(
+  status: string,
+  rowReason: string,
+  version: string,
+  now: Date
+): Described | undefined {
+  switch (status) {
+    case GREENLIGHT_STATUS_LAND:
+      return {
+        headline: GREENLIGHT_LAND_HEADLINE,
+        body: "",
+        reason: rowReason,
+      };
+    case GREENLIGHT_STATUS_NO_LAND:
+      return {
+        headline: GREENLIGHT_NO_LAND_HEADLINE,
+        body: "",
+        reason: rowReason,
+      };
+    case GREENLIGHT_STATUS_REVERTED:
+      return {
+        headline: GREENLIGHT_REVERTED_HEADLINE,
+        body: GREENLIGHT_REVERTED_BODY,
+        reason: "",
+      };
+    case GREENLIGHT_STATUS_AI_REVIEW_STARTED:
+    case GREENLIGHT_STATUS_AI_REVIEW_DISPATCHED:
+      // An in-flight row that outlived the window means the terminal emit was
+      // lost. Saying "in progress" for as long as the row stands would be worse
+      // than admitting the run is presumed gone.
+      return isInProgressStale(version, now)
+        ? {
+            headline: GREENLIGHT_INCOMPLETE_HEADLINE,
+            body: "",
+            reason: GREENLIGHT_STALLED_REASON,
+          }
+        : {
+            headline: GREENLIGHT_REVIEWING_HEADLINE,
+            body: GREENLIGHT_REVIEWING_BODY,
+            reason: "",
+          };
+    case GREENLIGHT_STATUS_CANCELLED:
+    case GREENLIGHT_STATUS_FAILED:
+      return {
+        headline: GREENLIGHT_INCOMPLETE_HEADLINE,
+        body: "",
+        reason: status.toLowerCase(),
+      };
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Renders nothing when the repo is outside GREENLIGHT_REPOS, when the commit has
+ * no PR, or when GreenLight has no state for that PR -- an absent panel says
+ * "GreenLight did not weigh in", which is true and is what a reader needs.
+ */
+export default function GreenLightSection({
+  repoOwner,
+  repoName,
+  prNumber,
+  sha,
+}: {
+  repoOwner: string;
+  repoName: string;
+  prNumber: number | null | undefined;
+  sha: string;
+}) {
+  const { data: rows } = useGreenlightPrHistory(repoOwner, repoName, prNumber);
+  const selected = selectStateForSha(rows, sha);
+  if (selected === undefined) {
+    return null;
+  }
+
+  const { state, isForThisSha } = selected;
+  const described = describeStatus(
+    state.status.trim(),
+    state.reason ?? "",
+    state.version,
+    new Date()
+  );
+  if (described === undefined) {
+    return null;
+  }
+
+  const approved = isGreenlightApproved(state.status);
+  const reason = described.reason;
+  // The same cap the Dr.CI render applies, for the same reason: `message` is an
+  // unbounded ClickHouse String and nothing upstream bounds what a model wrote.
+  const message = Array.from(state.message ?? "")
+    .slice(0, GREENLIGHT_MESSAGE_CAP)
+    .join("");
+  const jobUrl = (state.eval_job ?? "").trim();
+
+  return (
+    <Accordion
+      disableGutters
+      // Expanded when GreenLight approved, collapsed otherwise. An approval is
+      // the claim a reader most needs to be able to check without a click; every
+      // other state is either self-evident from the headline or a non-event.
+      defaultExpanded={approved}
+      sx={{ mt: 2, mb: 2 }}
+    >
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <GreenLightIcon status={state.status} size={14} />
+          <Typography fontWeight="bold">GREEN LIGHT</Typography>
+          <Typography color="text.secondary">
+            {isForThisSha ? "" : "(earlier commit) "}
+            {described.headline}
+          </Typography>
+        </Stack>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Stack spacing={1}>
+          {described.body && (
+            <Typography variant="body2" color="text.secondary">
+              {described.body}
+            </Typography>
+          )}
+          {message && (
+            <Box
+              component="pre"
+              sx={{
+                m: 0,
+                p: 1.5,
+                borderRadius: 1,
+                // Palette tokens rather than literals, so the block tracks both
+                // modes (torchci/CLAUDE.md).
+                bgcolor: "action.hover",
+                color: "text.primary",
+                fontSize: "0.8rem",
+                whiteSpace: "pre-wrap",
+                overflowWrap: "anywhere",
+              }}
+            >
+              {message}
+            </Box>
+          )}
+          {reason && (
+            <Typography variant="body2" color="text.secondary">
+              reason: <code>{reason}</code>
+            </Typography>
+          )}
+          {state.head_sha && (
+            <Typography variant="body2" color="text.secondary">
+              Reviewed commit: <code>{shortSha(state.head_sha)}</code>
+              {!isForThisSha && ` (not the commit shown, ${shortSha(sha)})`}
+            </Typography>
+          )}
+          {SAFE_JOB_URL_RE.test(jobUrl) && (
+            <Link
+              href={jobUrl}
+              target="_blank"
+              rel="noreferrer"
+              variant="body2"
+            >
+              Inference job
+            </Link>
+          )}
+        </Stack>
+      </AccordionDetails>
+    </Accordion>
+  );
+}

--- a/torchci/lib/greenlight/greenlightHudState.ts
+++ b/torchci/lib/greenlight/greenlightHudState.ts
@@ -91,3 +91,86 @@ export function buildStatusByPr(
     Array.from(authoritative, ([prNumber, row]) => [prNumber, row.status])
   );
 }
+
+/**
+ * A commit sha in the one form every lookup here uses. Git shas are lowercase
+ * hex, but the sha reaching these helpers comes from a URL or a `<select>` value
+ * as often as from the database, so normalise rather than assume.
+ */
+export function normalizeSha(sha: string | undefined | null): string {
+  return (sha ?? "").trim().toLowerCase();
+}
+
+/**
+ * Collapse `greenlight_pr_state_history` rows to `head_sha -> row`, keeping the
+ * authoritative row per commit. The query already collapses per head_sha; this
+ * re-applies the same selection for the reason `buildStatusByPr` does.
+ */
+export function buildStateBySha(
+  rows: GreenlightPrStateRow[] | undefined
+): Map<string, GreenlightPrStateRow> {
+  const bySha = new Map<string, GreenlightPrStateRow>();
+  for (const row of rows ?? []) {
+    const sha = normalizeSha(row.head_sha);
+    if (sha === "") {
+      continue;
+    }
+    const incumbent = bySha.get(sha);
+    if (incumbent === undefined || supersedes(row, incumbent)) {
+      bySha.set(sha, row);
+    }
+  }
+  return bySha;
+}
+
+/**
+ * The PR's authoritative row across every commit it has been reviewed on -- the
+ * one the merge gate acted on and Dr.CI renders. Undefined when the PR has no
+ * recorded state at all.
+ */
+export function authoritativeState(
+  rows: GreenlightPrStateRow[] | undefined
+): GreenlightPrStateRow | undefined {
+  let best: GreenlightPrStateRow | undefined;
+  for (const row of rows ?? []) {
+    if (best === undefined || supersedes(row, best)) {
+      best = row;
+    }
+  }
+  return best;
+}
+
+/** What to show about GreenLight for one particular commit. */
+export interface GreenlightStateForSha {
+  state: GreenlightPrStateRow;
+  /**
+   * Whether `state` is the verdict GreenLight reached on the commit asked
+   * about, as opposed to the PR's latest verdict shown in its absence.
+   *
+   * False is the ordinary case on a commit page for a landed commit: pytorch
+   * rebases on merge, so the trunk sha is never the PR head sha GreenLight
+   * reviewed. It is also what a push GreenLight has not reviewed yet looks like
+   * on the PR page. Both need saying out loud -- an unlabelled verdict from
+   * another commit reads as a current statement about this one.
+   */
+  isForThisSha: boolean;
+}
+
+/**
+ * Pick the state to show for `sha`: that commit's own verdict when GreenLight
+ * reviewed it, otherwise the PR's authoritative verdict, flagged as belonging to
+ * a different commit. Undefined when the PR has no recorded state.
+ */
+export function selectStateForSha(
+  rows: GreenlightPrStateRow[] | undefined,
+  sha: string | undefined | null
+): GreenlightStateForSha | undefined {
+  const exact = buildStateBySha(rows).get(normalizeSha(sha));
+  if (exact !== undefined) {
+    return { state: exact, isForThisSha: true };
+  }
+  const latest = authoritativeState(rows);
+  return latest === undefined
+    ? undefined
+    : { state: latest, isForThisSha: false };
+}

--- a/torchci/lib/greenlight/useGreenlightPrHistory.ts
+++ b/torchci/lib/greenlight/useGreenlightPrHistory.ts
@@ -1,0 +1,46 @@
+// Fetches one PR's GreenLight state, one row per commit GreenLight reviewed.
+// Shared by the commit page's verdict section and the PR page's commit picker,
+// which both need the same rows keyed different ways -- so they must issue one
+// request between them, not one each.
+
+import { useClickHouseAPIImmutable } from "lib/GeneralUtils";
+import {
+  greenlightRepoKey,
+  isGreenlightRepo,
+} from "lib/greenlight/greenlightConfig";
+import { GreenlightPrStateRow } from "lib/greenlight/greenlightHudState";
+
+/**
+ * `greenlight_pr_state_history` rows for `prNumber`, or undefined while loading
+ * or when there is nothing to ask for -- a repo outside GREENLIGHT_REPOS, or a
+ * commit with no associated PR (`prNum` is null for a direct push).
+ *
+ * Immutable, matching the advisor and CRCR reads elsewhere in the HUD. A live
+ * review does move: AI_REVIEW_DISPATCHED -> AI_REVIEW_STARTED -> a verdict, over
+ * tens of minutes. SWR still revalidates on focus and on remount, which is when
+ * someone watching a PR page actually looks, and polling a ~35-minute transition
+ * on an interval would cost far more reads than it informs.
+ */
+export function useGreenlightPrHistory(
+  repoOwner: string | undefined,
+  repoName: string | undefined,
+  prNumber: number | null | undefined
+) {
+  const enabled =
+    repoOwner !== undefined &&
+    repoName !== undefined &&
+    isGreenlightRepo(repoOwner, repoName) &&
+    prNumber != null &&
+    prNumber > 0;
+
+  return useClickHouseAPIImmutable<GreenlightPrStateRow>(
+    "greenlight_pr_state_history",
+    {
+      // Empty strings rather than a conditional object: the hook must be called
+      // unconditionally, and `enabled` already stops the request being made.
+      repo: enabled ? greenlightRepoKey(repoOwner, repoName) : "",
+      prNumber: enabled ? prNumber : 0,
+    },
+    enabled
+  );
+}

--- a/torchci/test/greenlightHudState.test.ts
+++ b/torchci/test/greenlightHudState.test.ts
@@ -1,7 +1,11 @@
 import {
+  authoritativeState,
+  buildStateBySha,
   buildStatusByPr,
   GreenlightPrStateRow,
   isGreenlightApproved,
+  normalizeSha,
+  selectStateForSha,
   supersedes,
 } from "lib/greenlight/greenlightHudState";
 import {
@@ -112,5 +116,126 @@ describe("buildStatusByPr", () => {
   test("undefined and empty input give an empty map", () => {
     expect(buildStatusByPr(undefined).size).toBe(0);
     expect(buildStatusByPr([]).size).toBe(0);
+  });
+});
+
+const SHA_A = "a".repeat(40);
+const SHA_B = "b".repeat(40);
+const SHA_C = "c".repeat(40);
+
+describe("normalizeSha", () => {
+  test("folds case and trims, and maps absent input to empty", () => {
+    expect(normalizeSha(`  ${SHA_A.toUpperCase()} `)).toBe(SHA_A);
+    expect(normalizeSha(undefined)).toBe("");
+    expect(normalizeSha(null)).toBe("");
+  });
+});
+
+describe("buildStateBySha", () => {
+  test("keys each reviewed commit's row by its head sha", () => {
+    const bySha = buildStateBySha([
+      row({ head_sha: SHA_A, status: GREENLIGHT_STATUS_NO_LAND }),
+      row({ head_sha: SHA_B, status: GREENLIGHT_STATUS_LAND }),
+    ]);
+    expect(bySha.get(SHA_A)?.status).toBe(GREENLIGHT_STATUS_NO_LAND);
+    expect(bySha.get(SHA_B)?.status).toBe(GREENLIGHT_STATUS_LAND);
+  });
+
+  test("a sha reviewed twice keeps the later run", () => {
+    const bySha = buildStateBySha([
+      row({ head_sha: SHA_A, status: GREENLIGHT_STATUS_NO_LAND, run_id: 4 }),
+      row({ head_sha: SHA_A, status: GREENLIGHT_STATUS_LAND, run_id: 7 }),
+    ]);
+    expect(bySha.get(SHA_A)?.status).toBe(GREENLIGHT_STATUS_LAND);
+  });
+
+  test("lookups are case-insensitive on the sha", () => {
+    const bySha = buildStateBySha([row({ head_sha: SHA_A.toUpperCase() })]);
+    expect(bySha.get(SHA_A)).toBeDefined();
+  });
+
+  test("drops rows with no head sha", () => {
+    expect(buildStateBySha([row({ head_sha: "" })]).size).toBe(0);
+    expect(buildStateBySha([row({ head_sha: "   " })]).size).toBe(0);
+  });
+});
+
+describe("authoritativeState", () => {
+  test("picks the highest run_id across commits, not the latest version", () => {
+    const best = authoritativeState([
+      row({
+        head_sha: SHA_A,
+        run_id: 9,
+        version: "2026-01-01 00:00:00.000",
+        status: GREENLIGHT_STATUS_LAND,
+      }),
+      row({
+        head_sha: SHA_B,
+        run_id: 8,
+        version: "2026-09-01 00:00:00.000",
+        status: GREENLIGHT_STATUS_NO_LAND,
+      }),
+    ]);
+    expect(best?.status).toBe(GREENLIGHT_STATUS_LAND);
+  });
+
+  test("undefined when the PR has no recorded state", () => {
+    expect(authoritativeState(undefined)).toBeUndefined();
+    expect(authoritativeState([])).toBeUndefined();
+  });
+});
+
+describe("selectStateForSha", () => {
+  const rows = [
+    row({ head_sha: SHA_A, status: GREENLIGHT_STATUS_NO_LAND, run_id: 4 }),
+    row({ head_sha: SHA_B, status: GREENLIGHT_STATUS_LAND, run_id: 7 }),
+  ];
+
+  test("a reviewed commit gets its own verdict, flagged as such", () => {
+    expect(selectStateForSha(rows, SHA_A)).toEqual({
+      state: rows[0],
+      isForThisSha: true,
+    });
+  });
+
+  test("an unreviewed commit falls back to the PR's authoritative verdict", () => {
+    // The trunk case: pytorch rebases on merge, so a landed commit's sha is
+    // never a sha GreenLight reviewed.
+    expect(selectStateForSha(rows, SHA_C)).toEqual({
+      state: rows[1],
+      isForThisSha: false,
+    });
+  });
+
+  test("the fallback is never the newest row by version alone", () => {
+    const raced = [
+      row({
+        head_sha: SHA_A,
+        run_id: 9,
+        version: "2026-01-01 00:00:00.000",
+        status: GREENLIGHT_STATUS_LAND,
+      }),
+      row({
+        head_sha: SHA_B,
+        run_id: 8,
+        version: "2026-09-01 00:00:00.000",
+        status: GREENLIGHT_STATUS_NO_LAND,
+      }),
+    ];
+    expect(selectStateForSha(raced, SHA_C)?.state.status).toBe(
+      GREENLIGHT_STATUS_LAND
+    );
+  });
+
+  test("undefined when the PR has no recorded state at all", () => {
+    expect(selectStateForSha(undefined, SHA_A)).toBeUndefined();
+    expect(selectStateForSha([], SHA_A)).toBeUndefined();
+  });
+
+  test("an absent sha still yields the PR's authoritative verdict", () => {
+    expect(selectStateForSha(rows, undefined)).toEqual({
+      state: rows[1],
+      isForThisSha: false,
+    });
   });
 });


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #8749
* __->__ #8748
* #8747

Adds a GREEN LIGHT panel above the job grid on the commit page, holding
the model's own reason for its decision, and a traffic-light glyph next
to the commit title.

The panel is expanded when GreenLight approved and collapsed otherwise:
an approval is the claim a reader most needs to be able to check without
a click, while every other state is either self-evident from the
headline or a non-event.

Commit-scoped, so the read is too. greenlight_pr_states collapses to one
row per PR, which answers "what did GreenLight last say about this PR"
-- the question Dr.CI asks. A commit page asks about a commit, so this
adds a sibling saved query, greenlight_pr_state_history, that takes one
PR and collapses per head_sha instead, with the same (run_id DESC,
version DESC) ordering that makes the existing read race-proof.

selectStateForSha then prefers the commit's own verdict and falls back
to the PR's authoritative one, flagged as belonging to a different
commit. The fallback is the ordinary case here, not an edge: pytorch
rebases on merge, so a landed commit's sha is never a sha GreenLight
reviewed. Both the panel headline and the glyph tooltip say so rather
than letting an earlier commit's verdict read as a statement about this
one.

Two notes on what is deliberately not copied from the Dr.CI renderer:

- The model's message needs no code fence and no @-mention defanging
  here. Those exist because that surface is markdown GitHub renders;
  React escapes a text node instead. The 4000-character cap is kept --
  `message` is an unbounded ClickHouse String.

- eval_job is still matched against an anchored github.com pattern
  before it becomes a link. It is a database column, and "contains
  github.com" is satisfied by both a userinfo prefix and a lookalike
  host.

The panel lives in CommitInfo, which the PR page also renders, so it
appears there too for whichever commit that page has selected. Wiring it
into that page's commit picker is the next change in this stack.

Test plan: yarn test test/greenlightHudState.test.ts