### PR TITLE
Capture the Claude Code CLI stderr the SDK discards

### DIFF
--- a/.github/workflows/_claude-code.yml
+++ b/.github/workflows/_claude-code.yml
@@ -190,7 +190,104 @@ jobs:
             core.exportVariable('GIT_AUTHOR_EMAIL', email);
             console.log(`Set commit author to: ${name} <${email}>`);
 
+      # ---------------------------------------------------------------------
+      # Diagnostic: capture the Claude Code CLI's stderr.
+      #
+      # claude-code-action drives the CLI through the Agent SDK's query() without
+      # a `stderr` handler, so when the child process dies the action can only
+      # report "SDK execution error: Error: Claude Code process exited with code
+      # 1" -- the child's own error text is discarded, and on that path the
+      # uploaded execution log is 2 bytes. pytorch/pytorch has been hitting this
+      # 1-13 times a day since 2026-09-06 with no way to diagnose or report any
+      # instance, because nobody can see what the CLI actually said.
+      #
+      # `path_to_claude_code_executable` is a documented action input: when set,
+      # the action skips its own install and runs that binary. Pointing it at a
+      # thin wrapper recovers the stderr without forking the action.
+      #
+      # BEST-EFFORT BY CONSTRUCTION. If this step fails, the action input below
+      # resolves empty and the action installs and runs the CLI exactly as it
+      # does today. That matters because this workflow is shared by the pytorch,
+      # meta-pytorch and executorch repos. The guarantee is scoped to a FAILURE
+      # OF THIS STEP -- it does not cover a wrapper that misbehaves once Claude
+      # is already running, and it does not undo a partial install.
+      - name: Install Claude Code CLI with stderr capture
+        id: stderr-capture
+        continue-on-error: true
+        # Bounded so a hung download cannot eat the invocation's whole budget:
+        # continue-on-error cannot rescue a job that has already timed out.
+        timeout-minutes: 4
+        shell: bash
+        env:
+          # MUST match the `uses:` SHA on the Run Claude Code step below; change
+          # the two together. The CLI VERSION is read from that revision rather
+          # than duplicated here, because the action hardcodes it as a constant
+          # in src/entrypoints/run.ts -- so a pin bump moves the CLI, and a
+          # hardcoded copy here would silently install a stale one.
+          CLAUDE_ACTION_SHA: 593d7a5c4e0073569f74772c2b7b64c30ec14707
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          SRC=$(gh api "repos/anthropics/claude-code-action/contents/src/entrypoints/run.ts?ref=${CLAUDE_ACTION_SHA}" --jq '.content' | base64 -d)
+          VERSION=$(printf '%s' "$SRC" | sed -n 's/.*claudeCodeVersion = "\([0-9][0-9.]*\)".*/\1/p' | head -1)
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::warning::could not read claudeCodeVersion from the pinned action; skipping stderr capture"
+            exit 1
+          fi
+          echo "action ${CLAUDE_ACTION_SHA} pins Claude Code v${VERSION}"
+
+          # This is the same installer the action itself runs; the bounds are so a
+          # stalled download cannot consume the invocation's whole time budget.
+          for attempt in 1 2 3; do
+            if curl -fsSL --connect-timeout 15 --max-time 120 https://claude.ai/install.sh \
+                 | timeout 120 bash -s -- "$VERSION"; then break; fi
+            [ "$attempt" = 3 ] && { echo "::warning::CLI install failed; skipping stderr capture"; exit 1; }
+            sleep 5
+          done
+
+          REAL_BIN="$HOME/.local/bin/claude"
+          [ -x "$REAL_BIN" ] || { echo "::warning::no executable at $REAL_BIN; skipping stderr capture"; exit 1; }
+
+          # A partial install can leave an executable that is not the version the
+          # action expects. Publishing that would be worse than not capturing.
+          INSTALLED=$("$REAL_BIN" --version 2>&1 | head -1 || true)
+          case "$INSTALLED" in
+            *"$VERSION"*) ;;
+            *) echo "::warning::installed CLI ('$INSTALLED') is not v${VERSION}; skipping stderr capture"; exit 1 ;;
+          esac
+
+          ERRLOG="$RUNNER_TEMP/claude-cli-stderr.log"
+          : > "$ERRLOG"
+          mkdir -p "$RUNNER_TEMP/claude-wrap"
+          WRAPPER="$RUNNER_TEMP/claude-wrap/claude"
+
+          # Paths are baked in with %q rather than read from the environment: the
+          # action's own `env:` block shadows names it sets, so this must not
+          # depend on which of them happen to pass through, and %q survives a
+          # quote or space in a runner path.
+          {
+            echo '#!/usr/bin/env bash'
+            printf 'exec %q "$@" 2>> %q\n' "$REAL_BIN" "$ERRLOG"
+          } > "$WRAPPER"
+          chmod +x "$WRAPPER"
+          # `exec` deliberately: it replaces this shell with the CLI, so the SDK's
+          # child IS the CLI. A wrapper that stayed resident would add a PID the
+          # SDK does not know about -- signals aimed at the child would hit bash
+          # instead, and a cancelled run could leave the CLI alive holding
+          # credentials. The cost is losing a wrapper-written timing footer; the
+          # stderr text is the thing worth having, and stdin (which the SDK
+          # streams the prompt over) and the exit code both pass through
+          # untouched.
+
+          {
+            echo "wrapper=$WRAPPER"
+            echo "errlog=$ERRLOG"
+            echo "cli_version=$VERSION"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Run Claude Code
+        id: claude
         uses: anthropics/claude-code-action@593d7a5c4e0073569f74772c2b7b64c30ec14707 # v1.0.141
         with:
           allowed_bots: "*"
@@ -198,10 +295,75 @@ jobs:
           claude_args: "--model ${{ inputs.model }} ${{ inputs.additional_claude_args }} ${{ steps.ghstack-check.outputs.extra_claude_args }}"
           settings: ${{ inputs.settings }}
           show_full_output: ${{ inputs.show_full_output }}
+          # Gated on the step's OUTCOME, not just a non-empty output: step
+          # outputs are not transactional, so a failure partway through writing
+          # them could otherwise publish a wrapper path the step then abandoned.
+          # Empty restores today's behaviour exactly.
+          path_to_claude_code_executable: ${{ steps.stderr-capture.outcome == 'success' && steps.stderr-capture.outputs.wrapper || '' }}
         env:
           APPEND_SYSTEM_PROMPT: |
               ${{ steps.ghstack-check.outputs.ghstack_notice }}
               ${{ inputs.append_system_prompt }}
+
+      # Printed ONLY when Claude failed. On a healthy run the CLI's stderr is
+      # noise, and these logs are public on pytorch/pytorch -- so the failing
+      # case, the one nobody can currently see, is the only one worth widening
+      # the surface for.
+      - name: Report captured CLI stderr
+        if: always() && steps.claude.outcome == 'failure' && steps.stderr-capture.outcome == 'success'
+        continue-on-error: true
+        shell: bash
+        env:
+          ERRLOG: ${{ steps.stderr-capture.outputs.errlog }}
+          CLI_VERSION: ${{ steps.stderr-capture.outputs.cli_version }}
+        run: |
+          set -euo pipefail
+          if [ ! -s "$ERRLOG" ]; then
+            echo "Claude Code CLI v${CLI_VERSION} wrote nothing to stderr."
+            exit 0
+          fi
+          # Two-layer redaction, because this can reach a PUBLIC log and the CLI
+          # runs with live AWS credentials in its environment -- the crash-dump
+          # case this exists to capture is exactly the one that prints an
+          # environment.
+          #
+          # Layer 1, and the load-bearing one: replace the VALUES actually in
+          # this job's environment. Shape matching alone misses
+          # AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN entirely, since neither
+          # has a recognisable prefix. GitHub also masks registered secrets, but
+          # that is not something this step should assume on a public repo.
+          python3 - "$ERRLOG" "${ERRLOG}.scrubbed" <<'PY'
+          import os, pathlib, sys
+          src, dst = sys.argv[1], sys.argv[2]
+          text = pathlib.Path(src).read_text(errors="replace")
+          for name in ("AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_ACCESS_KEY_ID",
+                       "AWS_BEARER_TOKEN_BEDROCK", "ANTHROPIC_API_KEY",
+                       "CLAUDE_CODE_OAUTH_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"):
+              value = os.environ.get(name, "")
+              # Short values are not credentials and a blind replace would shred
+              # ordinary text.
+              if len(value) >= 12:
+                  text = text.replace(value, f"***{name}***")
+          pathlib.Path(dst).write_text(text)
+          PY
+          # Layer 2: shapes, for anything not in this environment.
+          sed -E -i \
+            -e 's/(ASIA|AKIA)[A-Z0-9]{16}/***AWS_KEY_ID***/g' \
+            -e 's/sk-ant-[A-Za-z0-9_-]{16,}/***ANTHROPIC_KEY***/g' \
+            -e 's/(ghp|gho|ghs|ghu)_[A-Za-z0-9]{20,}/***GITHUB_TOKEN***/g' \
+            -e 's/github_pat_[A-Za-z0-9_]{20,}/***GITHUB_PAT***/g' \
+            -e 's/([Bb]earer )[A-Za-z0-9._~+\/-]{20,}=*/\1***REDACTED***/g' \
+            "${ERRLOG}.scrubbed"
+          echo "Claude Code CLI v${CLI_VERSION} stderr ($(stat -c %s "$ERRLOG") bytes, last 200 lines, credentials redacted):"
+          # Stop workflow-command parsing: this is program output, so an embedded
+          # ::...:: line must not be able to drive the runner. The token is
+          # random rather than a timestamp so it cannot be predicted from the log,
+          # and the resume is printed with a leading newline so it still starts on
+          # its own line if the captured text ended mid-line.
+          GUARD="stopcmd-$(openssl rand -hex 16)"
+          echo "::stop-commands::${GUARD}"
+          tail -200 "${ERRLOG}.scrubbed"
+          printf '\n::%s::\n' "$GUARD"
 
       - name: Upload usage metrics
         if: always()

--- a/.github/workflows/_claude-code.yml
+++ b/.github/workflows/_claude-code.yml
@@ -305,65 +305,49 @@ jobs:
               ${{ steps.ghstack-check.outputs.ghstack_notice }}
               ${{ inputs.append_system_prompt }}
 
-      # Printed ONLY when Claude failed. On a healthy run the CLI's stderr is
-      # noise, and these logs are public on pytorch/pytorch -- so the failing
-      # case, the one nobody can currently see, is the only one worth widening
-      # the surface for.
-      - name: Report captured CLI stderr
-        if: always() && steps.claude.outcome == 'failure' && steps.stderr-capture.outcome == 'success'
+      # Uploaded VERBATIM to a PRIVATE S3 prefix -- never printed to the job log,
+      # and never redacted.
+      #
+      # Redaction was the wrong tool here. The CLI runs with live AWS credentials
+      # in its environment, so publishing raw stderr to a pytorch/pytorch job log
+      # (which is public) would need a scrubber, and a scrubber is both lossy on
+      # the exact text we are trying to read and unfalsifiable -- you cannot show
+      # it caught everything. Writing somewhere non-public removes the need for
+      # one entirely, and gets the WHOLE stream rather than a truncated tail.
+      #
+      # `ossci-raw-job-status` grants public read by an explicit prefix
+      # ALLOWLIST -- log/, review-logs/, additional_info/, test_run/,
+      # test_run_summary/, failed_test_runs/, ossci_tutorials_stats/. Anything
+      # outside that list is readable only by the account, so `claude_cli_stderr/`
+      # is private by construction. Note this is deliberately NOT under
+      # `review-logs/`, where the execution log goes: that prefix IS public.
+      #
+      # Requires `s3:PutObject` on `claude_cli_stderr/*` for the
+      # gha_workflow_claude_code role, which is granted per-prefix. Until that
+      # lands the upload just fails and this step is a no-op.
+      - name: Upload captured CLI stderr
+        if: always() && steps.stderr-capture.outcome == 'success'
         continue-on-error: true
+        timeout-minutes: 2
         shell: bash
         env:
           ERRLOG: ${{ steps.stderr-capture.outputs.errlog }}
           CLI_VERSION: ${{ steps.stderr-capture.outputs.cli_version }}
+          CLAUDE_OUTCOME: ${{ steps.claude.outcome }}
+          ENTITY_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number || 0 }}
         run: |
           set -euo pipefail
           if [ ! -s "$ERRLOG" ]; then
-            echo "Claude Code CLI v${CLI_VERSION} wrote nothing to stderr."
+            echo "Claude Code CLI v${CLI_VERSION} wrote nothing to stderr; nothing to upload."
             exit 0
           fi
-          # Two-layer redaction, because this can reach a PUBLIC log and the CLI
-          # runs with live AWS credentials in its environment -- the crash-dump
-          # case this exists to capture is exactly the one that prints an
-          # environment.
-          #
-          # Layer 1, and the load-bearing one: replace the VALUES actually in
-          # this job's environment. Shape matching alone misses
-          # AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN entirely, since neither
-          # has a recognisable prefix. GitHub also masks registered secrets, but
-          # that is not something this step should assume on a public repo.
-          python3 - "$ERRLOG" "${ERRLOG}.scrubbed" <<'PY'
-          import os, pathlib, sys
-          src, dst = sys.argv[1], sys.argv[2]
-          text = pathlib.Path(src).read_text(errors="replace")
-          for name in ("AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_ACCESS_KEY_ID",
-                       "AWS_BEARER_TOKEN_BEDROCK", "ANTHROPIC_API_KEY",
-                       "CLAUDE_CODE_OAUTH_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"):
-              value = os.environ.get(name, "")
-              # Short values are not credentials and a blind replace would shred
-              # ordinary text.
-              if len(value) >= 12:
-                  text = text.replace(value, f"***{name}***")
-          pathlib.Path(dst).write_text(text)
-          PY
-          # Layer 2: shapes, for anything not in this environment.
-          sed -E -i \
-            -e 's/(ASIA|AKIA)[A-Z0-9]{16}/***AWS_KEY_ID***/g' \
-            -e 's/sk-ant-[A-Za-z0-9_-]{16,}/***ANTHROPIC_KEY***/g' \
-            -e 's/(ghp|gho|ghs|ghu)_[A-Za-z0-9]{20,}/***GITHUB_TOKEN***/g' \
-            -e 's/github_pat_[A-Za-z0-9_]{20,}/***GITHUB_PAT***/g' \
-            -e 's/([Bb]earer )[A-Za-z0-9._~+\/-]{20,}=*/\1***REDACTED***/g' \
-            "${ERRLOG}.scrubbed"
-          echo "Claude Code CLI v${CLI_VERSION} stderr ($(stat -c %s "$ERRLOG") bytes, last 200 lines, credentials redacted):"
-          # Stop workflow-command parsing: this is program output, so an embedded
-          # ::...:: line must not be able to drive the runner. The token is
-          # random rather than a timestamp so it cannot be predicted from the log,
-          # and the resume is printed with a leading newline so it still starts on
-          # its own line if the captured text ended mid-line.
-          GUARD="stopcmd-$(openssl rand -hex 16)"
-          echo "::stop-commands::${GUARD}"
-          tail -200 "${ERRLOG}.scrubbed"
-          printf '\n::%s::\n' "$GUARD"
+          KEY="claude_cli_stderr/${GITHUB_REPOSITORY}/${ENTITY_NUMBER}/${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}.log"
+          aws s3 cp "$ERRLOG" "s3://ossci-raw-job-status/${KEY}" \
+            --metadata "cli-version=${CLI_VERSION},claude-outcome=${CLAUDE_OUTCOME}"
+          # The pointer is safe to print; the contents are not. Anyone debugging a
+          # failure needs to know the capture exists and where it is.
+          echo "Claude Code CLI v${CLI_VERSION} stderr ($(stat -c %s "$ERRLOG") bytes, claude outcome=${CLAUDE_OUTCOME})"
+          echo "  s3://ossci-raw-job-status/${KEY}"
 
       - name: Upload usage metrics
         if: always()


### PR DESCRIPTION
✴️ iz2: `@claude` failures on pytorch/pytorch are currently undiagnosable — the CLI's error text is discarded before anyone can read it. This recovers it.

## The problem

`claude-code-action` drives the CLI through the Agent SDK's `query()` without a `stderr` handler ([`base-action/src/run-claude-sdk.ts`](https://github.com/anthropics/claude-code-action/blob/v1.0.141/base-action/src/run-claude-sdk.ts)). When the child dies, all the action can report is:

```
SDK execution error: Error: Claude Code process exited with code 1
```

The child's own stderr is dropped, and on that path `upload_execution_log` writes a **2-byte** file. On pytorch/pytorch, failures matching that shape (job duration 34–70s) ran **13 / 3 / 10 / 7** on Sep 6–9 against a 1–3/day baseline before Sep 6. No issue in `anthropics/claude-code-action` or `anthropics/claude-code` matches — unsurprising, since the error text isn't available to quote.

## The change

`path_to_claude_code_executable` is a documented action input: when set, the action skips its own install and runs that binary. Pointing it at a thin wrapper recovers stderr without forking the action.

The CLI version is **read from the pinned action revision at runtime** rather than duplicated here, because the action hardcodes `claudeCodeVersion` as a constant in `run.ts` (`v1.0.141` → `2.1.169`, `v1.0.220` → `2.1.267`); a copy in this file would go stale on a pin bump.

The wrapper is an `exec` form, so the SDK's child *is* the CLI — no extra PID, signals and exit codes pass through, and the streamed-stdin prompt is untouched.

## Where the stderr goes

**Verbatim to a private S3 prefix — not to the job log, and not redacted.**

The CLI runs with live AWS credentials in its environment, so pytorch/pytorch's public job logs are the wrong destination: they would require a scrubber, which is lossy on the exact text being read and cannot be shown to be complete.

`ossci-raw-job-status` grants public read via an explicit prefix allowlist — `log/`, `review-logs/`, `additional_info/`, `test_run/`, `test_run_summary/`, `failed_test_runs/`, `ossci_tutorials_stats/`. Anything outside it is account-only, so `claude_cli_stderr/` is private by construction. Note this is deliberately not under `review-logs/`, where the execution log goes: that prefix is public.

This also captures the whole stream rather than a truncated tail; the job log carries only a pointer to the object.

## Dependency

Needs `s3:PutObject` on `arn:aws:s3:::ossci-raw-job-status/claude_cli_stderr/*` added to the `gha_workflow_claude_code` inline policy (`claude_code_s3_upload`), which is scoped per prefix and currently covers `review-logs/`, `claude_code_usage/`, the autorevert-advisor prefixes and `pr_review_*`. **Until that grant lands the upload fails and the step is a no-op** — it is `continue-on-error`, so nothing else is affected.

## Blast radius

This workflow runs every `@claude` in the pytorch, meta-pytorch and executorch repos, so the setup step is best-effort by construction: `continue-on-error`, with the action input gated on `steps.stderr-capture.outcome == 'success'`. Any failure — version lookup, download, install, or a binary not reporting the expected version — leaves the input empty and the action installs and runs the CLI exactly as it does today. The install is bounded (`timeout-minutes: 4`, `curl --max-time`) so a stalled download cannot consume the invocation's budget.

Precise scope of that guarantee: it covers a **failure of the setup step**. It does not cover a wrapper misbehaving once Claude is already running, and it does not undo a partial install.

## Test plan

Exercised end-to-end against a mirror repo whose caller was temporarily pinned to this branch:

| control | result |
|---|---|
| Bogus CLI flag, forcing a fast failure | job failed; capture contained `error: unknown option '--iz2-nonexistent-flag'` — a sub-second exit-1, matching the production shape, with the real text recovered |
| Normal `@claude` review | succeeded, 25s |
| Version lookup broken via a bogus action SHA | job **succeeded**, with the action printing its own `Installing Claude Code v2.1.169...` — confirming the input was empty and default behaviour restored |
| Both re-run against the `exec` wrapper | crash captured; normal review succeeded in 16s and posted a completed task |

Those runs exercise the capture mechanism — wrapper, version lookup, and fallback — which the S3 destination does not change.

Plus a local harness on wrapper generation: exit-code propagation through `exec`, streamed stdin surviving the wrapper, and a runner path containing a space.

## Known residual

The action SHA appears twice — the `uses:` line and `CLAUDE_ACTION_SHA`. Bumping only one installs a CLI the action does not expect, and both configurations pass the version-format and executable checks, so neither falls back. A comment binds them; a lint asserting they match would be the mechanical fix, and I can add one here if reviewers prefer that to a follow-up.
