### PR TITLE
Redirect the HF writes that a read-only cache cannot take

### DIFF
--- a/.github/workflows/linux_job_v3.yml
+++ b/.github/workflows/linux_job_v3.yml
@@ -220,7 +220,8 @@ jobs:
 
       # Refresh run (PR labeled 'ci-refresh-hf-cache'): point HF at writable
       # ${RUNNER_TEMP} and download fresh, overriding the read-only /mnt/hf_cache
-      # mount; the sync step below pushes it back to S3. Otherwise leave the mount.
+      # mount; the sync step below pushes it back to S3. Otherwise read models
+      # from the mount, with everything HF writes redirected somewhere writable.
       - name: Resolve HF cache mode
         shell: bash
         env:
@@ -271,7 +272,22 @@ jobs:
               cp -a /mnt/hf_cache/datasets/. "${RUNNER_TEMP}/hf_datasets/" 2>/dev/null || true
             fi
           else
-            echo "HF_CACHE_REFRESH=0" >> "${GITHUB_ENV}"
+            # Models come from the mount, everything HF writes does not. HF_HOME
+            # holds stored_tokens and the .cache/meta_checkpoints that
+            # executorch's hf_download.py derives from it, and datasets writes
+            # its arrow build and .lock files even for a fully seeded dataset,
+            # so that dir is writable and warmed from the mount. Same shape as
+            # pytorch's _linux-test.yml.
+            {
+              echo "HF_CACHE_REFRESH=0"
+              echo "HF_HOME=${RUNNER_TEMP}/hf_home"
+              echo "HF_HUB_CACHE=/mnt/hf_cache/hub"
+              echo "HF_DATASETS_CACHE=${RUNNER_TEMP}/hf_datasets"
+            } >> "${GITHUB_ENV}"
+            mkdir -p "${RUNNER_TEMP}/hf_home" "${RUNNER_TEMP}/hf_datasets"
+            if [[ -d /mnt/hf_cache/datasets ]]; then
+              cp -a /mnt/hf_cache/datasets/. "${RUNNER_TEMP}/hf_datasets/" 2>/dev/null || true
+            fi
           fi
 
       - name: Run script

--- a/.github/workflows/test_linux_job_v3.yml
+++ b/.github/workflows/test_linux_job_v3.yml
@@ -291,3 +291,28 @@ jobs:
         esac
         [[ -n "${AWS_ACCESS_KEY_ID:-}" ]] || { echo "expected credentials in this repository"; exit 1; }
         [[ "${SCCACHE_S3_NO_CREDENTIALS}" == "false" ]] || { echo "credentials loaded, so anonymous access should be off"; exit 1; }
+
+  # The default: models shared from the mount, everything HF writes redirected.
+  # Each probe below is one of the writes that reverted pytorch/executorch#22247.
+  test-hf-cache-default-writes:
+    uses: ./.github/workflows/linux_job_v3.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      job-name: "linux-hf-cache-default"
+      runner: mt-l-x86iavx512-8-64
+      test-infra-repository: ${{ github.repository }}
+      test-infra-ref: ${{ github.ref }}
+      gpu-arch-type: cpu
+      gpu-arch-version: ""
+      script: |
+        set -x
+        [[ "${HF_CACHE_REFRESH}" == "0" ]] || { echo "expected no refresh"; exit 1; }
+        [[ "${HF_HUB_CACHE}" == "/mnt/hf_cache/hub" ]] || { echo "HF_HUB_CACHE=${HF_HUB_CACHE:-<unset>}"; exit 1; }
+        [[ "${HF_HOME}" == "${RUNNER_TEMP}/hf_home" ]] || { echo "HF_HOME=${HF_HOME:-<unset>}"; exit 1; }
+        [[ "${HF_DATASETS_CACHE}" == "${RUNNER_TEMP}/hf_datasets" ]] || { echo "HF_DATASETS_CACHE=${HF_DATASETS_CACHE:-<unset>}"; exit 1; }
+        mkdir -p "${HF_HOME}/.cache/meta_checkpoints"
+        touch "${HF_HOME}/stored_tokens"
+        touch "${HF_DATASETS_CACHE}/some_dataset.lock"
+        echo "hf-cache default env OK"


### PR DESCRIPTION
**pytorch already solves this, and this workflow's port of it missed half.**

In pytorch's `_linux-test.yml:334-342`, `HF_DATASETS_CACHE` is *unconditionally* a writable `${RUNNER_TEMP}` dir warmed by copying `/mnt/hf_cache/datasets`, because "the datasets library writes its arrow build + lock files even in offline mode and even for local datasets". And `HF_HOME` is never pointed at the mount — only their own `HF_CACHE`. Here that copy lived inside the refresh branch, and `HF_HOME` was left as the pod set it, so the ordinary path wrote straight at a read-only mount.

That accounts for all ten failures behind pytorch/executorch#22626, in three shapes independent of cache warmth:

| write | jobs | why warming can't help |
|---|---|---|
| `datasets/…_wikitext_…647234772b.lock` | wikitext, qnn llama ×2, voxtral | `datasets` locks even when fully seeded |
| `.cache/meta_checkpoints` | phi_4_mini, smollm2_135m | `hf_download.py:32-35` derives it from `HF_HOME` |
| `stored_tokens` | gemma3-4b | `huggingface_hub` login state |

The non-refresh path now keeps models shared via `HF_HUB_CACHE=/mnt/hf_cache/hub` and puts `HF_HOME` and `HF_DATASETS_CACHE` on writable job-local paths, warming the latter from the mount — pytorch's shape. `test-hf-cache-default-writes` asserts the env and writes to each of the three paths above.

A job whose models aren't seeded is a separate problem: a cold entry needs to create `hub/models--*/snapshots` or `refs/main`, which the mount can't take. That's for a refresh run to fix by seeding — `lora-linux`, `lora-multimethod` and `voxtral` are those jobs today.

Authored with Claude Code.
