### PR TITLE
[GREENLIGHT] Split the Dr. CI greenlight renderer into leaf modules

### DIFF
--- a/greenlight/tests/test_render_sync.py
+++ b/greenlight/tests/test_render_sync.py
@@ -1,9 +1,10 @@
 """Pins the values Dr. CI's TypeScript renderer re-declares from greenlight's Python source.
 
 ``torchci/lib/greenlight/greenlightRender.ts`` renders the same greenlight state the Python
-comment writer does, but re-declares the shared vocabulary as its own constants and nothing at
-build time links the two. Python is the source of truth: these tests fail when the TypeScript
-stops matching it, in either direction.
+comment writer does, but re-declares the shared vocabulary as its own constants -- its own and
+``torchci/lib/greenlight/greenlightSweep.ts``'s, which holds the part the Dr. CI sweep reads
+too -- and nothing at build time links any of it to Python. Python is the source of truth: these
+tests fail when the TypeScript stops matching it, in either direction.
 """
 
 import re
@@ -17,11 +18,13 @@ from greenlight import comment_format, constants
 ROOT = Path(__file__).resolve().parents[2]
 
 _TS_RENDER = "torchci/lib/greenlight/greenlightRender.ts"
+_TS_SWEEP = "torchci/lib/greenlight/greenlightSweep.ts"
 _TS_CONFIG = "torchci/lib/greenlight/greenlightConfig.ts"
 _PY_RENDER = "greenlight/src/greenlight/comment_format.py"
 _PY_CONSTANTS = "greenlight/src/greenlight/constants.py"
 
 assert (ROOT / _TS_RENDER).is_file()
+assert (ROOT / _TS_SWEEP).is_file()
 assert (ROOT / _TS_CONFIG).is_file()
 
 _TS_UNICODE_ESCAPE_RE = re.compile(r"\\u([0-9a-fA-F]{4})")
@@ -174,9 +177,9 @@ def test_message_cap_matches_python() -> None:
 
 
 def test_zero_width_space_matches_python() -> None:
-    extracted = _ts_string(_TS_RENDER, "ZERO_WIDTH_SPACE")
+    extracted = _ts_string(_TS_SWEEP, "ZERO_WIDTH_SPACE")
     assert extracted == comment_format._ZERO_WIDTH_SPACE, _drift(
-        _TS_RENDER,
+        _TS_SWEEP,
         _PY_RENDER,
         f"ZERO_WIDTH_SPACE is {extracted!r}, _ZERO_WIDTH_SPACE is {comment_format._ZERO_WIDTH_SPACE!r}",
     )

--- a/torchci/lib/greenlight/greenlightCommitLine.ts
+++ b/torchci/lib/greenlight/greenlightCommitLine.ts
@@ -1,0 +1,35 @@
+// Whether a verdict still speaks for the PR's head, and how the comment says so.
+// The sibling of greenlightStaleness.ts: that one ages an in-flight review out by
+// wall clock, this one retires a finished one by commit. Both answer "is this row
+// still about the PR as it stands now", and neither can be derived from the other
+// -- a verdict minutes old is stale the moment a push lands, and one from last
+// month still holds if nothing was pushed since.
+
+import { shortSha } from "lib/greenlight/greenlightInlineCode";
+
+// Whether the verdict was reached on something other than the PR's current head.
+// A missing sha on either side means the comparison cannot be made, which is not
+// evidence of a mismatch.
+export function isOutdatedVerdict(
+  reviewedSha: string,
+  currentSha: string
+): boolean {
+  const reviewed = (reviewedSha || "").trim().toLowerCase();
+  const current = (currentSha || "").trim().toLowerCase();
+  return reviewed !== "" && current !== "" && reviewed !== current;
+}
+
+export function reviewedCommitLines(
+  headSha: string,
+  currentHeadSha: string
+): string[] {
+  const sha = (headSha || "").trim();
+  if (!sha) {
+    return [];
+  }
+  const line = `Reviewed commit: ${shortSha(sha)}`;
+  if (!isOutdatedVerdict(sha, currentHeadSha)) {
+    return [line];
+  }
+  return [`${line} (NOT the current head ${shortSha(currentHeadSha)})`];
+}

--- a/torchci/lib/greenlight/greenlightInlineCode.ts
+++ b/torchci/lib/greenlight/greenlightInlineCode.ts
@@ -1,0 +1,28 @@
+// Renders an untrusted scalar -- a verdict reason, a commit sha -- as a markdown
+// inline code span. The span is containment against the value breaking the line
+// it sits on, and nothing more: it neither escapes nor defuses, so a caller that
+// puts one in the comment body owns running defuseSweepSentinels over the
+// FINISHED line. Not over the value on its way in -- stripInlineBreakers deletes,
+// and a deletion splices the text on either side of it together, so a predicate
+// broken by exactly one backtick is invisible to a defuse that ran before it.
+
+// Characters that would end an inline code span or the line holding it.
+export const INLINE_BREAKERS_RE = /[`\r\n]/g;
+
+function stripInlineBreakers(value: string): string {
+  return value.replace(INLINE_BREAKERS_RE, "");
+}
+
+export function inlineCode(value: string): string {
+  return `\`${stripInlineBreakers(value)}\``;
+}
+
+// shortSha is the one rendered value that never reaches defuseSweepSentinels.
+// What makes that safe is arithmetic: kept under SWEEP_PREDICATE_MIN_LENGTH in
+// greenlightSweep.ts, no sha it emits is long enough to spell a predicate,
+// whatever the sha holds.
+export const SHORT_SHA_LENGTH = 7;
+
+export function shortSha(sha: string): string {
+  return inlineCode(sha.trim().slice(0, SHORT_SHA_LENGTH));
+}

--- a/torchci/lib/greenlight/greenlightRender.ts
+++ b/torchci/lib/greenlight/greenlightRender.ts
@@ -11,8 +11,17 @@
 // never sees it), and has a stalled state for a terminal row that never arrived.
 // No ClickHouse / Octokit / server-only imports, so this is unit-testable as-is.
 
-import { ADVISOR_PENDING_ALT_ATTR } from "lib/advisor/advisorBadge";
+import {
+  isOutdatedVerdict,
+  reviewedCommitLines,
+} from "lib/greenlight/greenlightCommitLine";
+import { inlineCode } from "lib/greenlight/greenlightInlineCode";
 import { isInProgressStale } from "lib/greenlight/greenlightStaleness";
+import {
+  defuseSweepSentinels,
+  GREENLIGHT_PENDING_ALT_ATTR,
+  ZERO_WIDTH_SPACE,
+} from "lib/greenlight/greenlightSweep";
 
 export const GREENLIGHT_STATUS_LAND = "LAND";
 export const GREENLIGHT_STATUS_NO_LAND = "NO_LAND";
@@ -54,7 +63,6 @@ export const GREENLIGHT_SECTION_HEADER = "GREEN LIGHT";
 
 // Mirrors _MESSAGE_CAP in comment_format.py.
 export const GREENLIGHT_MESSAGE_CAP = 4000;
-export const ZERO_WIDTH_SPACE = "\u200b";
 
 // GitHub does not soft-wrap inside a code fence, so an unwrapped verdict renders
 // as one line behind a horizontal scrollbar. 80 is the conventional terminal and
@@ -65,55 +73,17 @@ export const ZERO_WIDTH_SPACE = "\u200b";
 // rendered line being within the column.
 export const GREENLIGHT_MESSAGE_WRAP_WIDTH = 80;
 
-// The in-progress sentinel, shaped like the advisor's alt attribute (see
-// ADVISOR_PENDING_ALT_ATTR in lib/advisor/advisorBadge.ts) so both AI surfaces
-// in the comment are matched by the same cheap substring search. It is emitted
-// ONLY while a review is live; every terminal render omits it, which is how the
-// Dr.CI re-render candidate set self-clears once a verdict lands.
-export const GREENLIGHT_PENDING_ALT = "Green Light: in progress";
-export const GREENLIGHT_PENDING_ALT_ATTR = `alt="${GREENLIGHT_PENDING_ALT}"`;
 // Greenlight has no badge image to hang the attribute on, so the sentinel rides
 // an HTML comment: invisible once GitHub renders the body, but present in the
 // raw comment text the candidate query greps (the same trick as
 // `<!-- drci-comment-start -->`).
 const GREENLIGHT_PENDING_MARKER = `<!-- greenlight ${GREENLIGHT_PENDING_ALT_ATTR} -->`;
 
-// Every literal getPRsNeedingCommentRefresh (drci.ts) pins a PR into the sweep
-// on. Those predicates run over the RAW comment body, and the greenlight message
-// is the only model-authored text in it that is not HTML-escaped -- the fence in
-// defangGreenlightMessage stops the text RENDERING as markup but leaves the
-// characters themselves intact -- so a terminal render that carries one pins the
-// PR into every sweep forever, defeating the self-clearing the sentinel design
-// rests on.
-export const SWEEP_SENTINELS = [
-  GREENLIGHT_PENDING_ALT_ATTR,
-  ADVISOR_PENDING_ALT_ATTR,
-];
-// The sweep's third predicate is the regex `\d Pending`, meant to match the
-// comment's own "3 Pending" job count. Text merely describing the PR's CI state
-// trips it with no adversary involved, so break the token rather than delete a
-// word the reader needs.
-const SWEEP_PENDING_WORD = "Pending";
-const SWEEP_PENDING_WORD_DEFUSED = `P${ZERO_WIDTH_SPACE}ending`;
-// Shortest raw-body text any of those predicates can match: both attributes are
-// far longer than a `\d Pending` match, which is a digit and a space ahead of the
-// word. Renderer output too short to reach this cannot carry a predicate however
-// it is crafted, which is the only thing that lets a value skip the defuse.
-export const SWEEP_PREDICATE_MIN_LENGTH = Math.min(
-  ...SWEEP_SENTINELS.map((sentinel) => sentinel.length),
-  SWEEP_PENDING_WORD.length + 2
-);
-
 // Rendered only when the URL cannot break out of the `[text](url)` link AND
 // points at github.com. The host anchor has to be literal `github.com/`: a
 // userinfo prefix (`https://u:p@github.com/`) and a lookalike host
 // (`https://github.com.example/`) both satisfy a mere "contains github.com".
 const SAFE_JOB_URL_RE = /^https:\/\/github\.com\/[^\s()<>"'\\]+$/;
-
-// shortSha is the one rendered value that never reaches defuseSweepSentinels.
-// What makes that safe is arithmetic: kept under SWEEP_PREDICATE_MIN_LENGTH, no
-// sha it emits is long enough to spell a predicate, whatever the sha holds.
-export const SHORT_SHA_LENGTH = 7;
 
 export interface GreenlightState {
   prNumber: number;
@@ -199,64 +169,6 @@ export function defangGreenlightMessage(text: string): string {
   const longest = runs ? Math.max(...runs.map((run) => run.length)) : 0;
   const fence = "`".repeat(Math.max(3, longest + 1));
   return `${fence}\n${wrapMessage(neutralized)}\n${fence}`;
-}
-
-// Substituting a zero-width space for each sentinel, rather than deleting it, is
-// what makes a single pass sufficient. No sentinel contains that character, so a
-// surviving occurrence would have to lie wholly inside one fragment of a split
-// that by construction has none: neither a nested forgery
-// (`alt="Green alt="Green Light: in progress"Light: in progress"`) nor one
-// sentinel spliced together across the gap left by removing another can
-// reassemble, and no later substitution can put one back. Deleting would need a
-// fixpoint loop instead, which is quadratic in the message length -- `message` is
-// an unbounded ClickHouse String and the cap in defangGreenlightMessage is
-// applied after this, so a deeply nested 600 KB payload blocks the event loop for
-// seconds in a shared handler.
-function defuseSweepSentinels(text: string): string {
-  let out = text;
-  for (const sentinel of SWEEP_SENTINELS) {
-    out = out.split(sentinel).join(ZERO_WIDTH_SPACE);
-  }
-  return out.split(SWEEP_PENDING_WORD).join(SWEEP_PENDING_WORD_DEFUSED);
-}
-
-// Characters that would end an inline code span or the line holding it.
-export const INLINE_BREAKERS_RE = /[`\r\n]/g;
-
-function stripInlineBreakers(value: string): string {
-  return value.replace(INLINE_BREAKERS_RE, "");
-}
-
-function inlineCode(value: string): string {
-  return `\`${stripInlineBreakers(value)}\``;
-}
-
-// Whether the verdict was reached on something other than the PR's current head.
-// A missing sha on either side means the comparison cannot be made, which is not
-// evidence of a mismatch.
-function isOutdatedVerdict(reviewedSha: string, currentSha: string): boolean {
-  const reviewed = (reviewedSha || "").trim().toLowerCase();
-  const current = (currentSha || "").trim().toLowerCase();
-  return reviewed !== "" && current !== "" && reviewed !== current;
-}
-
-function shortSha(sha: string): string {
-  return inlineCode(sha.trim().slice(0, SHORT_SHA_LENGTH));
-}
-
-function reviewedCommitLines(
-  headSha: string,
-  currentHeadSha: string
-): string[] {
-  const sha = (headSha || "").trim();
-  if (!sha) {
-    return [];
-  }
-  const line = `Reviewed commit: ${shortSha(sha)}`;
-  if (!isOutdatedVerdict(sha, currentHeadSha)) {
-    return [line];
-  }
-  return [`${line} (NOT the current head ${shortSha(currentHeadSha)})`];
 }
 
 // Nothing may DELETE a character after the defuse: a deletion splices the text on

--- a/torchci/lib/greenlight/greenlightSweep.ts
+++ b/torchci/lib/greenlight/greenlightSweep.ts
@@ -1,0 +1,63 @@
+// The literals Dr.CI's re-render sweep greps a comment body for, and the single
+// pass that breaks them. drci.ts spells those predicates and greenlightRender.ts
+// has to break exactly the ones it spells, so the vocabulary the two share sits
+// below both rather than inside either. A second copy is a copy that can be
+// widened alone, and a predicate the sweep looks for and the renderer no longer
+// breaks pins its PR into every sweep for as long as the comment stands.
+
+import { ADVISOR_PENDING_ALT_ATTR } from "lib/advisor/advisorBadge";
+
+export const ZERO_WIDTH_SPACE = "\u200b";
+
+// The in-progress sentinel, shaped like the advisor's alt attribute (see
+// ADVISOR_PENDING_ALT_ATTR in lib/advisor/advisorBadge.ts) so both AI surfaces
+// in the comment are matched by the same cheap substring search. It is emitted
+// ONLY while a review is live; every terminal render omits it, which is how the
+// Dr.CI re-render candidate set self-clears once a verdict lands.
+const GREENLIGHT_PENDING_ALT = "Green Light: in progress";
+export const GREENLIGHT_PENDING_ALT_ATTR = `alt="${GREENLIGHT_PENDING_ALT}"`;
+
+// Every literal getPRsNeedingCommentRefresh (drci.ts) pins a PR into the sweep
+// on. Those predicates run over the RAW comment body, and the greenlight message
+// is the only model-authored text in it that is not HTML-escaped -- the fence in
+// defangGreenlightMessage stops the text RENDERING as markup but leaves the
+// characters themselves intact -- so a terminal render that carries one pins the
+// PR into every sweep forever, defeating the self-clearing the sentinel design
+// rests on.
+export const SWEEP_SENTINELS = [
+  GREENLIGHT_PENDING_ALT_ATTR,
+  ADVISOR_PENDING_ALT_ATTR,
+];
+// The sweep's third predicate is the regex `\d Pending`, meant to match the
+// comment's own "3 Pending" job count. Text merely describing the PR's CI state
+// trips it with no adversary involved, so break the token rather than delete a
+// word the reader needs.
+const SWEEP_PENDING_WORD = "Pending";
+const SWEEP_PENDING_WORD_DEFUSED = `P${ZERO_WIDTH_SPACE}ending`;
+// Shortest raw-body text any of those predicates can match: both attributes are
+// far longer than a `\d Pending` match, which is a digit and a space ahead of the
+// word. Renderer output too short to reach this cannot carry a predicate however
+// it is crafted, which is the only thing that lets a value skip the defuse.
+export const SWEEP_PREDICATE_MIN_LENGTH = Math.min(
+  ...SWEEP_SENTINELS.map((sentinel) => sentinel.length),
+  SWEEP_PENDING_WORD.length + 2
+);
+
+// Substituting a zero-width space for each sentinel, rather than deleting it, is
+// what makes a single pass sufficient. No sentinel contains that character, so a
+// surviving occurrence would have to lie wholly inside one fragment of a split
+// that by construction has none: neither a nested forgery
+// (`alt="Green alt="Green Light: in progress"Light: in progress"`) nor one
+// sentinel spliced together across the gap left by removing another can
+// reassemble, and no later substitution can put one back. Deleting would need a
+// fixpoint loop instead, which is quadratic in the message length -- `message` is
+// an unbounded ClickHouse String and the cap in defangGreenlightMessage is
+// applied after this, so a deeply nested 600 KB payload blocks the event loop for
+// seconds in a shared handler.
+export function defuseSweepSentinels(text: string): string {
+  let out = text;
+  for (const sentinel of SWEEP_SENTINELS) {
+    out = out.split(sentinel).join(ZERO_WIDTH_SPACE);
+  }
+  return out.split(SWEEP_PENDING_WORD).join(SWEEP_PENDING_WORD_DEFUSED);
+}

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -48,7 +48,7 @@ import {
 } from "lib/fetchRecentWorkflows";
 import { getOctokit, getOctokitWithUserToken } from "lib/github";
 import { buildGreenlightSections } from "lib/greenlight/greenlightComment";
-import { GREENLIGHT_PENDING_ALT_ATTR } from "lib/greenlight/greenlightRender";
+import { GREENLIGHT_PENDING_ALT_ATTR } from "lib/greenlight/greenlightSweep";
 import {
   backfillMissingLog,
   getDisabledTestIssues,

--- a/torchci/test/greenlightComment.test.ts
+++ b/torchci/test/greenlightComment.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "fs";
 import * as clickhouse from "lib/clickhouse";
 import { buildGreenlightSections } from "lib/greenlight/greenlightComment";
 import * as greenlightRender from "lib/greenlight/greenlightRender";
+import { GREENLIGHT_PENDING_ALT_ATTR } from "lib/greenlight/greenlightSweep";
 import path from "path";
 
 const LAND_ROW = {
@@ -216,9 +217,7 @@ describe("buildGreenlightSections", () => {
       heads(row)
     );
 
-    expect(sections.get(row.pr_number)).toContain(
-      greenlightRender.GREENLIGHT_PENDING_ALT_ATTR
-    );
+    expect(sections.get(row.pr_number)).toContain(GREENLIGHT_PENDING_ALT_ATTR);
   });
 
   it("skips rows that render to nothing", async () => {

--- a/torchci/test/greenlightRender.test.ts
+++ b/torchci/test/greenlightRender.test.ts
@@ -1,5 +1,9 @@
 import { ADVISOR_PENDING_ALT_ATTR } from "lib/advisor/advisorBadge";
 import {
+  INLINE_BREAKERS_RE,
+  SHORT_SHA_LENGTH,
+} from "lib/greenlight/greenlightInlineCode";
+import {
   defangGreenlightMessage,
   GREENLIGHT_INCOMPLETE_HEADLINE,
   GREENLIGHT_LAND_HEADLINE,
@@ -7,19 +11,19 @@ import {
   GREENLIGHT_MESSAGE_WRAP_WIDTH,
   GREENLIGHT_NO_LAND_HEADLINE,
   GREENLIGHT_OUTDATED_HEADLINE_PREFIX,
-  GREENLIGHT_PENDING_ALT_ATTR,
   GREENLIGHT_REVERTED_BODY,
   GREENLIGHT_REVERTED_HEADLINE,
   GREENLIGHT_REVIEWING_HEADLINE,
   GreenlightState,
-  INLINE_BREAKERS_RE,
   renderGreenlightSection,
-  SHORT_SHA_LENGTH,
+} from "lib/greenlight/greenlightRender";
+import { GREENLIGHT_IN_PROGRESS_STALE_MS } from "lib/greenlight/greenlightStaleness";
+import {
+  GREENLIGHT_PENDING_ALT_ATTR,
   SWEEP_PREDICATE_MIN_LENGTH,
   SWEEP_SENTINELS,
   ZERO_WIDTH_SPACE,
-} from "lib/greenlight/greenlightRender";
-import { GREENLIGHT_IN_PROGRESS_STALE_MS } from "lib/greenlight/greenlightStaleness";
+} from "lib/greenlight/greenlightSweep";
 
 const JOB_URL = "https://github.com/pytorch/test-infra/actions/runs/42";
 // The shape ClickHouse returns for a DateTime64(3) under


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #8768
* #8767
* #8766
* #8765
* #8764
* __->__ #8763

**Impact:** CI only
**Risk:** low

## What
Moves three self-contained pieces out of the Dr. CI Green Light renderer and into
modules of their own: the markdown inline code span, the reviewed-commit line, and
the vocabulary Dr. CI's re-render sweep greps a comment body for. Pure code motion
-- the rendered comment is byte for byte what it was, and the tests that cover it
only change which module they import from.

## Why
greenlightRender.ts had become the place everything greenlight-shaped lived,
including two constants the Dr. CI route itself needs, so reaching them meant
importing a whole comment renderer into an API handler. A second message renderer
arrives later in this stack and shares the sweep vocabulary with the first, which
puts that vocabulary below both rather than inside either. A copy is a copy that
can be widened alone, and a predicate the sweep looks for and no renderer breaks
pins its PR into every sweep for as long as the comment stands.

# Notes
greenlight's Python drift test reads these constants out of the TypeScript by
path, so its zero-width-space check follows that constant to its new home.