### PR TITLE
[GREENLIGHT] Render outlines in the HUD panel

### DIFF
--- a/greenlight/README.md
+++ b/greenlight/README.md
@@ -192,11 +192,18 @@ just run verdict --pr 123 --head-sha "$SHA" --verdict-file verdict.json \
 The greenlight-review skill asks the model for a short markdown outline — a few topic bullets,
 each with a few detail bullets. Nothing enforces that shape. The Stop hook and the `verdict`
 command both check `status`, `reason` and a non-empty `message` and no more, so a message written
-as a paragraph is as valid as one written as an outline and renders correctly either way. Two
+as a paragraph is as valid as one written as an outline and renders correctly either way. Three
 surfaces render it: `comment_format` builds greenlight's own comment as the verdict is recorded,
-and `torchci/lib/greenlight/greenlightRender.ts` rebuilds Dr. CI's Green Light section from the
-stored row on every sweep. Two render paths are live, chosen per message rather than per
-deployment:
+`torchci/lib/greenlight/greenlightRender.ts` rebuilds Dr. CI's Green Light section from the stored
+row on every sweep, and `torchci/components/greenlight/GreenLightSection.tsx` shows that same row
+in the HUD's Green Light panel. The two comment surfaces emit markup, held by the raw HTML block
+described below. The panel emits none. `selectMessageView` in
+`torchci/lib/greenlight/greenlightHudState.ts` picks which of the two paths below a message takes,
+and `torchci/components/greenlight/GreenLightOutline.tsx` draws the list from the same parse the
+serializer reads — `parseOutline` in `torchci/lib/greenlight/greenlightOutline.ts`, which
+`renderOutlineHtml` serializes. A string handed to React as a child becomes a text node rather
+than markup, and that is the containment there, in place of the block. Two render paths are live,
+chosen per message rather than per deployment:
 
 - **Outline** — a message carrying at least two bullets with text after their markers becomes a
   raw HTML `<ul><li>` block, every leaf HTML-escaped. Two rather than one because a paragraph
@@ -233,6 +240,57 @@ and this section is one part of that body. What ceiling GitHub enforces on it is
 Dr. CI comments well past 65,536 characters are live on `pytorch/pytorch` today. The 12,000 is a
 bound greenlight puts on its own contribution, not a measured limit.
 
+Four of those five act on the outline's structure rather than on finished markup, so every surface
+carries them. The block budget is not: it measures finished markup, and the panel produces none.
+Two things follow from that, and only the second is a change of shape. Where the budget stops a
+later item, the comments drop the topics behind it and mark the cut, while the panel shows them all
+and marks nothing for that reason — though a message heavy enough to reach the budget may
+separately have run past the 4,000-character cap or the twelve-topic clamp, either of which puts a
+`(truncated)` entry on the panel's list anyway, standing for what those clamps cut rather than for
+the topics the budget dropped. Where the first item alone overruns it, `renderOutlineHtml` produces
+nothing and the comments fall through to the fence, while the panel still shows a bullet list — a
+difference in shape, not just a missing marker.
+
+Neither is reachable by an ordinary verdict, and how close one comes depends on its shape as much
+as its length, so every figure below states the shape it was measured on. The largest message the
+reviewer skill's own format admits — four topics of three details, every bullet at its
+200-character ceiling, a 27-character backticked path and a 10-character backticked symbol in each
+— is 3,271 characters and renders 3,769 of markup. Filling the 4,000-character cap takes a shape
+the skill never asks for, and buys little: the widest list the clamps allow, twelve topics of eight
+details, renders 4,658 in plain prose, because escaping is what inflates text sixfold and ordinary
+prose has almost nothing to escape. Density is what moves this number rather than length — two
+ten-character code spans in each of those 108 bullets, three quarters of a line only thirty-two
+characters long, render 7,034 out of the same 4,000 characters.
+
+Crossing 12,000 takes a density no verdict has reason to reach, and how far past depends on which
+character inflates. Only `"` and `'` escape to six characters: on that twelve-by-eight shape the
+renderer first drops an item when 1,471 of the 4,000 characters are one of those two; `&` escapes
+to five and needs 1,838, and `<` and `>` escape to four and need 2,451. Each of those is a floor
+rather than a fixed point, because twelve topics of eight details is the layout that starts from
+the most markup of any that fills the cap — every other one needs more of the character to get
+there. Twelve topics of no details, also filled to the cap, needs 1,569. Below about ten bullets no
+single figure is worth quoting: a cap-filled message gives each leaf more than 400 characters, so
+the leaf cap clips every one of them, and how many of the substituted characters fall inside the
+surviving prefix rather than the discarded tail depends on where the word breaks land — enough to
+move the floor by a couple of hundred between constructions that answer to the same description.
+
+The other route holds none of the five escaped characters at all — one-character code spans, where
+`<code>x</code>` turns three characters into fourteen, each separated from the next by a non-space
+character. The separator is load-bearing: the backticks between two adjacent spans form a single
+maximal run, so ``` `a``b` ``` leaves an odd run count and the whole leaf goes out as literal text
+with its backticks showing, while ``` `a``b``c` ``` renders `a` and `c` as spans and `b` as prose
+between them. Filled that way, twelve topics of eight details reach 14,162 measured with the budget
+lifted — against the 11,828 the renderer actually emits, being ten topics and the marker — and a
+single topic with seven details, each filled to the 400-character leaf cap, reaches 12,097, enough
+that `renderOutlineHtml` returns nothing at all and the message goes out fenced.
+
+The panel's message block sits outside its status switch, while `greenlightRender.ts` renders a
+message only for `LAND` and `NO_LAND`. Nothing reaches the panel through that gap, because no other
+status can carry a message: `verdict` returns an empty reason and message for every marker status,
+whether the status came from the CLI or from a verdict file, and the scan's own `REVERTED` and
+`AI_REVIEW_DISPATCHED` rows are emitted with the field hardcoded empty. The outline path therefore
+runs on the panel for exactly the two statuses it runs on in the comments.
+
 Neither path lets a verdict ping a person or issue a bot command, but they arrive there
 differently. The fence replaces every `@` unconditionally, and that one replacement stops both.
 The outline guards `@` in text segments only, deliberately skipping code spans: `code` is in
@@ -247,14 +305,30 @@ renderer breaks, on both paths, the literals its own re-render sweep greps the c
 verdict that merely mentions a pending job count would otherwise pin its PR into every sweep
 forever.
 
+The panel applies none of that, because none of those consumers reach it: it is a web page rather
+than a comment body, so GitHub's filters never see it, `cliParser.ts` never parses it, and the
+sweep greps neither it nor the table it reads. Dropping the guards there is a correctness gain and
+not a shortcut. Every one of them works by splicing an invisible zero-width space into the token
+it defuses — after each `@`, after a `#` or `gh-` that precedes a digit, after the opening colon
+of anything shortcode-shaped, which catches every `file.py:1234` written outside a code span — and
+it splits each 40-hex sha in two at column 20. All of that survives a copy, on a page whose whole
+job is showing commits and the paths they touch.
+
+One divergence runs the other way. The panel draws the `(truncated)` marker a clamp leaves behind
+in italic and a dimmer colour, so a leaf the model wrote reading `(truncated)` cannot pass for one
+the renderer added: the model authors text, never a presentation. In both comments that marker is
+an ordinary `<li>` and the two are indistinguishable. The panel and the comments therefore render
+one row deliberately differently, and nothing should assert the two agree.
+
 The escaper is written twice — `verdict_outline.py` and
-`torchci/lib/greenlight/greenlightOutline.ts` — because one stored row is rendered by a Python
-surface and a TypeScript one that have to agree character for character. Python is the source of
-truth, and three gates hold the mirror together: `greenlight/tests/outline_parity_cases.json`, a
-shared corpus both test suites assert identical output against; a literal scrape in
-`greenlight/tests/test_verdict_outline.py`, which also fails either implementation for using `\s`,
-`\d`, `\w` or `\b`, since each matches a different set of characters in the two languages; and
-`greenlight/tests/test_render_sync.py`, which fails when either side stops routing both formats.
+`torchci/lib/greenlight/greenlightOutline.ts` — because one stored row is rendered into a comment
+by a Python surface and a TypeScript one that have to agree character for character. Python is the
+source of truth, and three gates hold the mirror together:
+`greenlight/tests/outline_parity_cases.json`, a shared corpus both test suites assert identical
+output against; a literal scrape in `greenlight/tests/test_verdict_outline.py`, which also fails
+either implementation for using `\s`, `\d`, `\w` or `\b`, since each matches a different set of
+characters in the two languages; and `greenlight/tests/test_render_sync.py`, which fails when
+either side stops routing both formats.
 
 ### Who posts the status comment
 

--- a/greenlight/src/greenlight/verdict_outline.py
+++ b/greenlight/src/greenlight/verdict_outline.py
@@ -27,6 +27,14 @@ here, ``U+FEFF`` there), on ``\d`` (Unicode digits against ASCII only) and on ``
 e-acute is a word character in Python and not in JavaScript), so one shared shorthand renders two
 different comments from one row. Every character set below is a single-line literal for that
 reason: the drift test scrapes both files and compares the literals.
+
+The mirror is not symmetrical. That module also exports a parse layer with no counterpart here --
+``parseOutline`` and the ``OutlineSegment``, ``OutlineTopic`` and ``ParsedOutline`` shapes it
+returns -- feeding the HUD's Green Light panel, which builds DOM nodes rather than markup. Every
+clamp acting on structure sits in that layer there, where this module applies the topic clamp in
+``render_outline_html``, the detail clamp in ``_topic_html`` and the code-span split in
+``_leaf_html``. The gates compare finished HTML and scraped literals, so neither sees where either
+side computes it.
 """
 
 from __future__ import annotations

--- a/torchci/components/greenlight/GreenLightOutline.tsx
+++ b/torchci/components/greenlight/GreenLightOutline.tsx
@@ -1,0 +1,103 @@
+// A parsed verdict outline as a bullet list: topics emphasised, details nested
+// one level under them, code spans in a monospace face.
+//
+// Every leaf reaches the DOM as a React text node, which is what contains the
+// model's text here -- see the ban in GreenLightSection.tsx, which governs this
+// file too. Nothing below escapes, guards or defuses anything, and that is
+// correct: those defences answer GitHub's markdown pipeline, and on this surface
+// they would only show the reader entities and split the shas they copy out.
+
+import { Box, Typography } from "@mui/material";
+import {
+  OUTLINE_TRUNCATED_LABEL,
+  OutlineSegment,
+  ParsedOutline,
+} from "lib/greenlight/greenlightOutline";
+import { Fragment, ReactNode } from "react";
+
+// A leaf is one unbroken line that the parser lets run to OUTLINE_LEAF_CAP with
+// no space in it, and a list item offers no break opportunity of its own.
+const LIST_SX = { m: 0, pl: 3, overflowWrap: "anywhere" } as const;
+
+// The global bare-`code` rule paints --code-bg, which in dark mode is the same
+// #2a2a2a the panel's Paper is forced to. A palette token is what keeps the chip
+// legible on whichever background the mode gives it.
+const CODE_SX = { bgcolor: "action.hover" } as const;
+
+// An empty segment is always a text one: the parser splits on maximal backtick
+// runs, so only a leaf's first and last part can be empty and both of those are
+// text. Skipping them can therefore never drop a code span.
+function segmentNodes(segments: OutlineSegment[]): ReactNode[] {
+  return segments.flatMap(({ text, code }, index) => {
+    if (text === "") {
+      return [];
+    }
+    return [
+      code ? (
+        <Box component="code" key={index} sx={CODE_SX}>
+          {text}
+        </Box>
+      ) : (
+        <Fragment key={index}>{text}</Fragment>
+      ),
+    ];
+  });
+}
+
+function DetailItem({ children }: { children: ReactNode }) {
+  return (
+    <Typography component="li" variant="body2" color="text.secondary">
+      {children}
+    </Typography>
+  );
+}
+
+// The marker a clamp leaves behind, styled apart from every detail so that a
+// leaf the model wrote reading "(truncated)" cannot pass for one: the model
+// authors text, never a presentation. This holds on the panel and nowhere else.
+// On the comment surfaces the marker is a plain <li> that a forged detail
+// matches exactly, and nothing here closes that.
+function TruncatedItem() {
+  return (
+    <Typography
+      component="li"
+      variant="body2"
+      color="text.disabled"
+      fontStyle="italic"
+    >
+      {OUTLINE_TRUNCATED_LABEL}
+    </Typography>
+  );
+}
+
+export default function GreenLightOutline({
+  outline,
+}: {
+  outline: ParsedOutline;
+}) {
+  return (
+    <Box component="ul" sx={LIST_SX}>
+      {outline.topics.map((topic, index) => (
+        <Typography
+          key={index}
+          component="li"
+          variant="body2"
+          color="text.primary"
+        >
+          <strong>{segmentNodes(topic.text)}</strong>
+          {topic.details.length > 0 && (
+            <Box component="ul" sx={LIST_SX}>
+              {topic.details.map((detail, detailIndex) => (
+                <DetailItem key={detailIndex}>
+                  {segmentNodes(detail)}
+                </DetailItem>
+              ))}
+              {topic.detailsTruncated && <TruncatedItem />}
+            </Box>
+          )}
+        </Typography>
+      ))}
+      {outline.truncated && <TruncatedItem />}
+    </Box>
+  );
+}

--- a/torchci/components/greenlight/GreenLightSection.tsx
+++ b/torchci/components/greenlight/GreenLightSection.tsx
@@ -3,9 +3,14 @@
 // ways a commit is matched. Headline wording is shared with greenlightRender.ts
 // so the HUD and the Dr.CI comment cannot disagree about what a status means.
 //
-// The model's `message` renders as a text node, which is the containment --
-// nothing here may route it through dangerouslySetInnerHTML or a markdown
-// renderer.
+// Whatever part of the model's `message` reaches the DOM reaches it as a React
+// text node, whether it renders as one block of text or as the bullet list in
+// GreenLightOutline.tsx, and that is the containment: nothing on this surface
+// may route it through dangerouslySetInnerHTML or a markdown renderer. Two MUI
+// props reach the same place by a longer road and are equally out: spreading an
+// object built from the message into a component forwards a
+// dangerouslySetInnerHTML key straight through, and a `component` chosen from
+// the message renders whatever tag it names.
 
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import {
@@ -18,15 +23,16 @@ import {
   Typography,
 } from "@mui/material";
 import GreenLightIcon from "components/greenlight/GreenLightIcon";
+import GreenLightOutline from "components/greenlight/GreenLightOutline";
 import {
   isGreenlightApproved,
   normalizeSha,
+  selectMessageView,
   selectStateForSha,
 } from "lib/greenlight/greenlightHudState";
 import {
   GREENLIGHT_INCOMPLETE_HEADLINE,
   GREENLIGHT_LAND_HEADLINE,
-  GREENLIGHT_MESSAGE_CAP,
   GREENLIGHT_NO_LAND_HEADLINE,
   GREENLIGHT_REVERTED_BODY,
   GREENLIGHT_REVERTED_HEADLINE,
@@ -162,10 +168,7 @@ export default function GreenLightSection({
 
   const approved = isGreenlightApproved(state.status);
   const reason = described.reason;
-  // `message` is an unbounded ClickHouse String; same cap as the Dr.CI render.
-  const message = Array.from(state.message ?? "")
-    .slice(0, GREENLIGHT_MESSAGE_CAP)
-    .join("");
+  const messageView = selectMessageView(state.message);
   const jobUrl = (state.eval_job ?? "").trim();
 
   return (
@@ -208,22 +211,26 @@ export default function GreenLightSection({
               {described.body}
             </Typography>
           )}
-          {message && (
-            <Box
-              component="pre"
-              sx={{
-                m: 0,
-                p: 1.5,
-                borderRadius: 1,
-                bgcolor: "action.hover",
-                color: "text.primary",
-                fontSize: "0.8rem",
-                whiteSpace: "pre-wrap",
-                overflowWrap: "anywhere",
-              }}
-            >
-              {message}
-            </Box>
+          {messageView.kind === "outline" ? (
+            <GreenLightOutline outline={messageView.outline} />
+          ) : (
+            messageView.text && (
+              <Box
+                component="pre"
+                sx={{
+                  m: 0,
+                  p: 1.5,
+                  borderRadius: 1,
+                  bgcolor: "action.hover",
+                  color: "text.primary",
+                  fontSize: "0.8rem",
+                  whiteSpace: "pre-wrap",
+                  overflowWrap: "anywhere",
+                }}
+              >
+                {messageView.text}
+              </Box>
+            )
           )}
           {SAFE_JOB_URL_RE.test(jobUrl) && (
             <Link

--- a/torchci/lib/greenlight/greenlightHudState.ts
+++ b/torchci/lib/greenlight/greenlightHudState.ts
@@ -5,7 +5,16 @@
 //
 // No server-only imports, so this is unit-testable and importable anywhere.
 
-import { GREENLIGHT_STATUS_LAND } from "lib/greenlight/greenlightRender";
+import {
+  capCodePoints,
+  isOutline,
+  ParsedOutline,
+  parseOutline,
+} from "lib/greenlight/greenlightOutline";
+import {
+  GREENLIGHT_MESSAGE_CAP,
+  GREENLIGHT_STATUS_LAND,
+} from "lib/greenlight/greenlightRender";
 
 /** One `misc.greenlight_pr_state` row. Saved queries are untyped, so this is the cast target. */
 export interface GreenlightPrStateRow {
@@ -112,4 +121,46 @@ export function selectStateForSha(
       normalizeSha(row.head_sha) === wanted ||
       normalizeSha(row.merge_commit_sha) === wanted
   );
+}
+
+/** How the panel shows a verdict `message`: as a bullet list, or as raw text. */
+export type GreenlightMessageView =
+  | { kind: "outline"; outline: ParsedOutline }
+  | { kind: "text"; text: string };
+
+/**
+ * The same two-way choice renderVerdictMessage makes for the Dr.CI comment: a
+ * bullet outline becomes a list, everything else stays text. Two of the three
+ * routes that renderer takes to the fence are here -- a message that parses to
+ * no topic at all, and a parse that throws. The third is not, and the panel
+ * claims no parity on it: the comment renderer also falls through when its first
+ * item alone overruns OUTLINE_BLOCK_BUDGET, which bounds finished markup in a
+ * comment body this surface never builds.
+ *
+ * The parser reads the raw message, never a capped one. It takes its own prefix
+ * and decides `truncated` from the original length, so handing it text already
+ * cut to the cap would drop the marker saying the reader is missing the rest.
+ *
+ * The thrown error is logged without the message beside it: that text is
+ * model-authored and PR-influenceable, and a console is not where it gets
+ * replayed unbounded.
+ */
+export function selectMessageView(
+  message: string | undefined | null
+): GreenlightMessageView {
+  // A row is a cast over an untyped saved query, so `message` is a string by
+  // assertion alone. Anything else has to become one here: it reaches the panel
+  // as a React child, and React renders no object.
+  const raw = typeof message === "string" ? message : "";
+  try {
+    if (isOutline(raw)) {
+      const outline = parseOutline(raw);
+      if (outline.topics.length > 0) {
+        return { kind: "outline", outline };
+      }
+    }
+  } catch (e) {
+    console.error("greenlight outline parse threw", e);
+  }
+  return { kind: "text", text: capCodePoints(raw, GREENLIGHT_MESSAGE_CAP) };
 }

--- a/torchci/lib/greenlight/greenlightOutline.ts
+++ b/torchci/lib/greenlight/greenlightOutline.ts
@@ -1,9 +1,11 @@
-// Renders a model-authored verdict outline as a self-contained HTML bullet
-// list, mirroring greenlight/src/greenlight/verdict_outline.py byte for byte --
+// Parses a model-authored verdict outline into structure, and serializes that
+// structure into a self-contained HTML bullet list. The HTML is the mirrored
+// half: it matches greenlight/src/greenlight/verdict_outline.py byte for byte --
 // that one Python module against this one and greenlightReferenceGuards.ts
 // together. Python is the source of truth; tests/test_verdict_outline.py scrapes
 // the literals in both and a shared fixture pins the implementations to the same
-// output for the same input.
+// output for the same input. The parse layer is TypeScript's alone, because only
+// this side feeds a DOM.
 //
 // The reviewer writes `message` as a short markdown outline -- a few topic
 // bullets, each with a few detail bullets. That text is attacker-influenceable
@@ -58,6 +60,10 @@ export const OUTLINE_MAX_DETAILS = 8;
 // clamps above bound the block only after a worst-case escaping blowup.
 export const OUTLINE_BLOCK_BUDGET = 12000;
 export const OUTLINE_TRUNCATED_ITEM = "<li>(truncated)</li>";
+// Both markers stay plain quoted literals, never one composed from the other:
+// greenlight/tests/ts_source.py pins OUTLINE_TRUNCATED_ITEM by scraping this file
+// for a quoted literal of that name, and a template literal matches nothing.
+export const OUTLINE_TRUNCATED_LABEL = "(truncated)";
 export const OUTLINE_TRUNCATION_SUFFIX = "\u2026";
 // One bullet-shaped line in a paragraph is not an outline. Routing a paragraph
 // here would show the reader one leaf clipped to the leaf cap where the fenced
@@ -114,9 +120,29 @@ interface Leaf {
   text: string;
 }
 
-interface Topic {
+// Python's _Topic. OutlineTopic and parseOutline have no counterpart there.
+interface RawTopic {
   text: string;
   details: string[];
+}
+
+// A segment's `text` is the reviewer's own characters -- unescaped, unguarded,
+// and attacker-influenceable. Anything bound for a comment body has to be built
+// with renderOutlineHtml rather than read out of here.
+export interface OutlineSegment {
+  text: string;
+  code: boolean;
+}
+
+export interface OutlineTopic {
+  text: OutlineSegment[];
+  details: OutlineSegment[][];
+  detailsTruncated: boolean;
+}
+
+export interface ParsedOutline {
+  topics: OutlineTopic[];
+  truncated: boolean;
 }
 
 // Python slices and measures in code points; a UTF-16 slice would count an
@@ -252,8 +278,8 @@ function readLeaves(message: string): Leaf[] {
 // invents a parent and child out of two of the reviewer's own claims --
 // permanently, in public, and it is the exact relationship promotion exists to
 // prevent.
-function group(leaves: Leaf[]): Topic[] {
-  const topics: Topic[] = [];
+function group(leaves: Leaf[]): RawTopic[] {
+  const topics: RawTopic[] = [];
   let attachable = false;
   for (const leaf of leaves) {
     if (leaf.depth === 0) {
@@ -271,6 +297,39 @@ function group(leaves: Leaf[]): Topic[] {
   return topics;
 }
 
+// The outline as structure, with every clamp applied that does not need the
+// rendered HTML -- the detail clamp among them, which Python instead applies
+// where it renders a topic. The block budget measures escaped bytes, so it stays
+// in the serializer. Exported because the HUD panel builds a DOM out of this
+// rather than a comment body, and every defence below it answers GitHub's
+// markdown pipeline alone: a React text node cannot be opened by markup, so
+// escaped text there would only show the reader its entities, and the reference
+// guards splice a zero-width space into the shas and issue numbers a reader
+// copies out.
+export function parseOutline(message: string): ParsedOutline {
+  const raw = group(
+    readLeaves(message).map((leaf) => ({
+      depth: leaf.depth,
+      text: flatten(leaf.text),
+    }))
+  );
+  // A message past the cap was cut before the first leaf was read, so the list is
+  // short whatever the topic count says. The length test mirrors capCodePoints:
+  // a UTF-16 length at or under the cap is under it by code points too.
+  const truncated =
+    raw.length > OUTLINE_MAX_TOPICS ||
+    (message.length > OUTLINE_MESSAGE_CAP &&
+      codePointLength(message) > OUTLINE_MESSAGE_CAP);
+  return {
+    truncated,
+    topics: raw.slice(0, OUTLINE_MAX_TOPICS).map((topic) => ({
+      text: segments(topic.text),
+      details: topic.details.slice(0, OUTLINE_MAX_DETAILS).map(segments),
+      detailsTruncated: topic.details.length > OUTLINE_MAX_DETAILS,
+    })),
+  };
+}
+
 // HTML-escape, matching Python's html.escape(text, quote=True) byte for byte.
 // The two escape the same five characters and differ only on the apostrophe
 // entity. `&#x27;` is the form both sides settle on because the alternative,
@@ -286,32 +345,29 @@ function escape(text: string): string {
 // out as one text segment: backticks carry no meaning inside a raw HTML block,
 // so an unpaired run renders as itself rather than opening something that never
 // ends.
-function segments(leaf: string): string[] {
+function segments(leaf: string): OutlineSegment[] {
   const parts = leaf.split(BACKTICK_RUN_RE);
-  if ((parts.length - 1) % 2 === 1) return [leaf];
-  return parts;
+  if ((parts.length - 1) % 2 === 1) return [{ text: leaf, code: false }];
+  return parts.map((text, index) => ({ text, code: index % 2 === 1 }));
 }
 
-function leafHtml(leaf: string): string {
-  const rendered: string[] = [];
-  segments(leaf).forEach((segment, index) => {
-    const defused = defuseSweepSentinels(escape(segment));
-    rendered.push(
-      index % 2 === 1 ? `<code>${defused}</code>` : guardReferences(defused)
-    );
-  });
-  return rendered.join("");
+function leafHtml(leaf: OutlineSegment[]): string {
+  return leaf
+    .map(({ text, code }) => {
+      const defused = defuseSweepSentinels(escape(text));
+      return code ? `<code>${defused}</code>` : guardReferences(defused);
+    })
+    .join("");
 }
 
-function topicHtml(topic: Topic): string {
+function topicHtml(topic: OutlineTopic): string {
   const parts = [`<li><b>${leafHtml(topic.text)}</b>`];
-  const details = topic.details.slice(0, OUTLINE_MAX_DETAILS);
-  if (details.length > 0) {
+  if (topic.details.length > 0) {
     parts.push("<ul>");
-    for (const detail of details) parts.push(`<li>${leafHtml(detail)}</li>`);
-    if (topic.details.length > OUTLINE_MAX_DETAILS) {
-      parts.push(OUTLINE_TRUNCATED_ITEM);
+    for (const detail of topic.details) {
+      parts.push(`<li>${leafHtml(detail)}</li>`);
     }
+    if (topic.detailsTruncated) parts.push(OUTLINE_TRUNCATED_ITEM);
     parts.push("</ul>");
   }
   parts.push("</li>");
@@ -342,24 +398,13 @@ function assertContained(block: string): void {
 // over-budget item or over-cap tail leaves a truncation item behind, so a reader
 // can never mistake a cut list for a complete one.
 export function renderOutlineHtml(message: string): string {
-  const topics = group(
-    readLeaves(message).map((leaf) => ({
-      depth: leaf.depth,
-      text: flatten(leaf.text),
-    }))
-  );
-  if (topics.length === 0) return "";
+  const parsed = parseOutline(message);
+  if (parsed.topics.length === 0) return "";
 
   const items: string[] = [];
   let used = 0;
-  // A message past the cap was cut before the first leaf was read, so the list is
-  // short whatever the topic count says. The length test mirrors capCodePoints:
-  // a UTF-16 length at or under the cap is under it by code points too.
-  let truncated =
-    topics.length > OUTLINE_MAX_TOPICS ||
-    (message.length > OUTLINE_MESSAGE_CAP &&
-      codePointLength(message) > OUTLINE_MESSAGE_CAP);
-  for (const topic of topics.slice(0, OUTLINE_MAX_TOPICS)) {
+  let truncated = parsed.truncated;
+  for (const topic of parsed.topics) {
     const item = topicHtml(topic);
     // Measured before the append, not after: testing the running total alone
     // leaves whichever item crosses the budget unbounded, and one maximally

--- a/torchci/test/GreenLightOutline.test.tsx
+++ b/torchci/test/GreenLightOutline.test.tsx
@@ -1,0 +1,252 @@
+// The outline branch of the panel as a browser receives it. Every assertion
+// below reads the rendered markup rather than the React tree behind it, because
+// the DOM is where the model's text is either contained or not, and a tree that
+// looks right can still emit an element or an attribute nobody asked for.
+
+import { createTheme, ThemeProvider } from "@mui/material";
+import GreenLightOutline from "components/greenlight/GreenLightOutline";
+import { selectMessageView } from "lib/greenlight/greenlightHudState";
+import {
+  OUTLINE_MAX_DETAILS,
+  OUTLINE_MAX_TOPICS,
+  OUTLINE_TRUNCATED_LABEL,
+} from "lib/greenlight/greenlightOutline";
+import { ZERO_WIDTH_SPACE } from "lib/greenlight/greenlightSweep";
+import { renderToStaticMarkup } from "react-dom/server";
+
+// Emotion writes a <style> element beside each node it styles when it renders
+// on the server, and writes it again on every render rather than once per
+// process. So the element assertions read the markup with those removed, and
+// the presentation assertions read those alone -- from the same render, which
+// is what makes either of them independent of the order the tests run in.
+const STYLE_RE = /<style\b[^>]*>([\s\S]*?)<\/style>/g;
+const TAG_RE = /<([a-zA-Z][a-zA-Z0-9]*)((?:"[^"]*"|'[^']*'|[^>"'])*)>/g;
+const EMOTION_CLASS_RE = /css-[A-Za-z0-9-]+/;
+const LIST_ITEM_RE = /<li\b([^>]*)>([^<]*)/g;
+const ENTITY_RE = /&(?:amp|lt|gt|quot|#x27);/g;
+const ENTITIES: Record<string, string> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#x27;": "'",
+};
+
+function markupFor(message: string, mode: "light" | "dark" = "light"): string {
+  const view = selectMessageView(message);
+  if (view.kind !== "outline") {
+    throw new Error(`expected an outline view, got ${view.kind}`);
+  }
+  return renderToStaticMarkup(
+    <ThemeProvider theme={createTheme({ palette: { mode } })}>
+      <GreenLightOutline outline={view.outline} />
+    </ThemeProvider>
+  );
+}
+
+function tags(markup: string): { name: string; attributes: string }[] {
+  return Array.from(markup.replace(STYLE_RE, "").matchAll(TAG_RE), (match) => ({
+    name: match[1],
+    attributes: match[2],
+  }));
+}
+
+// The element tree with every attribute dropped. Emotion's class names change
+// with the styles behind them, and none of the structure here is about those.
+function skeleton(markup: string): string {
+  return markup.replace(STYLE_RE, "").replace(TAG_RE, "<$1>");
+}
+
+// What the reader sees, entities resolved back to the characters they stand for.
+function text(markup: string): string {
+  return markup
+    .replace(STYLE_RE, "")
+    .replace(/<[^>]*>/g, "")
+    .replace(ENTITY_RE, (entity) => ENTITIES[entity]);
+}
+
+function emotionClass(attributes: string): string {
+  return (attributes.match(EMOTION_CLASS_RE) ?? [""])[0];
+}
+
+/** The rules emotion emitted for one class: the CSS a browser actually gets. */
+function cssFor(markup: string, className: string): string {
+  return Array.from(markup.matchAll(STYLE_RE), (match) => match[1])
+    .filter((rule) => rule.startsWith(`.${className}{`))
+    .join("");
+}
+
+/** The emotion class on the first element with this tag name. */
+function classOfFirst(markup: string, name: string): string {
+  return emotionClass(
+    tags(markup).find((tag) => tag.name === name)!.attributes
+  );
+}
+
+/** The emotion class on every <li> whose own text is exactly `label`. */
+function classesOfItemsReading(markup: string, label: string): string[] {
+  return Array.from(markup.matchAll(LIST_ITEM_RE))
+    .filter((match) => match[2] === label)
+    .map((match) => emotionClass(match[1]));
+}
+
+const TWO_TOPICS = [
+  "- Scope is small",
+  "  - one file under torch/_inductor",
+  "  - no public API change",
+  "- Tests cover the change",
+  "  - test_torchinductor.py exercises both registrations",
+].join("\n");
+
+const CODE_MESSAGE = "- guarded by `is_fbcode()`\n- second topic";
+
+const MANY_DETAILS = [
+  "- one topic",
+  ...Array.from(
+    { length: OUTLINE_MAX_DETAILS + 1 },
+    (_, index) => `  - detail ${index}`
+  ),
+].join("\n");
+
+const MANY_TOPICS = Array.from(
+  { length: OUTLINE_MAX_TOPICS + 1 },
+  (_, index) => `- topic ${index}`
+).join("\n");
+
+// The same over-long detail list, with the marker's own wording written into
+// the first detail: the one input where a reader has to tell the renderer's
+// marker from the model's claim to have been cut short.
+const FORGED_MARKER = [
+  "- one topic",
+  ...Array.from({ length: OUTLINE_MAX_DETAILS + 1 }, (_, index) =>
+    index === 0 ? `  - ${OUTLINE_TRUNCATED_LABEL}` : `  - detail ${index}`
+  ),
+].join("\n");
+
+const HOSTILE = [
+  "- </code></li></ul><script>alert(1)</script>",
+  "  - <img src=x onerror=alert(1)>",
+  "  - `</code><script>alert(2)</script>`",
+  `- ampersand & quote " apostrophe '`,
+].join("\n");
+
+const SHA = "abc1234567890abc1234567890abc1234567890a";
+const REFERENCES = [
+  `- ping @octocat about #1234 in ${SHA}`,
+  "- and `@pytorchbot merge`",
+].join("\n");
+
+describe("GreenLightOutline", () => {
+  test("nests each topic's details one level under it", () => {
+    expect(skeleton(markupFor(TWO_TOPICS))).toBe(
+      "<ul>" +
+        "<li><strong>Scope is small</strong>" +
+        "<ul><li>one file under torch/_inductor</li>" +
+        "<li>no public API change</li></ul></li>" +
+        "<li><strong>Tests cover the change</strong>" +
+        "<ul><li>test_torchinductor.py exercises both registrations</li>" +
+        "</ul></li>" +
+        "</ul>"
+    );
+  });
+
+  test("puts a backticked span in <code>, and only the span", () => {
+    expect(skeleton(markupFor(CODE_MESSAGE))).toBe(
+      "<ul><li><strong>guarded by <code>is_fbcode()</code></strong></li>" +
+        "<li><strong>second topic</strong></li></ul>"
+    );
+  });
+
+  test("a leaf that is nothing but a code span emits no empty element", () => {
+    // That leaf parses to three segments with the outer two empty, which is
+    // every backticked path standing alone on a bullet.
+    expect(skeleton(markupFor("- `a`\n- b"))).toBe(
+      "<ul><li><strong><code>a</code></strong></li>" +
+        "<li><strong>b</strong></li></ul>"
+    );
+  });
+
+  test("a topic past the detail clamp ends its list with the marker", () => {
+    const details = Array.from(
+      { length: OUTLINE_MAX_DETAILS },
+      (_, index) => `<li>detail ${index}</li>`
+    ).join("");
+    expect(skeleton(markupFor(MANY_DETAILS))).toBe(
+      `<ul><li><strong>one topic</strong><ul>${details}` +
+        `<li>${OUTLINE_TRUNCATED_LABEL}</li></ul></li></ul>`
+    );
+  });
+
+  test("an outline past the topic clamp ends the outer list with the marker", () => {
+    const topics = Array.from(
+      { length: OUTLINE_MAX_TOPICS },
+      (_, index) => `<li><strong>topic ${index}</strong></li>`
+    ).join("");
+    expect(skeleton(markupFor(MANY_TOPICS))).toBe(
+      `<ul>${topics}<li>${OUTLINE_TRUNCATED_LABEL}</li></ul>`
+    );
+  });
+
+  test("the renderer's marker is told apart from one the model wrote", () => {
+    const markup = markupFor(FORGED_MARKER);
+    const reading = classesOfItemsReading(markup, OUTLINE_TRUNCATED_LABEL);
+    const [forged, generated] = reading;
+
+    expect(reading).toHaveLength(2);
+    expect(forged).not.toBe("");
+    expect(generated).not.toBe(forged);
+    expect(cssFor(markup, generated)).toContain("font-style:italic");
+    expect(cssFor(markup, forged)).not.toContain("font-style:italic");
+  });
+
+  test("a hostile leaf adds no element and no handler, and is still readable", () => {
+    const markup = markupFor(HOSTILE);
+
+    expect([...new Set(tags(markup).map((tag) => tag.name))].sort()).toEqual([
+      "code",
+      "li",
+      "strong",
+      "ul",
+    ]);
+    for (const tag of tags(markup)) {
+      expect(tag.attributes).not.toMatch(/\son[a-z]+ *=/i);
+    }
+    // Inert, not stripped: an `onerror=` the reader can see is the point, and a
+    // check that the string is absent would pass on a renderer that ate it.
+    const rendered = text(markup);
+    expect(rendered).toContain("</code></li></ul><script>alert(1)</script>");
+    expect(rendered).toContain("<img src=x onerror=alert(1)>");
+    expect(rendered).toContain("</code><script>alert(2)</script>");
+    expect(rendered).toContain(`ampersand & quote " apostrophe '`);
+  });
+
+  test("shas and references reach the reader whole, unsplit by any guard", () => {
+    const markup = markupFor(REFERENCES);
+
+    expect(text(markup)).toContain(`ping @octocat about #1234 in ${SHA}`);
+    expect(text(markup)).toContain("@pytorchbot merge");
+    expect(markup).not.toContain(ZERO_WIDTH_SPACE);
+  });
+
+  test("the list carries the wrap rule an unbroken leaf needs", () => {
+    // A leaf can reach OUTLINE_LEAF_CAP characters with no space in it, and
+    // nothing else on this surface offers a break opportunity.
+    const markup = markupFor(TWO_TOPICS);
+    expect(cssFor(markup, classOfFirst(markup, "ul"))).toContain(
+      "overflow-wrap:anywhere"
+    );
+  });
+
+  test("a code chip takes its background from the palette", () => {
+    const light = markupFor(CODE_MESSAGE, "light");
+    const dark = markupFor(CODE_MESSAGE, "dark");
+    const lightCss = cssFor(light, classOfFirst(light, "code"));
+    const darkCss = cssFor(dark, classOfFirst(dark, "code"));
+
+    expect(lightCss).toContain("background-color:");
+    expect(darkCss).toContain("background-color:");
+    // The global bare-`code` rule is one fixed colour per mode, and in dark mode
+    // it is the same #2a2a2a the panel's own Paper is forced to.
+    expect(darkCss).not.toBe(lightCss);
+  });
+});

--- a/torchci/test/greenlightHudState.test.ts
+++ b/torchci/test/greenlightHudState.test.ts
@@ -5,17 +5,24 @@ import {
   GreenlightPrStateRow,
   isGreenlightApproved,
   normalizeSha,
+  selectMessageView,
   selectStateForSha,
   supersedes,
 } from "lib/greenlight/greenlightHudState";
+// The namespace, not the bindings: the throw-path tests below spy on it, and a
+// destructured import would leave the route holding the real functions.
+import * as greenlightOutline from "lib/greenlight/greenlightOutline";
 import {
+  GREENLIGHT_MESSAGE_CAP,
   GREENLIGHT_STATUS_AI_REVIEW_STARTED,
   GREENLIGHT_STATUS_CANCELLED,
   GREENLIGHT_STATUS_LAND,
   GREENLIGHT_STATUS_NO_LAND,
   GREENLIGHT_STATUS_REVERTED,
 } from "lib/greenlight/greenlightRender";
+import { ZERO_WIDTH_SPACE } from "lib/greenlight/greenlightSweep";
 import path from "path";
+import { format } from "util";
 
 function row(overrides: Partial<GreenlightPrStateRow>): GreenlightPrStateRow {
   return {
@@ -215,6 +222,199 @@ describe("selectStateForSha", () => {
   test("undefined when the PR has no recorded state at all", () => {
     expect(selectStateForSha(undefined, SHA_A)).toBeUndefined();
     expect(selectStateForSha([], SHA_A)).toBeUndefined();
+  });
+});
+
+const OUTLINE_TOPIC = "torch/_inductor/lowering.py touched";
+const OUTLINE_DETAIL = "guarded by `is_fbcode()`";
+const OUTLINE_SECOND_TOPIC = "second topic";
+const OUTLINE_MESSAGE = `- ${OUTLINE_TOPIC}\n  - ${OUTLINE_DETAIL}\n- ${OUTLINE_SECOND_TOPIC}`;
+// Every leaf of that message with its bullet marker stripped. A redaction check
+// that named one phrase would pass on a log holding all the others.
+const OUTLINE_LEAVES = OUTLINE_MESSAGE.split("\n").map((line) =>
+  line.replace(/^\s*-\s*/, "")
+);
+
+// A message the classifier accepts -- two bullets, both with a body -- whose
+// every body flattens to nothing, so the parse yields no topic to render.
+const BLANK_OUTLINE = `- ${ZERO_WIDTH_SPACE}\n- ${ZERO_WIDTH_SPACE}`;
+
+// Over the cap with only two bullets, so `truncated` can only have been set by
+// the message length: a third bullet would set it through the topic clamp
+// instead and prove nothing about which string the parser read.
+const OVER_CAP_OUTLINE = `- ${OUTLINE_SECOND_TOPIC}\n- ${"x".repeat(
+  GREENLIGHT_MESSAGE_CAP
+)}`;
+const AT_CAP_OUTLINE = greenlightOutline.capCodePoints(
+  OVER_CAP_OUTLINE,
+  GREENLIGHT_MESSAGE_CAP
+);
+
+// The union is what makes the panel's two branches exhaustive, so narrowing it
+// here rather than asserting on `kind` keeps a wrong branch a type error.
+function outlineView(
+  message: string | undefined | null
+): greenlightOutline.ParsedOutline {
+  const view = selectMessageView(message);
+  if (view.kind !== "outline") {
+    throw new Error(`expected an outline view, got ${view.kind}`);
+  }
+  return view.outline;
+}
+
+function textView(message: string | undefined | null): string {
+  const view = selectMessageView(message);
+  if (view.kind !== "text") {
+    throw new Error(`expected a text view, got ${view.kind}`);
+  }
+  return view.text;
+}
+
+// What a console sink prints for the calls a console.error spy recorded.
+// JSON.stringify cannot stand in for it: Error.message and Error.stack are
+// non-enumerable, so it renders every logged error as `{}` and a redaction
+// check built on it passes whatever the error carries.
+function loggedText(spy: jest.SpyInstance): string {
+  return spy.mock.calls.map((call) => format(...call)).join("\n");
+}
+
+describe("selectMessageView", () => {
+  test("a bullet outline routes to the parsed list", () => {
+    const outline = outlineView(OUTLINE_MESSAGE);
+
+    expect(outline.truncated).toBe(false);
+    expect(outline.topics).toHaveLength(2);
+    expect(outline.topics[0].text).toEqual([
+      { text: OUTLINE_TOPIC, code: false },
+    ]);
+    // The trailing empty segment is why the renderer skips empty text: a leaf
+    // ending in a code span always parses to one.
+    expect(outline.topics[0].details).toEqual([
+      [
+        { text: "guarded by ", code: false },
+        { text: "is_fbcode()", code: true },
+        { text: "", code: false },
+      ],
+    ]);
+    expect(outline.topics[0].detailsTruncated).toBe(false);
+    expect(outline.topics[1].details).toEqual([]);
+  });
+
+  test("reads the `message` column the panel hands it", () => {
+    const state = selectStateForSha(
+      [row({ head_sha: SHA_A, message: OUTLINE_MESSAGE })],
+      SHA_A
+    );
+    expect(selectMessageView(state?.message).kind).toBe("outline");
+  });
+
+  test("prose routes to text, which is what every pre-outline row is", () => {
+    expect(textView("looks fine to me")).toBe("looks fine to me");
+    // One bullet-shaped line in a paragraph is not an outline.
+    expect(textView("a paragraph\n- with one bullet")).toBe(
+      "a paragraph\n- with one bullet"
+    );
+  });
+
+  test("an absent, empty or blank message routes to text", () => {
+    expect(textView(undefined)).toBe("");
+    expect(textView(null)).toBe("");
+    expect(textView("")).toBe("");
+    expect(textView("   ")).toBe("   ");
+  });
+
+  test("a message that is not a string at all routes to empty text", () => {
+    // The row is a cast over an untyped saved query, so the column's declared
+    // type is an assertion. The coercion is on the type rather than on what
+    // React happens to accept: a number and an array render, a plain object is
+    // not a valid child and takes the commit page down with it, and the panel
+    // has no business telling those apart.
+    expect(textView({} as unknown as string)).toBe("");
+    expect(textView(7 as unknown as string)).toBe("");
+    expect(textView(["- one", "- two"] as unknown as string)).toBe("");
+  });
+
+  test("an outline whose every leaf flattens away routes to text", () => {
+    // Not the empty list: the panel would show an empty <ul> where the fence
+    // shows the reader the characters that are actually in the row.
+    expect(textView(BLANK_OUTLINE)).toBe(BLANK_OUTLINE);
+  });
+
+  test("the parser reads the uncapped message, so an over-cap outline marks the cut", () => {
+    expect(OVER_CAP_OUTLINE.length).toBeGreaterThan(GREENLIGHT_MESSAGE_CAP);
+    expect(outlineView(OVER_CAP_OUTLINE).topics).toHaveLength(2);
+    expect(outlineView(OVER_CAP_OUTLINE).truncated).toBe(true);
+
+    // The same message pre-cut to the cap loses the marker, which is the whole
+    // reason the cap is applied to the text branch alone.
+    expect(AT_CAP_OUTLINE.length).toBe(GREENLIGHT_MESSAGE_CAP);
+    expect(outlineView(AT_CAP_OUTLINE).truncated).toBe(false);
+  });
+
+  test("the text branch is capped, since `message` is an unbounded String", () => {
+    const long = "x".repeat(GREENLIGHT_MESSAGE_CAP + 500);
+    expect(textView(long)).toBe("x".repeat(GREENLIGHT_MESSAGE_CAP));
+
+    // Counted in code points, not UTF-16 units: a cap that split a surrogate
+    // pair would hand the panel half a character.
+    const astral = "\u{1F600}".repeat(GREENLIGHT_MESSAGE_CAP);
+    expect(Array.from(textView(astral))).toHaveLength(GREENLIGHT_MESSAGE_CAP);
+  });
+
+  test("a parse that throws routes to text without logging the message", () => {
+    const thrown = new Error("parse read a message it could not handle");
+    const parse = jest
+      .spyOn(greenlightOutline, "parseOutline")
+      .mockImplementation(() => {
+        throw thrown;
+      });
+    const logged = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      expect(textView(OUTLINE_MESSAGE)).toBe(OUTLINE_MESSAGE);
+      expect(parse).toHaveBeenCalledWith(OUTLINE_MESSAGE);
+      expect(logged).toHaveBeenCalledWith(
+        expect.stringContaining("outline parse threw"),
+        thrown
+      );
+      // None of the model's text: `message` is PR-influenceable, and a console
+      // is not where it gets replayed unbounded.
+      const printed = loggedText(logged);
+      for (const leaf of OUTLINE_LEAVES) {
+        expect(printed).not.toContain(leaf);
+      }
+    } finally {
+      parse.mockRestore();
+      logged.mockRestore();
+    }
+  });
+
+  test("a classifier that throws routes to text too", () => {
+    // Choosing the branch reads the same untrusted text parsing it does, so it
+    // sits inside the same guard rather than outside it.
+    const thrown = new Error("classifier read a message it could not handle");
+    const classify = jest
+      .spyOn(greenlightOutline, "isOutline")
+      .mockImplementation(() => {
+        throw thrown;
+      });
+    const logged = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      expect(textView(OUTLINE_MESSAGE)).toBe(OUTLINE_MESSAGE);
+      expect(classify).toHaveBeenCalledWith(OUTLINE_MESSAGE);
+      expect(logged).toHaveBeenCalledWith(
+        expect.stringContaining("outline parse threw"),
+        thrown
+      );
+      const printed = loggedText(logged);
+      for (const leaf of OUTLINE_LEAVES) {
+        expect(printed).not.toContain(leaf);
+      }
+    } finally {
+      classify.mockRestore();
+      logged.mockRestore();
+    }
   });
 });
 

--- a/torchci/test/greenlightOutline.test.ts
+++ b/torchci/test/greenlightOutline.test.ts
@@ -8,7 +8,11 @@ import {
   OUTLINE_MAX_TOPICS,
   OUTLINE_MESSAGE_CAP,
   OUTLINE_TRUNCATED_ITEM,
+  OUTLINE_TRUNCATED_LABEL,
   OUTLINE_TRUNCATION_SUFFIX,
+  OutlineSegment,
+  OutlineTopic,
+  parseOutline,
   renderOutlineHtml,
 } from "lib/greenlight/greenlightOutline";
 import { SHA_SPLIT_COLUMN } from "lib/greenlight/greenlightReferenceGuards";
@@ -945,6 +949,164 @@ describe("bounds", () => {
     expect(countOf(block, "<li><b>")).toBe(10);
     expect(block).not.toContain(OUTLINE_TRUNCATION_SUFFIX);
     expect(block.endsWith(`${OUTLINE_TRUNCATED_ITEM}</ul>`)).toBe(true);
+  });
+});
+
+function leafText(leaf: OutlineSegment[]): string {
+  return leaf.map((segment) => segment.text).join("");
+}
+
+function topicText(topic: OutlineTopic): string {
+  return leafText(topic.text);
+}
+
+describe("parseOutline", () => {
+  it("nests details under their topic", () => {
+    const parsed = parseOutline(
+      bullet("- Topic one", "  - detail a", "  - detail b", "- Topic two")
+    );
+    expect(parsed.truncated).toBe(false);
+    expect(parsed.topics.map(topicText)).toEqual(["Topic one", "Topic two"]);
+    expect(parsed.topics.map((topic) => topic.details.map(leafText))).toEqual([
+      ["detail a", "detail b"],
+      [],
+    ]);
+    expect(parsed.topics.map((topic) => topic.detailsTruncated)).toEqual([
+      false,
+      false,
+    ]);
+  });
+
+  it("flags a code span and leaves the text either side of it unflagged", () => {
+    const [topic] = parseOutline(bullet("- call `foo(bar)` now", "- b")).topics;
+    expect(topic.text).toEqual([
+      { text: "call ", code: false },
+      { text: "foo(bar)", code: true },
+      { text: " now", code: false },
+    ]);
+  });
+
+  it("keeps an unbalanced backtick run as one text segment", () => {
+    const [topic] = parseOutline(bullet("- one ` backtick", "- b")).topics;
+    expect(topic.text).toEqual([{ text: "one ` backtick", code: false }]);
+  });
+
+  it("keeps the empty segments a code span leaves behind", () => {
+    // The consumer skips these; the parser must not. Which segment is code is
+    // decided by its index, so dropping an empty one here shifts every segment
+    // after it and renders the reviewer's prose as code, or the reverse.
+    const [topic] = parseOutline(bullet("- `a`", "- b")).topics;
+    expect(topic.text).toEqual([
+      { text: "", code: false },
+      { text: "a", code: true },
+      { text: "", code: false },
+    ]);
+  });
+
+  it("clips a leaf at the cap and marks it", () => {
+    const [topic] = parseOutline(
+      "- " + "x".repeat(OUTLINE_LEAF_CAP + 1)
+    ).topics;
+    expect(topicText(topic)).toBe(
+      "x".repeat(OUTLINE_LEAF_CAP) + OUTLINE_TRUNCATION_SUFFIX
+    );
+  });
+
+  it("does not mark a leaf that lands exactly on the cap", () => {
+    const [topic] = parseOutline("- " + "x".repeat(OUTLINE_LEAF_CAP)).topics;
+    expect(topicText(topic)).toBe("x".repeat(OUTLINE_LEAF_CAP));
+  });
+
+  it.each([
+    [OUTLINE_MAX_DETAILS, false],
+    [OUTLINE_MAX_DETAILS + 1, true],
+  ])("reports %i details as detailsTruncated=%s", (count, expected) => {
+    const [topic] = parseOutline(
+      bullet(
+        "- topic",
+        ...Array.from({ length: count }, (_v, index) => `  - detail ${index}`)
+      )
+    ).topics;
+    expect(topic.details.map(leafText)).toEqual(
+      Array.from(
+        { length: OUTLINE_MAX_DETAILS },
+        (_v, index) => `detail ${index}`
+      )
+    );
+    expect(topic.detailsTruncated).toBe(expected);
+  });
+
+  it.each([
+    [OUTLINE_MAX_TOPICS, false],
+    [OUTLINE_MAX_TOPICS + 1, true],
+  ])("reports %i topics as truncated=%s", (count, expected) => {
+    const parsed = parseOutline(
+      bullet(
+        ...Array.from({ length: count }, (_v, index) => `- topic ${index}`)
+      )
+    );
+    expect(parsed.topics.map(topicText)).toEqual(
+      Array.from({ length: OUTLINE_MAX_TOPICS }, (_v, i) => `topic ${i}`)
+    );
+    expect(parsed.truncated).toBe(expected);
+  });
+
+  it.each([
+    [OUTLINE_MESSAGE_CAP, false],
+    [OUTLINE_MESSAGE_CAP + 1, true],
+  ])("reports a %i character message as truncated=%s", (length, expected) => {
+    // The cap cuts before the first bullet is parsed, so nothing downstream can
+    // notice it: this flag is the only thing that tells a reader the outline
+    // they are looking at stops mid-verdict.
+    const parsed = parseOutline(sizedMessage(length, 10));
+    expect(parsed.topics.length).toBe(10);
+    expect(parsed.truncated).toBe(expected);
+  });
+
+  it.each([
+    ["empty", ""],
+    ["blank", "   "],
+    ["newlines", "\n\n\n"],
+    ["zero width", `- ${ZWSP}`],
+    [
+      "invisibles",
+      `- ${String.fromCharCode(0)}${String.fromCharCode(0x7f)}${BOM}`,
+    ],
+  ])("parses to no topics so the caller can fall back: %s", (_n, message) => {
+    expect(parseOutline(message).topics).toEqual([]);
+  });
+
+  it.each([
+    ["mention", "@user"],
+    ["issue reference", "#123"],
+    ["sha", SHA],
+    ["markup", "<script>alert(1)</script>"],
+    ["ampersand", "a & b"],
+    ["apostrophe", "it's"],
+    ["quotes", 'x" onload="y'],
+    ["emoji shortcode", ":shipit:"],
+    ["sweep predicate", "3 Pending"],
+  ])("hands a DOM consumer %s verbatim", (_name, payload) => {
+    // Escaping, the sweep defuse and the reference guards all answer GitHub's
+    // markdown pipeline. A React text node cannot be opened by markup, so an
+    // escaped one would show its entities to the reader; and the guards splice a
+    // zero-width space into exactly the references -- shas above all -- that a
+    // reader on the HUD is most likely to copy out.
+    const [topic] = parseOutline(
+      bullet(`- ${payload}`, `  - ${payload}`)
+    ).topics;
+    expect(topicText(topic)).toBe(payload);
+    expect(leafText(topic.details[0])).toBe(payload);
+    expect(topicText(topic)).not.toContain(ZWSP);
+  });
+});
+
+describe("the truncation marker", () => {
+  it("spells the same label the comment renderer emits", () => {
+    // Neither literal can be composed from the other -- see
+    // OUTLINE_TRUNCATED_LABEL -- so nothing but this stops the marker a DOM
+    // consumer draws from drifting from the one in the comment.
+    expect(OUTLINE_TRUNCATED_ITEM).toBe(`<li>${OUTLINE_TRUNCATED_LABEL}</li>`);
   });
 });
 


### PR DESCRIPTION
**Impact:** HUD Green Light panel
**Risk:** low

example: https://torchci-git-jeanschmidt-hudglmessagesnewformat-fbopensource.vercel.app/pytorch/pytorch/commit/b05cf6ed754d4654899f5088a33a797a1d2867c2

## What

Splits `greenlightOutline.ts` into a parse layer and an HTML serializer, and adds
`GreenLightOutline.tsx` so the HUD's Green Light panel draws a verdict outline as a real bullet
list instead of dumping the raw markdown into a `<pre>`. `selectMessageView` makes the same
outline-or-prose choice the Dr. CI renderer already makes, and everything that is not an outline
still renders exactly as before.

## Why

The outline format landed on both comment surfaces in the preceding commits; the panel was the
one place still showing the reviewer's markdown verbatim. It is the third consumer of one stored
row, so it shares the parser rather than the markup: the comments need escaping, the reference
guards and the block budget because they are fed to GitHub's markdown pipeline, and a React text
node needs none of them. Reusing the HTML would only show entities to the reader and splice
zero-width spaces into the shas and paths they copy off the page.

Two deliberate divergences from the comments, both covered in the README:

- The block budget stays in the serializer, so a message it would have clipped renders in full on
  the panel.
- The `(truncated)` marker is styled italic and dimmed, so a model-authored leaf reading
  "(truncated)" cannot pass for one the renderer added. The comments cannot tell those apart.

`renderOutlineHtml` now goes through `parseOutline`, so the Python/TypeScript parity gates
(`outline_parity_cases.json`, the literal scrape, `test_render_sync.py`) still cover the mirrored
half unchanged — the parse layer is TypeScript's alone and has no Python counterpart.