### PR TITLE
Trigger each nightly domain in its own job

### DIFF
--- a/.github/workflows/trigger_nightly.yml
+++ b/.github/workflows/trigger_nightly.yml
@@ -29,120 +29,64 @@ on:
           - all
 jobs:
   trigger:
+    name: Trigger nightly ${{ matrix.domain }} build
     runs-on: ubuntu-latest
     environment: trigger-nightly
     timeout-minutes: 60
+    strategy:
+      # One broken domain shouldn't stop the other ones from being triggered
+      fail-fast: false
+      matrix:
+        include:
+          - domain: audio
+            repository: pytorch/audio
+            ref: main
+          - domain: data
+            repository: pytorch/data
+            ref: main
+          - domain: vision
+            repository: pytorch/vision
+            ref: main
+          - domain: torchrec
+            repository: pytorch/torchrec
+            ref: main
+          - domain: tensorrt
+            repository: pytorch/tensorrt
+            ref: main
+          - domain: fbgemm
+            repository: pytorch/fbgemm
+            ref: main
+          - domain: mslk
+            repository: meta-pytorch/mslk
+            ref: main
+          - domain: executorch
+            repository: pytorch/executorch
+            ref: viable/strict
+          - domain: torchtune
+            repository: pytorch/torchtune
+            ref: main
+          - domain: torchcodec
+            repository: meta-pytorch/torchcodec
+            ref: main
+          - domain: torchvision-extra-decoders
+            repository: meta-pytorch/torchvision-extra-decoders
+            ref: main
+          - domain: torchtitan
+            repository: pytorch/torchtitan
+            ref: main
+          - domain: torchcomms
+            repository: meta-pytorch/torchcomms
+            ref: main
+          - domain: torchforge
+            repository: meta-pytorch/torchforge
+            ref: main
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Trigger nightly audio build
-        if: ${{ github.event_name == 'schedule' ||  inputs.domain == 'audio' || inputs.domain == 'all' }}
+      - name: Trigger nightly ${{ matrix.domain }} build
+        if: ${{ github.event_name == 'schedule' || inputs.domain == matrix.domain || inputs.domain == 'all' }}
         uses: ./.github/actions/trigger-nightly
         with:
-          ref: main
-          repository: pytorch/audio
+          ref: ${{ matrix.ref }}
+          repository: ${{ matrix.repository }}
           token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
-          path: audio
-      - name: Trigger nightly data build
-        if: ${{ github.event_name == 'schedule' ||  inputs.domain == 'data' || inputs.domain == 'all' }}
-        uses: ./.github/actions/trigger-nightly
-        with:
-          ref: main
-          repository: pytorch/data
-          token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
-          path: data
-      - name: Trigger nightly vision build
-        if: ${{ github.event_name == 'schedule' ||  inputs.domain == 'vision' || inputs.domain == 'all' }}
-        uses: ./.github/actions/trigger-nightly
-        with:
-          ref: main
-          repository: pytorch/vision
-          token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
-          path: vision
-      - name: Trigger nightly torchrec build
-        if: ${{ github.event_name == 'schedule' ||  inputs.domain == 'torchrec' || inputs.domain == 'all' }}
-        uses: ./.github/actions/trigger-nightly
-        with:
-          ref: main
-          repository: pytorch/torchrec
-          token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
-          path: torchrec
-      - name: Trigger nightly tensorrt build
-        if: ${{ github.event_name == 'schedule' ||  inputs.domain == 'tensorrt' || inputs.domain == 'all' }}
-        uses: ./.github/actions/trigger-nightly
-        with:
-          ref: main
-          repository: pytorch/tensorrt
-          token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
-          path: tensorrt
-      - name: Trigger nightly fbgemm build
-        if: ${{ github.event_name == 'schedule' ||  inputs.domain == 'fbgemm' || inputs.domain == 'all' }}
-        uses: ./.github/actions/trigger-nightly
-        with:
-          ref: main
-          repository: pytorch/fbgemm
-          token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
-          path: fbgemm
-      - name: Trigger nightly mslk build
-        if: ${{ github.event_name == 'schedule' ||  inputs.domain == 'mslk' || inputs.domain == 'all' }}
-        uses: ./.github/actions/trigger-nightly
-        with:
-          ref: main
-          repository: meta-pytorch/mslk
-          token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
-          path: mslk
-      - name: Trigger nightly executorch build
-        if: ${{ github.event_name == 'schedule' ||  inputs.domain == 'executorch' || inputs.domain == 'all' }}
-        uses: ./.github/actions/trigger-nightly
-        with:
-          ref: viable/strict
-          repository: pytorch/executorch
-          token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
-          path: executorch
-      - name: Trigger nightly torchtune build
-        if: ${{ github.event_name == 'schedule' ||  inputs.domain == 'torchtune' || inputs.domain == 'all' }}
-        uses: ./.github/actions/trigger-nightly
-        with:
-          ref: main
-          repository: pytorch/torchtune
-          token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
-          path: torchtune
-      - name: Trigger nightly torchcodec build
-        if: ${{ github.event_name == 'schedule' ||  inputs.domain == 'torchcodec' || inputs.domain == 'all' }}
-        uses: ./.github/actions/trigger-nightly
-        with:
-          ref: main
-          repository: meta-pytorch/torchcodec
-          token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
-          path: torchcodec
-      - name: Trigger nightly torchvision-extra-decoders build
-        if: ${{ github.event_name == 'schedule' ||  inputs.domain == 'torchvision-extra-decoders' || inputs.domain == 'all' }}
-        uses: ./.github/actions/trigger-nightly
-        with:
-          ref: main
-          repository: meta-pytorch/torchvision-extra-decoders
-          token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
-          path: torchvision-extra-decoders
-      - name: Trigger nightly torchtitan
-        if: ${{ github.event_name == 'schedule' ||  inputs.domain == 'torchtitan' || inputs.domain == 'all' }}
-        uses: ./.github/actions/trigger-nightly
-        with:
-          ref: main
-          repository: pytorch/torchtitan
-          token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
-          path: torchtitan
-      - name: Trigger nightly torchcomms
-        if: ${{ github.event_name == 'schedule' ||  inputs.domain == 'torchcomms' || inputs.domain == 'all' }}
-        uses: ./.github/actions/trigger-nightly
-        with:
-          ref: main
-          repository: meta-pytorch/torchcomms
-          token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
-          path: torchcomms
-      - name: Trigger nightly torchforge
-        if: ${{ github.event_name == 'schedule' ||  inputs.domain == 'torchforge' || inputs.domain == 'all' }}
-        uses: ./.github/actions/trigger-nightly
-        with:
-          ref: main
-          repository: meta-pytorch/torchforge
-          token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
-          path: torchforge
+          path: ${{ matrix.domain }}


### PR DESCRIPTION
The nightly domain trigger ran all 14 repos as sequential steps in one job, so the first failure skipped every repo after it. In [this run](https://github.com/pytorch/test-infra/actions/runs/34691509617/job/103547456350) the push to `pytorch/data` was rejected:

```
remote: Personal access tokens (classic) are forbidden from accessing this repository.
fatal: unable to access 'https://github.com/pytorch/data/': The requested URL returned error: 403
```

That took down the 12 domains queued behind it.

This fans the domains out into a matrix with `fail-fast: false`, so a broken repo only fails its own job and every domain reports status separately. The dispatch `domain` filter moves to the step level because `matrix` is not an available context in a job-level `if` (only `github`/`needs`/`vars`/`inputs`).

Verified the 14 matrix domains match the `workflow_dispatch` choice options, and `actionlint` reports no new findings.

Note this makes the nightly resilient but does not fix `pytorch/data` itself — that repo now rejects classic PATs, so `GH_PYTORCHBOT_TOKEN` needs to become a fine-grained/App token there (or the org setting relaxed) or it will keep failing nightly, just in isolation.