### PR TITLE
Widen useClickHouseAPI's parameters type to match its immutable sibling

### DIFF
--- a/torchci/lib/GeneralUtils.ts
+++ b/torchci/lib/GeneralUtils.ts
@@ -121,7 +121,11 @@ export async function hasWritePermissionsUsingOctokit(
  */
 export function useClickHouseAPI<T = any>(
   queryName: string,
-  parameters: { [key: string]: string },
+  // `any`, matching useClickHouseAPIImmutable below. Both stringify the whole
+  // object, so both have always accepted arrays and numbers at runtime; typing
+  // only this one as string-valued forced a cast at every array-parameter call
+  // site for no checking in return.
+  parameters: { [key: string]: any },
   condition: boolean = true,
   config?: SWRConfiguration<T[]>
 ) {

--- a/torchci/lib/GeneralUtils.ts
+++ b/torchci/lib/GeneralUtils.ts
@@ -121,10 +121,8 @@ export async function hasWritePermissionsUsingOctokit(
  */
 export function useClickHouseAPI<T = any>(
   queryName: string,
-  // `any`, matching useClickHouseAPIImmutable below. Both stringify the whole
-  // object, so both have always accepted arrays and numbers at runtime; typing
-  // only this one as string-valued forced a cast at every array-parameter call
-  // site for no checking in return.
+  // `any`, like useClickHouseAPIImmutable below: both stringify the whole
+  // object, so both already accept arrays and numbers.
   parameters: { [key: string]: any },
   condition: boolean = true,
   config?: SWRConfiguration<T[]>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #8752
* #8751
* #8753
* #8750
* __->__ #8755

----

- `useClickHouseAPI` typed `parameters` as `{ [key: string]: string }` while
  `useClickHouseAPIImmutable` types the same argument as `any`.
- Both JSON.stringify the whole object, so both already accepted arrays and
  numbers at runtime; the narrower type only forced a cast at array-parameter
  call sites.
- Needed by the GreenLight HUD change above it, which passes an array of shas.

Test plan: yarn build