### PR TITLE
[GREENLIGHT] Add the verdict outline renderer

### DIFF
--- a/greenlight/src/greenlight/verdict_outline.py
+++ b/greenlight/src/greenlight/verdict_outline.py
@@ -5,15 +5,19 @@ a few detail bullets. That text is attacker-influenceable (a PR diff can prompt-
 reviewer) and it lands permanently on a public PR, so the rendering has to hold whatever the
 model was talked into writing.
 
-Containment is a CommonMark type-6 raw HTML block: a ``<ul>`` opening at column 0 with no blank
-line anywhere inside it. CommonMark runs no inline parsing inside such a block, which is what
-leaves ``</details>``, ``# heading``, ``---``, ``1.``, ``[^1]``, ``[x]: y``, code fences,
-``<script>``, ``<img>`` and attribute smuggling inert, and what stops bare URLs and email
-addresses autolinking -- the last one is unreachable with markdown bullets, where even a fully
-backslash-escaped ``a\-\@b\.co`` still autolinks to ``mailto:``. A blank line ends the block and
-hands the rest of the comment back to the markdown parser, so the single global invariant is that
-the returned block holds no line break at all; every other defence is per-leaf. ``ul``, ``ol``,
-``li``, ``b`` and ``code`` are all on GitHub's sanitizer allowlist.
+Containment takes two defences answering two shapes of injection, and neither covers the other.
+Escaping each leaf answers the HTML shapes -- ``</details>``, ``<script>``, ``<img>``, attribute
+smuggling -- and holds wherever the leaf ends up. The markdown shapes are answered by a CommonMark
+type-6 raw HTML block: a ``<ul>`` opening at column 0 with no blank line anywhere inside it, within
+which CommonMark runs no inline parsing, leaving ``# heading``, ``---``, ``1.``, ``[^1]``,
+``[x]: y``, ``[text](url)``, ``![alt](src)``, code fences and emphasis inert and stopping bare URLs
+and email addresses autolinking -- the last one unreachable with markdown bullets, where even a
+fully backslash-escaped ``a\-\@b\.co`` still autolinks to ``mailto:``. ``html.escape`` touches
+``& < > " '`` and nothing else, so all of those markdown shapes reach the comment verbatim and the
+block is the only thing holding them. A blank line ends the block and hands the rest of the comment
+back to the markdown parser, so the single global invariant is that the returned block holds no
+line break at all; every other defence is per-leaf. ``ul``, ``ol``, ``li``, ``b`` and ``code`` are
+all on GitHub's sanitizer allowlist.
 
 ``torchci/lib/greenlight/greenlightOutline.ts`` renders the same message into the Dr. CI comment
 and has to produce byte-identical output. That is why no pattern here uses a shorthand character
@@ -196,22 +200,35 @@ def _leaves(message: str) -> list[_Leaf]:
 
 
 def _group(leaves: list[_Leaf]) -> list[_Topic]:
-    """Group flattened leaves into topics, promoting every detail that has no topic above it.
+    """Group flattened leaves into topics, dropping the ones that flattened to nothing.
 
-    Promotion covers two cases with one rule: nested bullets the model wrote before any top-level
-    one, and details whose topic was dropped for flattening to nothing. It runs until a real topic
-    appears rather than once, because orphans are peers of each other -- making the second one a
-    detail of the first asserts a relationship the reviewer never wrote. Dropping them instead
-    would silently discard text the reader was meant to see.
+    The drop belongs here rather than ahead of the grouping because it destroys the one thing the
+    grouping needs. A top-level bullet whose text flattens away is still a boundary the reviewer
+    wrote, and dropping it first leaves everything below reading as though it never existed --
+    which renders a ``NO_LAND`` detail as evidence for whichever unrelated topic came before it.
+
+    A detail with no topic to attach to is promoted: dropping it would silently discard text the
+    reader was meant to see, and adopting it would assert a relationship the reviewer never wrote.
+    Promotion never turns the promoted leaf into a parent for the details behind it, because peers
+    stay peers. Two details are siblings whether they were written before the first top-level
+    bullet or under one whose text flattened away, and subordinating the second to the first
+    invents a parent and child out of two of the reviewer's own claims -- permanently, in public,
+    and it is the exact relationship promotion exists to prevent.
     """
     topics: list[_Topic] = []
-    seen_topic = False
+    attachable = False
     for leaf in leaves:
-        if leaf.depth == 0 or not seen_topic:
-            topics.append(_Topic(text=leaf.text, details=[]))
-            seen_topic = seen_topic or leaf.depth == 0
+        if leaf.depth == 0:
+            attachable = leaf.text != ""
+            if attachable:
+                topics.append(_Topic(text=leaf.text, details=[]))
             continue
-        topics[-1].details.append(leaf.text)
+        if leaf.text == "":
+            continue
+        if attachable:
+            topics[-1].details.append(leaf.text)
+            continue
+        topics.append(_Topic(text=leaf.text, details=[]))
     return topics
 
 
@@ -331,8 +348,7 @@ def render_outline_html(message: str) -> str:
     topic, detail, over-budget item or over-cap tail leaves a truncation item behind, so a reader
     can never mistake a cut list for a complete one.
     """
-    flattened = (leaf._replace(text=_flatten(leaf.text)) for leaf in _leaves(message))
-    topics = _group([leaf for leaf in flattened if leaf.text != ""])
+    topics = _group([leaf._replace(text=_flatten(leaf.text)) for leaf in _leaves(message)])
     if not topics:
         return ""
 

--- a/greenlight/src/greenlight/verdict_outline.py
+++ b/greenlight/src/greenlight/verdict_outline.py
@@ -1,0 +1,360 @@
+r"""Render a model-authored verdict outline as a self-contained HTML bullet list.
+
+The reviewer writes ``message`` as a short markdown outline -- a few topic bullets, each with
+a few detail bullets. That text is attacker-influenceable (a PR diff can prompt-inject the
+reviewer) and it lands permanently on a public PR, so the rendering has to hold whatever the
+model was talked into writing.
+
+Containment is a CommonMark type-6 raw HTML block: a ``<ul>`` opening at column 0 with no blank
+line anywhere inside it. CommonMark runs no inline parsing inside such a block, which is what
+leaves ``</details>``, ``# heading``, ``---``, ``1.``, ``[^1]``, ``[x]: y``, code fences,
+``<script>``, ``<img>`` and attribute smuggling inert, and what stops bare URLs and email
+addresses autolinking -- the last one is unreachable with markdown bullets, where even a fully
+backslash-escaped ``a\-\@b\.co`` still autolinks to ``mailto:``. A blank line ends the block and
+hands the rest of the comment back to the markdown parser, so the single global invariant is that
+the returned block holds no line break at all; every other defence is per-leaf. ``ul``, ``ol``,
+``li``, ``b`` and ``code`` are all on GitHub's sanitizer allowlist.
+
+``torchci/lib/greenlight/greenlightOutline.ts`` renders the same message into the Dr. CI comment
+and has to produce byte-identical output. That is why no pattern here uses a shorthand character
+class: Python and JavaScript disagree on ``\s`` (29 code points against 25; within ASCII, Python
+alone counts ``U+001C``-``U+001F``, and each language counts one the other does not -- ``U+0085``
+here, ``U+FEFF`` there), on ``\d`` (Unicode digits against ASCII only) and on ``\b``/``\w`` (an
+e-acute is a word character in Python and not in JavaScript), so one shared shorthand renders two
+different comments from one row. Every character set below is a single-line literal for that
+reason: the drift test scrapes both files and compares the literals.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+from typing import NamedTuple
+
+__all__ = ["is_outline", "render_outline_html"]
+
+# Same budget the fenced renderer caps on, applied before escaping: escaping inflates the text up
+# to sixfold, so capping after it would let a sixth of a message through.
+MESSAGE_CAP = 4000
+LEAF_CAP = 400
+MAX_TOPICS = 12
+MAX_DETAILS = 8
+# Nothing downstream bounds the body: torchci/lib/drciUtils.ts hands the whole Dr. CI comment to
+# updateComment with no length guard, and this section is one part of that body. What ceiling
+# GitHub enforces on it is not established -- Dr. CI comments well past 65,536 characters are live
+# on pytorch/pytorch today. This is a bound greenlight puts on its own contribution, not a measured
+# limit: the clamps above bound the block only after a worst-case escaping blowup.
+BLOCK_BUDGET = 12000
+TRUNCATED_ITEM = "<li>(truncated)</li>"
+TRUNCATION_SUFFIX = "\u2026"
+# One bullet-shaped line in a paragraph is not an outline. Routing a paragraph here would show the
+# reader one leaf clipped to LEAF_CAP where the fenced renderer shows the whole message.
+MIN_BULLETS = 2
+SHA_LENGTH = 40
+SHA_SPLIT_COLUMN = 20
+
+ZERO_WIDTH_SPACE = "\u200b"
+LINE_BREAKS = "\n\r"
+HORIZONTAL_SPACE = " \t"
+BULLET_MARKERS = "-*+"
+ORDERED_TERMINATORS = ".)"
+DIGITS = "0-9"
+HEX_DIGITS = "0-9a-fA-F"
+ALPHANUMERIC = "0-9A-Za-z"
+# What GitHub accepts between the two colons of an emoji shortcode. Every name in its set is
+# lowercase, so an uppercase letter cannot be part of one.
+SHORTCODE_CHARACTERS = "a-z0-9_+-"
+# Everything that can end the HTML block, hide text from a reader, or reorder what they see, in
+# three groups. C0/C1 controls -- the line breaks among them -- plus DEL and the soft hyphen:
+FLATTEN_CONTROL_CODEPOINTS = "0000-001F,007F,0080-009F,00AD"
+# The bidi controls and isolates, the zero-width and word-joiner range, the line and paragraph
+# separators, the deprecated shaping and digit-shape controls, interlinear annotation, the
+# Egyptian and shorthand format controls, musical-notation controls, and the whole tag and
+# variation-selector-supplement block:
+FLATTEN_FORMAT_CODEPOINTS = (
+    "061C,200B-200F,2028-202E,2060-2064,2066-2069,206A-206F,FFF9-FFFB,13430-1343F,1BCA0-1BCA3,1D173-1D17A,E0000-E0FFF"
+)
+# And the characters that occupy space while showing nothing: the combining grapheme joiner, the
+# Hangul fillers, the inherent Khmer vowels, the Mongolian vowel separator and its free variation
+# selectors, braille blank, variation selectors, BOM, object replacement.
+FLATTEN_BLANK_CODEPOINTS = "034F,115F,1160,17B4-17B5,180B-180F,2800,3164,FE00-FE0F,FEFF,FFA0,FFFC"
+FLATTEN_CODEPOINTS = f"{FLATTEN_CONTROL_CODEPOINTS},{FLATTEN_FORMAT_CODEPOINTS},{FLATTEN_BLANK_CODEPOINTS}"
+
+# Re-declared from torchci/lib/greenlight/greenlightSweep.ts and lib/advisor/advisorBadge.ts
+# rather than imported, for the one reason nothing can fix: Python cannot import TypeScript. The
+# drift test scrapes both files and fails when a value there moves apart from the one here.
+GREENLIGHT_PENDING_ALT_ATTR = 'alt="Green Light: in progress"'
+ADVISOR_PENDING_ALT_ATTR = 'alt="AI verdict: pending"'
+SWEEP_SENTINELS = (GREENLIGHT_PENDING_ALT_ATTR, ADVISOR_PENDING_ALT_ATTR)
+SWEEP_PENDING_WORD = "Pending"
+SWEEP_PENDING_WORD_DEFUSED = "P" + ZERO_WIDTH_SPACE + "ending"
+
+
+def _codepoint_class(spec: str) -> str:
+    """Turn a ``"0000-001F,007F"`` range spec into a regex character class."""
+    parts = ["-".join(f"\\U{bound.zfill(8)}" for bound in entry.split("-")) for entry in spec.split(",")]
+    return "[" + "".join(parts) + "]"
+
+
+_BULLET_PREFIX_RE = re.compile(
+    f"^([{HORIZONTAL_SPACE}]*)(?:[{BULLET_MARKERS}]|[{DIGITS}]+[{ORDERED_TERMINATORS}])[{HORIZONTAL_SPACE}]+"
+)
+_FLATTEN_RE = re.compile(_codepoint_class(FLATTEN_CODEPOINTS))
+_SPACE_RUN_RE = re.compile(" +")
+_BACKTICK_RUN_RE = re.compile("`+")
+_HASH_REF_RE = re.compile(f"#(?=[{DIGITS}])")
+_GH_REF_RE = re.compile(f"([gG][hH]-)(?=[{DIGITS}])")
+_SHORTCODE_RE = re.compile(f":(?=[{SHORTCODE_CHARACTERS}])")
+# Lookarounds rather than \b, which disagrees across the two languages on any non-ASCII letter.
+_SHA_RE = re.compile(
+    f"(?<![{ALPHANUMERIC}])([{HEX_DIGITS}]{{{SHA_SPLIT_COLUMN}}})"
+    f"([{HEX_DIGITS}]{{{SHA_LENGTH - SHA_SPLIT_COLUMN}}})(?![{ALPHANUMERIC}])"
+)
+
+
+class _Leaf(NamedTuple):
+    depth: int
+    text: str
+
+
+class _Topic(NamedTuple):
+    text: str
+    details: list[str]
+
+
+def _split_lines(text: str) -> list[str]:
+    return text.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+
+
+def _bullet_body(line: str) -> tuple[str, str] | None:
+    """Split a bullet line into its leading indent and the text after the marker."""
+    match = _BULLET_PREFIX_RE.match(line)
+    if match is None:
+        return None
+    return match.group(1), line[match.end() :]
+
+
+def is_outline(message: str) -> bool:
+    """Whether ``message`` is a bullet outline rather than the fenced prose paragraph.
+
+    Deliberately conservative, for two reasons that hold independently. Nothing enforces the
+    outline shape, so a paragraph is a valid verdict and belongs on the fence; and no row stored
+    before the outline format existed carries a bullet marker at all, so every one of them stays
+    there too. It reads the same ``MESSAGE_CAP`` prefix the renderer does, so a bullet the
+    renderer never sees cannot decide which renderer runs.
+    """
+    bullets = 0
+    for line in _split_lines(message[:MESSAGE_CAP]):
+        body = _bullet_body(line)
+        if body is not None and body[1] != "":
+            bullets += 1
+            if bullets >= MIN_BULLETS:
+                return True
+    return False
+
+
+def _flatten(text: str) -> str:
+    """Collapse one leaf to a single line of visible text, marking it when the cap clips it.
+
+    Substitutes a space for each stripped character instead of deleting it. A deletion splices
+    what sat either side together, and ``9 Pen<stripped>ding`` re-forms into a live ``9 Pending``
+    -- one of the predicates that pins a PR into Dr. CI's re-render sweep forever.
+    """
+    substituted = _FLATTEN_RE.sub(" ", text)
+    collapsed = _SPACE_RUN_RE.sub(" ", substituted).strip(" ")
+    if len(collapsed) <= LEAF_CAP:
+        return collapsed
+    return collapsed[:LEAF_CAP] + TRUNCATION_SUFFIX
+
+
+def _leaves(message: str) -> list[_Leaf]:
+    parsed = [(line, _bullet_body(line)) for line in _split_lines(message[:MESSAGE_CAP])]
+    # Depth is relative to the shallowest bullet in the message. A model that indents the whole
+    # outline still means its outermost bullets as topics, and against an absolute threshold every
+    # one of them would read as a detail of whichever leaf happened to come first.
+    baseline = min((len(body[0]) for _, body in parsed if body is not None), default=0)
+    leaves: list[_Leaf] = []
+    wrapping = False
+    for line, body in parsed:
+        if body is not None:
+            indent, text = body
+            leaves.append(_Leaf(depth=1 if len(indent) > baseline else 0, text=text))
+            wrapping = True
+            continue
+        if line.strip(HORIZONTAL_SPACE) == "":
+            # The one unambiguous signal that what follows is not a wrap of the bullet above.
+            wrapping = False
+            continue
+        if wrapping:
+            # A model wrapping a long detail across lines means the continuation to be part of
+            # the bullet above it, so join rather than promote it to a bullet of its own.
+            leaves[-1] = leaves[-1]._replace(text=f"{leaves[-1].text} {line}")
+            continue
+        leaves.append(_Leaf(depth=0, text=line))
+        wrapping = True
+    return leaves
+
+
+def _group(leaves: list[_Leaf]) -> list[_Topic]:
+    """Group flattened leaves into topics, promoting every detail that has no topic above it.
+
+    Promotion covers two cases with one rule: nested bullets the model wrote before any top-level
+    one, and details whose topic was dropped for flattening to nothing. It runs until a real topic
+    appears rather than once, because orphans are peers of each other -- making the second one a
+    detail of the first asserts a relationship the reviewer never wrote. Dropping them instead
+    would silently discard text the reader was meant to see.
+    """
+    topics: list[_Topic] = []
+    seen_topic = False
+    for leaf in leaves:
+        if leaf.depth == 0 or not seen_topic:
+            topics.append(_Topic(text=leaf.text, details=[]))
+            seen_topic = seen_topic or leaf.depth == 0
+            continue
+        topics[-1].details.append(leaf.text)
+    return topics
+
+
+def _escape(text: str) -> str:
+    """HTML-escape, matching lodash's ``_.escape`` byte for byte.
+
+    Python and lodash escape the same five characters and differ only on the apostrophe entity.
+    ``&#x27;`` is the form both sides settle on because the alternative, ``&#39;``, carries a
+    ``#`` followed by a digit -- which the reference guard below would then split, turning every
+    apostrophe in the message into a visible, broken entity.
+    """
+    return html.escape(text, quote=True)
+
+
+def _defuse_sweep(text: str) -> str:
+    """Break the literals Dr. CI's re-render sweep greps a comment body for.
+
+    The sweep reads Dr. CI's own comment and nothing else -- its query filters on that bot's login
+    and on a ``<!-- drci-comment-start -->`` body prefix -- so a comment greenlight posts is never
+    a candidate. This runs on the Python side anyway because the TypeScript mirror renders the
+    same row into that comment, and the two have to emit the same bytes.
+
+    Applied to code spans too: the sweep matches the body, not the rendered HTML, so a predicate
+    inside a ``<code>`` pins the PR just as hard as one in prose. Substituting a zero-width space
+    for each sentinel rather than deleting it is what makes a single pass enough -- no sentinel
+    contains that character, so neither a nested forgery nor two sentinels spliced across the gap
+    left by removing a third can reassemble.
+
+    Both sentinels are spelled with ``"``, which ``_escape`` has already turned into ``&quot;`` by
+    the time the render path reaches here, so the loop matches nothing and the ``Pending``
+    substitution is the pass that fires. The loop stays as cover for a predicate spelled without
+    a quote, and for callers that hand this raw text.
+    """
+    out = text
+    for sentinel in SWEEP_SENTINELS:
+        out = out.replace(sentinel, ZERO_WIDTH_SPACE)
+    return out.replace(SWEEP_PENDING_WORD, SWEEP_PENDING_WORD_DEFUSED)
+
+
+def _guard_references(text: str) -> str:
+    """Stop GitHub turning the text into a mention, a cross-reference, a backlink, or an emoji.
+
+    The sha guard splits the run rather than prefixing it. A zero-width space is a non-word
+    character, so a prefixed one leaves both anchor styles GitHub's filters use -- ``\\b...\\b``
+    and ``(?:^|\\W)`` -- matching the untouched 40 hex digits behind it.
+
+    Text segments only, which is safe for two separate reasons. ``code`` is in GitHub's
+    MentionFilter.IGNORE_PARENTS, so a code span raises no mention in the rendered comment; and
+    pytorchbot reads the RAW body, matching ``^ *@pytorch(merge|)bot .+$`` per line (see
+    torchci/lib/bot/cliParser.ts), which nothing here can satisfy while the whole block is one
+    line opening ``<ul><li><b>``. Pretty-printing this block across several lines would make that
+    second reason false. A zero-width space inside a span corrupts a path or a sha the reader
+    copies out.
+    """
+    out = text.replace("@", "@" + ZERO_WIDTH_SPACE)
+    # Bare `#` is left alone so `#ifdef`, `#include` and `#pragma` survive intact.
+    out = _HASH_REF_RE.sub("#" + ZERO_WIDTH_SPACE, out)
+    out = _GH_REF_RE.sub(r"\1" + ZERO_WIDTH_SPACE, out)
+    # GitHub's EmojiFilter skips `pre`, `code` and `tt` -- not `li` -- so `:white_check_mark:` in a
+    # bullet renders as a green tick the reviewer never drew. Only the opening colon needs breaking:
+    # a name cannot start anywhere but immediately after one.
+    out = _SHORTCODE_RE.sub(":" + ZERO_WIDTH_SPACE, out)
+    return _SHA_RE.sub(r"\1" + ZERO_WIDTH_SPACE + r"\2", out)
+
+
+def _segments(leaf: str) -> list[str]:
+    """Split a leaf into alternating text and code-span segments, text first.
+
+    An odd number of backtick runs means the spans do not close, so the whole leaf goes out as one
+    text segment: backticks carry no meaning inside a raw HTML block, so an unpaired run renders
+    as itself rather than opening something that never ends.
+    """
+    parts = _BACKTICK_RUN_RE.split(leaf)
+    if (len(parts) - 1) % 2 == 1:
+        return [leaf]
+    return parts
+
+
+def _leaf_html(leaf: str) -> str:
+    rendered: list[str] = []
+    for index, segment in enumerate(_segments(leaf)):
+        defused = _defuse_sweep(_escape(segment))
+        if index % 2 == 1:
+            rendered.append(f"<code>{defused}</code>")
+        else:
+            rendered.append(_guard_references(defused))
+    return "".join(rendered)
+
+
+def _topic_html(topic: _Topic) -> str:
+    parts = [f"<li><b>{_leaf_html(topic.text)}</b>"]
+    details = topic.details[:MAX_DETAILS]
+    if details:
+        parts.append("<ul>")
+        parts += [f"<li>{_leaf_html(detail)}</li>" for detail in details]
+        if len(topic.details) > MAX_DETAILS:
+            parts.append(TRUNCATED_ITEM)
+        parts.append("</ul>")
+    parts.append("</li>")
+    return "".join(parts)
+
+
+def _assert_contained(block: str) -> None:
+    if any(char in block for char in LINE_BREAKS):
+        raise RuntimeError("verdict outline holds a line break, which would end the HTML block")
+    if block.count("<code>") != block.count("</code>"):
+        raise RuntimeError("verdict outline has unbalanced <code> tags")
+
+
+def render_outline_html(message: str) -> str:
+    """Render ``message`` as one contiguous HTML bullet list, or ``""`` if it produces no item.
+
+    Two inputs produce none: one whose every leaf flattened away, and one whose first item alone
+    overruns the budget, where a marker is all that would be left. Both send the message out
+    fenced, which shows the reader the text capped rather than an empty section or a bare marker.
+    Every clamp that drops text marks itself: a clipped leaf ends in an ellipsis, and a dropped
+    topic, detail, over-budget item or over-cap tail leaves a truncation item behind, so a reader
+    can never mistake a cut list for a complete one.
+    """
+    flattened = (leaf._replace(text=_flatten(leaf.text)) for leaf in _leaves(message))
+    topics = _group([leaf for leaf in flattened if leaf.text != ""])
+    if not topics:
+        return ""
+
+    items: list[str] = []
+    used = 0
+    # A message past the cap was cut before the first leaf was read, so the list is short whatever
+    # the topic count says.
+    truncated = len(topics) > MAX_TOPICS or len(message) > MESSAGE_CAP
+    for topic in topics[:MAX_TOPICS]:
+        item = _topic_html(topic)
+        # Measured before the append, not after: testing the running total alone leaves whichever
+        # item crosses the budget unbounded, and one maximally escaped item is worth 21,000 bytes.
+        if used + len(item) > BLOCK_BUDGET:
+            truncated = True
+            break
+        items.append(item)
+        used += len(item)
+    if truncated:
+        items.append(TRUNCATED_ITEM)
+    if items == [TRUNCATED_ITEM]:
+        return ""
+
+    block = "<ul>" + "".join(items) + "</ul>"
+    _assert_contained(block)
+    return block

--- a/greenlight/tests/test_render_sync.py
+++ b/greenlight/tests/test_render_sync.py
@@ -1,9 +1,10 @@
 """Pins the values Dr. CI's TypeScript renderer re-declares from greenlight's Python source.
 
 ``torchci/lib/greenlight/greenlightRender.ts`` renders the same greenlight state the Python
-comment writer does, but re-declares the shared vocabulary as its own constants and nothing at
-build time links the two. Python is the source of truth: these tests fail when the TypeScript
-stops matching it, in either direction.
+comment writer does, but re-declares the shared vocabulary as its own constants -- its own and
+``torchci/lib/greenlight/greenlightSweep.ts``'s, which holds the part the Dr. CI sweep reads
+too -- and nothing at build time links any of it to Python. Python is the source of truth: these
+tests fail when the TypeScript stops matching it, in either direction.
 """
 
 import re
@@ -17,11 +18,13 @@ from greenlight import comment_format, constants
 ROOT = Path(__file__).resolve().parents[2]
 
 _TS_RENDER = "torchci/lib/greenlight/greenlightRender.ts"
+_TS_SWEEP = "torchci/lib/greenlight/greenlightSweep.ts"
 _TS_CONFIG = "torchci/lib/greenlight/greenlightConfig.ts"
 _PY_RENDER = "greenlight/src/greenlight/comment_format.py"
 _PY_CONSTANTS = "greenlight/src/greenlight/constants.py"
 
 assert (ROOT / _TS_RENDER).is_file()
+assert (ROOT / _TS_SWEEP).is_file()
 assert (ROOT / _TS_CONFIG).is_file()
 
 _TS_UNICODE_ESCAPE_RE = re.compile(r"\\u([0-9a-fA-F]{4})")
@@ -174,9 +177,9 @@ def test_message_cap_matches_python() -> None:
 
 
 def test_zero_width_space_matches_python() -> None:
-    extracted = _ts_string(_TS_RENDER, "ZERO_WIDTH_SPACE")
+    extracted = _ts_string(_TS_SWEEP, "ZERO_WIDTH_SPACE")
     assert extracted == comment_format._ZERO_WIDTH_SPACE, _drift(
-        _TS_RENDER,
+        _TS_SWEEP,
         _PY_RENDER,
         f"ZERO_WIDTH_SPACE is {extracted!r}, _ZERO_WIDTH_SPACE is {comment_format._ZERO_WIDTH_SPACE!r}",
     )

--- a/greenlight/tests/test_verdict_outline.py
+++ b/greenlight/tests/test_verdict_outline.py
@@ -1,0 +1,751 @@
+"""Tests for the verdict outline renderer.
+
+Two things are pinned here. The first is containment: whatever the model was talked into
+writing, the rendered block stays one line of raw HTML whose only tags are the ones this module
+emits. The second is that the switch between the outline renderer and the fenced one is
+conservative enough that a paragraph goes out fenced, which is where prose belongs and where
+every already-stored row stays.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+import pytest
+
+from greenlight import comment_format, verdict_outline
+from greenlight.verdict_outline import is_outline, render_outline_html
+
+ZWSP = verdict_outline.ZERO_WIDTH_SPACE
+SHA = "abc1234567890abc1234567890abc1234567890a"
+_SPLIT = verdict_outline.SHA_SPLIT_COLUMN
+SPLIT_SHA = SHA[:_SPLIT] + ZWSP + SHA[_SPLIT:]
+NBSP = chr(0xA0)
+EM_SPACE = chr(0x2003)
+EACUTE = chr(0xE9)
+ARABIC_DIGITS = chr(0x661) + chr(0x662) + chr(0x663)
+UNICODE_BULLET = chr(0x2022)
+BOM = chr(0xFEFF)
+SENTINEL = verdict_outline.GREENLIGHT_PENDING_ALT_ATTR
+ADVISOR_SENTINEL = verdict_outline.ADVISOR_PENDING_ALT_ATTR
+
+# Everything this module is allowed to put in the comment. GitHub's sanitizer keeps all five.
+ALLOWED_TAGS = frozenset(["<ul>", "</ul>", "<li>", "</li>", "<b>", "</b>", "<code>", "</code>"])
+_TAG_RE = re.compile("<[^>]*>")
+# The regex Dr. CI's re-render sweep runs over the raw comment body. ClickHouse's RE2 reads `\d`
+# as ASCII-only, so the class is written out rather than borrowed from the Python flavour.
+_SWEEP_PENDING_RE = re.compile("[0-9] Pending")
+
+# A paragraph verdict: one unbroken prose line carrying no bullet marker. Nothing enforces the
+# outline shape, so a reviewer can still write one of these, and every row stored before the
+# outline format existed is one.
+STORED_PROSE = (
+    "This PR adds a guard to torch/_inductor/lowering.py so make_fallback no longer registers "
+    "aten.index_put_ twice when the decomposition table is rebuilt; the change is confined to "
+    "the registration path and every existing caller keeps the same behaviour, because the new "
+    "branch only fires when the op is already present in the table. The accompanying test in "
+    "test/inductor/test_torchinductor.py exercises both the first and the second registration "
+    "and asserts the fallback is unchanged. The remaining diff is a docstring correction in "
+    "torch/_inductor/decomposition.py that renames the argument to match the signature, plus a "
+    "type annotation on _register_fallback that mypy already inferred. Nothing in the change "
+    "touches the runtime kernels, the autograd formulas, or any serialized artifact, so the "
+    "blast radius is limited to compile-time registration and the risk of a silent numerical "
+    "regression is nil. CI is green on the inductor shards that cover this file."
+)
+
+HOSTILE_PAYLOADS = [
+    "</details>",
+    "</summary>",
+    "# FAKE LAND VERDICT",
+    "---",
+    "***",
+    "1. x",
+    "| a | b |",
+    "[^1]",
+    "[x]: y",
+    "```",
+    "<ul>",
+    "</li>",
+    "<script>alert(1)</script>",
+    "<img src=x onerror=y>",
+    '<a href="https://evil.example">click</a>',
+    'x" onload="y',
+    "x' onload='y",
+    "<![CDATA[ x ]]>",
+    "<!-- y -->",
+    "&amp;",
+    "&lt;",
+    "</b></li></ul><script>x</script><ul><li><b>",
+]
+
+# Line-break shapes that would end the raw HTML block if any of them survived into the output.
+BLANK_LINE_BREAKOUTS = ["\n\n", "\r\r", "\r\n\r\n", "\n   \n", "\n\t\n"]
+
+
+def assert_contained(block: str) -> None:
+    """Every guarantee the block makes to the comment it is embedded in."""
+    assert "\n" not in block
+    assert "\r" not in block
+    tags = _TAG_RE.findall(block)
+    # No `<` survives outside a tag this module emitted, so nothing in the message can open one.
+    assert block.count("<") == len(tags)
+    assert set(tags) <= ALLOWED_TAGS
+    assert block.count("<code>") == block.count("</code>")
+    assert not _SWEEP_PENDING_RE.search(block)
+
+
+def bullet(*leaves: str) -> str:
+    return "\n".join(leaves)
+
+
+# ---------------------------------------------------------------- is_outline
+
+
+def test_prose_is_not_an_outline() -> None:
+    assert is_outline(STORED_PROSE) is False
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "",
+        "   ",
+        "No bullets here at all.",
+        "-no space after the marker",
+        "- ",
+        "-\t",
+        "1.no space",
+        "a - b",
+        "  indented prose",
+        f"{UNICODE_BULLET} a unicode bullet",
+        f"{ARABIC_DIGITS}. arabic-indic digits are not [0-9]",
+        "- x",
+        "prose first\n- then one bullet",
+        "- one bullet\nthen prose",
+        f"{STORED_PROSE}\n- x",
+    ],
+)
+def test_not_an_outline(message: str) -> None:
+    assert is_outline(message) is False
+
+
+def test_one_bullet_line_leaves_a_paragraph_on_the_fenced_renderer() -> None:
+    # The cheap attack on the switch: two characters appended to a long paragraph move it onto a
+    # renderer that shows the reader one leaf of it and clips the rest.
+    assert len(STORED_PROSE) > verdict_outline.LEAF_CAP
+    assert is_outline(f"{STORED_PROSE}\n- x") is False
+    assert is_outline(f"{STORED_PROSE}\n- x\n- y") is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "- x\n- y",
+        "* x\n* y",
+        "+ x\n+ y",
+        "1. x\n2. y",
+        "2) x\n3) y",
+        "\t- x\n\t- y",
+        "   - x\n   - y",
+        "-\tx\n-\ty",
+        "prose first\n- then a bullet\n- and another",
+        "- x\r\n- y",
+        "- x\r- y",
+    ],
+)
+def test_is_an_outline(message: str) -> None:
+    assert is_outline(message) is True
+
+
+def test_the_classifier_reads_the_same_prefix_the_renderer_does() -> None:
+    # Bullets past the cap are text the renderer never sees, so they cannot decide which renderer
+    # runs -- otherwise the outline path receives a message it renders as a single clipped leaf.
+    beyond = "x" * verdict_outline.MESSAGE_CAP + "\n- a\n- b"
+    assert is_outline(beyond) is False
+    assert is_outline("- a\n- b\n" + beyond) is True
+
+
+# ---------------------------------------------------------------- structure
+
+
+def test_topics_and_details() -> None:
+    block = render_outline_html(bullet("- Topic one", "  - detail a", "  - detail b", "- Topic two"))
+    assert block == (
+        "<ul><li><b>Topic one</b><ul><li>detail a</li><li>detail b</li></ul></li><li><b>Topic two</b></li></ul>"
+    )
+
+
+def test_topic_without_details_has_no_inner_list() -> None:
+    assert render_outline_html("- Only a topic") == "<ul><li><b>Only a topic</b></li></ul>"
+
+
+def test_prose_without_bullets_becomes_one_capped_topic() -> None:
+    # A prose verdict never reaches this renderer -- is_outline sends it to the fence -- but if it
+    # ever did, the whole paragraph is one leaf and the leaf cap clips it.
+    clipped = STORED_PROSE[: verdict_outline.LEAF_CAP] + verdict_outline.TRUNCATION_SUFFIX
+    assert render_outline_html(STORED_PROSE) == f"<ul><li><b>{clipped}</b></li></ul>"
+
+
+def test_continuation_line_joins_the_bullet_above_it() -> None:
+    block = render_outline_html(bullet("- Topic that the model", "  wrapped over two lines"))
+    assert block == "<ul><li><b>Topic that the model wrapped over two lines</b></li></ul>"
+
+
+def test_continuation_line_joins_a_detail() -> None:
+    block = render_outline_html(bullet("- Topic", "  - detail that", "    kept going"))
+    assert block == "<ul><li><b>Topic</b><ul><li>detail that kept going</li></ul></li></ul>"
+
+
+def test_a_blank_line_ends_a_continuation() -> None:
+    # A closing paragraph is not evidence for the last detail above it, and the blank line is the
+    # one signal in the format that says so.
+    block = render_outline_html(bullet("- Scope", "  - one file", "", "Overall this looks safe."))
+    assert block == ("<ul><li><b>Scope</b><ul><li>one file</li></ul></li><li><b>Overall this looks safe.</b></li></ul>")
+
+
+def test_a_blank_line_ends_a_prose_continuation() -> None:
+    block = render_outline_html(bullet("first paragraph", "still the first", "", "second"))
+    assert block == "<ul><li><b>first paragraph still the first</b></li><li><b>second</b></li></ul>"
+
+
+def test_numbered_markers_flatten_to_the_same_shape() -> None:
+    block = render_outline_html(bullet("1. First", "2) Second", "   1. nested"))
+    assert block == "<ul><li><b>First</b></li><li><b>Second</b><ul><li>nested</li></ul></li></ul>"
+
+
+def test_the_shallowest_bullet_is_the_top_level() -> None:
+    assert render_outline_html(" - one space") == "<ul><li><b>one space</b></li></ul>"
+
+
+def test_a_uniformly_indented_outline_keeps_its_shape() -> None:
+    # Against an absolute threshold every one of these is a detail, so the second topic renders as
+    # evidence for the first -- a relationship the reviewer never wrote, posted permanently.
+    block = render_outline_html(bullet("  - Testing", "    - covers it", "  - Scope", "    - one file"))
+    assert block == (
+        "<ul><li><b>Testing</b><ul><li>covers it</li></ul></li><li><b>Scope</b><ul><li>one file</li></ul></li></ul>"
+    )
+
+
+@pytest.mark.parametrize("indent", [" ", "\t", "  ", "\t\t"])
+def test_any_deeper_indent_nests(indent: str) -> None:
+    block = render_outline_html(bullet("- topic", f"{indent}- nested"))
+    assert block == "<ul><li><b>topic</b><ul><li>nested</li></ul></li></ul>"
+
+
+def test_depth_is_clamped_to_one() -> None:
+    block = render_outline_html(bullet("- topic", "  - detail", "      - deeper still"))
+    assert block == "<ul><li><b>topic</b><ul><li>detail</li><li>deeper still</li></ul></li></ul>"
+
+
+def test_detail_before_any_topic_is_promoted() -> None:
+    block = render_outline_html(bullet("  - nested first", "- topic after"))
+    assert block == "<ul><li><b>nested first</b></li><li><b>topic after</b></li></ul>"
+
+
+def test_every_leading_orphan_is_promoted() -> None:
+    # Two orphans are peers. Promoting only the first makes the second read as evidence for it.
+    block = render_outline_html(bullet("  - first orphan", "  - second orphan", "- topic after"))
+    assert block == ("<ul><li><b>first orphan</b></li><li><b>second orphan</b></li><li><b>topic after</b></li></ul>")
+
+
+def test_details_survive_a_topic_that_flattens_away() -> None:
+    block = render_outline_html(bullet(f"- {ZWSP}{ZWSP}", "  - survivor"))
+    assert block == "<ul><li><b>survivor</b></li></ul>"
+
+
+def test_empty_leaves_emit_no_list_item() -> None:
+    block = render_outline_html(bullet("- ", "- kept", "- \t"))
+    assert block == "<ul><li><b>kept</b></li></ul>"
+
+
+@pytest.mark.parametrize("message", ["", "   ", "\n\n\n", f"- {ZWSP}", f"- {chr(0)}{chr(0x7F)}{BOM}"])
+def test_nothing_to_render_hands_the_message_to_the_fence(message: str) -> None:
+    assert render_outline_html(message) == ""
+
+
+# ---------------------------------------------------------------- containment
+
+
+@pytest.mark.parametrize("payload", HOSTILE_PAYLOADS)
+def test_hostile_payload_stays_contained(payload: str) -> None:
+    block = render_outline_html(bullet(f"- {payload}", f"  - {payload}"))
+    assert_contained(block)
+    assert _TAG_RE.findall(block) == [
+        "<ul>",
+        "<li>",
+        "<b>",
+        "</b>",
+        "<ul>",
+        "<li>",
+        "</li>",
+        "</ul>",
+        "</li>",
+        "</ul>",
+    ]
+
+
+@pytest.mark.parametrize("payload", HOSTILE_PAYLOADS)
+@pytest.mark.parametrize("breakout", BLANK_LINE_BREAKOUTS)
+def test_hostile_payload_with_a_blank_line_stays_one_line(payload: str, breakout: str) -> None:
+    assert_contained(render_outline_html(f"- {payload}{breakout}- {payload}"))
+
+
+def test_markup_is_escaped_not_stripped() -> None:
+    block = render_outline_html("- <script>alert(1)</script>")
+    assert block == "<ul><li><b>&lt;script&gt;alert(1)&lt;/script&gt;</b></li></ul>"
+
+
+def test_pre_encoded_entities_are_double_escaped() -> None:
+    assert render_outline_html("- &amp; &lt;") == "<ul><li><b>&amp;amp; &amp;lt;</b></li></ul>"
+
+
+def test_apostrophe_uses_the_entity_the_reference_guard_leaves_alone() -> None:
+    # `&#39;` would carry a `#` followed by a digit, which the issue-reference guard then splits
+    # into a broken entity the reader sees verbatim.
+    assert render_outline_html("- it's") == "<ul><li><b>it&#x27;s</b></li></ul>"
+
+
+def test_quotes_are_escaped() -> None:
+    assert render_outline_html('- x" onload="y') == "<ul><li><b>x&quot; onload=&quot;y</b></li></ul>"
+
+
+# ---------------------------------------------------------------- flattening
+
+
+def test_invisible_characters_become_spaces_not_deletions() -> None:
+    # A deletion would splice `Pen` onto `ding` and hand the sweep a live predicate.
+    block = render_outline_html(f"- 9 Pen{ZWSP}ding jobs")
+    assert block == "<ul><li><b>9 Pen ding jobs</b></li></ul>"
+    assert not _SWEEP_PENDING_RE.search(block)
+
+
+def test_space_runs_collapse_and_edges_are_stripped() -> None:
+    assert render_outline_html("-    a     b   ") == "<ul><li><b>a b</b></li></ul>"
+
+
+def test_non_ascii_spaces_are_left_alone() -> None:
+    # `\s` would have eaten these in Python and not in JavaScript, which is the whole reason no
+    # shorthand class appears in either implementation.
+    block = render_outline_html(f"- a{NBSP}b{EM_SPACE}c")
+    assert block == f"<ul><li><b>a{NBSP}b{EM_SPACE}c</b></li></ul>"
+
+
+def test_leaf_is_capped_before_escaping() -> None:
+    block = render_outline_html("- " + "<" * 500)
+    ellipsis = verdict_outline.TRUNCATION_SUFFIX
+    assert block == "<ul><li><b>" + "&lt;" * verdict_outline.LEAF_CAP + ellipsis + "</b></li></ul>"
+
+
+def test_a_leaf_exactly_at_the_cap_is_not_marked() -> None:
+    block = render_outline_html("- " + "x" * verdict_outline.LEAF_CAP)
+    assert block == "<ul><li><b>" + "x" * verdict_outline.LEAF_CAP + "</b></li></ul>"
+    assert verdict_outline.TRUNCATION_SUFFIX not in block
+
+
+def test_a_clipped_leaf_says_so() -> None:
+    # Without the mark, a bullet cut mid-word reads as the whole of what the reviewer wrote.
+    block = render_outline_html("- " + "x" * (verdict_outline.LEAF_CAP + 1))
+    assert block.endswith(f"{verdict_outline.TRUNCATION_SUFFIX}</b></li></ul>")
+
+
+def test_message_is_capped_in_codepoints() -> None:
+    block = render_outline_html("- " + "\U0001f600" * 4100)
+    leaf = "\U0001f600" * verdict_outline.LEAF_CAP + verdict_outline.TRUNCATION_SUFFIX
+    assert block == f"<ul><li><b>{leaf}</b></li>{verdict_outline.TRUNCATED_ITEM}</ul>"
+
+
+def test_message_cap_matches_the_fenced_renderer() -> None:
+    assert verdict_outline.MESSAGE_CAP == comment_format._MESSAGE_CAP
+
+
+def test_zero_width_space_matches_the_fenced_renderer() -> None:
+    # Each Python copy is pinned to the TypeScript beside it and to nothing else, so without this
+    # the two pairs can move apart together and stay green. Both routes write into the one Dr. CI
+    # comment body the sweep greps, and this character is what every defuse substitutes.
+    assert verdict_outline.ZERO_WIDTH_SPACE == comment_format._ZERO_WIDTH_SPACE
+
+
+# Everything a browser or a markdown parser treats as a line break, spelled with chr() so the
+# source itself cannot carry one.
+_LINE_BREAK_CODEPOINTS = ["\n", "\r", "\v", "\f", chr(0x85), chr(0x2028), chr(0x2029)]
+
+
+@pytest.mark.parametrize("char", _LINE_BREAK_CODEPOINTS)
+def test_every_line_break_character_is_flattened(char: str) -> None:
+    assert render_outline_html(f"- a{char}b") == "<ul><li><b>a b</b></li></ul>"
+
+
+# Characters that render as nothing yet survive into a permanent public comment: a variation
+# selector, an ASCII-smuggling tag character, an interlinear annotation anchor, a musical-notation
+# control, the Hangul choseong filler, and the object replacement character. The rest are the ones
+# that ride along invisibly without being able to break the block: the combining grapheme joiner,
+# the other Hangul fillers, an inherent Khmer vowel, the Mongolian free variation selectors, the
+# deprecated shaping controls, the Egyptian and shorthand format controls, and the two halves of
+# the supplementary plane block -- the assigned variation selectors at E0100 and the reserved tail
+# above them.
+_INVISIBLE_CODEPOINTS = [
+    chr(0xFE00),
+    chr(0xFE0F),
+    chr(0xE0000),
+    chr(0xE0041),
+    chr(0xE007F),
+    chr(0xFFF9),
+    chr(0xFFFB),
+    chr(0x1D173),
+    chr(0x1D17A),
+    chr(0x115F),
+    chr(0xFFFC),
+    chr(0x034F),
+    chr(0x1160),
+    chr(0xFFA0),
+    chr(0x17B4),
+    chr(0x17B5),
+    chr(0x180B),
+    chr(0x180F),
+    chr(0x206A),
+    chr(0x206F),
+    chr(0x13430),
+    chr(0x1BCA0),
+    chr(0xE0100),
+    chr(0xE01EF),
+    chr(0xE0FFF),
+]
+
+
+@pytest.mark.parametrize("char", _INVISIBLE_CODEPOINTS)
+def test_every_invisible_character_is_flattened(char: str) -> None:
+    assert render_outline_html(f"- a{char}b") == "<ul><li><b>a b</b></li></ul>"
+
+
+def test_a_smuggled_tag_block_message_flattens_away() -> None:
+    # The tag block spells ASCII in characters no reader sees; a whole hidden sentence has to
+    # collapse to whitespace rather than ride along under the visible text.
+    smuggled = "".join(chr(0xE0000 + ord(char)) for char in "LAND")
+    assert render_outline_html(f"- {smuggled}") == ""
+
+
+def test_no_codepoint_in_unicode_survives_as_a_line_break() -> None:
+    """The one invariant that is global rather than per-leaf, proved over the whole codespace."""
+    everything = "".join(chr(code) for code in range(0x110000) if not 0xD800 <= code <= 0xDFFF)
+    flattened = verdict_outline._FLATTEN_RE.sub(" ", everything)
+    assert "\n" not in flattened
+    assert "\r" not in flattened
+    # Nothing outside the flatten set is a Unicode line separator either, so no future renderer
+    # that re-splits this text can find a break the class missed.
+    survivors = [char for char in flattened if unicodedata.category(char) in {"Zl", "Zp"}]
+    assert survivors == []
+
+
+# ---------------------------------------------------------------- sweep sentinels
+
+
+def test_pending_job_count_is_defused() -> None:
+    block = render_outline_html("- 3 Pending checks were still running")
+    assert block == f"<ul><li><b>3 P{ZWSP}ending checks were still running</b></li></ul>"
+    assert not _SWEEP_PENDING_RE.search(block)
+
+
+def test_pending_is_defused_inside_a_code_span() -> None:
+    # The sweep greps the raw body, so a predicate inside <code> pins the PR just as hard.
+    block = render_outline_html("- `4 Pending` jobs")
+    assert block == f"<ul><li><b><code>4 P{ZWSP}ending</code> jobs</b></li></ul>"
+
+
+@pytest.mark.parametrize("sentinel", [SENTINEL, ADVISOR_SENTINEL])
+def test_a_sentinel_cannot_splice_a_pending_count(sentinel: str) -> None:
+    block = render_outline_html(f"- 9 Pen{sentinel}ding jobs")
+    assert_contained(block)
+    assert "Pending" not in block
+    assert sentinel not in block
+
+
+@pytest.mark.parametrize("sentinel", [SENTINEL, ADVISOR_SENTINEL])
+def test_a_sentinel_never_survives_the_defuse(sentinel: str) -> None:
+    assert sentinel not in render_outline_html(f"- {sentinel}")
+
+
+def test_a_nested_sentinel_forgery_cannot_reassemble() -> None:
+    forged = 'alt="Green alt="Green Light: in progress"Light: in progress"'
+    assert SENTINEL not in render_outline_html(f"- {forged}")
+
+
+def test_defusing_one_pending_cannot_build_another() -> None:
+    block = render_outline_html("- 7 PenPendingding")
+    assert "Pending" not in block
+
+
+def test_the_defuse_runs_on_raw_text_too() -> None:
+    # Escaping already breaks both `alt="..."` sentinels, so this exercises the pass directly:
+    # it has to keep working if the escape ever stops covering for it.
+    assert verdict_outline._defuse_sweep(f"9 Pen{SENTINEL}ding") == f"9 Pen{ZWSP}ding"
+    assert verdict_outline._defuse_sweep("3 Pending") == f"3 P{ZWSP}ending"
+
+
+# ---------------------------------------------------------------- reference guards
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        ("@user", f"@{ZWSP}user"),
+        ("@@double", f"@{ZWSP}@{ZWSP}double"),
+        ("#1234", f"#{ZWSP}1234"),
+        ("#0", f"#{ZWSP}0"),
+        ("GH-42", f"GH-{ZWSP}42"),
+        ("gh-42", f"gh-{ZWSP}42"),
+        ("Gh-42", f"Gh-{ZWSP}42"),
+        ("gH-42", f"gH-{ZWSP}42"),
+        (SHA, SPLIT_SHA),
+        (f"landed as {SHA} yesterday", f"landed as {SPLIT_SHA} yesterday"),
+        # A word character in Python and not in JavaScript: `\b` would have guarded on one side
+        # of the mirror only.
+        (f"caf{EACUTE}{SHA}", f"caf{EACUTE}{SPLIT_SHA}"),
+    ],
+)
+def test_reference_is_guarded(message: str, expected: str) -> None:
+    assert render_outline_html(f"- {message}") == f"<ul><li><b>{expected}</b></li></ul>"
+
+
+def test_the_sha_guard_splits_the_run_rather_than_prefixing_it() -> None:
+    # A zero-width space is a non-word character, so one sitting in front of the run leaves both
+    # `\b...\b` and `(?:^|\W)` matching the 40 intact hex digits behind it.
+    body = render_outline_html(f"- {SHA}").removeprefix("<ul><li><b>").removesuffix("</b></li></ul>")
+    assert body != f"{ZWSP}{SHA}"
+    assert SHA not in body
+    assert body.replace(ZWSP, "") == SHA
+    assert body.index(ZWSP) == verdict_outline.SHA_SPLIT_COLUMN
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "#ifdef",
+        "#include <stdio.h>",
+        "#pragma once",
+        "GH-x",
+        "GH-",
+        "a" * 39,
+        "a" * 41,
+        f"z{SHA}",
+        f"{SHA}z",
+    ],
+)
+def test_reference_is_not_guarded(message: str) -> None:
+    assert ZWSP not in render_outline_html(f"- {message}")
+
+
+def test_a_sha_in_a_code_span_is_left_intact() -> None:
+    # `code` is in GitHub's MentionFilter.IGNORE_PARENTS, and a zero-width space here would
+    # corrupt the sha a reader copies out.
+    block = render_outline_html(f"- see `{SHA}` there")
+    assert block == f"<ul><li><b>see <code>{SHA}</code> there</b></li></ul>"
+
+
+def test_a_mention_in_a_code_span_is_left_intact() -> None:
+    assert render_outline_html("- `@echo off`") == "<ul><li><b><code>@echo off</code></b></li></ul>"
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        (":white_check_mark: APPROVED", f":{ZWSP}white_check_mark: APPROVED"),
+        (":shipit:", f":{ZWSP}shipit:"),
+        (":+1:", f":{ZWSP}+1:"),
+        (":e-mail:", f":{ZWSP}e-mail:"),
+        ("done:tada:now", f"done:{ZWSP}tada:{ZWSP}now"),
+        ("::smile::", f"::{ZWSP}smile::"),
+        (":a::b:", f":{ZWSP}a::{ZWSP}b:"),
+    ],
+)
+def test_an_emoji_shortcode_cannot_render(message: str, expected: str) -> None:
+    # GitHub's EmojiFilter ignores pre, code and tt -- not li -- so an unguarded shortcode draws a
+    # green tick beside a verdict only the renderer is trusted to state.
+    assert render_outline_html(f"- {message}") == f"<ul><li><b>{expected}</b></li></ul>"
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Scope: one file",
+        "the ratio is 3 : 1",
+        "cast to Tensor:Long",
+        "https://hud.pytorch.org",
+        "::",
+    ],
+)
+def test_a_colon_that_cannot_open_a_shortcode_is_left_alone(message: str) -> None:
+    # A name is lowercase and starts immediately after the colon, so nothing here can open one --
+    # and a zero-width space in ordinary prose is a character the reader copies out unawares.
+    assert ZWSP not in render_outline_html(f"- {message}")
+
+
+def test_an_emoji_shortcode_in_a_code_span_is_left_intact() -> None:
+    # `code` is one of the parents EmojiFilter ignores, so the span is already inert, and a
+    # zero-width space here would corrupt what the reader copies out.
+    assert render_outline_html("- `:shipit:`") == "<ul><li><b><code>:shipit:</code></b></li></ul>"
+
+
+def test_the_gh_guard_fires_on_every_occurrence() -> None:
+    # A missed GH- guard writes a permanent backlink onto an unrelated issue, so one per leaf is
+    # not enough -- including the occurrences sitting between escaped characters.
+    block = render_outline_html('- GH-42 & "gh-7"')
+    assert block == f"<ul><li><b>GH-{ZWSP}42 &amp; &quot;gh-{ZWSP}7&quot;</b></li></ul>"
+
+
+# ---------------------------------------------------------------- code spans
+
+
+def test_code_span_round_trip() -> None:
+    assert render_outline_html("- call `foo(bar)` now") == "<ul><li><b>call <code>foo(bar)</code> now</b></li></ul>"
+
+
+def test_unbalanced_backticks_fall_back_to_text() -> None:
+    assert render_outline_html("- one ` backtick") == "<ul><li><b>one ` backtick</b></li></ul>"
+
+
+def test_a_leaf_that_is_only_backticks_stays_text() -> None:
+    assert render_outline_html("- ```") == "<ul><li><b>```</b></li></ul>"
+
+
+def test_a_code_span_cannot_close_the_block() -> None:
+    block = render_outline_html("- `</code></li></ul></details>`")
+    assert block == "<ul><li><b><code>&lt;/code&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/details&gt;</code></b></li></ul>"
+    assert_contained(block)
+
+
+def test_backtick_runs_are_not_split_apart() -> None:
+    assert render_outline_html("- ``a`b`` tail") == "<ul><li><b>``a`b`` tail</b></li></ul>"
+
+
+def test_several_code_spans_alternate() -> None:
+    block = render_outline_html("- `a` and `b`")
+    assert block == "<ul><li><b><code>a</code> and <code>b</code></b></li></ul>"
+
+
+# ---------------------------------------------------------------- bounds
+
+
+def test_topics_are_clamped() -> None:
+    block = render_outline_html(bullet(*(f"- topic {index}" for index in range(20))))
+    assert block.count("<li><b>") == verdict_outline.MAX_TOPICS
+    assert "topic 11" in block
+    assert "topic 12" not in block
+    # A NO_LAND whose thirteenth bullet held the blocker must not read as a complete list.
+    assert block.endswith(f"{verdict_outline.TRUNCATED_ITEM}</ul>")
+
+
+def test_exactly_max_topics_is_not_marked_truncated() -> None:
+    topics = verdict_outline.MAX_TOPICS
+    block = render_outline_html(bullet(*(f"- topic {index}" for index in range(topics))))
+    assert block.count("<li><b>") == topics
+    assert verdict_outline.TRUNCATED_ITEM not in block
+
+
+def test_details_are_clamped_per_topic() -> None:
+    block = render_outline_html(bullet("- topic", *(f"  - detail {index}" for index in range(20))))
+    assert block.count("<li>detail") == verdict_outline.MAX_DETAILS
+    assert "detail 7" in block
+    assert "detail 8" not in block
+    # The marker belongs inside the detail list: it is the details that were dropped.
+    assert block.endswith(f"{verdict_outline.TRUNCATED_ITEM}</ul></li></ul>")
+
+
+def test_exactly_max_details_is_not_marked_truncated() -> None:
+    details = verdict_outline.MAX_DETAILS
+    block = render_outline_html(bullet("- topic", *(f"  - detail {index}" for index in range(details))))
+    assert block.count("<li>detail") == details
+    assert verdict_outline.TRUNCATED_ITEM not in block
+
+
+def test_the_block_budget_stops_the_emit() -> None:
+    block = render_outline_html(bullet(*("- " + '"' * 390 for _ in range(10))))
+    assert block.endswith(f"{verdict_outline.TRUNCATED_ITEM}</ul>")
+    assert block.count("<li><b>") < 10
+    assert_contained(block)
+
+
+def _sized_topic(item_length: int) -> str:
+    """A bullet whose rendered ``<li>`` is exactly ``item_length`` characters long."""
+    # Each `"` escapes to the six characters of `&quot;`; each `x` stays one and is not hex, so it
+    # cannot join a sha guard. Spending as much of the length as possible on quotes keeps the leaf
+    # itself under LEAF_CAP, where nothing clips it.
+    quotes, spare = divmod(item_length - len("<li><b></b></li>"), 6)
+    return "- " + '"' * quotes + "x" * spare
+
+
+def test_an_item_that_exactly_fills_the_budget_is_kept() -> None:
+    # The boundary the emit loop turns on. Five of these reach the budget to the character, so
+    # testing `>=` rather than `>` would silently drop the last item that fits.
+    item = 2400
+    topics = verdict_outline.BLOCK_BUDGET // item
+    block = render_outline_html(bullet(*([_sized_topic(item)] * (topics + 1))))
+    assert block.count("<li><b>") == topics
+    assert len(block) == verdict_outline.BLOCK_BUDGET + len("<ul></ul>") + len(verdict_outline.TRUNCATED_ITEM)
+
+
+def test_the_emitted_block_never_exceeds_the_budget() -> None:
+    # The last item used to be unbounded: the check ran before the append and the increment after,
+    # so one maximally escaped topic could carry the block past the budget by 9,000 characters.
+    ceiling = verdict_outline.BLOCK_BUDGET + len("<ul></ul>") + len(verdict_outline.TRUNCATED_ITEM)
+    quotes = '"' * verdict_outline.LEAF_CAP
+    widest = bullet(*((f"- {quotes}",) * verdict_outline.MAX_TOPICS))
+    assert len(render_outline_html(widest)) <= ceiling
+    deepest = bullet(f"- {quotes}", *((f"  - {quotes}",) * verdict_outline.MAX_DETAILS))
+    assert len(render_outline_html(deepest)) <= ceiling
+
+
+def test_a_single_item_over_the_budget_hands_the_message_to_the_fence() -> None:
+    # One topic with eight maximally escaped details is worth 21,000 characters on its own. It is
+    # dropped rather than emitted, so the bound above holds for every input -- and with nothing
+    # left but the marker there is no list to post, so the caller falls through to the fence,
+    # where the reader gets the message capped rather than a bare "(truncated)".
+    quotes = '"' * verdict_outline.LEAF_CAP
+    deepest = bullet(f"- {quotes}", *((f"  - {quotes}",) * verdict_outline.MAX_DETAILS))
+    assert render_outline_html(deepest) == ""
+
+
+def test_a_message_within_budget_is_not_marked_truncated() -> None:
+    assert verdict_outline.TRUNCATED_ITEM not in render_outline_html(bullet("- a", "- b"))
+
+
+def _sized_message(length: int, topics: int) -> str:
+    """A ``topics``-bullet outline exactly ``length`` characters long, no leaf near the leaf cap."""
+    body = length - (topics - 1) - topics * len("- ")
+    base, spare = divmod(body, topics)
+    return bullet(*("- " + "x" * (base + (1 if index < spare else 0)) for index in range(topics)))
+
+
+def test_a_message_exactly_at_the_cap_is_not_marked_truncated() -> None:
+    message = _sized_message(verdict_outline.MESSAGE_CAP, 10)
+    assert len(message) == verdict_outline.MESSAGE_CAP
+    block = render_outline_html(message)
+    assert block.count("<li><b>") == 10
+    assert verdict_outline.TRUNCATED_ITEM not in block
+
+
+def test_a_message_past_the_cap_says_the_list_is_short() -> None:
+    # The cap cuts the message before the first bullet is parsed, so no later clamp can notice it:
+    # without this mark, a list missing whatever the reviewer wrote past 4,000 characters -- and
+    # ending mid-sentence -- reads as the whole verdict.
+    block = render_outline_html(_sized_message(verdict_outline.MESSAGE_CAP + 1, 10))
+    # Neither of the clamps that already marked themselves fired here: ten topics is under the
+    # clamp, and no leaf is long enough to be clipped.
+    assert block.count("<li><b>") == 10
+    assert verdict_outline.TRUNCATION_SUFFIX not in block
+    assert block.endswith(f"{verdict_outline.TRUNCATED_ITEM}</ul>")
+
+
+# ---------------------------------------------------------------- runtime tripwire
+
+
+def test_a_line_break_in_the_assembled_block_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(verdict_outline, "_topic_html", lambda topic: "<li><b>a\nb</b></li>")
+    with pytest.raises(RuntimeError, match="line break"):
+        render_outline_html("- a")
+
+
+def test_unbalanced_code_tags_in_the_assembled_block_raise(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(verdict_outline, "_topic_html", lambda topic: "<li><b><code>a</b></li>")
+    with pytest.raises(RuntimeError, match="unbalanced"):
+        render_outline_html("- a")

--- a/greenlight/tests/test_verdict_outline.py
+++ b/greenlight/tests/test_verdict_outline.py
@@ -254,6 +254,31 @@ def test_details_survive_a_topic_that_flattens_away() -> None:
     assert block == "<ul><li><b>survivor</b></li></ul>"
 
 
+@pytest.mark.parametrize("dropped", ["- ", "-\t", f"- {ZWSP}{ZWSP}", f"- {BOM} {chr(0)}"])
+def test_a_dropped_topic_never_hands_its_details_to_the_topic_above_it(dropped: str) -> None:
+    # One stray empty bullet, and a blocker renders as evidence for an unrelated topic -- exactly
+    # the relationship promotion exists to prevent, and posted permanently. No adversary needed.
+    block = render_outline_html(bullet("- Scope", "  - one file", dropped, "  - NO_LAND: secrets leak"))
+    assert block == "<ul><li><b>Scope</b><ul><li>one file</li></ul></li><li><b>NO_LAND: secrets leak</b></li></ul>"
+
+
+def test_a_dropped_topic_between_two_real_ones_keeps_all_three_apart() -> None:
+    block = render_outline_html(bullet("- Scope", "- ", "  - promoted", "- Testing"))
+    assert block == "<ul><li><b>Scope</b></li><li><b>promoted</b></li><li><b>Testing</b></li></ul>"
+
+
+def test_details_under_a_dropped_topic_stay_peers() -> None:
+    # Two details of one dropped marker are siblings, exactly as two leading orphans are. Nesting
+    # the second under the first invents a parent and child out of two of the reviewer's claims.
+    block = render_outline_html(bullet("- Scope", "- ", "  - promoted", "  - second claim"))
+    assert block == "<ul><li><b>Scope</b></li><li><b>promoted</b></li><li><b>second claim</b></li></ul>"
+
+
+def test_a_detail_that_flattens_away_is_dropped_silently() -> None:
+    block = render_outline_html(bullet("- topic", f"  - {ZWSP}", "  - kept"))
+    assert block == "<ul><li><b>topic</b><ul><li>kept</li></ul></li></ul>"
+
+
 def test_empty_leaves_emit_no_list_item() -> None:
     block = render_outline_html(bullet("- ", "- kept", "- \t"))
     assert block == "<ul><li><b>kept</b></li></ul>"

--- a/torchci/lib/greenlight/greenlightCommitLine.ts
+++ b/torchci/lib/greenlight/greenlightCommitLine.ts
@@ -1,0 +1,35 @@
+// Whether a verdict still speaks for the PR's head, and how the comment says so.
+// The sibling of greenlightStaleness.ts: that one ages an in-flight review out by
+// wall clock, this one retires a finished one by commit. Both answer "is this row
+// still about the PR as it stands now", and neither can be derived from the other
+// -- a verdict minutes old is stale the moment a push lands, and one from last
+// month still holds if nothing was pushed since.
+
+import { shortSha } from "lib/greenlight/greenlightInlineCode";
+
+// Whether the verdict was reached on something other than the PR's current head.
+// A missing sha on either side means the comparison cannot be made, which is not
+// evidence of a mismatch.
+export function isOutdatedVerdict(
+  reviewedSha: string,
+  currentSha: string
+): boolean {
+  const reviewed = (reviewedSha || "").trim().toLowerCase();
+  const current = (currentSha || "").trim().toLowerCase();
+  return reviewed !== "" && current !== "" && reviewed !== current;
+}
+
+export function reviewedCommitLines(
+  headSha: string,
+  currentHeadSha: string
+): string[] {
+  const sha = (headSha || "").trim();
+  if (!sha) {
+    return [];
+  }
+  const line = `Reviewed commit: ${shortSha(sha)}`;
+  if (!isOutdatedVerdict(sha, currentHeadSha)) {
+    return [line];
+  }
+  return [`${line} (NOT the current head ${shortSha(currentHeadSha)})`];
+}

--- a/torchci/lib/greenlight/greenlightInlineCode.ts
+++ b/torchci/lib/greenlight/greenlightInlineCode.ts
@@ -1,0 +1,28 @@
+// Renders an untrusted scalar -- a verdict reason, a commit sha -- as a markdown
+// inline code span. The span is containment against the value breaking the line
+// it sits on, and nothing more: it neither escapes nor defuses, so a caller that
+// puts one in the comment body owns running defuseSweepSentinels over the
+// FINISHED line. Not over the value on its way in -- stripInlineBreakers deletes,
+// and a deletion splices the text on either side of it together, so a predicate
+// broken by exactly one backtick is invisible to a defuse that ran before it.
+
+// Characters that would end an inline code span or the line holding it.
+export const INLINE_BREAKERS_RE = /[`\r\n]/g;
+
+function stripInlineBreakers(value: string): string {
+  return value.replace(INLINE_BREAKERS_RE, "");
+}
+
+export function inlineCode(value: string): string {
+  return `\`${stripInlineBreakers(value)}\``;
+}
+
+// shortSha is the one rendered value that never reaches defuseSweepSentinels.
+// What makes that safe is arithmetic: kept under SWEEP_PREDICATE_MIN_LENGTH in
+// greenlightSweep.ts, no sha it emits is long enough to spell a predicate,
+// whatever the sha holds.
+export const SHORT_SHA_LENGTH = 7;
+
+export function shortSha(sha: string): string {
+  return inlineCode(sha.trim().slice(0, SHORT_SHA_LENGTH));
+}

--- a/torchci/lib/greenlight/greenlightRender.ts
+++ b/torchci/lib/greenlight/greenlightRender.ts
@@ -11,8 +11,17 @@
 // never sees it), and has a stalled state for a terminal row that never arrived.
 // No ClickHouse / Octokit / server-only imports, so this is unit-testable as-is.
 
-import { ADVISOR_PENDING_ALT_ATTR } from "lib/advisor/advisorBadge";
+import {
+  isOutdatedVerdict,
+  reviewedCommitLines,
+} from "lib/greenlight/greenlightCommitLine";
+import { inlineCode } from "lib/greenlight/greenlightInlineCode";
 import { isInProgressStale } from "lib/greenlight/greenlightStaleness";
+import {
+  defuseSweepSentinels,
+  GREENLIGHT_PENDING_ALT_ATTR,
+  ZERO_WIDTH_SPACE,
+} from "lib/greenlight/greenlightSweep";
 
 export const GREENLIGHT_STATUS_LAND = "LAND";
 export const GREENLIGHT_STATUS_NO_LAND = "NO_LAND";
@@ -54,7 +63,6 @@ export const GREENLIGHT_SECTION_HEADER = "GREEN LIGHT";
 
 // Mirrors _MESSAGE_CAP in comment_format.py.
 export const GREENLIGHT_MESSAGE_CAP = 4000;
-export const ZERO_WIDTH_SPACE = "\u200b";
 
 // GitHub does not soft-wrap inside a code fence, so an unwrapped verdict renders
 // as one line behind a horizontal scrollbar. 80 is the conventional terminal and
@@ -65,55 +73,17 @@ export const ZERO_WIDTH_SPACE = "\u200b";
 // rendered line being within the column.
 export const GREENLIGHT_MESSAGE_WRAP_WIDTH = 80;
 
-// The in-progress sentinel, shaped like the advisor's alt attribute (see
-// ADVISOR_PENDING_ALT_ATTR in lib/advisor/advisorBadge.ts) so both AI surfaces
-// in the comment are matched by the same cheap substring search. It is emitted
-// ONLY while a review is live; every terminal render omits it, which is how the
-// Dr.CI re-render candidate set self-clears once a verdict lands.
-export const GREENLIGHT_PENDING_ALT = "Green Light: in progress";
-export const GREENLIGHT_PENDING_ALT_ATTR = `alt="${GREENLIGHT_PENDING_ALT}"`;
 // Greenlight has no badge image to hang the attribute on, so the sentinel rides
 // an HTML comment: invisible once GitHub renders the body, but present in the
 // raw comment text the candidate query greps (the same trick as
 // `<!-- drci-comment-start -->`).
 const GREENLIGHT_PENDING_MARKER = `<!-- greenlight ${GREENLIGHT_PENDING_ALT_ATTR} -->`;
 
-// Every literal getPRsNeedingCommentRefresh (drci.ts) pins a PR into the sweep
-// on. Those predicates run over the RAW comment body, and the greenlight message
-// is the only model-authored text in it that is not HTML-escaped -- the fence in
-// defangGreenlightMessage stops the text RENDERING as markup but leaves the
-// characters themselves intact -- so a terminal render that carries one pins the
-// PR into every sweep forever, defeating the self-clearing the sentinel design
-// rests on.
-export const SWEEP_SENTINELS = [
-  GREENLIGHT_PENDING_ALT_ATTR,
-  ADVISOR_PENDING_ALT_ATTR,
-];
-// The sweep's third predicate is the regex `\d Pending`, meant to match the
-// comment's own "3 Pending" job count. Text merely describing the PR's CI state
-// trips it with no adversary involved, so break the token rather than delete a
-// word the reader needs.
-const SWEEP_PENDING_WORD = "Pending";
-const SWEEP_PENDING_WORD_DEFUSED = `P${ZERO_WIDTH_SPACE}ending`;
-// Shortest raw-body text any of those predicates can match: both attributes are
-// far longer than a `\d Pending` match, which is a digit and a space ahead of the
-// word. Renderer output too short to reach this cannot carry a predicate however
-// it is crafted, which is the only thing that lets a value skip the defuse.
-export const SWEEP_PREDICATE_MIN_LENGTH = Math.min(
-  ...SWEEP_SENTINELS.map((sentinel) => sentinel.length),
-  SWEEP_PENDING_WORD.length + 2
-);
-
 // Rendered only when the URL cannot break out of the `[text](url)` link AND
 // points at github.com. The host anchor has to be literal `github.com/`: a
 // userinfo prefix (`https://u:p@github.com/`) and a lookalike host
 // (`https://github.com.example/`) both satisfy a mere "contains github.com".
 const SAFE_JOB_URL_RE = /^https:\/\/github\.com\/[^\s()<>"'\\]+$/;
-
-// shortSha is the one rendered value that never reaches defuseSweepSentinels.
-// What makes that safe is arithmetic: kept under SWEEP_PREDICATE_MIN_LENGTH, no
-// sha it emits is long enough to spell a predicate, whatever the sha holds.
-export const SHORT_SHA_LENGTH = 7;
 
 export interface GreenlightState {
   prNumber: number;
@@ -199,64 +169,6 @@ export function defangGreenlightMessage(text: string): string {
   const longest = runs ? Math.max(...runs.map((run) => run.length)) : 0;
   const fence = "`".repeat(Math.max(3, longest + 1));
   return `${fence}\n${wrapMessage(neutralized)}\n${fence}`;
-}
-
-// Substituting a zero-width space for each sentinel, rather than deleting it, is
-// what makes a single pass sufficient. No sentinel contains that character, so a
-// surviving occurrence would have to lie wholly inside one fragment of a split
-// that by construction has none: neither a nested forgery
-// (`alt="Green alt="Green Light: in progress"Light: in progress"`) nor one
-// sentinel spliced together across the gap left by removing another can
-// reassemble, and no later substitution can put one back. Deleting would need a
-// fixpoint loop instead, which is quadratic in the message length -- `message` is
-// an unbounded ClickHouse String and the cap in defangGreenlightMessage is
-// applied after this, so a deeply nested 600 KB payload blocks the event loop for
-// seconds in a shared handler.
-function defuseSweepSentinels(text: string): string {
-  let out = text;
-  for (const sentinel of SWEEP_SENTINELS) {
-    out = out.split(sentinel).join(ZERO_WIDTH_SPACE);
-  }
-  return out.split(SWEEP_PENDING_WORD).join(SWEEP_PENDING_WORD_DEFUSED);
-}
-
-// Characters that would end an inline code span or the line holding it.
-export const INLINE_BREAKERS_RE = /[`\r\n]/g;
-
-function stripInlineBreakers(value: string): string {
-  return value.replace(INLINE_BREAKERS_RE, "");
-}
-
-function inlineCode(value: string): string {
-  return `\`${stripInlineBreakers(value)}\``;
-}
-
-// Whether the verdict was reached on something other than the PR's current head.
-// A missing sha on either side means the comparison cannot be made, which is not
-// evidence of a mismatch.
-function isOutdatedVerdict(reviewedSha: string, currentSha: string): boolean {
-  const reviewed = (reviewedSha || "").trim().toLowerCase();
-  const current = (currentSha || "").trim().toLowerCase();
-  return reviewed !== "" && current !== "" && reviewed !== current;
-}
-
-function shortSha(sha: string): string {
-  return inlineCode(sha.trim().slice(0, SHORT_SHA_LENGTH));
-}
-
-function reviewedCommitLines(
-  headSha: string,
-  currentHeadSha: string
-): string[] {
-  const sha = (headSha || "").trim();
-  if (!sha) {
-    return [];
-  }
-  const line = `Reviewed commit: ${shortSha(sha)}`;
-  if (!isOutdatedVerdict(sha, currentHeadSha)) {
-    return [line];
-  }
-  return [`${line} (NOT the current head ${shortSha(currentHeadSha)})`];
 }
 
 // Nothing may DELETE a character after the defuse: a deletion splices the text on

--- a/torchci/lib/greenlight/greenlightSweep.ts
+++ b/torchci/lib/greenlight/greenlightSweep.ts
@@ -1,0 +1,63 @@
+// The literals Dr.CI's re-render sweep greps a comment body for, and the single
+// pass that breaks them. drci.ts spells those predicates and greenlightRender.ts
+// has to break exactly the ones it spells, so the vocabulary the two share sits
+// below both rather than inside either. A second copy is a copy that can be
+// widened alone, and a predicate the sweep looks for and the renderer no longer
+// breaks pins its PR into every sweep for as long as the comment stands.
+
+import { ADVISOR_PENDING_ALT_ATTR } from "lib/advisor/advisorBadge";
+
+export const ZERO_WIDTH_SPACE = "\u200b";
+
+// The in-progress sentinel, shaped like the advisor's alt attribute (see
+// ADVISOR_PENDING_ALT_ATTR in lib/advisor/advisorBadge.ts) so both AI surfaces
+// in the comment are matched by the same cheap substring search. It is emitted
+// ONLY while a review is live; every terminal render omits it, which is how the
+// Dr.CI re-render candidate set self-clears once a verdict lands.
+const GREENLIGHT_PENDING_ALT = "Green Light: in progress";
+export const GREENLIGHT_PENDING_ALT_ATTR = `alt="${GREENLIGHT_PENDING_ALT}"`;
+
+// Every literal getPRsNeedingCommentRefresh (drci.ts) pins a PR into the sweep
+// on. Those predicates run over the RAW comment body, and the greenlight message
+// is the only model-authored text in it that is not HTML-escaped -- the fence in
+// defangGreenlightMessage stops the text RENDERING as markup but leaves the
+// characters themselves intact -- so a terminal render that carries one pins the
+// PR into every sweep forever, defeating the self-clearing the sentinel design
+// rests on.
+export const SWEEP_SENTINELS = [
+  GREENLIGHT_PENDING_ALT_ATTR,
+  ADVISOR_PENDING_ALT_ATTR,
+];
+// The sweep's third predicate is the regex `\d Pending`, meant to match the
+// comment's own "3 Pending" job count. Text merely describing the PR's CI state
+// trips it with no adversary involved, so break the token rather than delete a
+// word the reader needs.
+const SWEEP_PENDING_WORD = "Pending";
+const SWEEP_PENDING_WORD_DEFUSED = `P${ZERO_WIDTH_SPACE}ending`;
+// Shortest raw-body text any of those predicates can match: both attributes are
+// far longer than a `\d Pending` match, which is a digit and a space ahead of the
+// word. Renderer output too short to reach this cannot carry a predicate however
+// it is crafted, which is the only thing that lets a value skip the defuse.
+export const SWEEP_PREDICATE_MIN_LENGTH = Math.min(
+  ...SWEEP_SENTINELS.map((sentinel) => sentinel.length),
+  SWEEP_PENDING_WORD.length + 2
+);
+
+// Substituting a zero-width space for each sentinel, rather than deleting it, is
+// what makes a single pass sufficient. No sentinel contains that character, so a
+// surviving occurrence would have to lie wholly inside one fragment of a split
+// that by construction has none: neither a nested forgery
+// (`alt="Green alt="Green Light: in progress"Light: in progress"`) nor one
+// sentinel spliced together across the gap left by removing another can
+// reassemble, and no later substitution can put one back. Deleting would need a
+// fixpoint loop instead, which is quadratic in the message length -- `message` is
+// an unbounded ClickHouse String and the cap in defangGreenlightMessage is
+// applied after this, so a deeply nested 600 KB payload blocks the event loop for
+// seconds in a shared handler.
+export function defuseSweepSentinels(text: string): string {
+  let out = text;
+  for (const sentinel of SWEEP_SENTINELS) {
+    out = out.split(sentinel).join(ZERO_WIDTH_SPACE);
+  }
+  return out.split(SWEEP_PENDING_WORD).join(SWEEP_PENDING_WORD_DEFUSED);
+}

--- a/torchci/pages/api/drci/drci.ts
+++ b/torchci/pages/api/drci/drci.ts
@@ -48,7 +48,7 @@ import {
 } from "lib/fetchRecentWorkflows";
 import { getOctokit, getOctokitWithUserToken } from "lib/github";
 import { buildGreenlightSections } from "lib/greenlight/greenlightComment";
-import { GREENLIGHT_PENDING_ALT_ATTR } from "lib/greenlight/greenlightRender";
+import { GREENLIGHT_PENDING_ALT_ATTR } from "lib/greenlight/greenlightSweep";
 import {
   backfillMissingLog,
   getDisabledTestIssues,

--- a/torchci/test/greenlightComment.test.ts
+++ b/torchci/test/greenlightComment.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "fs";
 import * as clickhouse from "lib/clickhouse";
 import { buildGreenlightSections } from "lib/greenlight/greenlightComment";
 import * as greenlightRender from "lib/greenlight/greenlightRender";
+import { GREENLIGHT_PENDING_ALT_ATTR } from "lib/greenlight/greenlightSweep";
 import path from "path";
 
 const LAND_ROW = {
@@ -216,9 +217,7 @@ describe("buildGreenlightSections", () => {
       heads(row)
     );
 
-    expect(sections.get(row.pr_number)).toContain(
-      greenlightRender.GREENLIGHT_PENDING_ALT_ATTR
-    );
+    expect(sections.get(row.pr_number)).toContain(GREENLIGHT_PENDING_ALT_ATTR);
   });
 
   it("skips rows that render to nothing", async () => {

--- a/torchci/test/greenlightRender.test.ts
+++ b/torchci/test/greenlightRender.test.ts
@@ -1,5 +1,9 @@
 import { ADVISOR_PENDING_ALT_ATTR } from "lib/advisor/advisorBadge";
 import {
+  INLINE_BREAKERS_RE,
+  SHORT_SHA_LENGTH,
+} from "lib/greenlight/greenlightInlineCode";
+import {
   defangGreenlightMessage,
   GREENLIGHT_INCOMPLETE_HEADLINE,
   GREENLIGHT_LAND_HEADLINE,
@@ -7,19 +11,19 @@ import {
   GREENLIGHT_MESSAGE_WRAP_WIDTH,
   GREENLIGHT_NO_LAND_HEADLINE,
   GREENLIGHT_OUTDATED_HEADLINE_PREFIX,
-  GREENLIGHT_PENDING_ALT_ATTR,
   GREENLIGHT_REVERTED_BODY,
   GREENLIGHT_REVERTED_HEADLINE,
   GREENLIGHT_REVIEWING_HEADLINE,
   GreenlightState,
-  INLINE_BREAKERS_RE,
   renderGreenlightSection,
-  SHORT_SHA_LENGTH,
+} from "lib/greenlight/greenlightRender";
+import { GREENLIGHT_IN_PROGRESS_STALE_MS } from "lib/greenlight/greenlightStaleness";
+import {
+  GREENLIGHT_PENDING_ALT_ATTR,
   SWEEP_PREDICATE_MIN_LENGTH,
   SWEEP_SENTINELS,
   ZERO_WIDTH_SPACE,
-} from "lib/greenlight/greenlightRender";
-import { GREENLIGHT_IN_PROGRESS_STALE_MS } from "lib/greenlight/greenlightStaleness";
+} from "lib/greenlight/greenlightSweep";
 
 const JOB_URL = "https://github.com/pytorch/test-infra/actions/runs/42";
 // The shape ClickHouse returns for a DateTime64(3) under


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #8768
* #8767
* #8766
* #8765
* __->__ #8764
* #8763

**Impact:** none yet -- a Python module nothing imports
**Risk:** low

## What
Adds `verdict_outline.py`, which turns a model-authored markdown outline into a
single self-contained HTML bullet list, and the tests that hold it to that. Nothing
calls it: both comment surfaces are wired up later in this stack, and until then
every verdict still goes out in the fence it goes out in today.

## Why
A verdict message is written by a model that has just read an untrusted PR diff,
and it lands permanently on a public PR. The backtick fence it goes out in today is
the containment -- it is why a verdict cannot close the enclosing `<details>`, ping
a team, or smuggle a merge command. An outline has to render as markup, so the
fence has to go and something has to take its place.

That something is a CommonMark type-6 raw HTML block: a `<ul>` opening at column 0
with no blank line anywhere inside it, where the parser runs no inline parsing at
all, holding leaves that were HTML-escaped on the way in. Escaping alone would not
be enough -- a bare URL or an email address autolinks even fully backslash-escaped,
and only being inside the raw block stops that. So the block's one global invariant
is that it holds no line break anywhere, a blank line being what ends it and hands
the rest of the comment back to the markdown parser. A tripwire raises at render
time rather than emit a block that broke it.

# Notes
Five bounds hold the block down -- the message read to 4,000 characters, each leaf
clipped to 400, 8 details to a topic, 12 topics to a block, and 12,000 characters
of finished markup -- and every one of them marks where it cut, so a reader never
takes a truncated list for a complete one. Both character caps run before escaping,
which inflates text up to sixfold.