### PR TITLE
Add misc.pr_review_verdicts and replicate it from S3

### DIFF
--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -866,6 +866,55 @@ def greenlight_pr_state_adapter(table, bucket, key):
     general_adapter(table, bucket, key, schema, ["gzip", "none"], "JSONEachRow")
 
 
+def pr_review_verdicts_adapter(table, bucket, key):
+    # KEEP THIS LIST IN THE SAME ORDER AS misc.pr_review_verdicts. general_adapter
+    # inserts positionally (`select *`), so a column added here but not in the
+    # same position of the table shifts every later value silently.
+    #
+    # Two row shapes share this prefix: the `started` row carries the first 20
+    # fields, the terminal row all 33. The rest rely on ClickHouse defaulting
+    # omitted JSON keys, and `verdict` arrives as an explicit null on the started
+    # row. Both are stock ClickHouse behaviour and neither is verified against
+    # this cluster - see the note in the schema file.
+    schema = """
+        `schema_version` UInt16,
+        `phase` String,
+        `harness` String,
+        `harness_version` String,
+        `repo` String,
+        `pr_number` Int64,
+        `head_sha` String,
+        `base_sha` String,
+        `is_fork` Bool,
+        `trigger_event` String,
+        `trigger_label` String,
+        `trigger_run_id` Int64,
+        `review_run_id` Int64,
+        `review_run_attempt` Int32,
+        `prompt_hash` String,
+        `trusted_sha` String,
+        `timestamp` DateTime64(3),
+        `status` String,
+        `verdict` String,
+        `summary` String,
+        `findings_count` Int32,
+        `findings_dropped` Int32,
+        `failure_detail` String,
+        `reasoning_uri` String,
+        `duration_ms` Int64,
+        `num_turns` Int32,
+        `total_cost_usd` Float64,
+        `input_tokens` Int64,
+        `output_tokens` Int64,
+        `cache_read_input_tokens` Int64,
+        `cache_creation_input_tokens` Int64,
+        `model` String,
+        `extra` Map(String, String)
+    """
+    # Uploaded with a plain `aws s3 cp` from the workflow, so no gzip variant.
+    general_adapter(table, bucket, key, schema, ["none"], "JSONEachRow")
+
+
 SUPPORTED_PATHS = {
     "merges": "default.merges",
     "queue_times_historical": "default.queue_times_historical",
@@ -888,6 +937,11 @@ SUPPORTED_PATHS = {
     "disabled_tests_historical": "misc.disabled_tests_historical",
     "claude_code_usage": "misc.claude_code_usage",
     "autorevert_advisor_verdicts": "misc.autorevert_advisor_verdicts",
+    # Hardened PR review. NOTE the sibling prefix `pr_review_traces/` is
+    # deliberately absent: it holds unsanitized model transcripts that the
+    # untrusted review role can overwrite, and it must not reach ClickHouse.
+    # Prefix matching is `startswith(f"{path}/")`, so this entry cannot catch it.
+    "pr_review_verdicts": "misc.pr_review_verdicts",
     # fbossci-cloudwatch-metrics bucket
     "ghci-related": "infra_metrics.cloudwatch_metrics",
     "test_jsons_while_running": "tests.all_test_runs",
@@ -918,6 +972,7 @@ OBJECT_CONVERTER = {
     "misc.disabled_tests_historical": disabled_tests_historical_adapter,
     "misc.claude_code_usage": claude_code_usage_adapter,
     "misc.autorevert_advisor_verdicts": autorevert_advisor_verdicts_adapter,
+    "misc.pr_review_verdicts": pr_review_verdicts_adapter,
     "infra_metrics.cloudwatch_metrics": cloudwatch_metrics_adapter,
     "misc.runner_fleet_count": runner_fleet_count_adapter,
     "misc.greenlight_pr_state": greenlight_pr_state_adapter,

--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -867,15 +867,9 @@ def greenlight_pr_state_adapter(table, bucket, key):
 
 
 def pr_review_verdicts_adapter(table, bucket, key):
-    # KEEP THIS LIST IN THE SAME ORDER AS misc.pr_review_verdicts. general_adapter
-    # inserts positionally (`select *`), so a column added here but not in the
-    # same position of the table shifts every later value silently.
-    #
-    # Two row shapes share this prefix: the `started` row carries 20 fields, the
-    # terminal row all 33. Absent fields take their type default, which is
-    # ordinary JSONEachRow behaviour. `verdict` is Nullable because it arrives as
-    # an explicit JSON null whenever there is no verdict - every started row, and
-    # any terminal row that did not reach one (e.g. status 'blocked').
+    # Order must match misc.pr_review_verdicts: general_adapter inserts
+    # positionally. `verdict` is null on started rows and on any terminal row
+    # without a verdict.
     schema = """
         `schema_version` UInt16,
         `phase` String,
@@ -911,7 +905,6 @@ def pr_review_verdicts_adapter(table, bucket, key):
         `model` String,
         `extra` Map(String, String)
     """
-    # Uploaded with a plain `aws s3 cp` from the workflow, so no gzip variant.
     general_adapter(table, bucket, key, schema, ["none"], "JSONEachRow")
 
 
@@ -937,10 +930,6 @@ SUPPORTED_PATHS = {
     "disabled_tests_historical": "misc.disabled_tests_historical",
     "claude_code_usage": "misc.claude_code_usage",
     "autorevert_advisor_verdicts": "misc.autorevert_advisor_verdicts",
-    # Hardened PR review. NOTE the sibling prefix `pr_review_traces/` is
-    # deliberately absent: it holds unsanitized model transcripts that the
-    # untrusted review role can overwrite, and it must not reach ClickHouse.
-    # Prefix matching is `startswith(f"{path}/")`, so this entry cannot catch it.
     "pr_review_verdicts": "misc.pr_review_verdicts",
     # fbossci-cloudwatch-metrics bucket
     "ghci-related": "infra_metrics.cloudwatch_metrics",

--- a/aws/lambda/clickhouse-replicator-s3/lambda_function.py
+++ b/aws/lambda/clickhouse-replicator-s3/lambda_function.py
@@ -871,11 +871,11 @@ def pr_review_verdicts_adapter(table, bucket, key):
     # inserts positionally (`select *`), so a column added here but not in the
     # same position of the table shifts every later value silently.
     #
-    # Two row shapes share this prefix: the `started` row carries the first 20
-    # fields, the terminal row all 33. The rest rely on ClickHouse defaulting
-    # omitted JSON keys, and `verdict` arrives as an explicit null on the started
-    # row. Both are stock ClickHouse behaviour and neither is verified against
-    # this cluster - see the note in the schema file.
+    # Two row shapes share this prefix: the `started` row carries 20 fields, the
+    # terminal row all 33. Absent fields take their type default, which is
+    # ordinary JSONEachRow behaviour. `verdict` is Nullable because it arrives as
+    # an explicit JSON null whenever there is no verdict - every started row, and
+    # any terminal row that did not reach one (e.g. status 'blocked').
     schema = """
         `schema_version` UInt16,
         `phase` String,
@@ -895,7 +895,7 @@ def pr_review_verdicts_adapter(table, bucket, key):
         `trusted_sha` String,
         `timestamp` DateTime64(3),
         `status` String,
-        `verdict` String,
+        `verdict` Nullable(String),
         `summary` String,
         `findings_count` Int32,
         `findings_dropped` Int32,

--- a/clickhouse_db_schema/misc.pr_review_verdicts/grants.sql
+++ b/clickhouse_db_schema/misc.pr_review_verdicts/grants.sql
@@ -1,8 +1,2 @@
--- Grant SELECT to hud_user so HUD / Dr.CI can render the review verdict.
--- Rendering is the whole point of the table: the workflow posts nothing to the
--- pull request, so this row is the only path from a review to a human.
---
--- Most tables in this directory carry no grants.sql, which suggests a default
--- role already covers hud_user. This file is explicit rather than assumed;
--- @clee2000 / @huydhn should drop it if the default role makes it redundant.
+-- HUD / Dr.CI reads the review verdict from here.
 GRANT SELECT ON misc.pr_review_verdicts TO hud_user;

--- a/clickhouse_db_schema/misc.pr_review_verdicts/grants.sql
+++ b/clickhouse_db_schema/misc.pr_review_verdicts/grants.sql
@@ -1,0 +1,8 @@
+-- Grant SELECT to hud_user so HUD / Dr.CI can render the review verdict.
+-- Rendering is the whole point of the table: the workflow posts nothing to the
+-- pull request, so this row is the only path from a review to a human.
+--
+-- Most tables in this directory carry no grants.sql, which suggests a default
+-- role already covers hud_user. This file is explicit rather than assumed;
+-- @clee2000 / @huydhn should drop it if the default role makes it redundant.
+GRANT SELECT ON misc.pr_review_verdicts TO hud_user;

--- a/clickhouse_db_schema/misc.pr_review_verdicts/schema.sql
+++ b/clickhouse_db_schema/misc.pr_review_verdicts/schema.sql
@@ -4,9 +4,12 @@
 --   `started`  - written by the prepare job before any model call, so an attempt
 --                that is cancelled or dies on the runner still leaves a trace.
 --   terminal   - written by the publish job under `if: always()`.
--- Three distinguishable states follow, which one row cannot express: no rows =
--- never triggered; started only = cancelled/superseded/runner died; both = the
--- attempt ran and `status` says how it ended.
+-- Two rows let a reader tell apart states one row cannot. Read them as
+-- EVIDENCE, not proof: missing rows mean "not triggered OR not emitted OR not
+-- ingested" - this table did not exist for the pipeline's first four runs, whose
+-- objects are still sitting in S3 - and "started only" covers still-running and
+-- late-ingested as well as cancelled. Ingestion order is not guaranteed, and a
+-- replay can duplicate rows; nothing here deduplicates.
 --
 -- COLUMN ORDER IS LOAD-BEARING. The S3 replicator inserts positionally
 -- (`insert into <table> select *, (...) as _meta from s3(...)`), so this order
@@ -14,13 +17,17 @@
 -- `aws/lambda/clickhouse-replicator-s3/lambda_function.py`. Appending a column
 -- here without adding it there, in the same position, shifts every later value.
 --
--- The started row carries 20 of these 33 fields. The remaining 13 rely on
--- ClickHouse filling defaults for omitted JSON keys, and `verdict` is emitted as
--- an explicit JSON `null` on the started row, which relies on nulls becoming
--- defaults. Both are ClickHouse defaults
--- (`input_format_defaults_for_omitted_fields`, `input_format_null_as_default`)
--- but NEITHER was verified against this cluster - the author holds no INSERT
--- grant. Confirm on the first real insert before trusting the started rows.
+-- The started row carries 20 of these 33 fields (the first 19, plus `extra`).
+-- The other 13 are simply absent from the JSON and take their type default,
+-- which is ordinary JSONEachRow behaviour and needs no special setting.
+--
+-- `verdict` is Nullable ON PURPOSE. It is emitted as an explicit JSON `null`
+-- whenever there is no verdict - on every started row AND on any terminal row
+-- that did not reach a verdict, e.g. `status = 'blocked'`. Declaring it
+-- non-nullable would make correct ingestion depend on
+-- `input_format_null_as_default`, which the author could not verify here (no
+-- INSERT grant on this cluster). Nullable keeps the emitted meaning instead of
+-- silently converting "no verdict" into the empty string.
 CREATE TABLE misc.pr_review_verdicts
 (
     -- Row identity and provenance.
@@ -45,14 +52,17 @@ CREATE TABLE misc.pr_review_verdicts
     `prompt_hash` String,
     `trusted_sha` String,
     `timestamp` DateTime64(3),
-    -- succeeded | schema_invalid | sanitizer_rejected | model_error | started
+    -- started | succeeded | blocked | schema_invalid | sanitizer_rejected |
+    -- model_error. Not an enum: a status the emitter adds must land as data
+    -- rather than break ingestion.
     `status` LowCardinality(String),
     -- Populated ONLY when status = 'succeeded'. A failed review must never
     -- surface as an objection: a reader cannot otherwise tell a real finding
     -- from an infrastructure hiccup.
-    `verdict` LowCardinality(String),
+    `verdict` LowCardinality(Nullable(String)),
 
-    -- Terminal-only below this line; defaulted on the `started` row.
+    -- Terminal-only from here to `model`; absent from the started row and
+    -- defaulted. `extra` at the end is present on BOTH rows.
     --
     -- MODEL-INFLUENCED, and the only fields here that are. `summary` is
     -- sanitized and length-capped upstream but is still derived from a model

--- a/clickhouse_db_schema/misc.pr_review_verdicts/schema.sql
+++ b/clickhouse_db_schema/misc.pr_review_verdicts/schema.sql
@@ -1,40 +1,13 @@
--- Telemetry for the hardened PR review (pytorch/ciforge, moving to pytorch/pytorch).
+-- Telemetry for the hardened PR review in pytorch/ciforge. Two rows per review
+-- attempt: `started` from the prepare job, then a terminal row from publish.
 --
--- TWO ROWS PER REVIEW ATTEMPT, and the pair is what makes the record readable:
---   `started`  - written by the prepare job before any model call, so an attempt
---                that is cancelled or dies on the runner still leaves a trace.
---   terminal   - written by the publish job under `if: always()`.
--- Two rows let a reader tell apart states one row cannot. Read them as
--- EVIDENCE, not proof: missing rows mean "not triggered OR not emitted OR not
--- ingested" - this table did not exist for the pipeline's first four runs, whose
--- objects are still sitting in S3 - and "started only" covers still-running and
--- late-ingested as well as cancelled. Ingestion order is not guaranteed, and a
--- replay can duplicate rows; nothing here deduplicates.
---
--- COLUMN ORDER IS LOAD-BEARING. The S3 replicator inserts positionally
--- (`insert into <table> select *, (...) as _meta from s3(...)`), so this order
--- must stay byte-for-byte in step with the schema string in
--- `aws/lambda/clickhouse-replicator-s3/lambda_function.py`. Appending a column
--- here without adding it there, in the same position, shifts every later value.
---
--- The started row carries 20 of these 33 fields (the first 19, plus `extra`).
--- The other 13 are simply absent from the JSON and take their type default,
--- which is ordinary JSONEachRow behaviour and needs no special setting.
---
--- `verdict` is Nullable ON PURPOSE. It is emitted as an explicit JSON `null`
--- whenever there is no verdict - on every started row AND on any terminal row
--- that did not reach a verdict, e.g. `status = 'blocked'`. Declaring it
--- non-nullable would make correct ingestion depend on
--- `input_format_null_as_default`, which the author could not verify here (no
--- INSERT grant on this cluster). Nullable keeps the emitted meaning instead of
--- silently converting "no verdict" into the empty string.
+-- Column order must match the schema string in
+-- aws/lambda/clickhouse-replicator-s3/lambda_function.py: the replicator
+-- inserts positionally, so a column added to one side shifts every later value.
 CREATE TABLE misc.pr_review_verdicts
 (
-    -- Row identity and provenance.
     `schema_version` UInt16,
     `phase` LowCardinality(String),
-    -- `gha-interim` now, `sandbox` after the credential-less harness replaces
-    -- it. Both write this same shape so the two eras stay comparable.
     `harness` LowCardinality(String),
     `harness_version` String,
     `repo` LowCardinality(String),
@@ -47,35 +20,20 @@ CREATE TABLE misc.pr_review_verdicts
     `trigger_run_id` Int64,
     `review_run_id` Int64,
     `review_run_attempt` Int32,
-    -- Hash of the trusted prompt/schema/sanitizer files, so a verdict can be
-    -- attributed to the exact rubric that produced it.
     `prompt_hash` String,
     `trusted_sha` String,
     `timestamp` DateTime64(3),
-    -- started | succeeded | blocked | schema_invalid | sanitizer_rejected |
-    -- model_error. Not an enum: a status the emitter adds must land as data
-    -- rather than break ingestion.
     `status` LowCardinality(String),
-    -- Populated ONLY when status = 'succeeded'. A failed review must never
-    -- surface as an objection: a reader cannot otherwise tell a real finding
-    -- from an infrastructure hiccup.
+    -- Null unless status = 'succeeded'; emitted as JSON null otherwise.
     `verdict` LowCardinality(Nullable(String)),
 
-    -- Terminal-only from here to `model`; absent from the started row and
-    -- defaulted. `extra` at the end is present on BOTH rows.
-    --
-    -- MODEL-INFLUENCED, and the only fields here that are. `summary` is
-    -- sanitized and length-capped upstream but is still derived from a model
-    -- reading attacker-authored code. Treat it as untrusted text on render -
-    -- do not interpolate it into HTML, shell or SQL.
+    -- Terminal-only from here to `model`; defaulted on the started row.
+    -- Model-authored and attacker-influenced. Sanitized upstream, but treat as
+    -- untrusted text on render.
     `summary` String,
     `findings_count` Int32,
     `findings_dropped` Int32,
     `failure_detail` String,
-    -- s3:// URI of the raw model transcript under `pr_review_traces/`. That
-    -- prefix is deliberately NOT replicated into ClickHouse: it is unsanitized
-    -- model output, and the untrusted review role can overwrite any key under
-    -- it. Never join it to these rows as though it were authenticated.
     `reasoning_uri` String,
     `duration_ms` Int64,
     `num_turns` Int32,
@@ -85,18 +43,11 @@ CREATE TABLE misc.pr_review_verdicts
     `cache_read_input_tokens` Int64,
     `cache_creation_input_tokens` Int64,
     `model` String,
-    -- Escape hatch, so a new field does not need the table re-cut.
     `extra` Map(String, String),
 
     `_meta` Tuple(bucket String, key String),
     `_inserted_at` DateTime MATERIALIZED now()
 )
 ENGINE = SharedMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}')
--- Identity of one attempt, with `phase` last so the started/terminal pair sits
--- adjacent. docs/hardened-pr-review.md in pytorch/ciforge proposed
--- `(repo, pr_number, head_sha, run_id, run_attempt)`; those last two names do
--- not exist in the emitted row, and without `phase` the two rows of a pair
--- share an identical key. Settle this before the table is created - adding a
--- column later is trivial, changing the sort key is not.
 ORDER BY (repo, pr_number, head_sha, review_run_id, review_run_attempt, phase)
 SETTINGS index_granularity = 8192

--- a/clickhouse_db_schema/misc.pr_review_verdicts/schema.sql
+++ b/clickhouse_db_schema/misc.pr_review_verdicts/schema.sql
@@ -1,0 +1,92 @@
+-- Telemetry for the hardened PR review (pytorch/ciforge, moving to pytorch/pytorch).
+--
+-- TWO ROWS PER REVIEW ATTEMPT, and the pair is what makes the record readable:
+--   `started`  - written by the prepare job before any model call, so an attempt
+--                that is cancelled or dies on the runner still leaves a trace.
+--   terminal   - written by the publish job under `if: always()`.
+-- Three distinguishable states follow, which one row cannot express: no rows =
+-- never triggered; started only = cancelled/superseded/runner died; both = the
+-- attempt ran and `status` says how it ended.
+--
+-- COLUMN ORDER IS LOAD-BEARING. The S3 replicator inserts positionally
+-- (`insert into <table> select *, (...) as _meta from s3(...)`), so this order
+-- must stay byte-for-byte in step with the schema string in
+-- `aws/lambda/clickhouse-replicator-s3/lambda_function.py`. Appending a column
+-- here without adding it there, in the same position, shifts every later value.
+--
+-- The started row carries 20 of these 33 fields. The remaining 13 rely on
+-- ClickHouse filling defaults for omitted JSON keys, and `verdict` is emitted as
+-- an explicit JSON `null` on the started row, which relies on nulls becoming
+-- defaults. Both are ClickHouse defaults
+-- (`input_format_defaults_for_omitted_fields`, `input_format_null_as_default`)
+-- but NEITHER was verified against this cluster - the author holds no INSERT
+-- grant. Confirm on the first real insert before trusting the started rows.
+CREATE TABLE misc.pr_review_verdicts
+(
+    -- Row identity and provenance.
+    `schema_version` UInt16,
+    `phase` LowCardinality(String),
+    -- `gha-interim` now, `sandbox` after the credential-less harness replaces
+    -- it. Both write this same shape so the two eras stay comparable.
+    `harness` LowCardinality(String),
+    `harness_version` String,
+    `repo` LowCardinality(String),
+    `pr_number` Int64,
+    `head_sha` String,
+    `base_sha` String,
+    `is_fork` Bool,
+    `trigger_event` LowCardinality(String),
+    `trigger_label` String,
+    `trigger_run_id` Int64,
+    `review_run_id` Int64,
+    `review_run_attempt` Int32,
+    -- Hash of the trusted prompt/schema/sanitizer files, so a verdict can be
+    -- attributed to the exact rubric that produced it.
+    `prompt_hash` String,
+    `trusted_sha` String,
+    `timestamp` DateTime64(3),
+    -- succeeded | schema_invalid | sanitizer_rejected | model_error | started
+    `status` LowCardinality(String),
+    -- Populated ONLY when status = 'succeeded'. A failed review must never
+    -- surface as an objection: a reader cannot otherwise tell a real finding
+    -- from an infrastructure hiccup.
+    `verdict` LowCardinality(String),
+
+    -- Terminal-only below this line; defaulted on the `started` row.
+    --
+    -- MODEL-INFLUENCED, and the only fields here that are. `summary` is
+    -- sanitized and length-capped upstream but is still derived from a model
+    -- reading attacker-authored code. Treat it as untrusted text on render -
+    -- do not interpolate it into HTML, shell or SQL.
+    `summary` String,
+    `findings_count` Int32,
+    `findings_dropped` Int32,
+    `failure_detail` String,
+    -- s3:// URI of the raw model transcript under `pr_review_traces/`. That
+    -- prefix is deliberately NOT replicated into ClickHouse: it is unsanitized
+    -- model output, and the untrusted review role can overwrite any key under
+    -- it. Never join it to these rows as though it were authenticated.
+    `reasoning_uri` String,
+    `duration_ms` Int64,
+    `num_turns` Int32,
+    `total_cost_usd` Float64,
+    `input_tokens` Int64,
+    `output_tokens` Int64,
+    `cache_read_input_tokens` Int64,
+    `cache_creation_input_tokens` Int64,
+    `model` String,
+    -- Escape hatch, so a new field does not need the table re-cut.
+    `extra` Map(String, String),
+
+    `_meta` Tuple(bucket String, key String),
+    `_inserted_at` DateTime MATERIALIZED now()
+)
+ENGINE = SharedMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}')
+-- Identity of one attempt, with `phase` last so the started/terminal pair sits
+-- adjacent. docs/hardened-pr-review.md in pytorch/ciforge proposed
+-- `(repo, pr_number, head_sha, run_id, run_attempt)`; those last two names do
+-- not exist in the emitted row, and without `phase` the two rows of a pair
+-- share an identical key. Settle this before the table is created - adding a
+-- column later is trivial, changing the sort key is not.
+ORDER BY (repo, pr_number, head_sha, review_run_id, review_run_attempt, phase)
+SETTINGS index_granularity = 8192


### PR DESCRIPTION
✴️ iz2: The hardened PR review in `pytorch/ciforge` writes telemetry to `s3://ossci-raw-job-status/pr_review_verdicts/`, and nothing ingests it. The verdicts stop at S3, so HUD / Dr.CI has nothing to render and a completed review reaches no human.

This adds the missing half.

## What's here

- `clickhouse_db_schema/misc.pr_review_verdicts/schema.sql` — the table. **Already applied** (thanks) and it matches this PR: 33 columns in the same order and types, `verdict` as `LowCardinality(Nullable(String))`, `_meta` at 34, `_inserted_at` MATERIALIZED, sort key `(repo, pr_number, head_sha, review_run_id, review_run_attempt, phase)`.
- `.../grants.sql` — **possibly redundant; your call.** As `hud_user` I can already `SELECT` from `misc.pr_review_verdicts`, and also from `misc.autorevert_advisor_verdicts`, whose own `grants.sql` names only `revert_lambda`. That shows this session has the access; it does **not** prove where the access comes from, and I can't read `system.grants` as `hud_user` to find out. If a database-wide role already covers `misc`, drop the file — I'd rather remove it than ship a redundant grant, but I can't establish that from here.
- `aws/lambda/clickhouse-replicator-s3/lambda_function.py` — prefix → table entry plus an adapter. This is the part still needed.

## Two rows per review attempt

`started` from the prepare job before any model call; the terminal row from publish under `if: always()`. `verdict` is populated only when `status = 'succeeded'`, so an infrastructure failure can never surface as a review objection.

Read row presence as evidence, not proof: missing rows mean "not triggered *or* not emitted *or* not ingested", and "started only" covers still-running and late-ingested as well as cancelled. Ingestion order isn't guaranteed and a replay can duplicate; nothing here deduplicates.

`verdict` is `Nullable` because it arrives as an explicit JSON `null` whenever there is no verdict — every started row, and any terminal row that didn't reach one. A fork probe returning `status = 'blocked'` produced exactly that.

## What I verified

Column order is load-bearing — `general_adapter` inserts positionally (`select *`), so a column added on one side shifts every later value. `schema.sql`, the adapter's schema string, and two real emitted rows from S3 (one `succeeded`, one `blocked`) all agree: 33 columns, same order, same names, and that now also matches the applied table. **This is schema agreement, not a successful insert** — I have no INSERT grant, so no row has actually gone in.

Routing checked including the negative: `pr_review_traces/` must not be replicated — unsanitized model transcripts the untrusted review role can overwrite — and matching is `startswith(f"{path}/")`, so the new entry can't catch it.

## Still open

The **sort key**. It's what the applied table already uses, so changing it now is a recreate rather than an edit — better to raise it before rows accumulate.

## Remaining steps after merge

The table is in place and currently empty, so the deploy is safe to do straight after merge.

1. Deploy the replicator lambda.
2. Confirm the replicator's ClickHouse principal has INSERT on `misc.pr_review_verdicts` — the grants question above concerns the *reader*, not the writer.
3. Exercise both shapes — a succeeded terminal row and a blocked one — and confirm the null `verdict` lands as null.
4. Backfill: adding a prefix does not reprocess existing objects. **41 objects across 20 runs** are already sitting under that prefix for `pytorch/ciforge` alone.
5. Confirm HUD / Dr.CI actually queries and renders it. I searched `pytorch/test-infra` for any consumer of this table — zero hits outside this PR's own files, and no ClickHouse view over it — against controls showing the sibling advisor feed has three `clickhouse_queries/` entries and that 166 such directories exist. So a display change looks like it is still needed; I may simply not have found a consumer that reaches the data another way.

One rendering contract for whoever builds that display: `status = 'blocked'` is a **failed** review. Do not read `findings_count = 0` on such a row as a clean result.