### PR TITLE
[CRCR] Change Max Execution Time to Overrun Rate metric for L3 readiness evaluation

### DIFF
--- a/torchci/clickhouse_queries/crcr_backend_summary/query.sql
+++ b/torchci/clickhouse_queries/crcr_backend_summary/query.sql
@@ -76,14 +76,18 @@ SELECT
     -- ceiling, not genuine run time, and would inflate this otherwise.
     maxIf(execution_time, conclusion != 'timed_out') AS max_exec_time_s,
     quantileExact(0.95)(execution_time) AS p95_exec_time_s,
-    -- Share of jobs whose own run exceeded 3h (timeouts excluded)
-    -- the promotion criterion check this rate instead of the raw max
-    -- so one slow outlier in the 14-day window doesn't fail promotion
-    -- until it ages out.
+    -- Share of jobs whose own run exceeded 3h, excluded from both the
+    -- numerator and the denominator (timeouts are already penalized via
+    -- timeout_rate, so this measures overrun purely among jobs that
+    -- reported a genuine execution_time). The promotion criterion checks
+    -- this rate instead of the raw max, so one slow outlier in the
+    -- 14-day window doesn't fail promotion until it ages out.
+    -- NOTE: the 3h cutoff here must stay in sync with the copy of it in
+    -- crcr_l3_summary/query.sql.
     if(
-        total_jobs > 0,
+        countIf(conclusion != 'timed_out') > 0,
         countIf(execution_time > 3 * 3600 AND conclusion != 'timed_out')
-            / total_jobs,
+            / countIf(conclusion != 'timed_out'),
         0
     ) AS overrun_rate,
     -- E2E time is per-run (RFC-0050); run_rn = 1 keeps one sample per run.

--- a/torchci/clickhouse_queries/crcr_backend_summary/query.sql
+++ b/torchci/clickhouse_queries/crcr_backend_summary/query.sql
@@ -76,6 +76,16 @@ SELECT
     -- ceiling, not genuine run time, and would inflate this otherwise.
     maxIf(execution_time, conclusion != 'timed_out') AS max_exec_time_s,
     quantileExact(0.95)(execution_time) AS p95_exec_time_s,
+    -- Share of jobs whose own run exceeded 3h (timeouts excluded)
+    -- the promotion criterion check this rate instead of the raw max
+    -- so one slow outlier in the 14-day window doesn't fail promotion
+    -- until it ages out.
+    if(
+        total_jobs > 0,
+        countIf(execution_time > 3 * 3600 AND conclusion != 'timed_out')
+            / total_jobs,
+        0
+    ) AS overrun_rate,
     -- E2E time is per-run (RFC-0050); run_rn = 1 keeps one sample per run.
     -- Exact (not sampled) quantiles since this gates L3 promotion decisions.
     quantileExactIf(0.5)(

--- a/torchci/clickhouse_queries/crcr_l3_summary/query.sql
+++ b/torchci/clickhouse_queries/crcr_l3_summary/query.sql
@@ -77,6 +77,16 @@ SELECT
     -- Excludes timed-out jobs: their execution_time reflects the timeout
     -- ceiling, not genuine run time, and would inflate this otherwise.
     maxIf(execution_time, conclusion != 'timed_out') AS max_exec_time_s,
+    -- Share of jobs whose own run exceeded 3h (timeouts excluded)
+    -- the promotion criterion check this rate instead of the raw max
+    -- so one slow outlier in the 14-day window doesn't fail promotion
+    -- until it ages out.
+    if(
+        total_jobs > 0,
+        countIf(execution_time > 3 * 3600 AND conclusion != 'timed_out')
+            / total_jobs,
+        0
+    ) AS overrun_rate,
     -- E2E time is per-run; run_rn = 1 keeps one sample per run.
     quantileExactIf(0.5)(
         run_queue_time_s + run_span_s,

--- a/torchci/clickhouse_queries/crcr_l3_summary/query.sql
+++ b/torchci/clickhouse_queries/crcr_l3_summary/query.sql
@@ -77,14 +77,18 @@ SELECT
     -- Excludes timed-out jobs: their execution_time reflects the timeout
     -- ceiling, not genuine run time, and would inflate this otherwise.
     maxIf(execution_time, conclusion != 'timed_out') AS max_exec_time_s,
-    -- Share of jobs whose own run exceeded 3h (timeouts excluded)
-    -- the promotion criterion check this rate instead of the raw max
-    -- so one slow outlier in the 14-day window doesn't fail promotion
-    -- until it ages out.
+    -- Share of jobs whose own run exceeded 3h, excluded from both the
+    -- numerator and the denominator (timeouts are already penalized via
+    -- timeout_rate, so this measures overrun purely among jobs that
+    -- reported a genuine execution_time). The promotion criterion checks
+    -- this rate instead of the raw max, so one slow outlier in the
+    -- 14-day window doesn't fail promotion until it ages out.
+    -- NOTE: the 3h cutoff here must stay in sync with the copy of it in
+    -- crcr_backend_summary/query.sql.
     if(
-        total_jobs > 0,
+        countIf(conclusion != 'timed_out') > 0,
         countIf(execution_time > 3 * 3600 AND conclusion != 'timed_out')
-            / total_jobs,
+            / countIf(conclusion != 'timed_out'),
         0
     ) AS overrun_rate,
     -- E2E time is per-run; run_rn = 1 keeps one sample per run.

--- a/torchci/lib/crcr/l3Readiness.ts
+++ b/torchci/lib/crcr/l3Readiness.ts
@@ -19,6 +19,7 @@ export interface L3Metrics {
   pass_rate: number;
   avg_queue_time_s: number | null;
   max_exec_time_s: number | null;
+  overrun_rate: number;
   median_e2e_time_s: number | null;
   timeout_rate: number;
 }
@@ -115,8 +116,8 @@ const METRICS: {
   },
   {
     threshold: L3_THRESHOLDS.maxExecTimeS,
-    format: "duration",
-    getMeasured: (s) => s?.max_exec_time_s ?? null,
+    format: "percent",
+    getMeasured: (s) => (s ? s.overrun_rate : null),
   },
   {
     threshold: L3_THRESHOLDS.avgQueueTimeS,

--- a/torchci/lib/crcr/l3Readiness.ts
+++ b/torchci/lib/crcr/l3Readiness.ts
@@ -115,7 +115,7 @@ const METRICS: {
     getMeasured: (s) => s?.median_e2e_time_s ?? null,
   },
   {
-    threshold: L3_THRESHOLDS.maxExecTimeS,
+    threshold: L3_THRESHOLDS.overrunRate,
     format: "percent",
     getMeasured: (s) => (s ? s.overrun_rate : null),
   },

--- a/torchci/lib/crcr/l3Thresholds.ts
+++ b/torchci/lib/crcr/l3Thresholds.ts
@@ -6,7 +6,7 @@ import { useTheme } from "@mui/material";
  * of hardcoding a number, otherwise the two drift.
  *
  * There are six L3 promotion criteria: tenure + five metrics
- * (end-to-end time, max execution time, avg queue time, timeout rate, job
+ * (end-to-end time, overrun rate, avg queue time, timeout rate, job
  * pass rate).
  */
 
@@ -43,11 +43,12 @@ export const L3_THRESHOLDS = {
     provisional: false,
     demotionRelevant: true,
   },
+  // Measured as the *rate* of jobs individually exceeding 3h
   maxExecTimeS: {
     key: "maxExecTimeS",
-    label: "Max Execution Time",
-    targetLabel: "< 3 h",
-    target: 3 * 3600,
+    label: "Overrun Rate",
+    targetLabel: "< 1% of jobs over 3h",
+    target: 0.01,
     direction: "below",
     provisional: false,
     demotionRelevant: false,

--- a/torchci/lib/crcr/l3Thresholds.ts
+++ b/torchci/lib/crcr/l3Thresholds.ts
@@ -44,8 +44,8 @@ export const L3_THRESHOLDS = {
     demotionRelevant: true,
   },
   // Measured as the *rate* of jobs individually exceeding 3h
-  maxExecTimeS: {
-    key: "maxExecTimeS",
+  overrunRate: {
+    key: "overrunRate",
     label: "Overrun Rate",
     targetLabel: "< 1% of jobs over 3h",
     target: 0.01,

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -11,6 +11,7 @@ import {
   Stack,
   Tooltip,
   Typography,
+  useTheme,
 } from "@mui/material";
 import { durationDisplay } from "components/common/TimeUtils";
 import TooltipTarget from "components/common/tooltipTarget/TooltipTarget";
@@ -85,6 +86,7 @@ interface SummaryStats {
   avg_queue_time_s: number | null;
   avg_exec_time_s: number | null;
   max_exec_time_s: number | null;
+  overrun_rate: number;
   median_e2e_time_s: number | null;
   p95_exec_time_s: number | null;
   p95_e2e_time_s: number | null;
@@ -128,7 +130,7 @@ function dataCoverageDisplay(
 
 // RFC-0050 L3 promotion/demotion infrastructure gates (rfcs#102, ratified).
 const L3_AVG_QUEUE_TIME_S = 30 * 60; // < 30 min
-const L3_MAX_EXEC_TIME_S = 3 * 3600; // < 3 h
+const L3_OVERRUN_RATE = 0.01; // < 1% of jobs over 3h
 const L3_E2E_TIME_S = 3 * 3600; // < 3 h (P50 time-to-signal)
 const L3_TIMEOUT_RATE = 0.01; // < 1%
 
@@ -190,12 +192,19 @@ function SummaryCards({
   stats: SummaryStats;
   healthCard?: ReactNode;
 }) {
+  const theme = useTheme();
   const passColor =
     stats.pass_rate >= 1.0
       ? "#2e7d32"
       : stats.pass_rate >= 0.9
       ? "#ed6c02"
       : "#d32f2f";
+  const overrunColor =
+    stats.overrun_rate >= L3_OVERRUN_RATE
+      ? theme.palette.error.main
+      : stats.overrun_rate > 0
+      ? theme.palette.warning.main
+      : theme.palette.success.main;
 
   return (
     <Stack spacing={2}>
@@ -247,24 +256,20 @@ function SummaryCards({
           sub="start to completion"
         />
         <StatCard
-          label="Max Execution Time"
-          value={
-            stats.max_exec_time_s != null
-              ? durationDisplay(Math.round(stats.max_exec_time_s))
-              : "–"
-          }
+          label="Overrun Rate"
+          value={`${(stats.overrun_rate * 100).toFixed(1)}%`}
           sub={
-            stats.p95_exec_time_s != null
-              ? `p95: ${durationDisplay(Math.round(stats.p95_exec_time_s))}`
-              : "start to completion"
+            stats.max_exec_time_s != null
+              ? `max: ${durationDisplay(Math.round(stats.max_exec_time_s))}` +
+                (stats.p95_exec_time_s != null
+                  ? ` · p95: ${durationDisplay(
+                      Math.round(stats.p95_exec_time_s)
+                    )}`
+                  : "")
+              : "share of jobs over 3h"
           }
-          color={
-            stats.max_exec_time_s != null &&
-            stats.max_exec_time_s > L3_MAX_EXEC_TIME_S
-              ? "#d32f2f"
-              : undefined
-          }
-          tooltip="The single longest job run in this window. p95 = the run time 95% of jobs finish within — a steadier read than the max, which one outlier job can skew."
+          color={overrunColor}
+          tooltip="Share of jobs that individually overran 3h. max = the single longest job run; p95 = the run time 95% of jobs finish within."
         />
         <StatCard
           label="End-to-End Time (P50)"

--- a/torchci/pages/crcr/[org]/[repo].tsx
+++ b/torchci/pages/crcr/[org]/[repo].tsx
@@ -257,7 +257,14 @@ function SummaryCards({
         />
         <StatCard
           label="Overrun Rate"
-          value={`${(stats.overrun_rate * 100).toFixed(1)}%`}
+          value={
+            // A tiny nonzero rate (e.g. 0.03%) would otherwise round to
+            // "0.0%" at 1 decimal while still rendering warning-yellow
+            // below — showing "<0.1%" instead avoids that mismatch.
+            stats.overrun_rate > 0 && stats.overrun_rate < 0.001
+              ? "<0.1%"
+              : `${(stats.overrun_rate * 100).toFixed(1)}%`
+          }
           sub={
             stats.max_exec_time_s != null
               ? `max: ${durationDisplay(Math.round(stats.max_exec_time_s))}` +

--- a/torchci/test/l3Readiness.test.ts
+++ b/torchci/test/l3Readiness.test.ts
@@ -75,6 +75,7 @@ function summaryRow(overrides: Partial<L3SummaryRow>): L3SummaryRow {
     pass_rate: 1.0,
     avg_queue_time_s: 60,
     max_exec_time_s: 3600,
+    overrun_rate: 0,
     median_e2e_time_s: 3600,
     timeout_rate: 0,
     ...overrides,
@@ -142,6 +143,28 @@ describe("buildCriteriaRows / summarizeReadiness", () => {
     const result = summarizeReadiness(rows);
     expect(result.judgedCount).toBe(0);
     expect(result.ready).toBe(false);
+  });
+});
+
+describe("maxExecTimeS — overrun rate, not the raw max", () => {
+  it("passes when a rare job runs over 3h, as long as the rate stays under 1%", () => {
+    // A single slow job out of 200 (0.5%) used to fail this outright via
+    // the old max-based check; the rate-based check should let it through.
+    const rows = buildCriteriaRows(
+      summaryRow({ max_exec_time_s: 5 * 3600, overrun_rate: 0.005 }),
+      goodTenure
+    );
+    const row = rows.find((r) => r.key === "maxExecTimeS");
+    expect(row?.verdict).toBe(true);
+  });
+
+  it("fails once the rate of over-3h jobs reaches 1%", () => {
+    const rows = buildCriteriaRows(
+      summaryRow({ max_exec_time_s: 5 * 3600, overrun_rate: 0.01 }),
+      goodTenure
+    );
+    const row = rows.find((r) => r.key === "maxExecTimeS");
+    expect(row?.verdict).toBe(false);
   });
 });
 

--- a/torchci/test/l3Readiness.test.ts
+++ b/torchci/test/l3Readiness.test.ts
@@ -94,7 +94,7 @@ describe("buildCriteriaRows / summarizeReadiness", () => {
     expect(rows.map((r) => r.key)).toEqual([
       "tenureAtL2Days",
       "e2eTimeS",
-      "maxExecTimeS",
+      "overrunRate",
       "avgQueueTimeS",
       "timeoutRate",
       "passRate",
@@ -146,7 +146,7 @@ describe("buildCriteriaRows / summarizeReadiness", () => {
   });
 });
 
-describe("maxExecTimeS — overrun rate, not the raw max", () => {
+describe("overrunRate — rate of long-running jobs, not the raw max", () => {
   it("passes when a rare job runs over 3h, as long as the rate stays under 1%", () => {
     // A single slow job out of 200 (0.5%) used to fail this outright via
     // the old max-based check; the rate-based check should let it through.
@@ -154,7 +154,7 @@ describe("maxExecTimeS — overrun rate, not the raw max", () => {
       summaryRow({ max_exec_time_s: 5 * 3600, overrun_rate: 0.005 }),
       goodTenure
     );
-    const row = rows.find((r) => r.key === "maxExecTimeS");
+    const row = rows.find((r) => r.key === "overrunRate");
     expect(row?.verdict).toBe(true);
   });
 
@@ -163,8 +163,14 @@ describe("maxExecTimeS — overrun rate, not the raw max", () => {
       summaryRow({ max_exec_time_s: 5 * 3600, overrun_rate: 0.01 }),
       goodTenure
     );
-    const row = rows.find((r) => r.key === "maxExecTimeS");
+    const row = rows.find((r) => r.key === "overrunRate");
     expect(row?.verdict).toBe(false);
+  });
+
+  it("is unjudged (not failed) when summary data is missing", () => {
+    const rows = buildCriteriaRows(null, goodTenure);
+    const row = rows.find((r) => r.key === "overrunRate");
+    expect(row?.verdict).toBeNull();
   });
 });
 
@@ -224,7 +230,7 @@ describe("mergeCriteriaRows", () => {
     }
     // Tenure and the two demotion-irrelevant metrics never get a demotion verdict.
     expect(merged.find((r) => r.key === "tenureAtL2Days")?.demotion).toBeNull();
-    expect(merged.find((r) => r.key === "maxExecTimeS")?.demotion).toBeNull();
+    expect(merged.find((r) => r.key === "overrunRate")?.demotion).toBeNull();
     expect(merged.find((r) => r.key === "avgQueueTimeS")?.demotion).toBeNull();
   });
 


### PR DESCRIPTION
## Summary

Changes the L3 "Max Execution Time" promotion criterion from a raw single-job max to a rate-based check.

Previously, one job exceeding 3h anywhere in the 14-day window failed this criterion outright until that job aged out of the window.

Now it's judged on the share of jobs individually over 3h (`overrun_rate`), using the same timeout-exclusion logic already used for max_exec_time_s. Target stays at < 1%.

The /crcr/[org]/[repo] stat card is renamed to "Overrun Rate" and colors on this rate instead of the single worst job (green/yellow/red at 0% / 0–1% / ≥1%, theme-sourced for dark/light mode), with the raw max and p95 durations kept as secondary context.

Adds two tests locking in the boundary: a rare (<1%) over-3h job still passes; hitting 1% fails.
