### PR TITLE
build_wheels_linux: make it work on OSDC runners

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -172,7 +172,13 @@ jobs:
         run: |
           set -euxo pipefail
           echo "::group::Cleanup debug output"
-          rm -rf "${GITHUB_WORKSPACE}"
+          # Clear the workspace without removing the directory itself. On an OSDC
+          # runner GITHUB_WORKSPACE is a bind mount into the job container, and
+          # deleting it detaches the mount: later steps fail with "getcwd: cannot
+          # access parent directories" and local actions resolve against a host
+          # path that no longer matches what the container sees. EC2 runners reuse
+          # the workspace between jobs, so its contents still need clearing.
+          find "${GITHUB_WORKSPACE}" -mindepth 1 -delete 2>/dev/null || true
           mkdir -p "${GITHUB_WORKSPACE}"
 
           if [[ "${{ inputs.architecture }}" = "aarch64" ]]; then

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -219,14 +219,14 @@ jobs:
           source /opt/conda/etc/profile.d/conda.sh
           conda config --set ssl_verify False
           echo "/opt/conda/bin" >> $GITHUB_PATH
-      - uses: ./test-infra/.github/actions/set-channel
+      - uses: pytorch/test-infra/.github/actions/set-channel@main
       - name: Set PYTORCH_VERSION
         if: ${{ env.CHANNEL == 'test' }}
         run: |
           # When building RC, set the version to be the current candidate version,
           # otherwise, leave it alone so nightly will pick up the latest
           echo "PYTORCH_VERSION=${{ matrix.stable_version }}" >> "${GITHUB_ENV}"
-      - uses: ./test-infra/.github/actions/setup-binary-builds
+      - uses: pytorch/test-infra/.github/actions/setup-binary-builds@main
         env:
           PLATFORM: ${{ inputs.architecture == 'aarch64'  && 'linux-aarch64' || ''}}
         with:
@@ -261,7 +261,7 @@ jobs:
           ${CONDA_RUN} ${PIP_INSTALL_TORCH} ${{ inputs.pip-install-torch-extra-args }}
       - name: Run Pre-Script with Caching
         if: ${{ inputs.pre-script != '' }}
-        uses: ./test-infra/.github/actions/run-script-with-cache
+        uses: pytorch/test-infra/.github/actions/run-script-with-cache@main
         with:
           cache-path: ${{ inputs.cache-path }}
           cache-key: ${{ inputs.cache-key }}
@@ -307,7 +307,7 @@ jobs:
           done
       - name: Run Post-Script
         if: ${{ inputs.post-script != '' }}
-        uses: ./test-infra/.github/actions/run-script-with-cache
+        uses: pytorch/test-infra/.github/actions/run-script-with-cache@main
         with:
           repository: ${{ inputs.repository  }}
           script: ${{ inputs.post-script }}

--- a/.github/workflows/generate_binary_build_matrix.yml
+++ b/.github/workflows/generate_binary_build_matrix.yml
@@ -39,6 +39,15 @@ on:
         description: "Build with XPU?"
         default: "disable"
         type: string
+      runner-fleet:
+        description: |
+          Which runner fleet each row's validation_runner should name: "ec2"
+          (default) or "osdc". On osdc the Linux rows get ARC labels, release
+          isolated on the refs a wheel is published from and regular otherwise;
+          Windows and macOS rows are unchanged, having no OSDC equivalent.
+        default: "ec2"
+        required: false
+        type: string
       use-only-dl-pytorch-org:
         description: "Use only download.pytorch.org when generating wheel install command?"
         default: "false"
@@ -92,6 +101,7 @@ jobs:
           WITH_ROCM: ${{ inputs.with-rocm }}
           WITH_CPU: ${{ inputs.with-cpu }}
           WITH_XPU: ${{ inputs.with-xpu }}
+          RUNNER_FLEET: ${{ inputs.runner-fleet }}
           # limit pull request builds to one version of python unless ciflow/binaries/all is applied to the workflow
           # should not affect builds that are from events that are not the pull_request event
           LIMIT_PR_BUILDS: ${{ github.event_name == 'pull_request' && !contains( github.event.pull_request.labels.*.name, 'ciflow/binaries/all') }}

--- a/tools/scripts/generate_binary_build_matrix.py
+++ b/tools/scripts/generate_binary_build_matrix.py
@@ -147,6 +147,42 @@ WIN_CPU_RUNNER = "windows.4xlarge"
 WIN_ARM64_RUNNER = "windows-11-arm64-preview"
 MACOS_M1_RUNNER = "macos-m1-stable"
 
+# OSDC (ARC) equivalents, selected by the runner-fleet input. Release-isolated
+# rel- runners on the refs a wheel is published from, regular ones otherwise, so
+# a pull request build does not sit in the release fleet. Only Linux has OSDC
+# runners; Windows and macOS keep the labels above either way.
+EC2 = "ec2"
+OSDC = "osdc"
+
+OSDC_LINUX_CPU_RUNNER = "mt-l-x86iavx512-8-64"
+OSDC_LINUX_GPU_RUNNER = "mt-l-x86aavx2-29-113-a10g"
+OSDC_LINUX_AARCH64_RUNNER = "mt-l-arm64g4-16-62"
+OSDC_REL_LINUX_CPU_RUNNER = "mt-rel-l-x86iavx512-44-340"
+OSDC_REL_LINUX_GPU_RUNNER = "mt-rel-l-x86aavx2-29-113-l4"
+OSDC_REL_LINUX_AARCH64_RUNNER = "mt-rel-l-arm64g3-44-340"
+
+# aarch64 has no OSDC GPU runner, which matches the EC2 label it replaces:
+# linux.arm64.m7g.4xlarge has no device either, so a cuda-aarch64 row's smoke
+# test skips its device checks there today.
+OSDC_RUNNERS = {
+    (LINUX, CUDA): (OSDC_LINUX_GPU_RUNNER, OSDC_REL_LINUX_GPU_RUNNER),
+    (LINUX, CPU): (OSDC_LINUX_CPU_RUNNER, OSDC_REL_LINUX_CPU_RUNNER),
+    (LINUX_AARCH64, CUDA_AARCH64): (
+        OSDC_LINUX_AARCH64_RUNNER,
+        OSDC_REL_LINUX_AARCH64_RUNNER,
+    ),
+    (LINUX_AARCH64, CPU): (OSDC_LINUX_AARCH64_RUNNER, OSDC_REL_LINUX_AARCH64_RUNNER),
+}
+
+# The refs a wheel is published from, matching pytorch/pytorch's
+# _select-release-runner.yml.
+RELEASE_REF_PREFIXES = (
+    "refs/heads/main",
+    "refs/heads/nightly",
+    "refs/heads/release/",
+    "refs/tags/v",
+)
+
 PACKAGES_TO_INSTALL_WHL = "torch torchvision"
 PACKAGES_TO_INSTALL_GETTING_STARTED_WHL = "torch torchvision"
 PACKAGES_TO_INSTALL_WHL_WIN_ARM64 = "torch"
@@ -176,7 +212,34 @@ def arch_type(arch_version: str) -> str:
         return CPU
 
 
+def runner_fleet() -> str:
+    """Which runner fleet the matrix should name. Module level because
+    validation_runner()'s `os` parameter shadows the os module."""
+    return os.getenv("RUNNER_FLEET", EC2).strip().lower()
+
+
+def github_ref() -> str:
+    return os.getenv("GITHUB_REF", "")
+
+
+def is_release_ref(ref: str) -> bool:
+    return any(ref.startswith(prefix) for prefix in RELEASE_REF_PREFIXES)
+
+
+def osdc_validation_runner(arch_type: str, os: str, ref: str) -> Optional[str]:
+    """The OSDC label for a row, or None where OSDC has no equivalent."""
+    key = (os, arch_type if arch_type in (CUDA, CUDA_AARCH64) else CPU)
+    labels = OSDC_RUNNERS.get(key)
+    if labels is None:
+        return None
+    return labels[1] if is_release_ref(ref) else labels[0]
+
+
 def validation_runner(arch_type: str, os: str) -> str:
+    if runner_fleet() == OSDC:
+        osdc = osdc_validation_runner(arch_type, os, github_ref())
+        if osdc is not None:
+            return osdc
     if os == LINUX:
         if arch_type == CUDA:
             return LINUX_GPU_RUNNER

--- a/tools/tests/test_generate_binary_build_matrix.py
+++ b/tools/tests/test_generate_binary_build_matrix.py
@@ -8,6 +8,7 @@ from tools.scripts.generate_binary_build_matrix import (
     generate_build_matrix,
     parse_version,
     ROCM_ARCHES_DICT,
+    validation_runner,
 )
 
 
@@ -360,6 +361,64 @@ def parse_args():
         help="Update reference files with the generated output",
     )
     return parser.parse_known_args()
+
+
+class TestRunnerFleet(TestCase):
+    def tearDown(self) -> None:
+        os.environ.pop("RUNNER_FLEET", None)
+        os.environ.pop("GITHUB_REF", None)
+
+    def test_ec2_is_the_default(self) -> None:
+        self.assertEqual(validation_runner("cpu", "linux"), "linux.2xlarge")
+        self.assertEqual(
+            validation_runner("cuda", "linux"),
+            "linux.g5.4xlarge.nvidia.gpu",
+        )
+
+    def test_osdc_off_a_release_ref(self) -> None:
+        os.environ["RUNNER_FLEET"] = "osdc"
+        os.environ["GITHUB_REF"] = "refs/pull/1/merge"
+        self.assertEqual(
+            validation_runner("cpu", "linux"),
+            "mt-l-x86iavx512-8-64",
+        )
+        self.assertEqual(
+            validation_runner("cuda", "linux"),
+            "mt-l-x86aavx2-29-113-a10g",
+        )
+
+    def test_osdc_on_a_release_ref(self) -> None:
+        os.environ["RUNNER_FLEET"] = "osdc"
+        os.environ["GITHUB_REF"] = "refs/tags/v0.29.0-rc1"
+        self.assertEqual(
+            validation_runner("cpu", "linux"),
+            "mt-rel-l-x86iavx512-44-340",
+        )
+        self.assertEqual(
+            validation_runner("cuda", "linux"),
+            "mt-rel-l-x86aavx2-29-113-l4",
+        )
+
+    def test_aarch64_has_no_gpu_runner(self) -> None:
+        os.environ["RUNNER_FLEET"] = "osdc"
+        os.environ["GITHUB_REF"] = "refs/heads/nightly"
+        for arch in ("cpu", "cuda-aarch64"):
+            self.assertEqual(
+                validation_runner(arch, "linux-aarch64"),
+                "mt-rel-l-arm64g3-44-340",
+            )
+
+    def test_windows_and_macos_are_unchanged(self) -> None:
+        os.environ["RUNNER_FLEET"] = "osdc"
+        os.environ["GITHUB_REF"] = "refs/heads/nightly"
+        self.assertEqual(
+            validation_runner("cuda", "windows"),
+            "windows.g4dn.xlarge",
+        )
+        self.assertEqual(
+            validation_runner("cpu", "macos-arm64"),
+            "macos-m1-stable",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two things stopped `build_wheels_linux.yml` running on an OSDC pod, both found by probing executorch's x86 wheel build on `mt-l-x86iavx512-8-64`:

- the workspace clean removed `GITHUB_WORKSPACE`, detaching the mount, so every later step failed with `getcwd: cannot access parent directories`. It now clears the contents instead.
- the four `uses: ./test-infra/...` actions could not resolve. OSDC copies the workspace into the pod, so a checkout inside it is invisible to the runner on the host. They are referenced remotely now, as `linux_job_v3.yml` and `_binary-build-linux.yml` already do.

Also adds a `runner-fleet` input to `generate_binary_build_matrix.yml`. On `osdc` each row's `validation_runner` becomes its ARC equivalent, so callers move off EC2 with one input and no per-repo runner plumbing. Defaults to `ec2`, so existing callers are unaffected.

Release-isolated on `main`, `nightly`, `release/*` and `v*` tags; regular otherwise. Treating `main` as a publish ref is deliberate — it matches pytorch/pytorch's `_select-release-runner.yml`, and means a repo that builds wheels on main pushes (vision does, executorch does not) uses the release fleet for them.

| arch | rows | regular | release |
| --- | --- | --- | --- |
| x86_64 | cpu / rocm / xpu | `mt-l-x86iavx512-8-64` | `mt-rel-l-x86iavx512-44-340` |
| x86_64 | cuda | `mt-l-x86aavx2-29-113-a10g` | `mt-rel-l-x86aavx2-29-113-l4` |
| aarch64 | any | `mt-l-arm64g4-16-62` | `mt-rel-l-arm64g3-44-340` |

aarch64 gets one label either way — OSDC has no arm64 GPU runner, matching the `linux.arm64.m7g.4xlarge` it replaces. Windows and macOS rows are untouched.

Consumers: pytorch/executorch#22753, pytorch/vision#9668 — both green on OSDC.