### PR TITLE
[GreenLight] Surface GreenLight per-commit in the PR page's picker

### DIFF
--- a/torchci/components/greenlight/GreenLightCommitBadge.tsx
+++ b/torchci/components/greenlight/GreenLightCommitBadge.tsx
@@ -19,7 +19,13 @@ export default function GreenLightCommitBadge({
   repoOwner: string;
   repoName: string;
   prNumber: number | null | undefined;
-  sha: string;
+  /**
+   * The commit to answer about. Omit it to ask about the PR instead, which is
+   * what a PR title wants: no sha matches, so the selection falls through to the
+   * PR's authoritative verdict and the tooltip names the commit it was reached
+   * on.
+   */
+  sha?: string;
   size?: number;
 }) {
   const { data: rows } = useGreenlightPrHistory(repoOwner, repoName, prNumber);

--- a/torchci/components/greenlight/GreenLightIcon.tsx
+++ b/torchci/components/greenlight/GreenLightIcon.tsx
@@ -66,12 +66,23 @@ const STATUS_TONES: Record<string, { tone: Tone; label: string }> = {
   },
 };
 
-/** The tooltip/aria text for a status, or "" if the status is unrecognised. */
-export function greenlightStatusLabel(
-  status: string | undefined | null
-): string {
+// The same signal as the svg, as one character, for the one place that cannot
+// hold an element: a native <option>. Its content is text, and no browser lets
+// you colour that text reliably -- so the colour has to be in the glyph itself.
+const TONE_GLYPHS: Record<Tone, string> = {
+  approved: "\u{1F7E2}", // green circle
+  declined: "\u{1F534}", // red circle
+  running: "\u{1F7E1}", // yellow circle
+  inconclusive: "⚪", // white circle
+};
+
+/**
+ * The single-character form of the glyph, or "" if the status is unrecognised.
+ * Callers concatenate it into plain text, so "" has to mean "add nothing".
+ */
+export function greenlightGlyphChar(status: string | undefined | null): string {
   const entry = STATUS_TONES[(status ?? "").trim()];
-  return entry === undefined ? "" : `Green Light: ${entry.label}`;
+  return entry === undefined ? "" : TONE_GLYPHS[entry.tone];
 }
 
 export default function GreenLightIcon({

--- a/torchci/components/greenlight/GreenLightSection.tsx
+++ b/torchci/components/greenlight/GreenLightSection.tsx
@@ -175,6 +175,11 @@ export default function GreenLightSection({
   return (
     <Accordion
       disableGutters
+      // defaultExpanded is read once per mount, so without a key that changes
+      // with the verdict the panel would keep whatever expand state the previous
+      // commit left it in. That is reachable from the PR page, whose picker
+      // switches commits under this component.
+      key={`${normalizeSha(sha)}:${state.status}`}
       // Expanded when GreenLight approved, collapsed otherwise. An approval is
       // the claim a reader most needs to be able to check without a click; every
       // other state is either self-evident from the headline or a non-event.

--- a/torchci/pages/[repoOwner]/[repoName]/pull/[prNumber].tsx
+++ b/torchci/pages/[repoOwner]/[repoName]/pull/[prNumber].tsx
@@ -3,8 +3,15 @@ import { CommitInfo } from "components/commit/CommitInfo";
 import DrCIButton from "components/common/DrCIButton";
 import ErrorBoundary from "components/common/ErrorBoundary";
 import CrcrPrSection from "components/crcr/CrcrPrSection";
+import GreenLightCommitBadge from "components/greenlight/GreenLightCommitBadge";
+import { greenlightGlyphChar } from "components/greenlight/GreenLightIcon";
 import { useSetTitle } from "components/layout/DynamicTitle";
 import { fetcher } from "lib/GeneralUtils";
+import {
+  buildStateBySha,
+  normalizeSha,
+} from "lib/greenlight/greenlightHudState";
+import { useGreenlightPrHistory } from "lib/greenlight/useGreenlightPrHistory";
 import { PRData } from "lib/types";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
@@ -23,6 +30,14 @@ function CommitHeader({
 }) {
   const router = useRouter();
   const pr = router.query.prNumber as string;
+  // Deduped by SWR against the same read in CommitInfo and in the title badge,
+  // so all three cost one request.
+  const { data: greenlightRows } = useGreenlightPrHistory(
+    repoOwner,
+    repoName,
+    Number(pr)
+  );
+  const greenlightBySha = buildStateBySha(greenlightRows);
   return (
     <div>
       Commit:{" "}
@@ -34,11 +49,22 @@ function CommitHeader({
           );
         }}
       >
-        {prData.shas.map(({ sha, title }) => (
-          <option key={sha} value={sha}>
-            {title + ` (${sha.substring(0, 6)})`}
-          </option>
-        ))}
+        {prData.shas.map(({ sha, title }) => {
+          // A character rather than the svg the rest of these surfaces use: an
+          // <option> holds text, and its colour is not reliably styleable, so
+          // the colour has to be carried by the glyph. Only shas GreenLight
+          // actually reviewed are marked -- there is no fallback to the PR's
+          // verdict here, because the whole point of the list is to tell the
+          // commits apart.
+          const glyph = greenlightGlyphChar(
+            greenlightBySha.get(normalizeSha(sha))?.status
+          );
+          return (
+            <option key={sha} value={sha}>
+              {`${glyph ? `${glyph} ` : ""}${title} (${sha.substring(0, 6)})`}
+            </option>
+          );
+        })}
       </select>
     </div>
   );
@@ -89,6 +115,15 @@ function Page() {
         }}
       >
         <h1>
+          {/* No sha: the title is about the PR, so this asks for the PR's
+          authoritative verdict rather than the selected commit's, and its
+          tooltip names the commit that verdict was reached on. The picker below
+          and the panel under it are the per-commit view. */}
+          <GreenLightCommitBadge
+            repoOwner={repoOwner as string}
+            repoName={repoName as string}
+            prNumber={prNumber ? parseInt(prNumber as string) : null}
+          />{" "}
           {prData.title}{" "}
           <code>
             <a


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #8749
* #8748
* #8747

The GREEN LIGHT panel already reaches the PR page, because it lives in
CommitInfo which that page renders for the selected commit. This wires
up the two things specific to the page: the picker, and the title.

- Commit picker: each option carries a coloured circle for the verdict
  GreenLight reached on that commit, so the list says at a glance which
  pushes were reviewed and how they went. A character, not the svg the
  other surfaces use -- an <option> holds text and its colour is not
  reliably styleable across browsers, so the colour has to be in the
  glyph itself. greenlightGlyphChar sits beside the svg's tone map so
  the two cannot drift.

  Only shas GreenLight actually reviewed are marked. There is
  deliberately no fallback to the PR's latest verdict here: the point of
  the list is to tell the commits apart, and a glyph on every row would
  destroy exactly that.

- PR title: a glyph for the PR's authoritative verdict, i.e. the one the
  merge gate acted on. GreenLightCommitBadge's `sha` becomes optional to
  express that -- omitting it means "ask about the PR" -- and the
  tooltip names the commit the verdict was reached on, since on a title
  it is otherwise unclear which one that was.

Also fixes the panel's expand state under the picker: defaultExpanded is
read once per mount, so switching commits would have left it however the
previous one did. Keyed on the sha and status now.

Alternative considered for the picker: replacing the native <select>
with a MUI Select, which renders elements and would let the real svg be
used there too, at the cost of restyling a control this change
otherwise leaves alone. Happy to do that instead if preferred.

Test plan: yarn test test/greenlightHudState.test.ts

Note: the wider `yarn test` run fails to load ~18 suites with "Cannot
find module '@aws-sdk/client-lambda' from 'lib/lambda.ts'". That is a
stale local node_modules -- the package is declared in package.json --
and is unrelated to this stack, which touches nothing in those import
chains.