### PR TITLE
Let the merges replicator name its insert columns

### DIFF
--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 
 # `import urllib` alone does not bind the `parse` submodule. encode_url_component
 # works today only because clickhouse_connect imports urllib.parse first.
@@ -322,36 +323,50 @@ def handle_test_run_summary(table, bucket, key) -> None:
         log_failure_to_clickhouse(table, bucket, key, e)
 
 
-# The columns `merges_adapter`'s insert writes, in the order its SELECT produces
-# them: the fields MERGES_SCHEMA declares, then the meta tuple. Naming them is
-# what lets `ai_not_related_checks` (pytorch/pytorch#195503) be ALTERed into
-# default.merges before the schema string below declares it -- the insert simply
-# does not mention it, so it takes its default. Keep this list and MERGES_SCHEMA
-# in the same order; aws/lambda/tests/test_clickhouse_replicator_s3.py checks
-# that they agree.
-MERGES_COLUMNS = [
-    "`_id`",
-    "`author`",
-    "`broken_trunk_checks`",
-    "`comment_id`",
-    "`dry_run`",
-    "`error`",
-    "`failed_checks`",
-    "`flaky_checks`",
-    "`ignore_current`",
-    "`ignore_current_checks`",
-    "`is_failed`",
-    "`last_commit_sha`",
-    "`merge_base_sha`",
-    "`merge_commit_sha`",
-    "`owner`",
-    "`pending_checks`",
-    "`pr_num`",
-    "`project`",
-    "`skip_mandatory_checks`",
-    "`unstable_checks`",
-    "`_meta`",
-]
+META_COLUMN = "`_meta`"
+
+# The only column declaration flat_schema_columns is willing to read: one per
+# line, a backtick-quoted name, then a type built from identifiers, digits and
+# parentheses alone. Forbidding spaces and commas INSIDE those parentheses is
+# the real guard, and it is structural rather than a spelling check: every
+# ClickHouse construct that carries FIELD NAMES -- Tuple, Map, Nested -- needs
+# one, so all of them are refused, however they are spelled or wrapped across
+# lines. Valid-but-unsupported shapes go the same way (Enum8('a' = 1), and any
+# second column sharing a line); refusing is the safe direction and
+# MERGES_SCHEMA uses none of them.
+FLAT_COLUMN_DECLARATION = re.compile(
+    r"`([A-Za-z_][A-Za-z0-9_]*)`\s+[A-Za-z0-9_]+(?:\([A-Za-z0-9_()]*\))?,?"
+)
+
+
+def flat_schema_columns(schema) -> List[str]:
+    """Backtick-quoted column names from a FLAT structure string, in order.
+
+    Flat is defined by FLAT_COLUMN_DECLARATION above. The construct that makes
+    it necessary is a nested tuple: its inner fields occupy their own lines and
+    would each be counted as a column, though `select *` produces a single
+    expression for the whole tuple. `handle_test_run_s3`'s `properties` field
+    is exactly that shape. Hence refusing rather than guessing -- a name that
+    is not a column fails every insert for that table, and a wrong ORDER does
+    not fail at all, it writes into the wrong column.
+
+    Only `merges_adapter` uses this. Doing it for every table this lambda
+    serves needs a real parser -- split on commas at paren depth zero, outside
+    quotes -- which is what pytorch/test-infra#8716 is for.
+    """
+    columns = []
+    for line in schema.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        match = FLAT_COLUMN_DECLARATION.fullmatch(line)
+        if not match:
+            raise ValueError(
+                f"schema is not flat; expected one `name` Type per line, got: {line!r}"
+            )
+        columns.append(f"`{match.group(1)}`")
+    return columns
+
 
 MERGES_SCHEMA = """
     `_id` String,
@@ -375,6 +390,16 @@ MERGES_SCHEMA = """
     `skip_mandatory_checks` Bool,
     `unstable_checks` Array(Array(String))
     """
+
+# The columns merges_adapter's insert writes, in the order its SELECT produces
+# them: the fields MERGES_SCHEMA declares, then the meta tuple. Naming them is
+# what lets `ai_not_related_checks` (pytorch/pytorch#195503) be ALTERed into
+# default.merges before the schema string above declares it -- the insert does
+# not mention it, so it takes its default. The names this is expected to
+# produce are pinned in aws/lambda/tests/test_clickhouse_replicator_s3.py, so a
+# bug in the derivation surfaces as a test failure rather than as data in a
+# wrong column; adding a column means editing MERGES_SCHEMA and that fixture.
+MERGES_COLUMNS = flat_schema_columns(MERGES_SCHEMA) + [META_COLUMN]
 
 
 def merges_adapter(table, bucket, key) -> None:

--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -323,7 +323,23 @@ def handle_test_run_summary(table, bucket, key) -> None:
         log_failure_to_clickhouse(table, bucket, key, e)
 
 
-META_COLUMN = "`_meta`"
+# Every table this lambda serves records which S3 object a row came from in a
+# tuple column. Three of them predate the `_meta` spelling and call theirs
+# `meta`; a positional insert matched by position and never had to know, so
+# naming the columns is what surfaces the difference. Checked against
+# system.columns on 2026-09-10: of the 21 tables general_adapter serves, 18 use
+# `_meta`, these 3 use `meta`, and none has both.
+DEFAULT_META_COLUMN = "`_meta`"
+META_COLUMN_BY_TABLE = {
+    "default.merge_bases": "`meta`",
+    "default.queue_times_historical": "`meta`",
+    "default.rerun_disabled_tests": "`meta`",
+}
+
+
+def meta_column(table) -> str:
+    return META_COLUMN_BY_TABLE.get(table, DEFAULT_META_COLUMN)
+
 
 # The only column declaration flat_schema_columns is willing to read: one per
 # line, a backtick-quoted name, then a type built from identifiers, digits and
@@ -466,23 +482,26 @@ def general_adapter(
     cannot be changed at the same instant.
 
     Set `use_named_columns` to name the destination columns instead. They are
-    read straight out of `schema`, which already lists them, plus META_COLUMN
+    read out of `schema`, which already lists them, plus `meta_column(table)`
     for the tuple this SELECT appends. Column ORDER and COUNT on the table then
     stop mattering, and any column not named takes its default, so a new column
     can be ALTERed in before the code that populates it.
 
-    Two conditions, both currently met only by `merges_adapter`, which is the
-    sole caller that sets it. `schema` must satisfy FLAT_COLUMN_DECLARATION --
-    `flat_schema_columns` raises rather than guess otherwise. And the table's
-    meta tuple must be called `_meta`: `default.merge_bases`,
-    `default.queue_times_historical` and `default.rerun_disabled_tests` call
-    theirs `meta`, which a positional insert never had to know, so naming the
-    columns for one of those needs META_COLUMN to become per-table first.
+    Two things to check before opting a NEW table in, neither of which this
+    function can see:
+
+    - `schema` must satisfy FLAT_COLUMN_DECLARATION. Most schemas in this file
+      do not -- anything with a Tuple or a Map is refused -- so check rather
+      than assume. `flat_schema_columns` raises rather than guess.
+    - The destination's provenance tuple must be named as META_COLUMN_BY_TABLE
+      says. That map is a dated snapshot, not a live lookup, and its fallback
+      is `_meta`, so a table that uses `meta` and is missing from it would get
+      a name the table does not have and fail every insert.
     """
     url = f"https://{bucket}.s3.amazonaws.com/{encode_url_component(key)}"
     target = table
     if use_named_columns:
-        columns = flat_schema_columns(schema) + [META_COLUMN]
+        columns = flat_schema_columns(schema) + [meta_column(table)]
         target = f"{table} ({', '.join(columns)})"
 
     def get_insert_query(compression):

--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -391,18 +391,14 @@ MERGES_SCHEMA = """
     `unstable_checks` Array(Array(String))
     """
 
-# The columns merges_adapter's insert writes, in the order its SELECT produces
-# them: the fields MERGES_SCHEMA declares, then the meta tuple. Naming them is
-# what lets `ai_not_related_checks` (pytorch/pytorch#195503) be ALTERed into
-# default.merges before the schema string above declares it -- the insert does
-# not mention it, so it takes its default. The names this is expected to
-# produce are pinned in aws/lambda/tests/test_clickhouse_replicator_s3.py, so a
-# bug in the derivation surfaces as a test failure rather than as data in a
-# wrong column; adding a column means editing MERGES_SCHEMA and that fixture.
-MERGES_COLUMNS = flat_schema_columns(MERGES_SCHEMA) + [META_COLUMN]
-
 
 def merges_adapter(table, bucket, key) -> None:
+    # Named columns so `ai_not_related_checks` (pytorch/pytorch#195503) can be
+    # ALTERed into default.merges before MERGES_SCHEMA declares it: the insert
+    # does not mention the new column, so it takes its default. The names the
+    # derivation is expected to produce are pinned in
+    # aws/lambda/tests/test_clickhouse_replicator_s3.py, so a bug in it shows
+    # up as a test failure rather than as data in the wrong column.
     general_adapter(
         table,
         bucket,
@@ -410,7 +406,7 @@ def merges_adapter(table, bucket, key) -> None:
         MERGES_SCHEMA,
         ["none"],
         "JSONEachRow",
-        columns=MERGES_COLUMNS,
+        use_named_columns=True,
     )
 
 
@@ -459,7 +455,7 @@ def log_failure_to_clickhouse(table, bucket, key, error) -> None:
 
 
 def general_adapter(
-    table, bucket, key, schema, compressions, format, columns=None
+    table, bucket, key, schema, compressions, format, use_named_columns=False
 ) -> None:
     """Copy one S3 object into `table`.
 
@@ -469,14 +465,25 @@ def general_adapter(
     table a breaking change until `schema` is updated to match, and the two
     cannot be changed at the same instant.
 
-    Pass `columns` -- the destination column names in the order the SELECT
-    produces them, meta tuple included -- to name the targets instead. Column
-    ORDER and COUNT on the table then stop mattering, and any column not named
-    takes its default, so a new column can be ALTERed in before the code that
-    populates it. Callers that pass nothing keep the positional form.
+    Set `use_named_columns` to name the destination columns instead. They are
+    read straight out of `schema`, which already lists them, plus META_COLUMN
+    for the tuple this SELECT appends. Column ORDER and COUNT on the table then
+    stop mattering, and any column not named takes its default, so a new column
+    can be ALTERed in before the code that populates it.
+
+    Two conditions, both currently met only by `merges_adapter`, which is the
+    sole caller that sets it. `schema` must satisfy FLAT_COLUMN_DECLARATION --
+    `flat_schema_columns` raises rather than guess otherwise. And the table's
+    meta tuple must be called `_meta`: `default.merge_bases`,
+    `default.queue_times_historical` and `default.rerun_disabled_tests` call
+    theirs `meta`, which a positional insert never had to know, so naming the
+    columns for one of those needs META_COLUMN to become per-table first.
     """
     url = f"https://{bucket}.s3.amazonaws.com/{encode_url_component(key)}"
-    target = f"{table} ({', '.join(columns)})" if columns else table
+    target = table
+    if use_named_columns:
+        columns = flat_schema_columns(schema) + [META_COLUMN]
+        target = f"{table} ({', '.join(columns)})"
 
     def get_insert_query(compression):
         return f"""

--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -1,6 +1,9 @@
 import json
 import os
-import urllib
+
+# `import urllib` alone does not bind the `parse` submodule. encode_url_component
+# works today only because clickhouse_connect imports urllib.parse first.
+import urllib.parse
 from collections import defaultdict
 from enum import Enum
 from functools import lru_cache
@@ -319,8 +322,38 @@ def handle_test_run_summary(table, bucket, key) -> None:
         log_failure_to_clickhouse(table, bucket, key, e)
 
 
-def merges_adapter(table, bucket, key) -> None:
-    schema = """
+# The columns `merges_adapter`'s insert writes, in the order its SELECT produces
+# them: the fields MERGES_SCHEMA declares, then the meta tuple. Naming them is
+# what lets `ai_not_related_checks` (pytorch/pytorch#195503) be ALTERed into
+# default.merges before the schema string below declares it -- the insert simply
+# does not mention it, so it takes its default. Keep this list and MERGES_SCHEMA
+# in the same order; aws/lambda/tests/test_clickhouse_replicator_s3.py checks
+# that they agree.
+MERGES_COLUMNS = [
+    "`_id`",
+    "`author`",
+    "`broken_trunk_checks`",
+    "`comment_id`",
+    "`dry_run`",
+    "`error`",
+    "`failed_checks`",
+    "`flaky_checks`",
+    "`ignore_current`",
+    "`ignore_current_checks`",
+    "`is_failed`",
+    "`last_commit_sha`",
+    "`merge_base_sha`",
+    "`merge_commit_sha`",
+    "`owner`",
+    "`pending_checks`",
+    "`pr_num`",
+    "`project`",
+    "`skip_mandatory_checks`",
+    "`unstable_checks`",
+    "`_meta`",
+]
+
+MERGES_SCHEMA = """
     `_id` String,
     `author` String,
     `broken_trunk_checks` Array(Array(String)),
@@ -343,7 +376,17 @@ def merges_adapter(table, bucket, key) -> None:
     `unstable_checks` Array(Array(String))
     """
 
-    general_adapter(table, bucket, key, schema, ["none"], "JSONEachRow")
+
+def merges_adapter(table, bucket, key) -> None:
+    general_adapter(
+        table,
+        bucket,
+        key,
+        MERGES_SCHEMA,
+        ["none"],
+        "JSONEachRow",
+        columns=MERGES_COLUMNS,
+    )
 
 
 def merge_bases_adapter(table, bucket, key) -> None:
@@ -390,12 +433,29 @@ def log_failure_to_clickhouse(table, bucket, key, error) -> None:
     )
 
 
-def general_adapter(table, bucket, key, schema, compressions, format) -> None:
+def general_adapter(
+    table, bucket, key, schema, compressions, format, columns=None
+) -> None:
+    """Copy one S3 object into `table`.
+
+    The insert is positional by default: `select *` yields exactly the fields
+    `schema` declares, so the destination must have precisely those columns, in
+    that order, with the meta tuple last. That makes adding a column to the
+    table a breaking change until `schema` is updated to match, and the two
+    cannot be changed at the same instant.
+
+    Pass `columns` -- the destination column names in the order the SELECT
+    produces them, meta tuple included -- to name the targets instead. Column
+    ORDER and COUNT on the table then stop mattering, and any column not named
+    takes its default, so a new column can be ALTERed in before the code that
+    populates it. Callers that pass nothing keep the positional form.
+    """
     url = f"https://{bucket}.s3.amazonaws.com/{encode_url_component(key)}"
+    target = f"{table} ({', '.join(columns)})" if columns else table
 
     def get_insert_query(compression):
         return f"""
-        insert into {table}
+        insert into {target}
         select *, ('{bucket}', '{key}') as _meta
         from s3('{url}', '{format}', '{schema}', '{compression}',
             extra_credentials(

--- a/aws/lambda/tests/test_clickhouse_replicator_s3.py
+++ b/aws/lambda/tests/test_clickhouse_replicator_s3.py
@@ -1,0 +1,161 @@
+"""Checks on the one insert in the S3 replicator that names its target columns.
+
+`general_adapter` inserts positionally by default. `merges_adapter` opts out by
+passing `columns`, so `ai_not_related_checks` can be ALTERed into
+`default.merges` before the schema string declares it. The risk that buys is
+drift: `MERGES_COLUMNS` and `MERGES_SCHEMA` are two hand-maintained lists that
+must stay in the same order, and a name that is not a column on the table would
+fail every merge insert silently -- `general_adapter` routes the exception to
+`errors.gen_errors` and nothing reads that table.
+
+Lives here rather than beside the lambda so the existing "Test aws lambda" job
+in tests.yml picks it up on every pull request. The lambda's own directory name
+is hyphenated and so cannot be imported as a package; hence the path load below.
+"""
+
+import ast
+import importlib.util
+import pathlib
+import re
+import sys
+import types
+from unittest import mock
+
+
+LAMBDA_DIR = pathlib.Path(__file__).resolve().parents[1] / "clickhouse-replicator-s3"
+
+try:  # pragma: no cover - present in CI via test_requirements.txt
+    import clickhouse_connect  # noqa: F401
+except ImportError:
+    # Only stub when the real package is absent, so this file can run outside
+    # CI without shadowing the module other tests in the session may need.
+    sys.modules["clickhouse_connect"] = types.SimpleNamespace(
+        get_client=lambda **kwargs: None
+    )
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "clickhouse_replicator_s3_lambda", LAMBDA_DIR / "lambda_function.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+lambda_function = _load()
+
+
+def captured_query(call, *args, **kwargs):
+    """Run an adapter with the ClickHouse client stubbed; return the SQL it sent."""
+    queries = []
+    client = mock.Mock()
+    client.query.side_effect = lambda sql: queries.append(sql)
+    with mock.patch.object(lambda_function, "get_clickhouse_client", lambda: client):
+        call(*args, **kwargs)
+    assert len(queries) == 1, f"expected one query, got {len(queries)}"
+    return queries[0]
+
+
+def test_schema_is_flat_so_the_name_scan_below_is_valid():
+    # The next test reads column names line-wise. A nested `Tuple(...)` breaks
+    # that: its inner fields sit on their own lines, backtick-quoted, and get
+    # counted as columns even though `select *` produces one expression for the
+    # whole tuple. The backtick count alone does not catch it -- a list that
+    # wrongly included both the tuple and an inner field would balance -- so
+    # reject the construct outright. Naming a tuple column here means teaching
+    # this file to parse, which is the thing this PR exists to avoid.
+    schema = lambda_function.MERGES_SCHEMA
+    assert "tuple(" not in schema.lower(), "MERGES_SCHEMA is no longer flat"
+    assert schema.count("`") % 2 == 0
+    assert schema.count("`") // 2 == len(lambda_function.MERGES_COLUMNS) - 1
+
+
+def test_columns_match_the_schema_string_in_order_with_meta_last():
+    declared = [
+        f"`{name}`"
+        for name in re.findall(
+            r"^\s*`([^`]+)`", lambda_function.MERGES_SCHEMA, re.MULTILINE
+        )
+    ]
+    assert lambda_function.MERGES_COLUMNS[:-1] == declared
+    assert lambda_function.MERGES_COLUMNS[-1] == "`_meta`"
+
+
+def test_every_name_is_backtick_quoted():
+    # An unquoted name would still be valid SQL for most of these, but `error`
+    # is close enough to reserved that quoting is not optional by inspection --
+    # so require it of all of them.
+    for name in lambda_function.MERGES_COLUMNS:
+        assert re.fullmatch(r"`[^`]+`", name), name
+
+
+def test_merges_insert_names_its_columns():
+    sql = captured_query(
+        lambda_function.merges_adapter, "default.merges", "bkt", "some/key.json"
+    )
+    expected = ", ".join(lambda_function.MERGES_COLUMNS)
+    assert f"insert into default.merges ({expected})" in sql
+
+
+def test_a_caller_passing_no_columns_still_emits_the_positional_form():
+    # The whole point of `columns` being opt-in: the other tables this lambda
+    # serves must emit exactly what they emitted before.
+    sql = captured_query(
+        lambda_function.merge_bases_adapter,
+        "default.merge_bases",
+        "bkt",
+        "some/key.json",
+    )
+    assert "insert into default.merge_bases\n" in sql
+    assert "insert into default.merge_bases (" not in sql
+
+
+def test_columns_none_and_columns_omitted_produce_identical_sql():
+    args = ("default.t", "bkt", "k", "`a` String", ["none"], "JSONEachRow")
+    assert captured_query(lambda_function.general_adapter, *args) == captured_query(
+        lambda_function.general_adapter, *args, columns=None
+    )
+
+
+def test_the_named_list_is_used_verbatim_in_order():
+    # Two names for the two expressions a one-field structure produces (the
+    # field, then the meta tuple), so the fixture is arity-correct SQL. The
+    # names are deliberately out of alphabetical order: anything that sorted or
+    # reordered the list would render `(`a`, `z`)`.
+    sql = captured_query(
+        lambda_function.general_adapter,
+        "default.t",
+        "bkt",
+        "k",
+        "`a` String",
+        ["none"],
+        "JSONEachRow",
+        columns=["`z`", "`a`"],
+    )
+    assert "insert into default.t (`z`, `a`)" in sql
+
+
+def test_merges_adapter_is_the_only_caller_that_names_columns():
+    # Source-level via AST, deliberately: invoking every adapter would need S3
+    # and a cluster, and a textual search for one spelling would miss
+    # `columns=SOMETHING_ELSE`, an inline list, or a seventh positional
+    # argument. If a second table opts in, that is a decision someone should
+    # make on purpose, and this test is where they notice.
+    tree = ast.parse((LAMBDA_DIR / "lambda_function.py").read_text())
+    naming = []
+    for func in ast.walk(tree):
+        if not isinstance(func, ast.FunctionDef):
+            continue
+        for node in ast.walk(func):
+            if not isinstance(node, ast.Call):
+                continue
+            if getattr(node.func, "id", None) != "general_adapter":
+                continue
+            passes_columns = len(node.args) >= 7 or any(
+                kw.arg == "columns" for kw in node.keywords
+            )
+            if passes_columns:
+                naming.append(func.name)
+    assert naming == ["merges_adapter"]

--- a/aws/lambda/tests/test_clickhouse_replicator_s3.py
+++ b/aws/lambda/tests/test_clickhouse_replicator_s3.py
@@ -65,7 +65,7 @@ def captured_query(call, *args, **kwargs):
 
 # The insert projection merges_adapter is expected to write: the destination
 # names, in the order its SELECT produces them. Written out on purpose --
-# MERGES_COLUMNS is derived from MERGES_SCHEMA, so without an independent
+# the lambda derives them from MERGES_SCHEMA, so without an independent
 # statement of the answer the derivation would only be compared against itself.
 # Each name was confirmed to be a column of default.merges against
 # system.columns on 2026-09-10; it is NOT a snapshot of the whole table, and
@@ -98,15 +98,21 @@ EXPECTED_MERGES_COLUMNS = [
 ]
 
 
-def test_derived_columns_are_the_columns_the_table_has():
-    assert lambda_function.MERGES_COLUMNS == EXPECTED_MERGES_COLUMNS
+def derived_merges_columns():
+    return lambda_function.flat_schema_columns(lambda_function.MERGES_SCHEMA) + [
+        lambda_function.META_COLUMN
+    ]
+
+
+def test_derived_columns_are_the_projection_the_table_expects():
+    assert derived_merges_columns() == EXPECTED_MERGES_COLUMNS
 
 
 def test_every_name_is_backtick_quoted():
     # An unquoted name would still be valid SQL for most of these, but `error`
     # is close enough to reserved that quoting is not optional by inspection --
     # so require it of all of them.
-    for name in lambda_function.MERGES_COLUMNS:
+    for name in derived_merges_columns():
         assert re.fullmatch(r"`[^`]+`", name), name
 
 
@@ -156,15 +162,17 @@ def test_a_flat_schema_reads_cleanly():
 
 
 def test_merges_insert_names_its_columns():
+    # End to end, against the independently written projection rather than
+    # against the derivation's own output.
     sql = captured_query(
         lambda_function.merges_adapter, "default.merges", "bkt", "some/key.json"
     )
-    expected = ", ".join(lambda_function.MERGES_COLUMNS)
+    expected = ", ".join(EXPECTED_MERGES_COLUMNS)
     assert f"insert into default.merges ({expected})" in sql
 
 
-def test_a_caller_passing_no_columns_still_emits_the_positional_form():
-    # The whole point of `columns` being opt-in: the other tables this lambda
+def test_a_caller_that_does_not_opt_in_still_emits_the_positional_form():
+    # The whole point of the flag being opt-in: the other tables this lambda
     # serves must emit exactly what they emitted before.
     sql = captured_query(
         lambda_function.merge_bases_adapter,
@@ -176,37 +184,92 @@ def test_a_caller_passing_no_columns_still_emits_the_positional_form():
     assert "insert into default.merge_bases (" not in sql
 
 
-def test_columns_none_and_columns_omitted_produce_identical_sql():
+def test_opting_out_explicitly_and_omitting_the_flag_are_the_same_sql():
     args = ("default.t", "bkt", "k", "`a` String", ["none"], "JSONEachRow")
     assert captured_query(lambda_function.general_adapter, *args) == captured_query(
-        lambda_function.general_adapter, *args, columns=None
+        lambda_function.general_adapter, *args, use_named_columns=False
     )
 
 
-def test_the_named_list_is_used_verbatim_in_order():
-    # Two names for the two expressions a one-field structure produces (the
-    # field, then the meta tuple), so the fixture is arity-correct SQL. The
-    # names are deliberately out of alphabetical order: anything that sorted or
-    # reordered the list would render `(`a`, `z`)`.
+def test_the_names_follow_the_schema_order_with_the_meta_tuple_last():
+    # Declared out of alphabetical order on purpose: anything that sorted the
+    # derived names would render `(`a`, `z`, `_meta`)`.
     sql = captured_query(
         lambda_function.general_adapter,
         "default.t",
         "bkt",
         "k",
-        "`a` String",
+        "`z` String,\n`a` Int64",
         ["none"],
         "JSONEachRow",
-        columns=["`z`", "`a`"],
+        use_named_columns=True,
     )
-    assert "insert into default.t (`z`, `a`)" in sql
+    assert "insert into default.t (`z`, `a`, `_meta`)" in sql
 
 
-def test_merges_adapter_is_the_only_caller_that_names_columns():
+def test_a_schema_the_parser_would_reject_is_fine_when_not_opted_in():
+    # The restricted parser must never be applied to a caller that did not ask
+    # for it -- most of the schemas in this file would fail it.
+    sql = captured_query(
+        lambda_function.general_adapter,
+        "default.t",
+        "bkt",
+        "k",
+        "`t` Tuple(bucket String, key String)",
+        ["none"],
+        "JSONEachRow",
+    )
+    assert "insert into default.t\n" in sql
+    assert "insert into default.t (" not in sql
+
+
+def test_opting_in_with_a_schema_it_cannot_read_raises():
+    # Raised before the query is built, so it propagates out of
+    # general_adapter rather than being logged as an insert failure. It can
+    # only be reached by editing a schema constant, which is why this test --
+    # which runs on every pull request -- is the gate that matters.
+    with pytest.raises(ValueError, match="not flat"):
+        captured_query(
+            lambda_function.general_adapter,
+            "default.t",
+            "bkt",
+            "k",
+            "`t` Tuple(bucket String, key String)",
+            ["none"],
+            "JSONEachRow",
+            use_named_columns=True,
+        )
+
+
+def opts_in(call):
+    """True if this general_adapter() call turns named columns ON.
+
+    Reads the VALUE, not merely the argument's presence: an explicit
+    `use_named_columns=False` leaves the SQL positional and must not count.
+    Anything that is not a literal False does count, including a name this
+    cannot resolve -- unrecognised is treated as opting in, so the test errs
+    toward flagging.
+    """
+    supplied = [kw.value for kw in call.keywords if kw.arg == "use_named_columns"]
+    if len(call.args) >= 7:
+        supplied.append(call.args[6])
+    return any(
+        not (isinstance(value, ast.Constant) and value.value is False)
+        for value in supplied
+    )
+
+
+def test_merges_adapter_is_the_only_caller_that_turns_named_columns_on():
     # Source-level via AST, deliberately: invoking every adapter would need S3
-    # and a cluster, and a textual search for one spelling would miss
-    # `columns=SOMETHING_ELSE`, an inline list, or a seventh positional
-    # argument. If a second table opts in, that is a decision someone should
-    # make on purpose, and this test is where they notice.
+    # and a cluster, and a textual search would miss the flag passed as a
+    # seventh positional argument. Opting a second table in is a decision
+    # someone should make on purpose -- both preconditions in
+    # general_adapter's docstring have to be rechecked for it -- and this test
+    # is where they notice.
+    #
+    # A source-convention guard, not structural enforcement: forwarding the
+    # flag through **kwargs, or calling general_adapter through an alias,
+    # would evade it.
     tree = ast.parse((LAMBDA_DIR / "lambda_function.py").read_text())
     naming = []
     for func in ast.walk(tree):
@@ -217,9 +280,6 @@ def test_merges_adapter_is_the_only_caller_that_names_columns():
                 continue
             if getattr(node.func, "id", None) != "general_adapter":
                 continue
-            passes_columns = len(node.args) >= 7 or any(
-                kw.arg == "columns" for kw in node.keywords
-            )
-            if passes_columns:
+            if opts_in(node):
                 naming.append(func.name)
     assert naming == ["merges_adapter"]

--- a/aws/lambda/tests/test_clickhouse_replicator_s3.py
+++ b/aws/lambda/tests/test_clickhouse_replicator_s3.py
@@ -2,11 +2,14 @@
 
 `general_adapter` inserts positionally by default. `merges_adapter` opts out by
 passing `columns`, so `ai_not_related_checks` can be ALTERed into
-`default.merges` before the schema string declares it. The risk that buys is
-drift: `MERGES_COLUMNS` and `MERGES_SCHEMA` are two hand-maintained lists that
-must stay in the same order, and a name that is not a column on the table would
-fail every merge insert silently -- `general_adapter` routes the exception to
-`errors.gen_errors` and nothing reads that table.
+`default.merges` before the schema string declares it.
+
+`MERGES_COLUMNS` is derived from `MERGES_SCHEMA`, so the risk that buys is a
+derivation bug: a name that is not a column on the table would fail every merge
+insert silently -- `general_adapter` routes the exception to `errors.gen_errors`
+and nothing reads that table -- and a wrong ORDER would not fail at all, it
+would write into the wrong column. Hence `EXPECTED_MERGES_COLUMNS` below, which
+states the answer independently instead of recomputing it.
 
 Lives here rather than beside the lambda so the existing "Test aws lambda" job
 in tests.yml picks it up on every pull request. The lambda's own directory name
@@ -20,6 +23,8 @@ import re
 import sys
 import types
 from unittest import mock
+
+import pytest
 
 
 LAMBDA_DIR = pathlib.Path(__file__).resolve().parents[1] / "clickhouse-replicator-s3"
@@ -58,29 +63,43 @@ def captured_query(call, *args, **kwargs):
     return queries[0]
 
 
-def test_schema_is_flat_so_the_name_scan_below_is_valid():
-    # The next test reads column names line-wise. A nested `Tuple(...)` breaks
-    # that: its inner fields sit on their own lines, backtick-quoted, and get
-    # counted as columns even though `select *` produces one expression for the
-    # whole tuple. The backtick count alone does not catch it -- a list that
-    # wrongly included both the tuple and an inner field would balance -- so
-    # reject the construct outright. Naming a tuple column here means teaching
-    # this file to parse, which is the thing this PR exists to avoid.
-    schema = lambda_function.MERGES_SCHEMA
-    assert "tuple(" not in schema.lower(), "MERGES_SCHEMA is no longer flat"
-    assert schema.count("`") % 2 == 0
-    assert schema.count("`") // 2 == len(lambda_function.MERGES_COLUMNS) - 1
+# The insert projection merges_adapter is expected to write: the destination
+# names, in the order its SELECT produces them. Written out on purpose --
+# MERGES_COLUMNS is derived from MERGES_SCHEMA, so without an independent
+# statement of the answer the derivation would only be compared against itself.
+# Each name was confirmed to be a column of default.merges against
+# system.columns on 2026-09-10; it is NOT a snapshot of the whole table, and
+# after `ai_not_related_checks` is ALTERed in it deliberately will not name it.
+# What has to hold is that these agree with the SELECT's expressions, so a
+# wrong ORDER is the dangerous failure: several of these share a type, and
+# mismatched names would write into the wrong column without failing.
+EXPECTED_MERGES_COLUMNS = [
+    "`_id`",
+    "`author`",
+    "`broken_trunk_checks`",
+    "`comment_id`",
+    "`dry_run`",
+    "`error`",
+    "`failed_checks`",
+    "`flaky_checks`",
+    "`ignore_current`",
+    "`ignore_current_checks`",
+    "`is_failed`",
+    "`last_commit_sha`",
+    "`merge_base_sha`",
+    "`merge_commit_sha`",
+    "`owner`",
+    "`pending_checks`",
+    "`pr_num`",
+    "`project`",
+    "`skip_mandatory_checks`",
+    "`unstable_checks`",
+    "`_meta`",
+]
 
 
-def test_columns_match_the_schema_string_in_order_with_meta_last():
-    declared = [
-        f"`{name}`"
-        for name in re.findall(
-            r"^\s*`([^`]+)`", lambda_function.MERGES_SCHEMA, re.MULTILINE
-        )
-    ]
-    assert lambda_function.MERGES_COLUMNS[:-1] == declared
-    assert lambda_function.MERGES_COLUMNS[-1] == "`_meta`"
+def test_derived_columns_are_the_columns_the_table_has():
+    assert lambda_function.MERGES_COLUMNS == EXPECTED_MERGES_COLUMNS
 
 
 def test_every_name_is_backtick_quoted():
@@ -89,6 +108,51 @@ def test_every_name_is_backtick_quoted():
     # so require it of all of them.
     for name in lambda_function.MERGES_COLUMNS:
         assert re.fullmatch(r"`[^`]+`", name), name
+
+
+def test_a_nested_tuple_is_refused_rather_than_miscounted():
+    # The real shape this guards: handle_test_run_s3's `properties` field. A
+    # line-wise scan would return `properties`, `property`, `name` and `value`
+    # as four columns where `select *` produces one expression.
+    with pytest.raises(ValueError, match="not flat"):
+        lambda_function.flat_schema_columns(
+            """
+            `job_id` Int64,
+            `properties` Tuple(
+                property Tuple(name String, value String)
+            )
+            """
+        )
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        "`a` String, `b` String",  # a second quoted column on the line
+        "`a` String, b String",  # a second UNQUOTED column on the line
+        "a String",  # name not backtick-quoted
+        "`a`",  # no type
+        "`` String",  # empty name
+        "`t` Tuple(bucket String, key String)",  # field names, one line
+        "`t` Tuple (\n`x` String)",  # a space before the paren
+        "`m` Map(String, String)",  # field types, comma inside the parens
+        "`e` Enum8('a' = 1)",  # valid ClickHouse, deliberately unsupported
+    ],
+)
+def test_a_declaration_it_cannot_read_raises_rather_than_guessing(schema):
+    with pytest.raises(ValueError, match="not flat"):
+        lambda_function.flat_schema_columns(schema)
+
+
+def test_a_flat_schema_reads_cleanly():
+    assert lambda_function.flat_schema_columns(
+        """
+        `sha` String,
+        `tags` Array(Array(String)),
+        `when` DateTime64(3),
+        `ok` Bool
+        """
+    ) == ["`sha`", "`tags`", "`when`", "`ok`"]
 
 
 def test_merges_insert_names_its_columns():

--- a/aws/lambda/tests/test_clickhouse_replicator_s3.py
+++ b/aws/lambda/tests/test_clickhouse_replicator_s3.py
@@ -100,7 +100,7 @@ EXPECTED_MERGES_COLUMNS = [
 
 def derived_merges_columns():
     return lambda_function.flat_schema_columns(lambda_function.MERGES_SCHEMA) + [
-        lambda_function.META_COLUMN
+        lambda_function.meta_column("default.merges")
     ]
 
 
@@ -205,6 +205,40 @@ def test_the_names_follow_the_schema_order_with_the_meta_tuple_last():
         use_named_columns=True,
     )
     assert "insert into default.t (`z`, `a`, `_meta`)" in sql
+
+
+@pytest.mark.parametrize(
+    "table",
+    [
+        "default.merge_bases",
+        "default.queue_times_historical",
+        "default.rerun_disabled_tests",
+    ],
+)
+def test_the_three_tables_that_call_it_meta_get_meta(table):
+    # Confirmed against system.columns on 2026-09-10: of the 21 tables
+    # general_adapter serves these are the only three, and none has both.
+    assert lambda_function.meta_column(table) == "`meta`"
+
+
+@pytest.mark.parametrize("table", ["default.merges", "misc.stable_pushes", "a.b"])
+def test_every_other_table_gets_the_underscore_spelling(table):
+    assert lambda_function.meta_column(table) == "`_meta`"
+
+
+def test_an_opted_in_insert_uses_the_tables_own_meta_spelling():
+    # The end that matters: the destination list, not just the lookup.
+    sql = captured_query(
+        lambda_function.general_adapter,
+        "default.merge_bases",
+        "bkt",
+        "k",
+        "`sha` String",
+        ["none"],
+        "JSONEachRow",
+        use_named_columns=True,
+    )
+    assert "insert into default.merge_bases (`sha`, `meta`)" in sql
 
 
 def test_a_schema_the_parser_would_reject_is_fine_when_not_opted_in():


### PR DESCRIPTION
✴️ iz2: opened on behalf of @izaitsevfb

`default.merges` needs a new column, `ai_not_related_checks Array(Array(String))`, written by pytorch/pytorch#195503. It cannot simply be ALTERed in.

`general_adapter` builds a positional insert:

```sql
insert into <table>
select *, ('<bucket>', '<key>') as _meta
from s3(<url>, 'JSONEachRow', '<structure>', ...)
```

`select *` yields exactly the fields the structure declares, so the insert supplies (declared fields + 1) expressions and the table must have precisely that many columns. ALTER the table alone and every merge insert fails on column count; change the structure string alone and it fails the other way. The two cannot be changed at the same instant, and the failure is silent — `general_adapter` routes the exception to `errors.gen_errors`, which nothing reads, and the S3 objects are not reprocessed.

## What changed

`general_adapter` takes `use_named_columns`. When set, it names the destination columns, reading them out of the `schema` string it is already given plus `meta_column(table)` for the provenance tuple its SELECT appends. `merges_adapter` is the only caller that sets it. **Nothing else changes**: the structure string is untouched, so the rows written to `default.merges` are identical, and every other caller emits byte-for-byte the SQL it emits today.

Also `import urllib` → `import urllib.parse`. The bare form does not bind the submodule; `encode_url_component` works today only because `clickhouse_connect` imports `urllib.parse` first. The new test surfaced it by stubbing that dependency out.

## The reader is deliberately narrow, and refuses rather than guessing

`flat_schema_columns` accepts one declaration per line: a backtick-quoted name, then a type built from identifiers, digits and parentheses alone. Forbidding spaces and commas *inside* those parentheses is the actual guard, and it is structural rather than a spelling check — every ClickHouse construct that carries field names (`Tuple`, `Map`, `Nested`) needs one, so all of them are refused however they are spelled or wrapped across lines. That matters because a tuple's inner fields occupy their own lines and would each be counted as a column while `select *` produces one expression for the whole tuple; `handle_test_run_s3`'s `properties` field is exactly that shape.

Most schemas in this file would **not** satisfy it, which is deliberate: refusing is the safe direction, and the one table opting in does satisfy it. Doing this properly for all 21 tables means splitting on commas at paren depth zero outside quotes, which is #8716.

## Both spellings of the provenance tuple are supported

Three tables call that column `meta` rather than `_meta` — a positional insert matched by position and never had to know. `meta_column()` looks it up rather than assuming, so named inserts are available to any of them.

The map is a **dated snapshot, not a live lookup**. Checked against `system.columns` on 2026-09-10: of the 21 tables `general_adapter` serves, 18 use `_meta`, exactly `default.merge_bases`, `default.queue_times_historical` and `default.rerun_disabled_tests` use `meta`, and none has both. Its fallback is `_meta`, so a future table that uses `meta` and is missing from the map would get a name the table does not have. That, and the parser condition above, are the two things `general_adapter`'s docstring tells a new caller to check for itself.

## Why this shape

Once the insert names its targets, a column can be ALTERed in before the code that populates it — the insert simply does not mention it and it takes its default. That unblocks the rest without an ingestion gap:

1. **this PR**, deployed on its own
2. `ALTER TABLE default.merges ADD COLUMN IF NOT EXISTS \`ai_not_related_checks\` Array(Array(String)) AFTER \`unstable_checks\`` — before `_meta`, so the provenance tuple stays last
3. add the field to `MERGES_SCHEMA` and to the test's expected projection, deploy, and the data lands

Deliberately scoped to `default.merges`. #8716 does the same thing for all 21 tables; the blast radius was the objection there.

Since the derivation happens per call rather than at import, a schema the reader cannot read raises out of `general_adapter` into `lambda_handler`'s per-record handler, which warns. It can only be reached by editing a schema constant, so the PR check below is the gate.

## Test plan

`aws/lambda/tests/test_clickhouse_replicator_s3.py`, which the existing "Test aws lambda" job in `tests.yml` runs on every pull request — no workflow change. The lambda's directory name is hyphenated, so the test loads `lambda_function.py` by path.

- The derived names equal the insert projection written out independently in the test, each confirmed a column of `default.merges` against `system.columns`, and every name backtick-quoted. The captured merges INSERT is compared against that same independent list, so corrupting the derivation is observable end to end.
- A flat schema reads cleanly; ten declarations the reader must refuse do raise — a nested `Tuple`, `Tuple (` with a space, `Map(String, String)`, an `Enum8`, a second column on a line whether quoted or not, an unquoted name, a missing type, an empty name.
- Each of the three `meta` tables resolves to `` `meta` ``, others to `` `_meta` ``, and an opted-in insert against one of the three names `meta` in its destination list.
- A caller that does not opt in still emits the positional form, including when its schema is one the reader would reject. Omitting the flag and passing it `False` produce identical SQL. Names follow schema order, so sorting them would be caught.
- An AST check that `merges_adapter` is the only caller turning the flag on. It reads the argument's **value**, so an explicit `use_named_columns=False` elsewhere is correctly not flagged. A source-convention guard, not structural enforcement: `**kwargs` forwarding or an alias would evade it.

Run locally on python 3.12 against `aws/lambda/tests/test_requirements.txt`: **85 passed** (58 pre-existing, 27 new). `ruff format --check`, `usort check`, `ruff check --config=pyproject.toml` and `flake8 7.3.0` clean.

Mutation-tested, 18 mutants, each in a fresh copy of the tree, each verified to have matched its anchor exactly once and to still parse before running — reverting to a positional insert, dropping the opt-in, defaulting the flag on, ignoring it, dropping the provenance column from the list, misspelling the default one, ignoring the per-table map, dropping an entry from it, misspelling an entry, sorting / reversing / truncating the derived names, dropping the backticks, `fullmatch` → `search`, admitting spaces and commas inside the type parentheses, skipping the raise, adding a nested `Tuple` to `MERGES_SCHEMA`, and a second adapter opting in. All 18 turn the suite red; unmutated is green. One positive control too: adding an explicit `use_named_columns=False` to another adapter keeps the suite green, which an earlier presence-based version of that check would have failed.

## Not verified here

That a named insert omitting a column takes that column's default **on this cluster** — step 2's premise. The tests above establish query construction, not ingestion after the ALTER. That is standard ClickHouse behaviour, but I have no INSERT grant to run the positive control, so it is worth confirming against a disposable table first.
