### PR TITLE
Add artifact retention controls to reusable jobs

### DIFF
--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -21,6 +21,14 @@ on:
           under dist/ and any files under artifacts-to-be-uploaded/ will be uploaded
         default: ''
         type: string
+      upload-artifact-retention-days:
+        description: 'Number of days to retain GitHub artifacts. 0 uses the repository default.'
+        default: 0
+        type: number
+      upload-artifact-on-failure:
+        description: 'Whether to upload artifacts when an earlier step fails.'
+        default: true
+        type: boolean
       upload-artifact-to-s3:
         description: |
           Upload the artifact to S3 instead of GitHub. This is used for large artifacts like
@@ -335,7 +343,7 @@ jobs:
           ALPINE_IMAGE: ${{ env.ALPINE_IMAGE }}
 
       - name: Prepare artifacts for upload
-        if: always()
+        if: ${{ always() && (inputs.upload-artifact-on-failure || success()) }}
         working-directory: ${{ inputs.repository || github.repository }}
         id: check-artifacts
         env:
@@ -372,15 +380,16 @@ jobs:
       # our AWS runners have access to S3
       - name: Upload artifacts to GitHub (if any)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ always() && inputs.upload-artifact != '' && !inputs.upload-artifact-to-s3 }}
+        if: ${{ always() && (inputs.upload-artifact-on-failure || success()) && inputs.upload-artifact != '' && !inputs.upload-artifact-to-s3 }}
         with:
           name: ${{ inputs.upload-artifact }}
           path: ${{ runner.temp }}/artifacts/
+          retention-days: ${{ inputs.upload-artifact-retention-days }}
 
       # NB: This only works with our AWS runners
       - name: Upload artifacts to S3 (if any)
         uses: ./test-infra/.github/actions/upload-artifact-s3
-        if: ${{ always() && inputs.upload-artifact != '' && inputs.upload-artifact-to-s3 }}
+        if: ${{ always() && (inputs.upload-artifact-on-failure || success()) && inputs.upload-artifact != '' && inputs.upload-artifact-to-s3 }}
         with:
           retention-days: 14
           s3-bucket: gha-artifacts

--- a/.github/workflows/linux_job_v3.yml
+++ b/.github/workflows/linux_job_v3.yml
@@ -22,6 +22,14 @@ on:
           under dist/ and any files under artifacts-to-be-uploaded/ will be uploaded
         default: ''
         type: string
+      upload-artifact-retention-days:
+        description: 'Number of days to retain GitHub artifacts. 0 uses the repository default.'
+        default: 0
+        type: number
+      upload-artifact-on-failure:
+        description: 'Whether to upload artifacts when an earlier step fails.'
+        default: true
+        type: boolean
       upload-artifact-to-s3:
         description: |
           Upload the artifact to S3 instead of GitHub. This is used for large artifacts like
@@ -311,7 +319,7 @@ jobs:
           fail-on-empty: false
 
       - name: Prepare artifacts for upload
-        if: always()
+        if: ${{ always() && (inputs.upload-artifact-on-failure || success()) }}
         shell: bash
         working-directory: ${{ inputs.repository || github.repository }}
         id: check-artifacts
@@ -345,14 +353,15 @@ jobs:
 
       - name: Upload artifacts to GitHub (if any)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ always() && inputs.upload-artifact != '' && !inputs.upload-artifact-to-s3 }}
+        if: ${{ always() && (inputs.upload-artifact-on-failure || success()) && inputs.upload-artifact != '' && !inputs.upload-artifact-to-s3 }}
         with:
           name: ${{ inputs.upload-artifact }}
           path: ${{ runner.temp }}/artifacts/
+          retention-days: ${{ inputs.upload-artifact-retention-days }}
 
       - name: Upload artifacts to S3 (if any)
         uses: pytorch/test-infra/.github/actions/upload-artifact-s3@main
-        if: ${{ always() && inputs.upload-artifact != '' && inputs.upload-artifact-to-s3 }}
+        if: ${{ always() && (inputs.upload-artifact-on-failure || success()) && inputs.upload-artifact != '' && inputs.upload-artifact-to-s3 }}
         with:
           retention-days: 14
           s3-bucket: gha-artifacts

--- a/.github/workflows/macos_job.yml
+++ b/.github/workflows/macos_job.yml
@@ -21,6 +21,14 @@ on:
           under dist/ and any files under artifacts-to-be-uploaded/ will be uploaded
         default: ""
         type: string
+      upload-artifact-retention-days:
+        description: 'Number of days to retain GitHub artifacts. 0 uses the repository default.'
+        default: 0
+        type: number
+      upload-artifact-on-failure:
+        description: 'Whether to upload artifacts when an earlier step fails.'
+        default: true
+        type: boolean
       upload-artifact-to-s3:
         description: |
           Upload the artifact to S3 instead of GitHub. This is used for large artifacts like
@@ -189,7 +197,7 @@ jobs:
         shell: bash -l {0}
         working-directory: ${{ inputs.repository || github.repository }}
         id: check-artifacts
-        if: ${{ always() && inputs.upload-artifact != '' }}
+        if: ${{ always() && (inputs.upload-artifact-on-failure || success()) && inputs.upload-artifact != '' }}
         env:
           UPLOAD_ARTIFACT_NAME: ${{ inputs.upload-artifact }}
         run: |
@@ -210,16 +218,17 @@ jobs:
       # our AWS runners have access to S3
       - name: Upload artifacts to GitHub (if any)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ always() && inputs.upload-artifact != '' && !inputs.upload-artifact-to-s3 }}
+        if: ${{ always() && (inputs.upload-artifact-on-failure || success()) && inputs.upload-artifact != '' && !inputs.upload-artifact-to-s3 }}
         with:
           name: ${{ inputs.upload-artifact }}
           path: ${{ runner.temp }}/artifacts/
           if-no-files-found: ${{ steps.check-artifacts.outputs.if-no-files-found }}
+          retention-days: ${{ inputs.upload-artifact-retention-days }}
 
       # NB: This only works with our AWS runners
       - name: Upload artifacts to S3 (if any)
         uses: seemethere/upload-artifact-s3@baba72d0712b404f646cebe0730933554ebce96a # v5.1.0
-        if: ${{ always() && inputs.upload-artifact != '' && inputs.upload-artifact-to-s3 }}
+        if: ${{ always() && (inputs.upload-artifact-on-failure || success()) && inputs.upload-artifact != '' && inputs.upload-artifact-to-s3 }}
         with:
           retention-days: 14
           s3-bucket: gha-artifacts

--- a/.github/workflows/test_linux_job_v2.yml
+++ b/.github/workflows/test_linux_job_v2.yml
@@ -75,6 +75,8 @@ jobs:
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
       upload-artifact: my-cool-artifact
+      upload-artifact-retention-days: 1
+      upload-artifact-on-failure: false
       script: |
         echo "hello" > "${RUNNER_ARTIFACT_DIR}/cool_beans"
   test-upload-artifact-no-artifact:

--- a/.github/workflows/test_linux_job_v3.yml
+++ b/.github/workflows/test_linux_job_v3.yml
@@ -130,6 +130,8 @@ jobs:
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
       upload-artifact: my-cool-artifact-v3
+      upload-artifact-retention-days: 1
+      upload-artifact-on-failure: false
       script: |
         echo "hello" > "${RUNNER_ARTIFACT_DIR}/cool_beans"
   test-upload-artifact-no-artifact:

--- a/.github/workflows/test_macos_job.yml
+++ b/.github/workflows/test_macos_job.yml
@@ -48,6 +48,8 @@ jobs:
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
       upload-artifact: my-cool-artifact
+      upload-artifact-retention-days: 1
+      upload-artifact-on-failure: false
       script: |
         echo "hello" > "${RUNNER_ARTIFACT_DIR}/cool_beans"
   test-upload-artifact-s3:

--- a/.github/workflows/test_windows_job.yml
+++ b/.github/workflows/test_windows_job.yml
@@ -44,6 +44,8 @@ jobs:
       test-infra-repository: ${{ github.repository }}
       test-infra-ref: ${{ github.ref }}
       upload-artifact: my-cool-artifact
+      upload-artifact-retention-days: 1
+      upload-artifact-on-failure: false
       script: |
         echo "hello" > "${RUNNER_ARTIFACT_DIR}/cool_beans"
   test-upload-artifact-s3:

--- a/.github/workflows/windows_job.yml
+++ b/.github/workflows/windows_job.yml
@@ -21,6 +21,14 @@ on:
           under dist/ and any files under artifacts-to-be-uploaded/ will be uploaded
         default: ''
         type: string
+      upload-artifact-retention-days:
+        description: 'Number of days to retain GitHub artifacts. 0 uses the repository default.'
+        default: 0
+        type: number
+      upload-artifact-on-failure:
+        description: 'Whether to upload artifacts when an earlier step fails.'
+        default: true
+        type: boolean
       upload-artifact-to-s3:
         description: |
           Upload the artifact to S3 instead of GitHub. This is used for large artifacts like
@@ -180,7 +188,7 @@ jobs:
         shell: bash -l {0}
         working-directory: ${{ inputs.repository || github.repository }}
         id: check-artifacts
-        if: ${{ always() && inputs.upload-artifact != '' }}
+        if: ${{ always() && (inputs.upload-artifact-on-failure || success()) && inputs.upload-artifact != '' }}
         env:
           UPLOAD_ARTIFACT_NAME: ${{ inputs.upload-artifact }}
         run: |
@@ -201,16 +209,17 @@ jobs:
       # our AWS runners have access to S3
       - name: Upload artifacts to GitHub (if any)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ always() && inputs.upload-artifact != '' && !inputs.upload-artifact-to-s3 }}
+        if: ${{ always() && (inputs.upload-artifact-on-failure || success()) && inputs.upload-artifact != '' && !inputs.upload-artifact-to-s3 }}
         with:
           name: ${{ inputs.upload-artifact }}
           path: ${{ runner.temp }}/artifacts/
           if-no-files-found: ${{ steps.check-artifacts.outputs.if-no-files-found }}
+          retention-days: ${{ inputs.upload-artifact-retention-days }}
 
       # NB: This only works with our AWS runners
       - name: Upload artifacts to S3 (if any)
         uses: ./test-infra/.github/actions/upload-artifact-s3
-        if: ${{ always() && inputs.upload-artifact != '' && inputs.upload-artifact-to-s3 }}
+        if: ${{ always() && (inputs.upload-artifact-on-failure || success()) && inputs.upload-artifact != '' && inputs.upload-artifact-to-s3 }}
         with:
           retention-days: 14
           s3-bucket: gha-artifacts


### PR DESCRIPTION
## Summary

Expose two backward-compatible artifact upload controls on the Linux v2, Linux v3, macOS, and Windows reusable jobs:

- `upload-artifact-retention-days` forwards a caller-selected retention period to `actions/upload-artifact`; its default of `0` preserves the repository setting.
- `upload-artifact-on-failure` lets callers skip incomplete artifacts after a failed build; its default of `true` preserves current behavior.

The failure policy also applies to S3 uploads for consistent semantics. Existing upload/download workflow tests opt into a one-day retention and success-only upload, exercising the new inputs without changing other callers.

This enables short-lived job-to-job hand-offs such as exported models while keeping longer retention for diagnostic reports.

## Test plan

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.6.21` on all eight changed workflows
- Parse all eight changed workflows with `yq`
- Existing Linux v2/v3, macOS, and Windows artifact upload/download workflow tests exercise the new inputs in CI
