### PR TITLE
[GreenLight] Exclude shadow rows from the HUD trunk and PR history queries

### DIFF
--- a/torchci/clickhouse_queries/greenlight_pr_state_history/query.sql
+++ b/torchci/clickhouse_queries/greenlight_pr_state_history/query.sql
@@ -9,6 +9,10 @@
 -- never landed. Mergebot rebases, so a trunk commit never carries the sha that
 -- was reviewed; this is what lets a commit page match its verdict without
 -- falling back to "some other verdict for the same PR".
+--
+-- Shadow rows carry no authority, and the exclusion sits in WHERE so they are
+-- gone before LIMIT 1 BY picks a winner: filtering after the collapse would
+-- hide the genuine verdict a later shadow row outranked.
 WITH reviewed AS (
     SELECT
         pr_number,
@@ -23,6 +27,7 @@ WITH reviewed AS (
     WHERE
         repo = {repo: String}
         AND pr_number = {prNumber: Int64}
+        AND shadow = false
     ORDER BY head_sha, run_id DESC, version DESC
     LIMIT 1 BY head_sha
 ),

--- a/torchci/clickhouse_queries/greenlight_trunk_commit_states/query.sql
+++ b/torchci/clickhouse_queries/greenlight_trunk_commit_states/query.sql
@@ -9,12 +9,17 @@
 -- head_sha with a higher run_id, which would otherwise erase the approval from
 -- a commit that was genuinely approved when it landed. The fixed re-landing is
 -- never reviewed again, so it has no row and the join drops it.
+--
+-- Shadow rows carry no authority, and the exclusion sits in WHERE so they are
+-- gone before LIMIT 1 BY picks a winner: filtering after the collapse would
+-- hide the genuine verdict a later shadow row outranked.
 WITH reviewed AS
 (
     SELECT pr_number, head_sha, status
     FROM misc.greenlight_pr_state
     WHERE repo = {repo: String}
       AND status IN ('LAND', 'NO_LAND')
+      AND shadow = false
     ORDER BY pr_number, head_sha, run_id DESC, version DESC
     LIMIT 1 BY pr_number, head_sha
 ),

--- a/torchci/test/greenlightHudState.test.ts
+++ b/torchci/test/greenlightHudState.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "fs";
 import {
   buildStateBySha,
   buildStatusByTrunkSha,
@@ -14,6 +15,7 @@ import {
   GREENLIGHT_STATUS_NO_LAND,
   GREENLIGHT_STATUS_REVERTED,
 } from "lib/greenlight/greenlightRender";
+import path from "path";
 
 function row(overrides: Partial<GreenlightPrStateRow>): GreenlightPrStateRow {
   return {
@@ -213,5 +215,60 @@ describe("selectStateForSha", () => {
   test("undefined when the PR has no recorded state at all", () => {
     expect(selectStateForSha(undefined, SHA_A)).toBeUndefined();
     expect(selectStateForSha([], SHA_A)).toBeUndefined();
+  });
+});
+
+// The helpers above are handed rows the HUD fetches by query name, so nothing here runs
+// the SQL and the only place its text can be pinned is the file itself.
+//
+// Comments are stripped because each header names both `shadow` and `LIMIT 1 BY` while
+// explaining why they sit in that order, and these assertions are about the statement.
+//
+// Both files declare a second CTE with its own WHERE / ORDER BY / LIMIT 1 BY, so a bare
+// indexOf would land in whichever one is written first. Slicing to `reviewed` is what
+// makes the ordering assertions about the CTE that reads misc.greenlight_pr_state rather
+// than about declaration order.
+function reviewedCte(queryName: string): string {
+  const sql = readFileSync(
+    path.resolve(__dirname, "..", "clickhouse_queries", queryName, "query.sql"),
+    "utf-8"
+  ).replace(/--.*$/gm, "");
+
+  const start = sql.indexOf("reviewed AS");
+  const end = sql.indexOf("landed AS");
+  if (start < 0 || end <= start) {
+    throw new Error(
+      `${queryName}: expected a \`reviewed\` CTE declared ahead of \`landed\``
+    );
+  }
+  return sql.slice(start, end);
+}
+
+describe.each([
+  ["greenlight_trunk_commit_states"],
+  ["greenlight_pr_state_history"],
+])("%s query.sql, reviewed CTE", (queryName) => {
+  const cte = reviewedCte(queryName);
+
+  test("excludes shadow rows, whose evaluation carries no authority", () => {
+    expect(cte).toContain("AND shadow = false");
+  });
+
+  test("filters in WHERE, ahead of the LIMIT 1 BY collapse", () => {
+    const where = cte.indexOf("WHERE");
+    const shadow = cte.indexOf("shadow");
+    const order = cte.indexOf("ORDER BY");
+    const limit = cte.indexOf("LIMIT 1 BY");
+
+    expect(where).toBeGreaterThan(-1);
+    expect(shadow).toBeGreaterThan(where);
+    expect(shadow).toBeLessThan(order);
+    expect(order).toBeLessThan(limit);
+    // run_id climbs with every dispatch, so a shadow row written after a real verdict
+    // outranks it: filtering only after the collapse would let that row win LIMIT 1 BY
+    // and then be dropped, hiding the genuine verdict instead of falling back to it. A
+    // second mention placed after the collapse satisfies every check above, so pin that
+    // there is exactly one.
+    expect(cte.lastIndexOf("shadow")).toBe(shadow);
   });
 });


### PR DESCRIPTION
**Impact:** HUD viewers — the trunk GreenLight column and the PR page's per-commit picker 
**Risk:** low

## What
Adds `AND shadow = false` to the `reviewed` CTE of `greenlight_trunk_commit_states` and `greenlight_pr_state_history`, so shadow evaluations no longer surface as verdicts on the HUD. The filter sits in `WHERE`, ahead of `LIMIT 1 BY`, and the new tests pin both the exclusion and its position.

## Why
Shadow evaluations are dry runs with no authority — Dr.CI has always dropped them (`greenlight_pr_states` filters on `shadow`), but the two commit-scoped queries added later never did. Result: shadow verdicts were rendered on trunk and PR pages for repos and authors that are not opted into GreenLight, which reads as a real land/no-land signal.

Placement matters as much as the filter itself. `run_id` climbs with every dispatch, so a shadow row written after a genuine verdict outranks it; filtering only after the collapse would let the shadow row win `LIMIT 1 BY` and then be dropped, hiding the real verdict instead of falling back to it.

# Notes
Nothing runs this SQL in tests, so the assertions read `query.sql` directly and slice out the `reviewed` CTE — both files have a second CTE with its own `WHERE`/`ORDER BY`/`LIMIT 1 BY`, and a bare `indexOf` would land in the wrong one.