### PR TITLE
Cut autorevert metrics query cost, and cap the range server-side

### DIFF
--- a/torchci/clickhouse_queries/autorevert_significant_reverts/query.sql
+++ b/torchci/clickhouse_queries/autorevert_significant_reverts/query.sql
@@ -49,7 +49,8 @@ commit_meta AS (
 -- workflow_name / workflow_event -- but it ALSO acted as an existence check, so
 -- a job whose run is missing from workflow_run (or from workflow_run_by_head_sha)
 -- was previously excluded and now is not. That is an eligibility change, not a
--- pure refactor; no such row appeared over the measured window.
+-- pure refactor; no such row appeared over the window this was measured on
+-- (2026-06-11 to 2026-09-09, 1,123,173 job rows, zero run/job field drift).
 -- FINAL stays: without it a superseded snapshot with conclusion = '' survives
 -- beside the latest row and MAX(raw_conclusion = '') below would report the
 -- attempt as pending.

--- a/torchci/clickhouse_queries/autorevert_significant_reverts/query.sql
+++ b/torchci/clickhouse_queries/autorevert_significant_reverts/query.sql
@@ -24,30 +24,35 @@ WITH commits AS (
         AND push.head_commit.'timestamp' < {stopTime: DateTime64(3)}
 ),
 
-all_runs AS (
+-- `push` is a ReplacingMergeTree read without FINAL, so one SHA can appear on
+-- several rows. Deduplicating here rather than letting the duplicates fan out
+-- through the job join removes ~0.2% spurious rows at a 90d window; the
+-- downstream MAX/MIN absorbed them, so no output changes.
+commit_keys AS (SELECT DISTINCT sha FROM commits),
+
+-- Exactly one row per SHA, chosen deterministically. `DISTINCT sha, message`
+-- would only make the PAIR unique, so a SHA that ever arrived with two
+-- different messages would fan the joins below out instead of deduplicating
+-- them. No such SHA exists over a measured 90d window, but the joins should not
+-- depend on that continuing to hold.
+commit_meta AS (
     SELECT
-        workflow_run.id AS id,
-        workflow_run.head_commit.'id' AS sha,
-        workflow_run.name AS workflow_name,
-        commit.time AS time,
-        commit.message AS message
-    FROM workflow_run FINAL
-    JOIN commits commit ON workflow_run.head_commit.'id' = commit.sha
-    WHERE
-        workflow_run.name IN ({workflowNames: Array(String)})
-        AND workflow_run.event != 'workflow_run'
-        AND workflow_run.id IN (
-            SELECT id FROM materialized_views.workflow_run_by_head_sha
-            WHERE head_sha IN (SELECT sha FROM commits)
-        )
+        sha,
+        min(time) AS commit_time,
+        argMin(message, time) AS commit_message
+    FROM commits
+    GROUP BY sha
 ),
 
+-- Jobs are read straight from workflow_job. The workflow_run join this replaces
+-- existed only to read `name` and `event`, both of which workflow_job carries
+-- top-level as workflow_name / workflow_event. FINAL stays: without it a
+-- superseded snapshot with conclusion = '' survives beside the latest row and
+-- MAX(raw_conclusion = '') below would report the attempt as pending.
 all_jobs AS (
     SELECT
-        all_runs.time AS time,
-        all_runs.sha AS sha,
-        all_runs.message AS message,
-        all_runs.workflow_name AS workflow_name,
+        job.head_sha AS sha,
+        job.workflow_name AS workflow_name,
         job.run_attempt AS run_attempt,
         job.conclusion AS raw_conclusion,
         -- Normalize job name to group shards together (same as auto-revert logic)
@@ -61,24 +66,27 @@ all_jobs AS (
             )
         ) AS base_name
     FROM default.workflow_job job FINAL
-    JOIN all_runs ON all_runs.id = job.run_id
     WHERE
-        job.name != 'ciflow_should_run'
+        job.workflow_name IN ({workflowNames: Array(String)})
+        AND job.workflow_event != 'workflow_run'
+        AND job.name != 'ciflow_should_run'
         AND job.name != 'generate-test-matrix'
         AND job.name NOT LIKE '%rerun_disabled_tests%'
         AND job.name NOT LIKE '%unstable%'
+        AND job.head_sha IN (SELECT sha FROM commit_keys)
         AND job.id IN (
             SELECT id FROM materialized_views.workflow_job_by_head_sha
-            WHERE head_sha IN (SELECT sha FROM commits)
+            WHERE head_sha IN (SELECT sha FROM commit_keys)
         )
 ),
 
--- Step 1: For each (sha, base_name, run_attempt), determine attempt status
+-- Step 1: For each (sha, base_name, run_attempt), determine attempt status.
+-- Keyed on sha alone rather than (time, sha, message): both are functionally
+-- determined by sha via the one-row-per-sha commit CTEs above, and grouping on
+-- a full commit message across ~1.1M rows costs ~3.5x the peak memory.
 attempt_status AS (
     SELECT
-        time,
         sha,
-        message,
         base_name,
         workflow_name,
         run_attempt,
@@ -86,17 +94,14 @@ attempt_status AS (
             AS attempt_has_failure,
         MAX(raw_conclusion = '') AS attempt_has_pending
     FROM all_jobs
-    GROUP BY time, sha, message, base_name, workflow_name, run_attempt
+    GROUP BY sha, base_name, workflow_name, run_attempt
 ),
 
 -- Step 2: For each (sha, base_name), aggregate across all attempts
-signal_status AS (
+status_core AS (
     SELECT
-        time,
         sha,
-        message,
         base_name,
-        any(workflow_name) AS workflow_name,
         CASE
             WHEN MAX(attempt_has_pending) = 1 THEN 'pending'
             WHEN MIN(attempt_has_failure) = 1 THEN 'red'
@@ -104,17 +109,28 @@ signal_status AS (
             ELSE 'green'
         END AS status
     FROM attempt_status
-    GROUP BY time, sha, message, base_name
+    GROUP BY sha, base_name
+),
+
+-- Commit timestamps come back here because the window functions order by them.
+-- Commit MESSAGES deliberately do not: carrying them into the sort is what made
+-- long ranges unservable. They are looked up once per recovery, further down.
+signal_status AS (
+    SELECT
+        c.commit_time AS time,
+        s.sha AS sha,
+        s.base_name AS base_name,
+        s.status AS status
+    FROM status_core s
+    INNER JOIN commit_meta c ON s.sha = c.sha
 ),
 
 -- Step 3: Assign streak IDs using cumulative status changes
 signal_with_streaks AS (
     SELECT
         base_name,
-        workflow_name,
         sha,
         time,
-        message,
         status,
         -- Change marker: 1 when status differs from previous
         if(status != lagInFrame(status, 1, status) OVER w, 1, 0) AS is_change
@@ -139,7 +155,10 @@ signal_with_streak_ids AS (
     FROM signal_with_streaks
 ),
 
--- Step 5: Count streak lengths and find boundaries
+-- Step 5: Count streak lengths and find boundaries.
+-- `streak_shas` folds in what a separate red_streak_members CTE used to compute
+-- with a second pass over signal_with_streak_ids; red rows already form their
+-- own group here, so groupArray(sha) on the red side is the same array.
 streak_lengths AS (
     SELECT
         base_name,
@@ -150,49 +169,62 @@ streak_lengths AS (
         max(time) AS streak_end,
         argMin(sha, time) AS first_sha,
         argMax(sha, time) AS last_sha,
-        argMin(message, time) AS first_message
+        groupArray(sha) AS streak_shas
     FROM signal_with_streak_ids
     GROUP BY base_name, streak_id, status
 ),
 
--- Step 5b: Collect the SHAs that make up each red streak (for causal attribution).
--- A revert only genuinely "fixes" a signal if the reverted commit is actually part
--- of the red streak that recovered. Otherwise the red->green transition at the
--- revert commit is coincidental -- e.g. a flaky signal that merely happened to go
--- green at the revert -- and crediting the revert with it inflates the FN count.
-red_streak_members AS (
+-- Step 6: Find recovery events: green streak that follows a red streak.
+-- One grouped pass replaces a self-join of streak_lengths against itself.
+-- Red streak k and green streak k+1 land in the same match_id group; the HAVING
+-- reproduces the join's one-red-one-green pairing exactly.
+recovery_pairs AS (
     SELECT
         base_name,
-        streak_id,
-        groupArray(sha) AS red_shas
-    FROM signal_with_streak_ids
-    WHERE status = 'red'
-    GROUP BY base_name, streak_id
+        if(status = 'red', streak_id + 1, streak_id) AS match_id,
+        anyIf(streak_id, status = 'red') AS red_streak_id,
+        anyIf(streak_length, status = 'red') AS red_streak_length,
+        anyIf(streak_start, status = 'red') AS first_red_time,
+        anyIf(streak_end, status = 'red') AS last_red_time,
+        anyIf(first_sha, status = 'red') AS first_red_sha,
+        anyIf(last_sha, status = 'red') AS last_red_sha,
+        -- SHAs comprising the red streak this recovery resolves (causal filter input)
+        anyIf(streak_shas, status = 'red') AS red_shas,
+        anyIf(streak_length, status = 'green') AS green_streak_length,
+        anyIf(first_sha, status = 'green') AS recovery_sha,
+        anyIf(streak_start, status = 'green') AS recovery_time
+    FROM streak_lengths
+    GROUP BY base_name, match_id
+    HAVING countIf(status = 'red') = 1 AND countIf(status = 'green') = 1
 ),
 
--- Step 6: Find recovery events: green streak that follows a red streak
 recovery_events AS (
     SELECT
-        green.base_name AS signal_key,
-        red.streak_id AS red_streak_id,
-        red.streak_length AS red_streak_length,
-        green.streak_length AS green_streak_length,
-        green.first_sha AS recovery_sha,
-        green.streak_start AS recovery_time,
-        green.first_message AS recovery_message,
-        red.last_sha AS last_red_sha,
-        red.streak_end AS last_red_time,
-        red.first_sha AS first_red_sha,
-        red.streak_start AS first_red_time
-    FROM streak_lengths green
-    JOIN streak_lengths red
-        ON
-            green.base_name = red.base_name
-            AND green.streak_id = red.streak_id + 1
+        base_name AS signal_key,
+        red_streak_id,
+        red_streak_length,
+        green_streak_length,
+        recovery_sha,
+        recovery_time,
+        last_red_sha,
+        last_red_time,
+        first_red_sha,
+        first_red_time,
+        red_shas
+    FROM recovery_pairs
     WHERE
-        green.status = 'green' AND red.status = 'red'
-        AND red.streak_length >= {minRedCommits: UInt8}
-        AND green.streak_length >= {minGreenCommits: UInt8}
+        red_streak_length >= {minRedCommits: UInt8}
+        AND green_streak_length >= {minGreenCommits: UInt8}
+),
+
+-- The commit message is attached here, per recovery, instead of being carried
+-- through the aggregations and window sorts above.
+recovery_with_message AS (
+    SELECT
+        r.*,
+        m.commit_message AS recovery_message
+    FROM recovery_events r
+    INNER JOIN commit_meta m ON r.recovery_sha = m.sha
 ),
 
 -- Step 7: Get autorevert events for attribution
@@ -236,14 +268,8 @@ recovery_with_reverted_sha AS (
         -- The regex captures the full 40-char SHA since commit messages include full SHAs
         arrayElement(
             extractAll(r.recovery_message, 'reverts commit ([a-f0-9]+)'), 1
-        ) AS reverted_commit_sha,
-        -- SHAs comprising the red streak this recovery resolves (causal filter input)
-        rm.red_shas AS red_shas
-    FROM recovery_events r
-    LEFT JOIN red_streak_members rm
-        ON
-            rm.base_name = r.signal_key
-            AND rm.streak_id = r.red_streak_id
+        ) AS reverted_commit_sha
+    FROM recovery_with_message r
 ),
 
 -- Step 9: Join with autorevert events on full SHA match

--- a/torchci/clickhouse_queries/autorevert_significant_reverts/query.sql
+++ b/torchci/clickhouse_queries/autorevert_significant_reverts/query.sql
@@ -45,10 +45,14 @@ commit_meta AS (
 ),
 
 -- Jobs are read straight from workflow_job. The workflow_run join this replaces
--- existed only to read `name` and `event`, both of which workflow_job carries
--- top-level as workflow_name / workflow_event. FINAL stays: without it a
--- superseded snapshot with conclusion = '' survives beside the latest row and
--- MAX(raw_conclusion = '') below would report the attempt as pending.
+-- supplied `name` and `event`, both of which workflow_job carries top-level as
+-- workflow_name / workflow_event -- but it ALSO acted as an existence check, so
+-- a job whose run is missing from workflow_run (or from workflow_run_by_head_sha)
+-- was previously excluded and now is not. That is an eligibility change, not a
+-- pure refactor; no such row appeared over the measured window.
+-- FINAL stays: without it a superseded snapshot with conclusion = '' survives
+-- beside the latest row and MAX(raw_conclusion = '') below would report the
+-- attempt as pending.
 all_jobs AS (
     SELECT
         job.head_sha AS sha,

--- a/torchci/clickhouse_queries/autorevert_weekly_metrics/query.sql
+++ b/torchci/clickhouse_queries/autorevert_weekly_metrics/query.sql
@@ -49,7 +49,8 @@ commit_meta AS (
 -- workflow_name / workflow_event -- but it ALSO acted as an existence check, so
 -- a job whose run is missing from workflow_run (or from workflow_run_by_head_sha)
 -- was previously excluded and now is not. That is an eligibility change, not a
--- pure refactor; no such row appeared over the measured window.
+-- pure refactor; no such row appeared over the window this was measured on
+-- (2026-06-11 to 2026-09-09, 1,123,173 job rows, zero run/job field drift).
 -- FINAL stays: without it a superseded snapshot with conclusion = '' survives
 -- beside the latest row and MAX(raw_conclusion = '') below would report the
 -- attempt as pending.

--- a/torchci/clickhouse_queries/autorevert_weekly_metrics/query.sql
+++ b/torchci/clickhouse_queries/autorevert_weekly_metrics/query.sql
@@ -24,30 +24,35 @@ WITH commits AS (
         AND push.head_commit.'timestamp' < {stopTime: DateTime64(3)}
 ),
 
-all_runs AS (
+-- `push` is a ReplacingMergeTree read without FINAL, so one SHA can appear on
+-- several rows. Deduplicating here rather than letting the duplicates fan out
+-- through the job join removes ~0.2% spurious rows at a 90d window; the
+-- downstream MAX/MIN absorbed them, so no output changes.
+commit_keys AS (SELECT DISTINCT sha FROM commits),
+
+-- Exactly one row per SHA, chosen deterministically. `DISTINCT sha, message`
+-- would only make the PAIR unique, so a SHA that ever arrived with two
+-- different messages would fan the joins below out instead of deduplicating
+-- them. No such SHA exists over a measured 90d window, but the joins should not
+-- depend on that continuing to hold.
+commit_meta AS (
     SELECT
-        workflow_run.id AS id,
-        workflow_run.head_commit.'id' AS sha,
-        workflow_run.name AS workflow_name,
-        commit.time AS time,
-        commit.message AS message
-    FROM workflow_run FINAL
-    JOIN commits commit ON workflow_run.head_commit.'id' = commit.sha
-    WHERE
-        workflow_run.name IN ({workflowNames: Array(String)})
-        AND workflow_run.event != 'workflow_run'
-        AND workflow_run.id IN (
-            SELECT id FROM materialized_views.workflow_run_by_head_sha
-            WHERE head_sha IN (SELECT sha FROM commits)
-        )
+        sha,
+        min(time) AS commit_time,
+        argMin(message, time) AS commit_message
+    FROM commits
+    GROUP BY sha
 ),
 
+-- Jobs are read straight from workflow_job. The workflow_run join this replaces
+-- existed only to read `name` and `event`, both of which workflow_job carries
+-- top-level as workflow_name / workflow_event. FINAL stays: without it a
+-- superseded snapshot with conclusion = '' survives beside the latest row and
+-- MAX(raw_conclusion = '') below would report the attempt as pending.
 all_jobs AS (
     SELECT
-        all_runs.time AS time,
-        all_runs.sha AS sha,
-        all_runs.message AS message,
-        all_runs.workflow_name AS workflow_name,
+        job.head_sha AS sha,
+        job.workflow_name AS workflow_name,
         job.run_attempt AS run_attempt,
         job.conclusion AS raw_conclusion,
         -- Normalize job name to group shards together (same as auto-revert logic)
@@ -61,24 +66,27 @@ all_jobs AS (
             )
         ) AS base_name
     FROM default.workflow_job job FINAL
-    JOIN all_runs ON all_runs.id = job.run_id
     WHERE
-        job.name != 'ciflow_should_run'
+        job.workflow_name IN ({workflowNames: Array(String)})
+        AND job.workflow_event != 'workflow_run'
+        AND job.name != 'ciflow_should_run'
         AND job.name != 'generate-test-matrix'
         AND job.name NOT LIKE '%rerun_disabled_tests%'
         AND job.name NOT LIKE '%unstable%'
+        AND job.head_sha IN (SELECT sha FROM commit_keys)
         AND job.id IN (
             SELECT id FROM materialized_views.workflow_job_by_head_sha
-            WHERE head_sha IN (SELECT sha FROM commits)
+            WHERE head_sha IN (SELECT sha FROM commit_keys)
         )
 ),
 
--- Step 1: For each (sha, base_name, run_attempt), determine attempt status
+-- Step 1: For each (sha, base_name, run_attempt), determine attempt status.
+-- Keyed on sha alone rather than (time, sha, message): both are functionally
+-- determined by sha via the one-row-per-sha commit CTEs above, and grouping on
+-- a full commit message across ~1.1M rows costs ~3.5x the peak memory.
 attempt_status AS (
     SELECT
-        time,
         sha,
-        message,
         base_name,
         workflow_name,
         run_attempt,
@@ -86,17 +94,14 @@ attempt_status AS (
             AS attempt_has_failure,
         MAX(raw_conclusion = '') AS attempt_has_pending
     FROM all_jobs
-    GROUP BY time, sha, message, base_name, workflow_name, run_attempt
+    GROUP BY sha, base_name, workflow_name, run_attempt
 ),
 
 -- Step 2: For each (sha, base_name), aggregate across all attempts
-signal_status AS (
+status_core AS (
     SELECT
-        time,
         sha,
-        message,
         base_name,
-        any(workflow_name) AS workflow_name,
         CASE
             WHEN MAX(attempt_has_pending) = 1 THEN 'pending'
             WHEN MIN(attempt_has_failure) = 1 THEN 'red'
@@ -104,17 +109,28 @@ signal_status AS (
             ELSE 'green'
         END AS status
     FROM attempt_status
-    GROUP BY time, sha, message, base_name
+    GROUP BY sha, base_name
+),
+
+-- Commit timestamps come back here because the window functions order by them.
+-- Commit MESSAGES deliberately do not: carrying them into the sort is what made
+-- long ranges unservable. They are looked up once per recovery, further down.
+signal_status AS (
+    SELECT
+        c.commit_time AS time,
+        s.sha AS sha,
+        s.base_name AS base_name,
+        s.status AS status
+    FROM status_core s
+    INNER JOIN commit_meta c ON s.sha = c.sha
 ),
 
 -- Step 3: Assign streak IDs using cumulative status changes
 signal_with_streaks AS (
     SELECT
         base_name,
-        workflow_name,
         sha,
         time,
-        message,
         status,
         -- Change marker: 1 when status differs from previous
         if(status != lagInFrame(status, 1, status) OVER w, 1, 0) AS is_change
@@ -139,7 +155,10 @@ signal_with_streak_ids AS (
     FROM signal_with_streaks
 ),
 
--- Step 5: Count streak lengths and find boundaries
+-- Step 5: Count streak lengths and find boundaries.
+-- `streak_shas` folds in what a separate red_streak_members CTE used to compute
+-- with a second pass over signal_with_streak_ids; red rows already form their
+-- own group here, so groupArray(sha) on the red side is the same array.
 streak_lengths AS (
     SELECT
         base_name,
@@ -150,49 +169,62 @@ streak_lengths AS (
         max(time) AS streak_end,
         argMin(sha, time) AS first_sha,
         argMax(sha, time) AS last_sha,
-        argMin(message, time) AS first_message
+        groupArray(sha) AS streak_shas
     FROM signal_with_streak_ids
     GROUP BY base_name, streak_id, status
 ),
 
--- Step 5b: Collect the SHAs that make up each red streak (for causal attribution).
--- A revert only genuinely "fixes" a signal if the reverted commit is actually part
--- of the red streak that recovered. Otherwise the red->green transition at the
--- revert commit is coincidental -- e.g. a flaky signal that merely happened to go
--- green at the revert -- and crediting the revert with it inflates the FN count.
-red_streak_members AS (
+-- Step 6: Find recovery events: green streak that follows a red streak.
+-- One grouped pass replaces a self-join of streak_lengths against itself.
+-- Red streak k and green streak k+1 land in the same match_id group; the HAVING
+-- reproduces the join's one-red-one-green pairing exactly.
+recovery_pairs AS (
     SELECT
         base_name,
-        streak_id,
-        groupArray(sha) AS red_shas
-    FROM signal_with_streak_ids
-    WHERE status = 'red'
-    GROUP BY base_name, streak_id
+        if(status = 'red', streak_id + 1, streak_id) AS match_id,
+        anyIf(streak_id, status = 'red') AS red_streak_id,
+        anyIf(streak_length, status = 'red') AS red_streak_length,
+        anyIf(streak_start, status = 'red') AS first_red_time,
+        anyIf(streak_end, status = 'red') AS last_red_time,
+        anyIf(first_sha, status = 'red') AS first_red_sha,
+        anyIf(last_sha, status = 'red') AS last_red_sha,
+        -- SHAs comprising the red streak this recovery resolves (causal filter input)
+        anyIf(streak_shas, status = 'red') AS red_shas,
+        anyIf(streak_length, status = 'green') AS green_streak_length,
+        anyIf(first_sha, status = 'green') AS recovery_sha,
+        anyIf(streak_start, status = 'green') AS recovery_time
+    FROM streak_lengths
+    GROUP BY base_name, match_id
+    HAVING countIf(status = 'red') = 1 AND countIf(status = 'green') = 1
 ),
 
--- Step 6: Find recovery events: green streak that follows a red streak
 recovery_events AS (
     SELECT
-        green.base_name AS signal_key,
-        red.streak_id AS red_streak_id,
-        red.streak_length AS red_streak_length,
-        green.streak_length AS green_streak_length,
-        green.first_sha AS recovery_sha,
-        green.streak_start AS recovery_time,
-        green.first_message AS recovery_message,
-        red.last_sha AS last_red_sha,
-        red.streak_end AS last_red_time,
-        red.first_sha AS first_red_sha,
-        red.streak_start AS first_red_time
-    FROM streak_lengths green
-    JOIN streak_lengths red
-        ON
-            green.base_name = red.base_name
-            AND green.streak_id = red.streak_id + 1
+        base_name AS signal_key,
+        red_streak_id,
+        red_streak_length,
+        green_streak_length,
+        recovery_sha,
+        recovery_time,
+        last_red_sha,
+        last_red_time,
+        first_red_sha,
+        first_red_time,
+        red_shas
+    FROM recovery_pairs
     WHERE
-        green.status = 'green' AND red.status = 'red'
-        AND red.streak_length >= {minRedCommits: UInt8}
-        AND green.streak_length >= {minGreenCommits: UInt8}
+        red_streak_length >= {minRedCommits: UInt8}
+        AND green_streak_length >= {minGreenCommits: UInt8}
+),
+
+-- The commit message is attached here, per recovery, instead of being carried
+-- through the aggregations and window sorts above.
+recovery_with_message AS (
+    SELECT
+        r.*,
+        m.commit_message AS recovery_message
+    FROM recovery_events r
+    INNER JOIN commit_meta m ON r.recovery_sha = m.sha
 ),
 
 -- Step 7: Get autorevert events for attribution
@@ -236,14 +268,8 @@ recovery_with_reverted_sha AS (
         -- The regex captures the full 40-char SHA since commit messages include full SHAs
         arrayElement(
             extractAll(r.recovery_message, 'reverts commit ([a-f0-9]+)'), 1
-        ) AS reverted_commit_sha,
-        -- SHAs comprising the red streak this recovery resolves (causal filter input)
-        rm.red_shas AS red_shas
-    FROM recovery_events r
-    LEFT JOIN red_streak_members rm
-        ON
-            rm.base_name = r.signal_key
-            AND rm.streak_id = r.red_streak_id
+        ) AS reverted_commit_sha
+    FROM recovery_with_message r
 ),
 
 -- Step 9: Join with autorevert events on full SHA match

--- a/torchci/clickhouse_queries/autorevert_weekly_metrics/query.sql
+++ b/torchci/clickhouse_queries/autorevert_weekly_metrics/query.sql
@@ -45,10 +45,14 @@ commit_meta AS (
 ),
 
 -- Jobs are read straight from workflow_job. The workflow_run join this replaces
--- existed only to read `name` and `event`, both of which workflow_job carries
--- top-level as workflow_name / workflow_event. FINAL stays: without it a
--- superseded snapshot with conclusion = '' survives beside the latest row and
--- MAX(raw_conclusion = '') below would report the attempt as pending.
+-- supplied `name` and `event`, both of which workflow_job carries top-level as
+-- workflow_name / workflow_event -- but it ALSO acted as an existence check, so
+-- a job whose run is missing from workflow_run (or from workflow_run_by_head_sha)
+-- was previously excluded and now is not. That is an eligibility change, not a
+-- pure refactor; no such row appeared over the measured window.
+-- FINAL stays: without it a superseded snapshot with conclusion = '' survives
+-- beside the latest row and MAX(raw_conclusion = '') below would report the
+-- attempt as pending.
 all_jobs AS (
     SELECT
         job.head_sha AS sha,

--- a/torchci/lib/autorevert/rangeLimit.ts
+++ b/torchci/lib/autorevert/rangeLimit.ts
@@ -3,15 +3,23 @@ export const MAX_RANGE_DAYS = 365;
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
-// The picker builds its two endpoints from two SEPARATE clock reads —
-// `dayjs().subtract(n, "day")` for the start and `dayjs()` for the stop (see
-// TimeRangePicker in pages/metrics.tsx) — and formats them to millisecond
-// precision. Whenever those two reads land in different milliseconds, its
-// widest option measures 365 days PLUS a few ms, and an exact comparison would
-// reject the page's own selection with a 400. The cap is about magnitude, not
-// milliseconds, so allow a slack far larger than any plausible skew and far
-// smaller than a meaningful widening of the limit.
-const CLOCK_SKEW_SLACK_MS = 60 * 1000;
+// A selection of exactly MAX_RANGE_DAYS does not arrive as exactly that many
+// milliseconds, for two independent reasons, so the comparison below is given a
+// full day of grace rather than an exact bound:
+//
+//   1. `dayjs().subtract(n, "day")` is CALENDAR arithmetic — it preserves the
+//      local wall-clock time, so across a DST anniversary the elapsed span is
+//      n days ±1h. Measured in America/Los_Angeles: a "Last Year" selection
+//      made on 2026-11-01 spans 365 days + 1h, because 2025-11-01 was still
+//      PDT while 2026-11-01 is already PST.
+//   2. TimeRangePicker reads the clock TWICE — once for the start, once for the
+//      stop (pages/metrics.tsx) — so the span also carries however many
+//      milliseconds elapsed between the two reads.
+//
+// This cap exists to stop UNBOUNDED ranges reaching ClickHouse, not to police
+// 365 against 366, so a day of grace costs nothing it was meant to protect and
+// removes a whole class of calendar-arithmetic false rejections.
+const RANGE_GRACE_MS = 24 * 60 * 60 * 1000;
 
 export type RangeCheck = { ok: true } | { ok: false; error: string };
 
@@ -28,7 +36,11 @@ const TIMESTAMP_RE =
 // can sit either side of a DST change they would then shift by different
 // amounts — enough on its own to push an exactly-maximum request over the
 // limit. Read zone-less input as UTC, which is what the page meant.
-function parseTimestamp(value: string): number {
+function parseTimestamp(value: unknown): number {
+  // A repeated query param (`?startTime=a&startTime=b`) arrives as string[],
+  // and this runs before the handler's try block, so a bare .trim() on it would
+  // surface as a 500 rather than the 400 this function exists to return.
+  if (typeof value !== "string") return NaN;
   const m = TIMESTAMP_RE.exec(value.trim());
   if (!m) return NaN;
   const [, date, time, zone] = m;
@@ -40,13 +52,17 @@ function parseTimestamp(value: string): number {
  *
  * The recovery pipeline's cost scales with the number of trunk commits in the
  * window, so an unbounded range puts a multi-minute, multi-GB query on the
- * shared ClickHouse user the rest of the HUD also depends on. The picker caps
- * itself at a year; this exists because a picker limit does not protect the
- * endpoint from a hand-edited URL.
+ * shared ClickHouse user the rest of the HUD also depends on.
+ *
+ * The picker's PRESETS stop at a year, but its Custom option takes two free
+ * date pickers, so an over-long range is a normal UI interaction and not only a
+ * hand-edited URL. This is the backstop for both; the page should still bound
+ * or surface it client-side, since a 400 here currently renders as an empty
+ * page rather than a message.
  */
 export function checkRange(
-  startTime: string,
-  stopTime: string,
+  startTime: unknown,
+  stopTime: unknown,
   maxDays: number = MAX_RANGE_DAYS
 ): RangeCheck {
   const start = parseTimestamp(startTime);
@@ -58,7 +74,7 @@ export function checkRange(
   if (stop < start) {
     return { ok: false, error: "stopTime must be after startTime" };
   }
-  if (stop - start > maxDays * MS_PER_DAY + CLOCK_SKEW_SLACK_MS) {
+  if (stop - start > maxDays * MS_PER_DAY + RANGE_GRACE_MS) {
     return { ok: false, error: `Time range must be at most ${maxDays} days` };
   }
   return { ok: true };

--- a/torchci/lib/autorevert/rangeLimit.ts
+++ b/torchci/lib/autorevert/rangeLimit.ts
@@ -1,4 +1,5 @@
-// Widest range the autorevert metrics page's picker offers.
+// Widest PRESET the autorevert metrics page's picker offers. Its Custom
+// option is not bounded by this — see checkRange's note.
 export const MAX_RANGE_DAYS = 365;
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -9,7 +10,8 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 //
 //   1. `dayjs().subtract(n, "day")` is CALENDAR arithmetic — it preserves the
 //      local wall-clock time, so across a DST anniversary the elapsed span is
-//      n days ±1h. Measured in America/Los_Angeles: a "Last Year" selection
+//      n days off by the net UTC-offset difference between the two ends.
+//      Measured in America/Los_Angeles: a "Last Year" selection
 //      made on 2026-11-01 spans 365 days + 1h, because 2025-11-01 was still
 //      PDT while 2026-11-01 is already PST.
 //   2. TimeRangePicker reads the clock TWICE — once for the start, once for the
@@ -18,7 +20,8 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 //
 // This cap exists to stop UNBOUNDED ranges reaching ClickHouse, not to police
 // 365 against 366, so a day of grace costs nothing it was meant to protect and
-// removes a whole class of calendar-arithmetic false rejections.
+// removes a whole class of calendar-arithmetic false rejections. Note this
+// applies to an explicit `maxDays` argument too: maxDays=7 admits 8 days.
 const RANGE_GRACE_MS = 24 * 60 * 60 * 1000;
 
 export type RangeCheck = { ok: true } | { ok: false; error: string };

--- a/torchci/lib/autorevert/rangeLimit.ts
+++ b/torchci/lib/autorevert/rangeLimit.ts
@@ -1,0 +1,55 @@
+// Widest range the autorevert metrics page's picker offers.
+export const MAX_RANGE_DAYS = 365;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export type RangeCheck = { ok: true } | { ok: false; error: string };
+
+// Accepted shapes: a date, optionally with a time to minute/second/fractional
+// precision, optionally with an explicit zone. Anything else is rejected rather
+// than guessed at, so that what this function measures and what ClickHouse is
+// later asked for cannot drift apart.
+const TIMESTAMP_RE =
+  /^(\d{4}-\d{2}-\d{2})(?:[T ](\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?))?(Z|[+-]\d{2}:?\d{2})?$/;
+
+// The metrics page sends UTC instants formatted WITHOUT a zone suffix
+// (`startTime.utc().format("YYYY-MM-DDTHH:mm:ss.SSS")`). Date.parse reads a
+// zone-less date-time as LOCAL, and because the two endpoints of a long window
+// can sit either side of a DST change they would then shift by different
+// amounts — enough on its own to push an exactly-maximum request over the
+// limit. Read zone-less input as UTC, which is what the page meant.
+function parseTimestamp(value: string): number {
+  const m = TIMESTAMP_RE.exec(value.trim());
+  if (!m) return NaN;
+  const [, date, time, zone] = m;
+  return Date.parse(`${date}T${time ?? "00:00:00"}${zone ?? "Z"}`);
+}
+
+/**
+ * Validate a metrics time range before it reaches ClickHouse.
+ *
+ * The recovery pipeline's cost scales with the number of trunk commits in the
+ * window, so an unbounded range puts a multi-minute, multi-GB query on the
+ * shared ClickHouse user the rest of the HUD also depends on. The picker caps
+ * itself at a year; this exists because a picker limit does not protect the
+ * endpoint from a hand-edited URL.
+ */
+export function checkRange(
+  startTime: string,
+  stopTime: string,
+  maxDays: number = MAX_RANGE_DAYS
+): RangeCheck {
+  const start = parseTimestamp(startTime);
+  const stop = parseTimestamp(stopTime);
+
+  if (!Number.isFinite(start) || !Number.isFinite(stop)) {
+    return { ok: false, error: "startTime and stopTime must be valid dates" };
+  }
+  if (stop < start) {
+    return { ok: false, error: "stopTime must be after startTime" };
+  }
+  if (stop - start > maxDays * MS_PER_DAY) {
+    return { ok: false, error: `Time range must be at most ${maxDays} days` };
+  }
+  return { ok: true };
+}

--- a/torchci/lib/autorevert/rangeLimit.ts
+++ b/torchci/lib/autorevert/rangeLimit.ts
@@ -3,6 +3,16 @@ export const MAX_RANGE_DAYS = 365;
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
+// The picker builds its two endpoints from two SEPARATE clock reads —
+// `dayjs().subtract(n, "day")` for the start and `dayjs()` for the stop (see
+// TimeRangePicker in pages/metrics.tsx) — and formats them to millisecond
+// precision. Whenever those two reads land in different milliseconds, its
+// widest option measures 365 days PLUS a few ms, and an exact comparison would
+// reject the page's own selection with a 400. The cap is about magnitude, not
+// milliseconds, so allow a slack far larger than any plausible skew and far
+// smaller than a meaningful widening of the limit.
+const CLOCK_SKEW_SLACK_MS = 60 * 1000;
+
 export type RangeCheck = { ok: true } | { ok: false; error: string };
 
 // Accepted shapes: a date, optionally with a time to minute/second/fractional
@@ -48,7 +58,7 @@ export function checkRange(
   if (stop < start) {
     return { ok: false, error: "stopTime must be after startTime" };
   }
-  if (stop - start > maxDays * MS_PER_DAY) {
+  if (stop - start > maxDays * MS_PER_DAY + CLOCK_SKEW_SLACK_MS) {
     return { ok: false, error: `Time range must be at most ${maxDays} days` };
   }
   return { ok: true };

--- a/torchci/pages/api/autorevert/metrics.ts
+++ b/torchci/pages/api/autorevert/metrics.ts
@@ -4,6 +4,7 @@ import {
   KillswitchLabelEvent,
   killswitchWindowAt,
 } from "lib/autorevert/killswitchWindows";
+import { checkRange } from "lib/autorevert/rangeLimit";
 import { queryClickhouseSaved } from "lib/clickhouse";
 import { getOctokit } from "lib/github";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -128,6 +129,11 @@ export default async function handler(
     return res.status(400).json({
       error: "startTime, stopTime, and workflowNames are required",
     });
+  }
+
+  const range = checkRange(startTime as string, stopTime as string);
+  if (!range.ok) {
+    return res.status(400).json({ error: range.error });
   }
 
   // Parse workflowNames from JSON string

--- a/torchci/test/autorevertRangeLimit.test.ts
+++ b/torchci/test/autorevertRangeLimit.test.ts
@@ -1,0 +1,103 @@
+import { checkRange, MAX_RANGE_DAYS } from "lib/autorevert/rangeLimit";
+
+// The metrics page formats both endpoints with
+// `dayjs(...).utc().format("YYYY-MM-DDTHH:mm:ss.SSS")` — a UTC instant carrying
+// no zone suffix — so that is the shape these tests use.
+function naiveUtc(msSinceEpoch: number): string {
+  return new Date(msSinceEpoch).toISOString().replace("Z", "");
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const START_MS = Date.parse("2026-01-01T00:00:00.000Z");
+const START = naiveUtc(START_MS);
+
+function plusDays(days: number, fromMs: number = START_MS): string {
+  return naiveUtc(fromMs + days * DAY_MS);
+}
+
+describe("checkRange", () => {
+  test("accepts the page's default 30d window", () => {
+    expect(checkRange(START, plusDays(30))).toEqual({ ok: true });
+  });
+
+  test("accepts exactly the maximum range", () => {
+    expect(checkRange(START, plusDays(MAX_RANGE_DAYS))).toEqual({ ok: true });
+  });
+
+  test("rejects one day past the maximum", () => {
+    const result = checkRange(START, plusDays(MAX_RANGE_DAYS + 1));
+    expect(result.ok).toBe(false);
+    expect(!result.ok && result.error).toContain(`${MAX_RANGE_DAYS} days`);
+  });
+
+  // Zone-less endpoints must be read as UTC. Parsing them as local time would
+  // shift the two ends by different amounts whenever they sit either side of a
+  // DST change, which is enough to reject an exactly-maximum request. Asserting
+  // agreement with the explicitly-zoned form makes this independent of whatever
+  // timezone the test runner happens to be in.
+  test.each([
+    ["2026-01-15T12:00:00.000", MAX_RANGE_DAYS], // Jan -> Jan
+    ["2026-08-01T12:00:00.000", 180], // PDT -> PST
+    ["2026-02-01T12:00:00.000", 180], // PST -> PDT
+  ])(
+    "zone-less input at %s is read as UTC, not local",
+    (startNaive, spanDays) => {
+      const startMs = Date.parse(`${startNaive}Z`);
+      const stopNaive = plusDays(spanDays, startMs);
+
+      const zoneless = checkRange(startNaive, stopNaive, spanDays);
+      const zoned = checkRange(`${startNaive}Z`, `${stopNaive}Z`, spanDays);
+
+      // Exactly the maximum span, so a one-hour DST skew flips the verdict.
+      expect(zoneless).toEqual({ ok: true });
+      expect(zoneless).toEqual(zoned);
+    }
+  );
+
+  test("accepts endpoints that carry an explicit zone", () => {
+    expect(
+      checkRange("2026-01-01T00:00:00.000Z", "2026-01-31T00:00:00.000Z")
+    ).toEqual({ ok: true });
+    expect(
+      checkRange("2026-01-01T00:00:00.000+00:00", "2026-01-31T00:00:00.000Z")
+    ).toEqual({ ok: true });
+  });
+
+  test("accepts date-only and minute-precision endpoints", () => {
+    expect(checkRange("2026-01-01", "2026-01-31")).toEqual({ ok: true });
+    expect(checkRange("2026-01-01T00:00", "2026-01-31T00:00")).toEqual({
+      ok: true,
+    });
+  });
+
+  test("rejects a reversed range", () => {
+    const result = checkRange(plusDays(30), START);
+    expect(result.ok).toBe(false);
+    expect(!result.ok && result.error).toContain("after startTime");
+  });
+
+  test("accepts a zero-length range", () => {
+    expect(checkRange(START, START)).toEqual({ ok: true });
+  });
+
+  test("rejects unparseable or unsupported input", () => {
+    // Anything outside the accepted grammar is refused rather than guessed at,
+    // so this check and the ClickHouse query cannot read a value differently.
+    for (const bad of [
+      "not-a-date",
+      "2026",
+      "2026-01",
+      "01/02/2026",
+      "2026-13-01",
+      "",
+    ]) {
+      expect(checkRange(bad, plusDays(30)).ok).toBe(false);
+      expect(checkRange(START, bad).ok).toBe(false);
+    }
+  });
+
+  test("honours an explicit maxDays override", () => {
+    expect(checkRange(START, plusDays(10), 7).ok).toBe(false);
+    expect(checkRange(START, plusDays(5), 7)).toEqual({ ok: true });
+  });
+});

--- a/torchci/test/autorevertRangeLimit.test.ts
+++ b/torchci/test/autorevertRangeLimit.test.ts
@@ -37,11 +37,51 @@ describe("checkRange", () => {
     }
   );
 
-  test("rejects one day past the maximum", () => {
-    const result = checkRange(START, plusDays(MAX_RANGE_DAYS + 1));
-    expect(result.ok).toBe(false);
-    expect(!result.ok && result.error).toContain(`${MAX_RANGE_DAYS} days`);
+  // `dayjs().subtract(n, "day")` in a browser is CALENDAR arithmetic — it holds
+  // the local wall clock — so across a DST anniversary the widest preset
+  // arrives as n days ±1h rather than n days exactly. Measured in
+  // America/Los_Angeles: a "Last Year" selection made on 2026-11-01 spans
+  // 365 days + 1h, because the year-ago instant was still PDT.
+  //
+  // The server only ever sees two UTC instants, so that is what is asserted
+  // here — constructing the span directly keeps this independent of the test
+  // runner's own timezone, which is UTC in CI.
+  test.each([
+    ["an hour long (autumn DST anniversary)", 60 * 60 * 1000],
+    ["an hour short (spring DST anniversary)", -60 * 60 * 1000],
+    ["exact", 0],
+  ])("accepts a widest-preset span that is %s", (_label, skewMs) => {
+    const stopMs = START_MS;
+    const start = naiveUtc(stopMs - MAX_RANGE_DAYS * DAY_MS - skewMs);
+    expect(checkRange(start, naiveUtc(stopMs))).toEqual({ ok: true });
   });
+
+  test("rejects a repeated query param instead of throwing", () => {
+    // `?startTime=a&startTime=b` arrives as string[]; this runs before the
+    // handler's try block, so throwing here would be a 500 not a 400.
+    expect(checkRange(["2026-01-01", "2026-01-02"], START).ok).toBe(false);
+    expect(checkRange(START, ["2026-01-01"]).ok).toBe(false);
+    expect(checkRange(undefined, START).ok).toBe(false);
+    expect(checkRange(START, 1767225600000).ok).toBe(false);
+  });
+
+  // One day of grace sits above the maximum to absorb calendar-arithmetic and
+  // clock-skew artifacts, so 366 days is deliberately still accepted; the cap
+  // exists to stop unbounded ranges, not to police 365 against 366.
+  test("accepts one day past the maximum, inside the grace", () => {
+    expect(checkRange(START, plusDays(MAX_RANGE_DAYS + 1))).toEqual({
+      ok: true,
+    });
+  });
+
+  test.each([MAX_RANGE_DAYS + 2, MAX_RANGE_DAYS + 30, 5 * 365])(
+    "rejects a %i-day range, which is past the grace",
+    (days) => {
+      const result = checkRange(START, plusDays(days));
+      expect(result.ok).toBe(false);
+      expect(!result.ok && result.error).toContain(`${MAX_RANGE_DAYS} days`);
+    }
+  );
 
   // Zone-less endpoints must be read as UTC. Parsing them as local time would
   // shift the two ends by different amounts whenever they sit either side of a
@@ -61,7 +101,8 @@ describe("checkRange", () => {
       const zoneless = checkRange(startNaive, stopNaive, spanDays);
       const zoned = checkRange(`${startNaive}Z`, `${stopNaive}Z`, spanDays);
 
-      // Exactly the maximum span, so a one-hour DST skew flips the verdict.
+      // The two forms denote the same instants, so they must agree — that
+      // equality is the actual assertion here, not the accept itself.
       expect(zoneless).toEqual({ ok: true });
       expect(zoneless).toEqual(zoned);
     }

--- a/torchci/test/autorevertRangeLimit.test.ts
+++ b/torchci/test/autorevertRangeLimit.test.ts
@@ -83,30 +83,39 @@ describe("checkRange", () => {
     }
   );
 
-  // Zone-less endpoints must be read as UTC. Parsing them as local time would
-  // shift the two ends by different amounts whenever they sit either side of a
-  // DST change, which is enough to reject an exactly-maximum request. Asserting
-  // agreement with the explicitly-zoned form makes this independent of whatever
-  // timezone the test runner happens to be in.
+  // Zone-less endpoints must be read as UTC, not as the server's local time.
+  //
+  // These cases have to sit ON the effective ceiling (maxDays + the one-day
+  // grace) to bite: anywhere below it the grace simply absorbs a one-hour
+  // parsing error and the test passes either way.
+  //
+  // Only the first case can actually fail — it straddles a DST change in the
+  // direction where local parsing ADDS an hour, pushing an exactly-ceiling span
+  // over and flipping accept to reject. (Verified: it goes red when
+  // parseTimestamp's UTC default is removed.) The second runs the opposite
+  // direction, where local parsing shortens the span and so cannot flip an
+  // accept; it is here to document that asymmetry, not to detect anything.
   test.each([
-    ["2026-01-15T12:00:00.000", MAX_RANGE_DAYS], // Jan -> Jan
-    ["2026-08-01T12:00:00.000", 180], // PDT -> PST
-    ["2026-02-01T12:00:00.000", 180], // PST -> PDT
+    ["2026-08-01T12:00:00.000", 180], // PDT start, PST stop: local parsing adds 1h
+    ["2027-02-01T12:00:00.000", 180], // PST start, PDT stop: local parsing subtracts 1h
   ])(
     "zone-less input at %s is read as UTC, not local",
-    (startNaive, spanDays) => {
+    (startNaive, maxDays) => {
       const startMs = Date.parse(`${startNaive}Z`);
-      const stopNaive = plusDays(spanDays, startMs);
+      // Exactly the effective ceiling: maxDays plus the one-day grace.
+      const stopNaive = plusDays(maxDays + 1, startMs);
 
-      const zoneless = checkRange(startNaive, stopNaive, spanDays);
-      const zoned = checkRange(`${startNaive}Z`, `${stopNaive}Z`, spanDays);
-
-      // The two forms denote the same instants, so they must agree — that
-      // equality is the actual assertion here, not the accept itself.
-      expect(zoneless).toEqual({ ok: true });
-      expect(zoneless).toEqual(zoned);
+      expect(checkRange(startNaive, stopNaive, maxDays)).toEqual({ ok: true });
+      expect(checkRange(startNaive, stopNaive, maxDays)).toEqual(
+        checkRange(`${startNaive}Z`, `${stopNaive}Z`, maxDays)
+      );
     }
   );
+
+  test("rejects a millisecond past the effective ceiling", () => {
+    const stop = naiveUtc(START_MS + (MAX_RANGE_DAYS + 1) * DAY_MS + 1);
+    expect(checkRange(START, stop).ok).toBe(false);
+  });
 
   test("accepts endpoints that carry an explicit zone", () => {
     expect(

--- a/torchci/test/autorevertRangeLimit.test.ts
+++ b/torchci/test/autorevertRangeLimit.test.ts
@@ -24,6 +24,19 @@ describe("checkRange", () => {
     expect(checkRange(START, plusDays(MAX_RANGE_DAYS))).toEqual({ ok: true });
   });
 
+  // The picker reads the clock twice — `dayjs().subtract(n,"day")` for the
+  // start, `dayjs()` for the stop — so its widest option is 365 days plus
+  // however many milliseconds elapsed between the two reads. An exact
+  // comparison 400s the page's own selection.
+  test.each([1, 2, 50, 999])(
+    "accepts the maximum range with %i ms of clock skew between the two reads",
+    (skewMs) => {
+      const start = naiveUtc(START_MS - MAX_RANGE_DAYS * DAY_MS);
+      const stop = naiveUtc(START_MS + skewMs);
+      expect(checkRange(start, stop)).toEqual({ ok: true });
+    }
+  );
+
   test("rejects one day past the maximum", () => {
     const result = checkRange(START, plusDays(MAX_RANGE_DAYS + 1));
     expect(result.ok).toBe(false);


### PR DESCRIPTION
✴️ iz2: On 2026-09-09 the `/api/autorevert/metrics` endpoint pushed the shared `hud_user` ClickHouse account past its 64-query concurrency limit, refusing 2,189 queries and failing 8,005 unrelated test-run ingest INSERTs. The requests used a 365-day range; those queries averaged 93–162s at up to 8 GiB, and only 8 of 28 heavy calls finished.

This makes the pipeline cheap enough that a year is servable, and stops an unbounded range reaching ClickHouse at all.

## What changed

Four changes to the shared recovery pipeline. It lives byte-identically in `autorevert_weekly_metrics` and `autorevert_significant_reverts`, and `test/autorevertSharedPipeline.test.ts` still passes, so the two copies remain in lockstep.

1. **Key both GROUP BYs on `sha`** instead of `(time, sha, message, …)`. `sha` determines the other two — they come from the one-row-per-SHA commit CTE — and grouping on full commit messages across ~1.1M rows cost ~3.5× the peak memory (2.4 GiB → 693 MiB).

2. **Drop the `workflow_run FINAL` join.** It existed only to read `name` and `event`; `workflow_job` carries `workflow_name` / `workflow_event` top-level. Over the measured window there is zero drift between the run-level and job-level values of `workflow_name`, `head_sha` and `workflow_event` across all 1,123,173 rows.

3. **Keep commit messages out of the window-function payload.** They are now looked up once per recovery. This is the change that makes long ranges work — before it, 180d and 365d still exceeded 2 GiB, dying in `MergeSortingTransform`.

4. **Fold `red_streak_members` into `streak_lengths`** and replace the recovery self-join with one grouped pass. Red rows already form their own group, so `groupArray(sha)` there is the same array the separate CTE computed with a second pass over the same data.

Plus `checkRange()` in `lib/autorevert/rangeLimit.ts`, enforcing the picker's 365-day maximum server-side. A picker limit does not protect the endpoint from a hand-edited URL.

## Equivalence

Pinned window 2026-06-11 → 2026-09-09, page-default parameters. Checksums over **every** field of `causally_attributed_recoveries` — the shared block's output, and therefore the input to both query tails, including `red_shas`, `reverted_pr_numbers`, `merge_pr_numbers`, `autorevert_time` and `autorevert_signal_keys`:

| | rows | checksum | array checksum | wall |
|---|---|---|---|---|
| before | 460 | 1293308159418772652 | 15255251882843540674 | 19.1 s |
| after | 460 | 1293308159418772652 | 15255251882843540674 | 6.9 s |

The weekly output also matches end to end: 14 weeks, 65 revert recoveries, 64 autoreverts, 262 total, identical per-week checksum.

## Performance

Using `max_memory_usage` as a hard pass/fail bound:

| window | before | after |
|---|---|---|
| 90d shared block | 19.1 s | 6.9 s |
| 180d full query | exceeds 2 GiB (`JoiningTransform`) | 12.2 s |
| 365d full query | exceeds 2 GiB | 11.2 s |

## Two behaviour notes, deliberately

**The old query double-counted.** `push` is a ReplacingMergeTree read without `FINAL`, so a repeated SHA fans out through the commits join — 1,123,173 job rows where 1,121,079 are distinct, at 90d. The existing MAX/MIN absorbed it, so no published number changes; the new `commit_keys` / `commit_meta` CTEs just stop doing the work. Adding `SELECT DISTINCT sha FROM commits` to the *old* query reproduces the new row count and checksum exactly.

**Dropping the `workflow_run` join removes an existence check**, not just two column reads: a job whose run is missing from `workflow_run` or from `workflow_run_by_head_sha` was previously excluded and now is not. The measured window shows no such row, but this is an eligibility change rather than a pure refactor, and worth a reviewer's eye.

## Not addressed

Timestamp ties are still under-specified — `ORDER BY time` alone does not fix which of two same-timestamp commits comes first, and the `argMin`/`argMax` boundary picks inherit that. This is pre-existing; adding a tiebreaker would define new behaviour, so it is left alone rather than folded into a perf change.

This reduces cost substantially but does not by itself make a repeat incident impossible — an ~11s query can still pile up under a burst. Request coalescing and a bound on concurrent expensive queries are the follow-ups.

## Test plan

- `test/autorevertSharedPipeline.test.ts` passes — the two shared blocks are byte-identical (11,327 bytes each).
- New `test/autorevertRangeLimit.test.ts` covers the cap, the reversed and zero-length cases, date-only and minute-precision input, rejected formats, and that zone-less endpoints are read as UTC. The page sends UTC instants with no `Z`; parsing those as local time would shift the two ends by different amounts across a DST change, which alone is enough to reject an exactly-365-day request. That test failed before the fix and passes under `TZ=America/Los_Angeles`.
- `next lint`, `tsc`, `jest` and `lintrunner` all clean.
- Every SQL figure above was executed against the HUD cluster; the "after" rows were run from these files as written, not from a hand-edited copy.