### PR TITLE
Use Node.js 24 for setup-python action

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -12,6 +12,6 @@ inputs:
     default: ""
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'setup.js'
   post: 'cleanup.js'


### PR DESCRIPTION
The setup-python action declares Node.js 20, which produces a deprecation warning when GitHub forces it to run on Node.js 24. Change `runs.using` to `node24` for both setup and post-job cleanup.

Validation: both JavaScript entry points pass `node --check` with Node.js 24.3.0, and `git diff --check` passes. The existing Test Setup Python workflow exercises the local action on `macos-m1-stable`, the same runner label used by PyTorch's macOS builds and default tests. Full runner validation is pending CI; this workflow does not cover the `macos-m2-15` runners used for PyTorch's MPS tests.
