### PR TITLE
Preserve host-provisioned NVIDIA drivers during job setup

### DIFF
--- a/.github/actions/setup-nvidia/action.yml
+++ b/.github/actions/setup-nvidia/action.yml
@@ -4,13 +4,9 @@ description: Set up NVIDIA driver and NVIDIA-docker runtime on Linux runner
 
 inputs:
   driver-version:
-    description: which driver version to install
+    description: 'Exact driver version to install; empty preserves a working driver at least 580.65.06'
     required: false
     type: string
-    default: "580.65.06" # https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-580-65-06/
-  driver-download-url:
-    description: 'Driver installer URL; empty uses the ossci-linux mirror'
-    required: false
     default: ''
 
 outputs:
@@ -79,8 +75,7 @@ runs:
       if: ${{ steps.detect-gpu.outputs.HAS_NVIDIA == 'true' && steps.check-container.outputs.IN_CONTAINER_RUNNER != 'true' }}
       uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
       env:
-        DRIVER_VERSION: ${{ inputs.driver-version }}
-        DRIVER_DOWNLOAD_URL: ${{ inputs.driver-download-url }}
+        REQUESTED_DRIVER_VERSION: ${{ inputs.driver-version }}
       with:
         timeout_minutes: 10
         max_attempts: 3
@@ -90,6 +85,7 @@ runs:
           set -eou pipefail
 
           DISTRIBUTION=$(. /etc/os-release;echo $ID$VERSION_ID)
+          DRIVER_VERSION="${REQUESTED_DRIVER_VERSION:-580.65.06}"
           DRIVER_FN="NVIDIA-Linux-x86_64-${DRIVER_VERSION}.run"
 
           install_nvidia_docker2_amzn2() {
@@ -152,19 +148,30 @@ runs:
 
                       if [ "$NVIDIA_SMI_STATUS" -ne 0 ] && [ "$NVIDIA_SMI_STATUS" -ne 14 ]; then
                           echo "Failed to get NVIDIA driver version ($INSTALLED_DRIVER_VERSION). Continuing"
-                      elif [ "$INSTALLED_DRIVER_VERSION" != "$DRIVER_VERSION" ]; then
-                          echo "NVIDIA driver ($INSTALLED_DRIVER_VERSION) has been installed, but we expect to have $DRIVER_VERSION instead. Continuing"
-
-                          # Turn off persistent mode so that the installation script can unload the kernel module
-                          sudo killall nvidia-persistenced || true
-                      else
-                          HAS_NVIDIA_DRIVER=1
-                          echo "NVIDIA driver ($INSTALLED_DRIVER_VERSION) has already been installed. Skipping NVIDIA driver installation"
+                      elif [[ "$INSTALLED_DRIVER_VERSION" =~ ^[0-9]+(\.[0-9]+)+$ ]] && {
+                          [ "$INSTALLED_DRIVER_VERSION" = "$DRIVER_VERSION" ] || {
+                              [ -z "$REQUESTED_DRIVER_VERSION" ] &&
+                              [ "$(printf '%s\n' "$DRIVER_VERSION" "$INSTALLED_DRIVER_VERSION" | sort -V | head -n 1)" = "$DRIVER_VERSION" ]
+                          }
+                      }; then
+                          # A version query alone can succeed even when the GPU has crashed.
+                          nvidia-smi --query-gpu=gpu_name --format=csv,noheader --id=0
+                          NVIDIA_SMI_STATUS=$?
+                          if [ "$NVIDIA_SMI_STATUS" -eq 0 ] || [ "$NVIDIA_SMI_STATUS" -eq 14 ]; then
+                              HAS_NVIDIA_DRIVER=1
+                              echo "Keeping installed NVIDIA driver $INSTALLED_DRIVER_VERSION"
+                          fi
                       fi
                       set -e
                   fi
 
                   if [ "$HAS_NVIDIA_DRIVER" -eq 0 ]; then
+                      echo "Installing NVIDIA driver $DRIVER_VERSION"
+                      # Stop persistence before replacing the driver, never on the retention path.
+                      sudo killall nvidia-persistenced || true
+                      if [[ "${DISTRIBUTION}" == amzn* ]]; then
+                          pre_install_nvidia_driver_amzn2
+                      fi
                       # CAUTION: this may need to be updated in future
                       if [ "${DISTRIBUTION}" != ubuntu20.04 ]; then
                             sudo yum groupinstall -y "Development Tools"
@@ -173,7 +180,7 @@ runs:
                             sudo yum install -y "kernel-devel-uname-r == $(uname -r)"
                             sudo modprobe backlight
                       fi
-                      sudo curl -fsL -o /tmp/nvidia_driver "${DRIVER_DOWNLOAD_URL:-https://s3.amazonaws.com/ossci-linux/nvidia_driver/$DRIVER_FN}"
+                      sudo curl -fsL -o /tmp/nvidia_driver "https://s3.amazonaws.com/ossci-linux/nvidia_driver/$DRIVER_FN"
 
                       set +e
                       sudo /bin/bash /tmp/nvidia_driver -s --no-drm
@@ -273,7 +280,6 @@ runs:
           install_nvidia_driver_amzn2() {
               (
                   set -x
-                  pre_install_nvidia_driver_amzn2
                   install_nvidia_driver_common
                   post_install_nvidia_driver_common
               )

--- a/.github/actions/setup-nvidia/action.yml
+++ b/.github/actions/setup-nvidia/action.yml
@@ -8,6 +8,10 @@ inputs:
     required: false
     type: string
     default: "580.65.06" # https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-580-65-06/
+  driver-download-url:
+    description: 'Driver installer URL; empty uses the ossci-linux mirror'
+    required: false
+    default: ''
 
 outputs:
   has-nvidia:
@@ -76,6 +80,7 @@ runs:
       uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
       env:
         DRIVER_VERSION: ${{ inputs.driver-version }}
+        DRIVER_DOWNLOAD_URL: ${{ inputs.driver-download-url }}
       with:
         timeout_minutes: 10
         max_attempts: 3
@@ -168,7 +173,7 @@ runs:
                             sudo yum install -y "kernel-devel-uname-r == $(uname -r)"
                             sudo modprobe backlight
                       fi
-                      sudo curl -fsL -o /tmp/nvidia_driver "https://s3.amazonaws.com/ossci-linux/nvidia_driver/$DRIVER_FN"
+                      sudo curl -fsL -o /tmp/nvidia_driver "${DRIVER_DOWNLOAD_URL:-https://s3.amazonaws.com/ossci-linux/nvidia_driver/$DRIVER_FN}"
 
                       set +e
                       sudo /bin/bash /tmp/nvidia_driver -s --no-drm

--- a/.github/scripts/test_setup_nvidia.py
+++ b/.github/scripts/test_setup_nvidia.py
@@ -1,0 +1,75 @@
+import os
+import subprocess
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class TestSetupNvidia(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        with (ROOT / ".github/actions/setup-nvidia/action.yml").open() as source:
+            cls.action = yaml.load(source, Loader=yaml.BaseLoader)
+        with (ROOT / ".github/workflows/linux_job_v2.yml").open() as source:
+            cls.workflow = yaml.load(source, Loader=yaml.BaseLoader)
+
+    def test_workflow_forwards_driver_inputs_with_existing_defaults(self):
+        inputs = self.workflow["on"]["workflow_call"]["inputs"]
+        step = next(
+            step
+            for step in self.workflow["jobs"]["job"]["steps"]
+            if step.get("id") == "install-nvidia-driver"
+        )
+        for name in ("driver-version", "driver-download-url"):
+            with self.subTest(name=name):
+                self.assertEqual(
+                    inputs[name]["default"], self.action["inputs"][name]["default"]
+                )
+                self.assertEqual(step["with"][name], "${{ inputs." + name + " }}")
+        self.assertEqual(inputs["driver-version"]["default"], "580.65.06")
+        self.assertEqual(inputs["driver-download-url"]["default"], "")
+
+    def test_download_uses_default_or_explicit_source(self):
+        step = next(
+            step
+            for step in self.action["runs"]["steps"]
+            if step.get("uses", "").startswith("nick-fields/retry@")
+        )
+        self.assertEqual(
+            step["env"]["DRIVER_DOWNLOAD_URL"], "${{ inputs.driver-download-url }}"
+        )
+        command = next(
+            line.strip()
+            for line in step["with"]["command"].splitlines()
+            if "sudo curl -fsL -o /tmp/nvidia_driver" in line
+        )
+        driver_file = "NVIDIA-Linux-x86_64-615.71.09.run"
+        mirror = "https://s3.amazonaws.com/ossci-linux/nvidia_driver/" + driver_file
+        official = (
+            "https://download.nvidia.com/XFree86/Linux-x86_64/615.71.09/" + driver_file
+        )
+        for url, expected in (("", mirror), (official, official)):
+            with self.subTest(url=url):
+                result = subprocess.run(
+                    ["bash", "-c", 'sudo() { printf "%s\\n" "$@"; }; ' + command],
+                    env={
+                        **os.environ,
+                        "DRIVER_FN": driver_file,
+                        "DRIVER_DOWNLOAD_URL": url,
+                    },
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(
+                    result.stdout.splitlines(),
+                    ["curl", "-fsL", "-o", "/tmp/nvidia_driver", expected],
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_setup_nvidia.py
+++ b/.github/scripts/test_setup_nvidia.py
@@ -1,5 +1,7 @@
 import os
+import shutil
 import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -8,67 +10,300 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
 
+# Execute the action's full command without touching host packages, devices, or Docker.
+STUBS = r"""
+record() { printf '%s\n' "$*" >> "$CALLS"; }
+function .() { ID="$OS_ID"; VERSION_ID="$OS_VERSION"; }
+command() {
+    if [ "$*" = '-v nvidia-smi' ]; then
+        [ "$MISSING_DRIVER" = 0 ] || [ -f "$INSTALLED" ] || return 1
+        printf '%s\n' "$FAKE_EXECUTABLE"
+    else
+        builtin command "$@"
+    fi
+}
+nvidia-smi() {
+    record "nvidia-smi $*"
+    case "$*" in
+        *query-gpu=driver_version*)
+            if [ -f "$INSTALLED" ]; then
+                cat "$INSTALLED"
+            else
+                printf '%s\n' "$HOST_DRIVER"
+                return "$VERSION_STATUS"
+            fi ;;
+        *query-gpu=gpu_name*)
+            printf 'NVIDIA A10G\n'
+            if [ ! -f "$INSTALLED" ] || [ "$REPAIR_HEALTH" = 0 ]; then
+                return "$HEALTH_STATUS"
+            fi ;;
+        *) return 0 ;;
+    esac
+}
+sudo() {
+    record "sudo $*"
+    case "$*" in
+        'curl '*) return "$DOWNLOAD_STATUS" ;;
+        '/bin/bash /tmp/nvidia_driver '*) printf '%s\n' "$DRIVER_VERSION" > "$INSTALLED" ;;
+    esac
+    return 0
+}
+lspci() { :; }
+lsmod() { :; }
+modinfo() { :; }
+uname() { printf 'test-kernel\n'; }
+dpkg-query() { printf 'installed\n'; }
+docker() { record "docker $*"; return "$DOCKER_STATUS"; }
+sleep() { :; }
+"""
+
 
 class TestSetupNvidia(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         with (ROOT / ".github/actions/setup-nvidia/action.yml").open() as source:
             cls.action = yaml.load(source, Loader=yaml.BaseLoader)
-        with (ROOT / ".github/workflows/linux_job_v2.yml").open() as source:
-            cls.workflow = yaml.load(source, Loader=yaml.BaseLoader)
-
-    def test_workflow_forwards_driver_inputs_with_existing_defaults(self):
-        inputs = self.workflow["on"]["workflow_call"]["inputs"]
-        step = next(
+        cls.install = next(
             step
-            for step in self.workflow["jobs"]["job"]["steps"]
-            if step.get("id") == "install-nvidia-driver"
-        )
-        for name in ("driver-version", "driver-download-url"):
-            with self.subTest(name=name):
-                self.assertEqual(
-                    inputs[name]["default"], self.action["inputs"][name]["default"]
-                )
-                self.assertEqual(step["with"][name], "${{ inputs." + name + " }}")
-        self.assertEqual(inputs["driver-version"]["default"], "580.65.06")
-        self.assertEqual(inputs["driver-download-url"]["default"], "")
-
-    def test_download_uses_default_or_explicit_source(self):
-        step = next(
-            step
-            for step in self.action["runs"]["steps"]
+            for step in cls.action["runs"]["steps"]
             if step.get("uses", "").startswith("nick-fields/retry@")
         )
+
+    def run_setup(self, requested=None, **overrides):
+        if requested is None:
+            requested = self.action["inputs"]["driver-version"]["default"]
+        with tempfile.TemporaryDirectory() as directory:
+            calls = Path(directory) / "calls"
+            env = {
+                **os.environ,
+                "CALLS": str(calls),
+                "INSTALLED": str(Path(directory) / "installed"),
+                "FAKE_EXECUTABLE": shutil.which("true"),
+                "HOST_DRIVER": "615.71.09",
+                "MISSING_DRIVER": "0",
+                "VERSION_STATUS": "0",
+                "HEALTH_STATUS": "0",
+                "REPAIR_HEALTH": "1",
+                "DOWNLOAD_STATUS": "0",
+                "DOCKER_STATUS": "0",
+                "OS_ID": "amzn",
+                "OS_VERSION": "2023",
+                **overrides,
+            }
+            for name, expression in self.install["env"].items():
+                if expression == "${{ inputs.driver-version }}":
+                    env[name] = requested
+                else:
+                    self.fail(f"Unexpected installer input: {name}={expression}")
+            result = subprocess.run(
+                ["bash", "-c", STUBS + self.install["with"]["command"]],
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            return result, calls.read_text().splitlines() if calls.exists() else []
+
+    def assert_retained(self, **options):
+        result, calls = self.run_setup(**options)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(
+            any(
+                marker in call
+                for call in calls
+                for marker in (
+                    "sudo yum remove",
+                    "sudo killall",
+                    "sudo curl",
+                    "sudo /bin/bash",
+                    "sudo tee",
+                    "sudo rm",
+                )
+            ),
+            calls,
+        )
+        self.assertIn(
+            "nvidia-smi --query-gpu=gpu_name --format=csv,noheader --id=0", calls
+        )
+        self.assertIn("sudo nvidia-persistenced", calls)
         self.assertEqual(
-            step["env"]["DRIVER_DOWNLOAD_URL"], "${{ inputs.driver-download-url }}"
+            calls[-1],
+            "docker run --rm -t --gpus=all public.ecr.aws/docker/library/python:3.13 nvidia-smi",
         )
-        command = next(
-            line.strip()
-            for line in step["with"]["command"].splitlines()
-            if "sudo curl -fsL -o /tmp/nvidia_driver" in line
+        return calls
+
+    def assert_installed(self, expected="580.65.06", **options):
+        result, calls = self.run_setup(**options)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        download = (
+            "sudo curl -fsL -o /tmp/nvidia_driver "
+            "https://s3.amazonaws.com/ossci-linux/nvidia_driver/"
+            f"NVIDIA-Linux-x86_64-{expected}.run"
         )
-        driver_file = "NVIDIA-Linux-x86_64-615.71.09.run"
-        mirror = "https://s3.amazonaws.com/ossci-linux/nvidia_driver/" + driver_file
-        official = (
-            "https://download.nvidia.com/XFree86/Linux-x86_64/615.71.09/" + driver_file
+        self.assertIn(download, calls)
+        self.assertIn("sudo /bin/bash /tmp/nvidia_driver -s --no-drm", calls)
+        return calls
+
+    def test_default_preserves_sufficient_healthy_drivers(self):
+        for driver in (
+            "580.65.06",
+            "580.82.07",
+            "580.100.01",
+            "580.178.04",
+            "615.71.09",
+        ):
+            with self.subTest(driver=driver):
+                self.assert_retained(HOST_DRIVER=driver)
+
+    def test_explicit_version_keeps_exact_selection(self):
+        for version in ("580.65.06", "615.71.09"):
+            with self.subTest(version=version):
+                self.assert_retained(requested=version, HOST_DRIVER=version)
+        self.assert_installed(requested="580.65.06", HOST_DRIVER="615.71.09")
+        self.assert_installed(
+            requested="615.71.09", HOST_DRIVER="580.65.06", expected="615.71.09"
         )
-        for url, expected in (("", mirror), (official, official)):
-            with self.subTest(url=url):
+
+    def test_default_repairs_missing_old_or_invalid_driver(self):
+        for options in (
+            {"MISSING_DRIVER": "1"},
+            {"HOST_DRIVER": "570.133.07"},
+            {"HOST_DRIVER": "580.9.10"},
+            {"HOST_DRIVER": "580.65.05"},
+            {"HOST_DRIVER": ""},
+            {"HOST_DRIVER": "N/A"},
+            {"HOST_DRIVER": "615.71.09\n615.71.09"},
+            {"VERSION_STATUS": "9"},
+            {"HEALTH_STATUS": "9"},
+        ):
+            with self.subTest(options=options):
+                self.assert_installed(**options)
+
+    def test_allowed_nvidia_query_status_is_preserved(self):
+        self.assert_retained(VERSION_STATUS="14", HEALTH_STATUS="14")
+
+    def test_package_removal_follows_driver_decision(self):
+        calls = self.assert_installed(HOST_DRIVER="570.133.07")
+        self.assertLess(
+            calls.index(
+                "nvidia-smi --query-gpu=driver_version --format=csv,noheader --id=0"
+            ),
+            calls.index("sudo yum remove -y nvidia-driver-latest-dkms"),
+        )
+        self.assertLess(
+            calls.index("sudo yum remove -y nvidia-driver-latest-dkms"),
+            calls.index("sudo /bin/bash /tmp/nvidia_driver -s --no-drm"),
+        )
+        self.assert_retained()
+
+    def test_ubuntu_preserves_driver_without_rpm_commands(self):
+        calls = self.assert_retained(OS_ID="ubuntu", OS_VERSION="20.04")
+        self.assertFalse(any("sudo yum" in call for call in calls), calls)
+        calls = self.assert_installed(
+            OS_ID="ubuntu", OS_VERSION="20.04", HOST_DRIVER="570.133.07"
+        )
+        self.assertFalse(any("sudo yum" in call for call in calls), calls)
+
+    def test_failures_still_fail_setup(self):
+        for options, expected in (
+            ({"HOST_DRIVER": "570.133.07", "DOWNLOAD_STATUS": "22"}, 22),
+            ({"HEALTH_STATUS": "9", "REPAIR_HEALTH": "0"}, 9),
+            ({"DOCKER_STATUS": "42"}, 42),
+            ({"OS_ID": "unsupported", "OS_VERSION": "1"}, 1),
+        ):
+            with self.subTest(options=options):
+                result, _ = self.run_setup(**options)
+                self.assertEqual(result.returncode, expected, result.stderr)
+
+    def test_gpu_detection_paths(self):
+        detect = next(
+            step
+            for step in self.action["runs"]["steps"]
+            if step.get("id") == "detect-gpu"
+        )
+        stubs = r"""
+command() { return 0; }
+nvidia-smi() { [ "$GPU_SOURCE" = smi ] && printf 'GPU 0: NVIDIA A10G\n'; }
+ls() { [ "$GPU_SOURCE" = device ] && printf '/dev/nvidia0\n'; }
+lspci() { [ "$GPU_SOURCE" = pci ] && printf 'NVIDIA Corporation\n'; }
+"""
+        for source in ("smi", "device", "pci", "none"):
+            with self.subTest(source=source):
+                with tempfile.TemporaryDirectory() as directory:
+                    output = Path(directory) / "output"
+                    command = detect["run"].replace(
+                        "/tmp/nvidia_devices", str(Path(directory) / "devices")
+                    )
+                    subprocess.run(
+                        ["bash", "-c", stubs + command],
+                        env={
+                            **os.environ,
+                            "GPU_SOURCE": source,
+                            "GITHUB_OUTPUT": str(output),
+                        },
+                        check=True,
+                        capture_output=True,
+                        text=True,
+                    )
+                    self.assertIn(
+                        f"HAS_NVIDIA={'false' if source == 'none' else 'true'}\n",
+                        output.read_text(),
+                    )
+
+    def test_container_guard_and_gpu_flag(self):
+        self.assertEqual(
+            self.install["if"],
+            "${{ steps.detect-gpu.outputs.HAS_NVIDIA == 'true' && "
+            "steps.check-container.outputs.IN_CONTAINER_RUNNER != 'true' }}",
+        )
+        marker_step = next(
+            step
+            for step in self.action["runs"]["steps"]
+            if step.get("id") == "check-container"
+        )
+        export_step = next(
+            step
+            for step in self.action["runs"]["steps"]
+            if step.get("name") == "Export GPU detection result"
+        )
+        for marker in ("", "/.inarc", "/.incontainer"):
+            with self.subTest(
+                marker=marker
+            ), tempfile.TemporaryDirectory() as directory:
+                output = Path(directory) / "output"
                 result = subprocess.run(
-                    ["bash", "-c", 'sudo() { printf "%s\\n" "$@"; }; ' + command],
-                    env={
-                        **os.environ,
-                        "DRIVER_FN": driver_file,
-                        "DRIVER_DOWNLOAD_URL": url,
-                    },
-                    check=True,
+                    [
+                        "bash",
+                        "-c",
+                        '[() { [[ "$1" = "-f" && "$2" = "$MARKER" ]]; }; '
+                        + marker_step["run"],
+                    ],
+                    env={**os.environ, "MARKER": marker, "GITHUB_OUTPUT": str(output)},
                     capture_output=True,
                     text=True,
+                    check=True,
                 )
                 self.assertEqual(
-                    result.stdout.splitlines(),
-                    ["curl", "-fsL", "-o", "/tmp/nvidia_driver", expected],
+                    output.read_text(),
+                    f"IN_CONTAINER_RUNNER={'true' if marker else 'false'}\n",
+                    result.stderr,
                 )
+        for has_gpu in ("true", "false"):
+            with self.subTest(
+                has_gpu=has_gpu
+            ), tempfile.TemporaryDirectory() as directory:
+                output = Path(directory) / "env"
+                subprocess.run(
+                    ["bash", "-c", export_step["run"]],
+                    env={
+                        **os.environ,
+                        "HAS_NVIDIA": has_gpu,
+                        "GITHUB_ENV": str(output),
+                    },
+                    check=True,
+                )
+                self.assertIn(f"HAS_NVIDIA_GPU={has_gpu}\n", output.read_text())
+                self.assertEqual("GPU_FLAG=" in output.read_text(), has_gpu == "true")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -94,14 +94,6 @@ on:
         description: "GPU arch version to use"
         default: ""
         type: string
-      driver-version:
-        description: 'NVIDIA driver version to install'
-        default: '580.65.06'
-        type: string
-      driver-download-url:
-        description: 'NVIDIA driver installer URL; empty uses the ossci-linux mirror'
-        default: ''
-        type: string
       job-name:
         description: "Name for the job, which is displayed in the GitHub UI"
         default: "linux-job"
@@ -249,9 +241,6 @@ jobs:
         id: install-nvidia-driver
         uses: ./test-infra/.github/actions/setup-nvidia
         if: ${{ inputs.gpu-arch-type == 'cuda' && steps.check_container_runner.outputs.IN_CONTAINER_RUNNER== 'false' }}
-        with:
-          driver-version: ${{ inputs.driver-version }}
-          driver-download-url: ${{ inputs.driver-download-url }}
 
       - name: Download artifacts (if any)
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/linux_job_v2.yml
+++ b/.github/workflows/linux_job_v2.yml
@@ -94,6 +94,14 @@ on:
         description: "GPU arch version to use"
         default: ""
         type: string
+      driver-version:
+        description: 'NVIDIA driver version to install'
+        default: '580.65.06'
+        type: string
+      driver-download-url:
+        description: 'NVIDIA driver installer URL; empty uses the ossci-linux mirror'
+        default: ''
+        type: string
       job-name:
         description: "Name for the job, which is displayed in the GitHub UI"
         default: "linux-job"
@@ -241,6 +249,9 @@ jobs:
         id: install-nvidia-driver
         uses: ./test-infra/.github/actions/setup-nvidia
         if: ${{ inputs.gpu-arch-type == 'cuda' && steps.check_container_runner.outputs.IN_CONTAINER_RUNNER== 'false' }}
+        with:
+          driver-version: ${{ inputs.driver-version }}
+          driver-download-url: ${{ inputs.driver-download-url }}
 
       - name: Download artifacts (if any)
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/test-setup-nvidia.yml
+++ b/.github/workflows/test-setup-nvidia.yml
@@ -5,7 +5,6 @@ on:
     paths:
       - .github/workflows/test-setup-nvidia.yml
       - .github/actions/setup-nvidia/action.yml
-      - .github/workflows/linux_job_v2.yml
       - .github/scripts/test_setup_nvidia.py
   workflow_dispatch:
 
@@ -17,32 +16,35 @@ jobs:
         runner-type:
           - linux.g5.4xlarge.nvidia.gpu
           - linux.g5.12xlarge.nvidia.gpu  # Choose a test case with multiple GPUs
-    name: Install NVIDIA driver on ${{ matrix.runner-type }}
+    name: Preserve NVIDIA driver on ${{ matrix.runner-type }}
     runs-on: ${{ matrix.runner-type }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Record host driver
+        id: host-driver
+        shell: bash
+        run: |
+          set -euo pipefail
+          nvidia-smi --query-gpu=gpu_name --format=csv,noheader
+          driver=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader --id=0)
+          test "$(printf '%s\n' '580.65.06' "$driver" | sort -V | head -n 1)" = '580.65.06'
+          echo "version=$driver" >> "$GITHUB_OUTPUT"
+
       - name: Test that setup-nvidia works
         uses: ./.github/actions/setup-nvidia
 
-  test-custom-driver:
-    uses: ./.github/workflows/linux_job_v2.yml
-    with:
-      runner: linux.g5.4xlarge.nvidia.gpu
-      timeout: 30
-      test-infra-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-      test-infra-ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      gpu-arch-type: cuda
-      gpu-arch-version: '13.4'
-      driver-version: '615.71.09'
-      driver-download-url: https://download.nvidia.com/XFree86/Linux-x86_64/615.71.09/NVIDIA-Linux-x86_64-615.71.09.run
-      use-custom-docker-registry: false
-      script: |
-        nvidia-smi
-        test "$(nvidia-smi --query-gpu=driver_version --format=csv,noheader --id=0)" = '615.71.09'
+      - name: Check host driver was preserved
+        shell: bash
+        env:
+          HOST_DRIVER: ${{ steps.host-driver.outputs.version }}
+        run: |
+          set -euo pipefail
+          test "$(nvidia-smi --query-gpu=driver_version --format=csv,noheader --id=0)" = "$HOST_DRIVER"
+          nvidia-smi --query-gpu=gpu_name --format=csv,noheader
 
-  test-inputs:
+  test-driver-policy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/test-setup-nvidia.yml
+++ b/.github/workflows/test-setup-nvidia.yml
@@ -49,5 +49,5 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
-      - run: pip install PyYAML
+      - run: pip install PyYAML==6.0.3
       - run: python .github/scripts/test_setup_nvidia.py

--- a/.github/workflows/test-setup-nvidia.yml
+++ b/.github/workflows/test-setup-nvidia.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - .github/workflows/test-setup-nvidia.yml
       - .github/actions/setup-nvidia/action.yml
+      - .github/workflows/linux_job_v2.yml
+      - .github/scripts/test_setup_nvidia.py
   workflow_dispatch:
 
 jobs:
@@ -23,3 +25,29 @@ jobs:
 
       - name: Test that setup-nvidia works
         uses: ./.github/actions/setup-nvidia
+
+  test-custom-driver:
+    uses: ./.github/workflows/linux_job_v2.yml
+    with:
+      runner: linux.g5.4xlarge.nvidia.gpu
+      timeout: 30
+      test-infra-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+      test-infra-ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      gpu-arch-type: cuda
+      gpu-arch-version: '13.4'
+      driver-version: '615.71.09'
+      driver-download-url: https://download.nvidia.com/XFree86/Linux-x86_64/615.71.09/NVIDIA-Linux-x86_64-615.71.09.run
+      use-custom-docker-registry: false
+      script: |
+        nvidia-smi
+        test "$(nvidia-smi --query-gpu=driver_version --format=csv,noheader --id=0)" = '615.71.09'
+
+  test-inputs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.12'
+      - run: pip install PyYAML
+      - run: python .github/scripts/test_setup_nvidia.py


### PR DESCRIPTION
## Problem

Default NVIDIA setup replaces any installed driver that differs from its fixed version, even when the host provides a newer working driver. On Amazon Linux, driver package removal also runs before the version check. Both behaviors can undo centrally managed host setup.

## Fix

When `driver-version` is omitted, keep a working driver at least 580.65.06. Missing, older, or unusable drivers still use the existing installer and mirror. An explicit version keeps its exact-version behavior. Decide whether replacement is needed before removing driver packages or stopping persistence. Keep GPU health and container-runtime checks.

Remove this PR's earlier workflow-level driver controls and custom download URL. This change preserves host provisioning; it does not deploy R615 or change Kubernetes node images. V100 runners must retain R580 support. The fleet upgrade approach remains under discussion in pytorch/ci-infra#1064.

ExecuTorch's merged CUDA compatibility workflow still uses the earlier pinned revision. That revision remains available and needs a separate caller update after the replacement host/image setup is validated. Its wheel workflow is separate and needs a compatible host before its container starts.

## Testing

Executable shell regressions cover default retention, explicit versions, invalid or unhealthy drivers, package-removal ordering, supported operating-system branches, container guards, GPU detection, and failure propagation. The retention and ordering checks fail on the base code. The old pinned caller's explicit setup was also checked after the revised default setup, with system operations intercepted.

Nine focused tests, the general test workflow, and lint pass. Both GPU jobs, with one and four A10Gs, preserved host driver 580.82.07 and passed the Docker GPU check. All GitHub Actions runs are complete without failures. Vercel separately requires deployment authorization. No new R615 installation or Kubernetes rollout has been validated.
