### PR TITLE
Show Green Light rejections on the HUD, behind an off-by-default toggle

### DIFF
--- a/torchci/lib/greenlight/greenlightHudState.ts
+++ b/torchci/lib/greenlight/greenlightHudState.ts
@@ -5,7 +5,10 @@
 //
 // No server-only imports, so this is unit-testable and importable anywhere.
 
-import { GREENLIGHT_STATUS_LAND } from "lib/greenlight/greenlightRender";
+import {
+  GREENLIGHT_STATUS_LAND,
+  GREENLIGHT_STATUS_NO_LAND,
+} from "lib/greenlight/greenlightRender";
 
 /** One `misc.greenlight_pr_state` row. Saved queries are untyped, so this is the cast target. */
 export interface GreenlightPrStateRow {
@@ -32,6 +35,37 @@ export function isGreenlightApproved(
   status: string | undefined | null
 ): boolean {
   return (status ?? "").trim() === GREENLIGHT_STATUS_LAND;
+}
+
+/**
+ * Only NO_LAND means Green Light looked at the commit and refused it. The other
+ * non-LAND statuses are absences, not refusals -- CANCELLED and FAILED mean no
+ * verdict was reached, REVERTED means the PR was excluded from review rather
+ * than judged, and the in-flight ones mean the review has not finished. Marking
+ * any of those as rejected would attribute a judgement that was never made.
+ */
+export function isGreenlightRejected(
+  status: string | undefined | null
+): boolean {
+  return (status ?? "").trim() === GREENLIGHT_STATUS_NO_LAND;
+}
+
+/**
+ * Whether the HUD puts a Green Light mark on a commit.
+ *
+ * Approvals are always marked. Refusals are opt-in and off by default: most of
+ * trunk was never approved by Green Light, so marking every refusal turns a
+ * sparse signal into a column of red that says little about the commit the
+ * reader is looking at. `showRejected` is the reader's own choice to see them.
+ */
+export function shouldShowGreenlightStatus(
+  status: string | undefined | null,
+  showRejected: boolean
+): boolean {
+  return (
+    isGreenlightApproved(status) ||
+    (showRejected && isGreenlightRejected(status))
+  );
 }
 
 /**

--- a/torchci/lib/useGroupingPreference.tsx
+++ b/torchci/lib/useGroupingPreference.tsx
@@ -90,6 +90,20 @@ export function useHideNonViableStrictPreference(): [
   return [state, setState];
 }
 
+// Off by default: approvals are the sparse signal worth surfacing on trunk,
+// while most commits carry no Green Light approval at all.
+export function useShowGreenlightRejectedPreference(): [
+  boolean,
+  (_showGreenlightRejectedValue: boolean) => void
+] {
+  const [state, setState] = usePreference(
+    "showGreenlightRejected",
+    /*override*/ undefined,
+    /*default*/ false
+  );
+  return [state, setState];
+}
+
 export function useHideAlwaysSkippedPreference(): [
   boolean,
   (_hideAlwaysSkippedValue: boolean) => void

--- a/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
+++ b/torchci/pages/hud/[repoOwner]/[repoName]/[branch]/[[...page]].tsx
@@ -36,8 +36,8 @@ import {
 import {
   buildStatusByTrunkSha,
   GreenlightTrunkStatusRow,
-  isGreenlightApproved,
   normalizeSha,
+  shouldShowGreenlightStatus,
 } from "lib/greenlight/greenlightHudState";
 import {
   getGroupingData,
@@ -69,6 +69,7 @@ import {
   useHideNonViableStrictPreference,
   useMonsterFailuresPreference,
   usePreference,
+  useShowGreenlightRejectedPreference,
 } from "lib/useGroupingPreference";
 import useHudData from "lib/useHudData";
 import useTableFilter from "lib/useTableFilter";
@@ -209,6 +210,7 @@ function HudRow({
   const greenlightStatus = useContext(GreenlightStatusesContext).get(
     normalizeSha(sha)
   );
+  const [showGreenlightRejected] = useContext(ShowGreenlightRejectedContext);
 
   let rowStyle = "";
   if (pinnedId.sha == sha) {
@@ -269,11 +271,12 @@ function HudRow({
                 <div>#{rowData.prNum}</div>
               )}
             </a>
-            {/* LAND only: every other status is a refusal or the absence
-            of one. */}
-            {isGreenlightApproved(greenlightStatus) && (
-              <GreenLightIcon status={greenlightStatus} size={14} />
-            )}
+            {/* LAND always; NO_LAND only when the reader has opted in. Every
+            other status is the absence of a verdict, never shown here. */}
+            {shouldShowGreenlightStatus(
+              greenlightStatus,
+              showGreenlightRejected
+            ) && <GreenLightIcon status={greenlightStatus} size={14} />}
           </div>
         )}
       </td>
@@ -421,6 +424,9 @@ function FiltersAndSettings({}: {}) {
   const { jobFilter, handleSubmit } = useTableFilter(params);
   const [mergeEphemeralLF, setMergeEphemeralLF] = useContext(MergeLFContext);
   const [mergeOSDC, setMergeOSDC] = useContext(MergeOSDCContext);
+  const [showGreenlightRejected, setShowGreenlightRejected] = useContext(
+    ShowGreenlightRejectedContext
+  );
   const [autorevertView, setAutorevertView] = useContext(AutorevertViewContext);
   const [settingsPanelOpen, setSettingsPanelOpen] = useState(false);
   const [hideUnstable, setHideUnstable] = usePreference("hideUnstable");
@@ -441,6 +447,10 @@ function FiltersAndSettings({}: {}) {
   // The viable/strict concept (and thus this filter) only exists for
   // pytorch/pytorch, so the toggle is a no-op for any other repo.
   const isPyTorchRepo = isPyTorchPyTorchRepo(params);
+
+  // No other repo is evaluated by Green Light, so there is nothing for the
+  // toggle to reveal there.
+  const isGreenlight = isGreenlightRepo(params.repoOwner, params.repoName);
 
   return (
     <div className={styles.hudControlsRow}>
@@ -467,6 +477,19 @@ function FiltersAndSettings({}: {}) {
                   labelText={"Use grouped view"}
                 />,
                 <MonsterFailuresCheckbox key="monsterFailures" />,
+                <CheckBoxSelector
+                  value={showGreenlightRejected}
+                  setValue={(value) => setShowGreenlightRejected(value)}
+                  checkBoxName="showGreenlightRejected"
+                  key="showGreenlightRejected"
+                  labelText={"Show Green Light rejections"}
+                  disabled={!isGreenlight}
+                  title={
+                    isGreenlight
+                      ? "Also mark PRs Green Light declined to approve"
+                      : "Only applies to repos Green Light reviews"
+                  }
+                />,
               ],
               "Filter Options": [
                 <CheckBoxSelector
@@ -552,6 +575,13 @@ export const AdvisorVerdictsContext = createContext<
 export const GreenlightStatusesContext = createContext<Map<string, string>>(
   new Map()
 );
+
+// Whether the rows also mark commits GreenLight refused. The default matches
+// useShowGreenlightRejectedPreference's: off, so a row rendered outside the
+// provider shows approvals only rather than every refusal.
+export const ShowGreenlightRejectedContext = createContext<
+  [boolean, (_value: boolean) => void]
+>([false, (_) => {}]);
 
 export const GroupingContext = createContext<{
   groupNameMapping: Map<string, Array<string>>;
@@ -643,6 +673,8 @@ export default function Hud() {
     /*override*/ undefined,
     /*default*/ false
   );
+  const [showGreenlightRejected, setShowGreenlightRejected] =
+    useShowGreenlightRejectedPreference();
   const [autorevertView, setAutorevertView] = useState(() =>
     isAutorevertActive(router.query)
   );
@@ -702,39 +734,43 @@ export default function Hud() {
             value={[mergeEphemeralLF, setMergeEphemeralLF]}
           >
             <MergeOSDCContext.Provider value={[mergeOSDC, setMergeOSDC]}>
-              <AutorevertViewContext.Provider
-                value={[autorevertView, setAutorevertView]}
+              <ShowGreenlightRejectedContext.Provider
+                value={[showGreenlightRejected, setShowGreenlightRejected]}
               >
-                {params.branch !== undefined && (
-                  <div onClick={handleClick}>
-                    <div style={{ display: "flex", alignItems: "flex-end" }}>
-                      <HudHeader params={params} />
-                      <CopyPermanentLink
-                        params={params}
-                        style={{ marginLeft: "10px" }}
-                        autorevertView={autorevertView}
-                      />
-                    </div>
-                    <div style={{ position: "relative", clear: "both" }}>
-                      <FiltersAndSettings />
-                      {autorevertView ? (
-                        <AutorevertView />
-                      ) : (
-                        <GroupedHudTable params={params} />
+                <AutorevertViewContext.Provider
+                  value={[autorevertView, setAutorevertView]}
+                >
+                  {params.branch !== undefined && (
+                    <div onClick={handleClick}>
+                      <div style={{ display: "flex", alignItems: "flex-end" }}>
+                        <HudHeader params={params} />
+                        <CopyPermanentLink
+                          params={params}
+                          style={{ marginLeft: "10px" }}
+                          autorevertView={autorevertView}
+                        />
+                      </div>
+                      <div style={{ position: "relative", clear: "both" }}>
+                        <FiltersAndSettings />
+                        {autorevertView ? (
+                          <AutorevertView />
+                        ) : (
+                          <GroupedHudTable params={params} />
+                        )}
+                      </div>
+                      {!autorevertView && (
+                        <>
+                          <PageSelector params={params} baseUrl="hud" />
+                          <br />
+                          <div>
+                            <em>This page automatically updates.</em>
+                          </div>
+                        </>
                       )}
                     </div>
-                    {!autorevertView && (
-                      <>
-                        <PageSelector params={params} baseUrl="hud" />
-                        <br />
-                        <div>
-                          <em>This page automatically updates.</em>
-                        </div>
-                      </>
-                    )}
-                  </div>
-                )}
-              </AutorevertViewContext.Provider>
+                  )}
+                </AutorevertViewContext.Provider>
+              </ShowGreenlightRejectedContext.Provider>
             </MergeOSDCContext.Provider>
           </MergeLFContext.Provider>
         </MonsterFailuresProvider>

--- a/torchci/test/greenlightHudState.test.ts
+++ b/torchci/test/greenlightHudState.test.ts
@@ -4,13 +4,17 @@ import {
   buildStatusByTrunkSha,
   GreenlightPrStateRow,
   isGreenlightApproved,
+  isGreenlightRejected,
   normalizeSha,
   selectStateForSha,
+  shouldShowGreenlightStatus,
   supersedes,
 } from "lib/greenlight/greenlightHudState";
 import {
+  GREENLIGHT_STATUS_AI_REVIEW_DISPATCHED,
   GREENLIGHT_STATUS_AI_REVIEW_STARTED,
   GREENLIGHT_STATUS_CANCELLED,
+  GREENLIGHT_STATUS_FAILED,
   GREENLIGHT_STATUS_LAND,
   GREENLIGHT_STATUS_NO_LAND,
   GREENLIGHT_STATUS_REVERTED,
@@ -54,6 +58,78 @@ describe("isGreenlightApproved", () => {
 
   test("tolerates the surrounding whitespace a ClickHouse String can carry", () => {
     expect(isGreenlightApproved(` ${GREENLIGHT_STATUS_LAND} `)).toBe(true);
+  });
+});
+
+describe("isGreenlightRejected", () => {
+  test("only NO_LAND counts as a refusal", () => {
+    expect(isGreenlightRejected(GREENLIGHT_STATUS_NO_LAND)).toBe(true);
+    // Every other non-LAND status is an absence of a verdict, not a refusal:
+    // the review never finished (dispatched / started), never reached one
+    // (cancelled / failed), or the PR was excluded rather than judged
+    // (reverted). Counting any of them here would put a red lamp on a commit
+    // Green Light never declined.
+    for (const status of [
+      GREENLIGHT_STATUS_LAND,
+      GREENLIGHT_STATUS_AI_REVIEW_DISPATCHED,
+      GREENLIGHT_STATUS_AI_REVIEW_STARTED,
+      GREENLIGHT_STATUS_CANCELLED,
+      GREENLIGHT_STATUS_FAILED,
+      GREENLIGHT_STATUS_REVERTED,
+    ]) {
+      expect(isGreenlightRejected(status)).toBe(false);
+    }
+  });
+
+  test("absent, empty and unknown statuses are not rejections", () => {
+    expect(isGreenlightRejected(undefined)).toBe(false);
+    expect(isGreenlightRejected(null)).toBe(false);
+    expect(isGreenlightRejected("")).toBe(false);
+    expect(isGreenlightRejected("SOMETHING_NEW")).toBe(false);
+  });
+
+  test("tolerates the surrounding whitespace a ClickHouse String can carry", () => {
+    expect(isGreenlightRejected(` ${GREENLIGHT_STATUS_NO_LAND} `)).toBe(true);
+  });
+});
+
+describe("shouldShowGreenlightStatus", () => {
+  test("approvals show whether or not refusals are opted into", () => {
+    expect(shouldShowGreenlightStatus(GREENLIGHT_STATUS_LAND, false)).toBe(
+      true
+    );
+    expect(shouldShowGreenlightStatus(GREENLIGHT_STATUS_LAND, true)).toBe(true);
+  });
+
+  test("a refusal is hidden by default and shown once opted into", () => {
+    expect(shouldShowGreenlightStatus(GREENLIGHT_STATUS_NO_LAND, false)).toBe(
+      false
+    );
+    expect(shouldShowGreenlightStatus(GREENLIGHT_STATUS_NO_LAND, true)).toBe(
+      true
+    );
+  });
+
+  test("opting into refusals does not surface the non-verdict statuses", () => {
+    // The toggle is about refusals only. An in-flight or abandoned review says
+    // nothing about the commit, so it stays off the HUD either way.
+    for (const status of [
+      GREENLIGHT_STATUS_AI_REVIEW_DISPATCHED,
+      GREENLIGHT_STATUS_AI_REVIEW_STARTED,
+      GREENLIGHT_STATUS_CANCELLED,
+      GREENLIGHT_STATUS_FAILED,
+      GREENLIGHT_STATUS_REVERTED,
+      "SOMETHING_NEW",
+    ]) {
+      expect(shouldShowGreenlightStatus(status, true)).toBe(false);
+      expect(shouldShowGreenlightStatus(status, false)).toBe(false);
+    }
+  });
+
+  test("a commit with no recorded status is never marked", () => {
+    expect(shouldShowGreenlightStatus(undefined, true)).toBe(false);
+    expect(shouldShowGreenlightStatus(null, true)).toBe(false);
+    expect(shouldShowGreenlightStatus("", true)).toBe(false);
   });
 });
 


### PR DESCRIPTION
The HUD marked a trunk commit only when Green Light approved the PR behind it. `greenlight_trunk_commit_states` already returns `NO_LAND` too — it was just dropped at render time. This surfaces it, gated on a new "Show Green Light rejections" checkbox under View Options.

Off by default, stored per-browser. Most of trunk was never approved by Green Light, so marking every refusal unconditionally would turn a sparse signal into a column of red.

Only `NO_LAND` counts as a refusal. `CANCELLED`, `FAILED`, `REVERTED` and the in-flight statuses are the absence of a verdict rather than a judgement, so the toggle leaves them hidden. That logic lives in `shouldShowGreenlightStatus` so it's unit-tested rather than inlined in the row.

Shadow rows stay excluded — the query already filters `shadow = false`.

No query changes.

### Preview

https://torchci-git-hud-greenlight-rejected-toggle-fbopensource.vercel.app/hud/pytorch/pytorch/4e561321b85d0c6357b46a379db9d92be0ba441a/1?per_page=50&mergeEphemeralLF=true